### PR TITLE
[codex] Add native Mix, Conan, SwiftPM, and sbt detectors

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,7 +51,11 @@ jobs:
             run: 'TestScan/scan-pub'
             dart: true
           - name: swift
-            run: 'TestScan/scan-cocoapods'
+            run: 'TestScan/(scan-cocoapods|scan-swiftpm)'
+          - name: elixir
+            run: 'TestScan/scan-mix'
+          - name: scala
+            run: 'TestScan/scan-sbt'
           - name: container
             run: 'TestContainer(Scan|Diff|Explain)|TestContainerAuditScan/container-scan-alpine-audit'
     steps:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,6 +106,8 @@ Implementation priority:
 | Lockfile parser | Package-manager-specific parsers where applicable                        | High     |
 | Third-party     | Syft detector, Grype matcher                                             | Lower    |
 
+Native detector coverage is quality-of-graph coverage, not just support-matrix labeling. A built-in detector should ship with deterministic package metadata, graph edges where the ecosystem source can provide them, direct/development/runtime classification when it can be inferred, package URLs, unit fixtures in the detector package, and smoke coverage when a stable root-level real repository is available. Syft remains the compatibility backstop for package managers or project shapes that Bomly cannot resolve directly.
+
 ## Build Modes
 
 Syft and Grype support two build modes:

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -15,8 +15,10 @@ Primary detector files are the preferred inputs for Bomly-owned resolution. Fall
 
 | Ecosystem | Package managers | Primary detector files | Fallback detector files | Detector |
 | --- | --- | --- | --- | --- |
+| `cpp` | `conan` | `conan.lock`, `conanfile.txt`, `conanfile.py`, `conaninfo.txt` | - | Native detector |
 | `dart` | `pub` | `pubspec.lock`, `pubspec.yaml`, `pubspec.yml` | - | Native detector |
 | `dotnet` | `nuget` | `packages.lock.json`, `packages.config`, `*.csproj`, `*.fsproj`, `*.vbproj`, `*.vcxproj`, `project.assets.json` | - | Native detector |
+| `elixir` | `mix` | `mix.lock`, `mix.exs` | - | Native detector |
 | `github-actions` | `github-actions` | `.github/workflows/*.yaml`, `.github/workflows/*.yml`, `.github/actions/*/action.yml`, `.github/actions/*/action.yaml` | - | Native detector |
 | `go` | `gomod` | `go.mod` | - | Native Go detector |
 | `maven` | `gradle`, `maven` | `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `gradle.lockfile*`, `pom.xml`, `*pom.xml` | - | Native Maven and Gradle detectors |
@@ -26,7 +28,8 @@ Primary detector files are the preferred inputs for Bomly-owned resolution. Fall
 | `ruby` | `bundler` | `Gemfile.lock`, `Gemfile.next.lock` | - | Native detector |
 | `rust` | `cargo` | `Cargo.lock`, `Cargo.toml` | - | Native detector |
 | `sbom` | `sbom` | `*.syft.json`, `*.bom.*`, `*.bom`, `bom`, `*.sbom.*`, `*.sbom`, `sbom`, `*.cdx.*`, `*.cdx`, `*.spdx.*`, `*.spdx` | - | Native SBOM detector |
-| `swift` | `cocoapods` | `Podfile.lock`, `Podfile` | - | Native detector |
+| `scala` | `sbt` | `build.sbt`, `project/plugins.sbt`, `project/build.properties` | - | Native detector |
+| `swift` | `cocoapods`, `swiftpm` | `Podfile.lock`, `Podfile`, `Package.resolved`, `.package.resolved`, `Package.swift`, `project.xcworkspace/xcshareddata/swiftpm/Package.resolved` | - | Native detector |
 
 ## Third-Party Support
 

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -1,0 +1,328 @@
+package conan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/internal/system"
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Detector resolves Conan dependency graphs from committed Conan files.
+type Detector struct {
+	Logger     *zap.Logger
+	WorkingDir string
+	Fallback   model.Detector
+}
+
+var evidencePatterns = []string{"conan.lock", "conanfile.txt", "conanfile.py", "conaninfo.txt"}
+
+type conanRef struct {
+	Name    string
+	Version string
+	Context string
+	Direct  bool
+}
+
+type graphInfo struct {
+	Graph struct {
+		Nodes map[string]graphNode `json:"nodes"`
+	} `json:"graph"`
+}
+
+type graphNode struct {
+	Ref           string   `json:"ref"`
+	Context       string   `json:"context"`
+	Requires      []string `json:"requires"`
+	BuildRequires []string `json:"build_requires"`
+}
+
+type conanLock struct {
+	Requires []string `json:"requires"`
+	Graph    struct {
+		Nodes map[string]graphNode `json:"nodes"`
+	} `json:"graph"`
+	GraphLock struct {
+		Nodes map[string]graphNode `json:"nodes"`
+	} `json:"graph_lock"`
+}
+
+var conanRefPattern = regexp.MustCompile(`([A-Za-z0-9_.+-]+)/([A-Za-z0-9_.+:-]+)`)
+
+// PackageManagerSupport returns Conan package-manager discovery metadata.
+func (d Detector) PackageManagerSupport() []model.PackageManagerSupport {
+	return []model.PackageManagerSupport{model.Support(model.PackageManagerConan, evidencePatterns...)}
+}
+
+// Ready reports whether committed Conan files can be parsed.
+func (d Detector) Ready() bool {
+	return true
+}
+
+// Applicable reports whether Conan files are present.
+func (d Detector) Applicable(ctx context.Context, req model.DetectionRequest) (bool, error) {
+	_ = ctx
+	workingDir := d.workingDir(req.ProjectPath)
+	for _, name := range []string{"conan.lock", "conanfile.txt", "conanfile.py", "conaninfo.txt"} {
+		if ok, err := system.FileExists(filepath.Join(workingDir, name)); ok || err != nil {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+// Descriptor describes the Conan detector.
+func (d Detector) Descriptor() model.DetectorDescriptor {
+	return model.DetectorDescriptor{
+		Name:                detectors.NameConan,
+		Enabled:             true,
+		ComponentType:       model.NativeComponent,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemCPP},
+		SupportedManagers:   []model.PackageManager{model.PackageManagerConan},
+		SupportedModes:      []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		Capabilities:        []string{"graph-resolution", "component-targeting", "lockfile-parsing", "scope-annotation"},
+	}
+}
+
+// ResolveGraph resolves a Conan dependency graph.
+func (d Detector) ResolveGraph(_ context.Context, req model.DetectionRequest) (model.DetectionResult, error) {
+	workingDir := d.workingDir(req.ProjectPath)
+	g, err := depGraphFromConanFiles(workingDir)
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+	return model.DetectionResult{Graphs: model.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
+}
+
+// FallbackDetector returns the configured fallback detector.
+func (d Detector) FallbackDetector() model.Detector {
+	return d.Fallback
+}
+
+func (d Detector) workingDir(projectPath string) string {
+	if d.WorkingDir != "" {
+		return d.WorkingDir
+	}
+	return projectPath
+}
+
+func depGraphFromConanFiles(workingDir string) (*model.Graph, error) {
+	for _, name := range []string{"conan.lock"} {
+		raw, err := readOptional(filepath.Join(workingDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		if g, err := depGraphFromJSON(raw); err == nil {
+			return g, nil
+		}
+	}
+	return depGraphFromManifestFiles(workingDir)
+}
+
+func depGraphFromJSON(raw []byte) (*model.Graph, error) {
+	var info graphInfo
+	if err := json.Unmarshal(raw, &info); err == nil && len(info.Graph.Nodes) > 0 {
+		return depGraphFromNodes(info.Graph.Nodes)
+	}
+	var lock conanLock
+	if err := json.Unmarshal(raw, &lock); err != nil {
+		return nil, fmt.Errorf("parse Conan JSON: %w", err)
+	}
+	switch {
+	case len(lock.Graph.Nodes) > 0:
+		return depGraphFromNodes(lock.Graph.Nodes)
+	case len(lock.GraphLock.Nodes) > 0:
+		return depGraphFromNodes(lock.GraphLock.Nodes)
+	case len(lock.Requires) > 0:
+		refs := make([]conanRef, 0, len(lock.Requires))
+		for _, value := range lock.Requires {
+			if ref, ok := parseConanRef(value); ok {
+				ref.Direct = true
+				refs = append(refs, ref)
+			}
+		}
+		return depGraphFromRefs(refs)
+	default:
+		return nil, fmt.Errorf("Conan JSON does not contain graph nodes or requirements")
+	}
+}
+
+func depGraphFromNodes(nodes map[string]graphNode) (*model.Graph, error) {
+	g := model.New()
+	root := rootNode()
+	if err := g.AddPackage(root); err != nil {
+		return nil, fmt.Errorf("add root node: %w", err)
+	}
+	nodePackages := make(map[string]*model.Package, len(nodes))
+	for id, item := range nodes {
+		ref, ok := parseConanRef(item.Ref)
+		if !ok {
+			continue
+		}
+		ref.Context = item.Context
+		node := packageNode(ref)
+		nodePackages[id] = node
+		if err := addNodeIfMissing(g, node); err != nil {
+			return nil, err
+		}
+	}
+	for _, id := range sortedNodeIDs(nodePackages) {
+		node := nodePackages[id]
+		item := nodes[id]
+		parent := root
+		if id != "0" {
+			parent = node
+		}
+		for _, depID := range append(item.Requires, item.BuildRequires...) {
+			child, ok := nodePackages[depID]
+			if !ok {
+				continue
+			}
+			if containsString(item.BuildRequires, depID) {
+				model.MergePackageScope(child, model.ScopeDevelopment)
+			}
+			if err := g.AddDependency(parent.ID, child.ID); err != nil {
+				return nil, fmt.Errorf("add Conan dependency %q -> %q: %w", parent.ID, child.ID, err)
+			}
+		}
+	}
+	return g, nil
+}
+
+func depGraphFromManifestFiles(workingDir string) (*model.Graph, error) {
+	var refs []conanRef
+	for _, name := range []string{"conanfile.txt", "conanfile.py", "conaninfo.txt"} {
+		raw, err := readOptional(filepath.Join(workingDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		for _, ref := range parseManifestRefs(string(raw)) {
+			ref.Direct = true
+			refs = append(refs, ref)
+		}
+	}
+	return depGraphFromRefs(refs)
+}
+
+func depGraphFromRefs(refs []conanRef) (*model.Graph, error) {
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("Conan files do not contain any dependencies")
+	}
+	g := model.New()
+	root := rootNode()
+	if err := g.AddPackage(root); err != nil {
+		return nil, fmt.Errorf("add root node: %w", err)
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		node := packageNode(ref)
+		if _, ok := seen[node.ID]; ok {
+			continue
+		}
+		seen[node.ID] = struct{}{}
+		if err := addNodeIfMissing(g, node); err != nil {
+			return nil, err
+		}
+		if err := g.AddDependency(root.ID, node.ID); err != nil {
+			return nil, fmt.Errorf("add Conan root dependency %q: %w", node.ID, err)
+		}
+	}
+	return g, nil
+}
+
+func readOptional(path string) ([]byte, error) {
+	ok, err := system.FileExists(path)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func parseManifestRefs(raw string) []conanRef {
+	matches := conanRefPattern.FindAllStringSubmatch(raw, -1)
+	refs := make([]conanRef, 0, len(matches))
+	for _, match := range matches {
+		ref := conanRef{Name: match[1], Version: match[2]}
+		if strings.Contains(raw[:strings.Index(raw, match[0])], "[tool_requires]") || strings.Contains(raw[:strings.Index(raw, match[0])], "tool_requires") {
+			ref.Context = "build"
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func parseConanRef(value string) (conanRef, bool) {
+	match := conanRefPattern.FindStringSubmatch(value)
+	if len(match) == 0 {
+		return conanRef{}, false
+	}
+	return conanRef{Name: match[1], Version: match[2]}, true
+}
+
+func rootNode() *model.Package {
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemCPP),
+		Name:        "root",
+		BuildSystem: model.PackageManagerConan.Name(),
+		Type:        "application",
+		Language:    "cpp",
+	})
+}
+
+func packageNode(ref conanRef) *model.Package {
+	pkg := model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemCPP),
+		Name:        strings.TrimSpace(ref.Name),
+		Version:     strings.TrimSpace(ref.Version),
+		BuildSystem: model.PackageManagerConan.Name(),
+		Type:        "package",
+		Language:    "cpp",
+		PURL:        model.BuildPackageURL("conan", "", ref.Name, ref.Version),
+	})
+	if strings.EqualFold(strings.TrimSpace(ref.Context), "build") {
+		model.MergePackageScope(pkg, model.ScopeDevelopment)
+	}
+	return pkg
+}
+
+func sortedNodeIDs(nodes map[string]*model.Package) []string {
+	values := make([]string, 0, len(nodes))
+	for id := range nodes {
+		values = append(values, id)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func addNodeIfMissing(g *model.Graph, node *model.Package) error {
+	if _, ok := g.Package(node.ID); ok {
+		return nil
+	}
+	if err := g.AddPackage(node); err != nil {
+		return fmt.Errorf("add node %q: %w", node.ID, err)
+	}
+	return nil
+}

--- a/internal/detectors/conan/detector_test.go
+++ b/internal/detectors/conan/detector_test.go
@@ -1,0 +1,67 @@
+package conan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestDetectorResolveGraphFromFixture(t *testing.T) {
+	projectDir := filepath.Join("testdata", "project")
+	detector := Detector{}
+	result, err := detector.ResolveGraph(context.Background(), model.DetectionRequest{
+		ProjectPath:    projectDir,
+		PackageManager: model.PackageManagerConan,
+		Ecosystem:      model.EcosystemCPP,
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph returned error: %v", err)
+	}
+	graph := result.Graphs.Entries[0].Graph
+	if graph == nil {
+		t.Fatal("expected graph")
+	}
+	zlib, ok := graph.Package("zlib@1.2.13")
+	if !ok {
+		t.Fatalf("expected zlib package, got %v", graph.Packages())
+	}
+	if zlib.PURL != "pkg:conan/zlib@1.2.13" {
+		t.Fatalf("expected zlib PURL, got %q", zlib.PURL)
+	}
+	cmake, ok := graph.Package("cmake@3.27.0")
+	if !ok {
+		t.Fatalf("expected cmake package, got %v", graph.Packages())
+	}
+	if cmake.Scope != string(model.ScopeDevelopment) {
+		t.Fatalf("expected cmake development scope, got %q", cmake.Scope)
+	}
+}
+
+func TestDetectorResolveGraphFromConanfilePy(t *testing.T) {
+	projectDir := t.TempDir()
+	raw := []byte(`from conan import ConanFile
+
+class Demo(ConanFile):
+    def requirements(self):
+        self.requires("fmt/10.2.1")
+`)
+	if err := os.WriteFile(filepath.Join(projectDir, "conanfile.py"), raw, 0o644); err != nil {
+		t.Fatalf("write conanfile.py: %v", err)
+	}
+	detector := Detector{}
+	result, err := detector.ResolveGraph(context.Background(), model.DetectionRequest{
+		ProjectPath:    projectDir,
+		PackageManager: model.PackageManagerConan,
+		Ecosystem:      model.EcosystemCPP,
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph returned error: %v", err)
+	}
+	graph := result.Graphs.Entries[0].Graph
+	if _, ok := graph.Package("fmt@10.2.1"); !ok {
+		t.Fatalf("expected fmt package, got %v", graph.Packages())
+	}
+}

--- a/internal/detectors/conan/testdata/project/conan.lock
+++ b/internal/detectors/conan/testdata/project/conan.lock
@@ -1,0 +1,21 @@
+{
+  "graph": {
+    "nodes": {
+      "0": {
+        "ref": "",
+        "requires": ["1"],
+        "build_requires": ["2"]
+      },
+      "1": {
+        "ref": "zlib/1.2.13#rev",
+        "context": "host",
+        "requires": []
+      },
+      "2": {
+        "ref": "cmake/3.27.0",
+        "context": "build",
+        "requires": []
+      }
+    }
+  }
+}

--- a/internal/detectors/conan/testdata/project/conanfile.txt
+++ b/internal/detectors/conan/testdata/project/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+zlib/1.2.13
+
+[tool_requires]
+cmake/3.27.0

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -1,0 +1,243 @@
+package mix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/internal/system"
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Detector resolves Elixir Mix dependency graphs from committed Mix files.
+type Detector struct {
+	Logger     *zap.Logger
+	WorkingDir string
+	Fallback   model.Detector
+}
+
+var evidencePatterns = []string{"mix.lock", "mix.exs"}
+
+type mixPackage struct {
+	Name    string
+	Version string
+	Source  string
+	Scope   model.Scope
+	Direct  bool
+}
+
+var (
+	mixLockHexPattern  = regexp.MustCompile(`"([^"]+)"\s*:\s*\{:(?:hex)\s*,\s*:([A-Za-z0-9_.-]+)\s*,\s*"([^"]+)"`)
+	mixDepPattern      = regexp.MustCompile(`\{(?:\s*:([A-Za-z0-9_.-]+)|\s*"([^"]+)")\s*,[^}\n]*(?:only:\s*(?::([A-Za-z0-9_]+)|\[([^\]]+)\]))?`)
+	mixOnlyAtomPattern = regexp.MustCompile(`:([A-Za-z0-9_]+)`)
+)
+
+// PackageManagerSupport returns Mix package-manager discovery metadata.
+func (d Detector) PackageManagerSupport() []model.PackageManagerSupport {
+	return []model.PackageManagerSupport{model.Support(model.PackageManagerMix, evidencePatterns...)}
+}
+
+// Ready reports whether committed Mix files can be parsed.
+func (d Detector) Ready() bool {
+	return true
+}
+
+// Applicable reports whether Mix files are present.
+func (d Detector) Applicable(ctx context.Context, req model.DetectionRequest) (bool, error) {
+	_ = ctx
+	workingDir := d.workingDir(req.ProjectPath)
+	for _, name := range []string{"mix.lock", "mix.exs"} {
+		if ok, err := system.FileExists(filepath.Join(workingDir, name)); ok || err != nil {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+// Descriptor describes the Mix detector.
+func (d Detector) Descriptor() model.DetectorDescriptor {
+	return model.DetectorDescriptor{
+		Name:                detectors.NameMix,
+		Enabled:             true,
+		ComponentType:       model.NativeComponent,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemElixir},
+		SupportedManagers:   []model.PackageManager{model.PackageManagerMix},
+		SupportedModes:      []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		Capabilities:        []string{"graph-resolution", "component-targeting", "lockfile-parsing", "scope-annotation"},
+	}
+}
+
+// ResolveGraph resolves a Mix dependency graph.
+func (d Detector) ResolveGraph(_ context.Context, req model.DetectionRequest) (model.DetectionResult, error) {
+	workingDir := d.workingDir(req.ProjectPath)
+	lockRaw, err := readOptional(filepath.Join(workingDir, "mix.lock"))
+	if err != nil {
+		return model.DetectionResult{}, fmt.Errorf("read mix.lock: %w", err)
+	}
+	manifestRaw, err := readOptional(filepath.Join(workingDir, "mix.exs"))
+	if err != nil {
+		return model.DetectionResult{}, fmt.Errorf("read mix.exs: %w", err)
+	}
+	g, err := depGraphFromMix(lockRaw, manifestRaw)
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+	return model.DetectionResult{Graphs: model.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
+}
+
+// FallbackDetector returns the configured fallback detector.
+func (d Detector) FallbackDetector() model.Detector {
+	return d.Fallback
+}
+
+func (d Detector) workingDir(projectPath string) string {
+	if d.WorkingDir != "" {
+		return d.WorkingDir
+	}
+	return projectPath
+}
+
+func readOptional(path string) ([]byte, error) {
+	ok, err := system.FileExists(path)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func depGraphFromMix(lockRaw, manifestRaw []byte) (*model.Graph, error) {
+	packages := parseMixLock(string(lockRaw))
+	for name, dep := range parseMixManifest(string(manifestRaw)) {
+		pkg := packages[name]
+		if pkg.Name == "" {
+			pkg.Name = name
+		}
+		pkg.Direct = true
+		pkg.Scope = dep.Scope
+		packages[name] = pkg
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("Mix files do not contain any dependencies")
+	}
+
+	g := model.New()
+	root := rootNode()
+	if err := g.AddPackage(root); err != nil {
+		return nil, fmt.Errorf("add root node: %w", err)
+	}
+	for _, name := range sortedMixNames(packages) {
+		pkg := packages[name]
+		node := packageNode(pkg)
+		if err := addNodeIfMissing(g, node); err != nil {
+			return nil, err
+		}
+		if pkg.Scope != "" {
+			if existing, ok := g.Package(node.ID); ok {
+				model.MergePackageScope(existing, pkg.Scope)
+			}
+		}
+		if pkg.Direct {
+			if err := g.AddDependency(root.ID, node.ID); err != nil {
+				return nil, fmt.Errorf("add Mix root dependency %q: %w", node.ID, err)
+			}
+		}
+	}
+	return g, nil
+}
+
+func parseMixLock(raw string) map[string]mixPackage {
+	packages := make(map[string]mixPackage)
+	for _, match := range mixLockHexPattern.FindAllStringSubmatch(raw, -1) {
+		lockName := strings.TrimSpace(match[1])
+		name := strings.TrimSpace(match[2])
+		if name == "" {
+			name = lockName
+		}
+		packages[name] = mixPackage{
+			Name:    name,
+			Version: strings.TrimSpace(match[3]),
+			Source:  "hex",
+		}
+	}
+	return packages
+}
+
+func parseMixManifest(raw string) map[string]mixPackage {
+	packages := make(map[string]mixPackage)
+	for _, match := range mixDepPattern.FindAllStringSubmatch(raw, -1) {
+		name := strings.TrimSpace(match[1])
+		if name == "" {
+			name = strings.TrimSpace(match[2])
+		}
+		if name == "" {
+			continue
+		}
+		scope := model.ScopeRuntime
+		onlyValues := match[0] + " " + match[3] + " " + match[4]
+		if strings.Contains(onlyValues, "test") || strings.Contains(onlyValues, "dev") {
+			scope = model.ScopeDevelopment
+		}
+		for _, only := range mixOnlyAtomPattern.FindAllStringSubmatch(onlyValues, -1) {
+			if only[1] == "prod" {
+				scope = model.ScopeRuntime
+			}
+		}
+		packages[name] = mixPackage{Name: name, Direct: true, Scope: scope}
+	}
+	return packages
+}
+
+func rootNode() *model.Package {
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemElixir),
+		Name:        "root",
+		BuildSystem: model.PackageManagerMix.Name(),
+		Type:        "application",
+		Language:    "elixir",
+	})
+}
+
+func packageNode(pkg mixPackage) *model.Package {
+	version := strings.TrimSpace(pkg.Version)
+	source := strings.TrimSpace(pkg.Source)
+	if source == "" {
+		source = "hex"
+	}
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemElixir),
+		Name:        strings.TrimSpace(pkg.Name),
+		Version:     version,
+		BuildSystem: model.PackageManagerMix.Name(),
+		Type:        "package",
+		Language:    "elixir",
+		PURL:        model.BuildPackageURL("hex", "", pkg.Name, version),
+		Metadata: map[string]any{
+			"source": source,
+		},
+	})
+}
+
+func sortedMixNames(packages map[string]mixPackage) []string {
+	values := make([]string, 0, len(packages))
+	for name := range packages {
+		values = append(values, name)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func addNodeIfMissing(g *model.Graph, node *model.Package) error {
+	if _, ok := g.Package(node.ID); ok {
+		return nil
+	}
+	if err := g.AddPackage(node); err != nil {
+		return fmt.Errorf("add node %q: %w", node.ID, err)
+	}
+	return nil
+}

--- a/internal/detectors/mix/detector_test.go
+++ b/internal/detectors/mix/detector_test.go
@@ -1,0 +1,47 @@
+package mix
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestDetectorResolveGraphFromFixture(t *testing.T) {
+	projectDir := filepath.Join("testdata", "project")
+	detector := Detector{}
+	result, err := detector.ResolveGraph(context.Background(), model.DetectionRequest{
+		ProjectPath:    projectDir,
+		PackageManager: model.PackageManagerMix,
+		Ecosystem:      model.EcosystemElixir,
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph returned error: %v", err)
+	}
+	graph := result.Graphs.Entries[0].Graph
+	if graph == nil {
+		t.Fatal("expected graph")
+	}
+	plug, ok := graph.Package("plug@1.15.3")
+	if !ok {
+		t.Fatalf("expected plug package, got %v", graph.Packages())
+	}
+	if plug.PURL != "pkg:hex/plug@1.15.3" {
+		t.Fatalf("expected plug PURL, got %q", plug.PURL)
+	}
+	credo, ok := graph.Package("credo@1.7.7")
+	if !ok {
+		t.Fatalf("expected credo package, got %v", graph.Packages())
+	}
+	if credo.Scope != string(model.ScopeDevelopment) {
+		t.Fatalf("expected credo development scope, got %q", credo.Scope)
+	}
+	deps, err := graph.Dependencies("root")
+	if err != nil {
+		t.Fatalf("root dependencies: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("expected two direct dependencies, got %d", len(deps))
+	}
+}

--- a/internal/detectors/mix/testdata/project/mix.exs
+++ b/internal/detectors/mix/testdata/project/mix.exs
@@ -1,0 +1,18 @@
+defmodule Demo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :demo,
+      version: "0.1.0",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:plug, "~> 1.15"},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
+    ]
+  end
+end

--- a/internal/detectors/mix/testdata/project/mix.lock
+++ b/internal/detectors/mix/testdata/project/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "credo": {:hex, :credo, "1.7.7", "checksum", [:mix], [{:bunt, "~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm", "checksum"},
+  "plug": {:hex, :plug, "1.15.3", "checksum", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "checksum"},
+  "mime": {:hex, :mime, "2.0.6", "checksum", [:mix], [], "hexpm", "checksum"}
+}

--- a/internal/detectors/names.go
+++ b/internal/detectors/names.go
@@ -21,6 +21,10 @@ const (
 	NameCargo         = "cargo-detector"
 	NamePub           = "pub-detector"
 	NameCocoaPods     = "cocoapods-detector"
+	NameSwiftPM       = "swiftpm-detector"
+	NameMix           = "mix-detector"
+	NameConan         = "conan-detector"
+	NameSBT           = "sbt-detector"
 	NameSBOM          = "sbom-detector"
 	NameSyft          = "syft-detector"
 )

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -1,0 +1,192 @@
+package sbt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/internal/system"
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Detector resolves Scala sbt dependency declarations from committed build files.
+type Detector struct {
+	Logger     *zap.Logger
+	WorkingDir string
+	Fallback   model.Detector
+}
+
+var evidencePatterns = []string{"build.sbt", "project/plugins.sbt", "project/build.properties"}
+
+type sbtPackage struct {
+	Org     string
+	Name    string
+	Version string
+	Scope   model.Scope
+}
+
+var sbtDependencyPattern = regexp.MustCompile(`"([^"]+)"\s*%{1,2}\s*"([^"]+)"\s*%\s*"([^"]+)"(?:\s*%\s*"?([^"\s,)]+)"?)?`)
+
+// PackageManagerSupport returns sbt package-manager discovery metadata.
+func (d Detector) PackageManagerSupport() []model.PackageManagerSupport {
+	return []model.PackageManagerSupport{model.Support(model.PackageManagerSBT, evidencePatterns...)}
+}
+
+// Ready reports whether committed sbt files can be parsed.
+func (d Detector) Ready() bool {
+	return true
+}
+
+// Applicable reports whether sbt build files are present.
+func (d Detector) Applicable(ctx context.Context, req model.DetectionRequest) (bool, error) {
+	_ = ctx
+	workingDir := d.workingDir(req.ProjectPath)
+	for _, name := range evidencePatterns {
+		if ok, err := system.FileExists(filepath.Join(workingDir, name)); ok || err != nil {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+// Descriptor describes the sbt detector.
+func (d Detector) Descriptor() model.DetectorDescriptor {
+	return model.DetectorDescriptor{
+		Name:                detectors.NameSBT,
+		Enabled:             true,
+		ComponentType:       model.NativeComponent,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemScala, model.EcosystemMaven},
+		SupportedManagers:   []model.PackageManager{model.PackageManagerSBT},
+		SupportedModes:      []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		Capabilities:        []string{"graph-resolution", "component-targeting", "manifest-parsing", "scope-annotation"},
+	}
+}
+
+// ResolveGraph resolves an sbt dependency graph.
+func (d Detector) ResolveGraph(_ context.Context, req model.DetectionRequest) (model.DetectionResult, error) {
+	workingDir := d.workingDir(req.ProjectPath)
+	g, err := depGraphFromSBTFiles(workingDir)
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+	return model.DetectionResult{Graphs: model.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
+}
+
+// FallbackDetector returns the configured fallback detector.
+func (d Detector) FallbackDetector() model.Detector {
+	return d.Fallback
+}
+
+func (d Detector) workingDir(projectPath string) string {
+	if d.WorkingDir != "" {
+		return d.WorkingDir
+	}
+	return projectPath
+}
+
+func depGraphFromSBTFiles(workingDir string) (*model.Graph, error) {
+	packages := make([]sbtPackage, 0)
+	for _, name := range []string{"build.sbt", "project/plugins.sbt"} {
+		raw, err := readOptional(filepath.Join(workingDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		packages = append(packages, parseSBTDependencies(string(raw))...)
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("sbt files do not contain any dependencies")
+	}
+	g := model.New()
+	root := rootNode()
+	if err := g.AddPackage(root); err != nil {
+		return nil, fmt.Errorf("add root node: %w", err)
+	}
+	seen := make(map[string]struct{}, len(packages))
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].Org+packages[i].Name+packages[i].Version < packages[j].Org+packages[j].Name+packages[j].Version
+	})
+	for _, pkg := range packages {
+		node := packageNode(pkg)
+		if _, ok := seen[node.ID]; ok {
+			continue
+		}
+		seen[node.ID] = struct{}{}
+		if err := addNodeIfMissing(g, node); err != nil {
+			return nil, err
+		}
+		if err := g.AddDependency(root.ID, node.ID); err != nil {
+			return nil, fmt.Errorf("add sbt root dependency %q: %w", node.ID, err)
+		}
+	}
+	return g, nil
+}
+
+func parseSBTDependencies(raw string) []sbtPackage {
+	matches := sbtDependencyPattern.FindAllStringSubmatch(raw, -1)
+	packages := make([]sbtPackage, 0, len(matches))
+	for _, match := range matches {
+		scope := model.ScopeRuntime
+		config := strings.ToLower(strings.Trim(match[4], `"`))
+		if strings.Contains(config, "test") || strings.Contains(config, "provided") {
+			scope = model.ScopeDevelopment
+		}
+		packages = append(packages, sbtPackage{
+			Org:     strings.TrimSpace(match[1]),
+			Name:    strings.TrimSpace(match[2]),
+			Version: strings.TrimSpace(match[3]),
+			Scope:   scope,
+		})
+	}
+	return packages
+}
+
+func readOptional(path string) ([]byte, error) {
+	ok, err := system.FileExists(path)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func rootNode() *model.Package {
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemScala),
+		Name:        "root",
+		BuildSystem: model.PackageManagerSBT.Name(),
+		Type:        "application",
+		Language:    "scala",
+	})
+}
+
+func packageNode(pkg sbtPackage) *model.Package {
+	node := model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemScala),
+		Org:         strings.TrimSpace(pkg.Org),
+		Name:        strings.TrimSpace(pkg.Name),
+		Version:     strings.TrimSpace(pkg.Version),
+		BuildSystem: model.PackageManagerSBT.Name(),
+		Type:        "package",
+		Language:    "scala",
+		PURL:        model.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version),
+	})
+	if pkg.Scope != "" {
+		model.MergePackageScope(node, pkg.Scope)
+	}
+	return node
+}
+
+func addNodeIfMissing(g *model.Graph, node *model.Package) error {
+	if _, ok := g.Package(node.ID); ok {
+		return nil
+	}
+	if err := g.AddPackage(node); err != nil {
+		return fmt.Errorf("add node %q: %w", node.ID, err)
+	}
+	return nil
+}

--- a/internal/detectors/sbt/detector_test.go
+++ b/internal/detectors/sbt/detector_test.go
@@ -1,0 +1,40 @@
+package sbt
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestDetectorResolveGraphFromFixture(t *testing.T) {
+	projectDir := filepath.Join("testdata", "project")
+	detector := Detector{}
+	result, err := detector.ResolveGraph(context.Background(), model.DetectionRequest{
+		ProjectPath:    projectDir,
+		PackageManager: model.PackageManagerSBT,
+		Ecosystem:      model.EcosystemScala,
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph returned error: %v", err)
+	}
+	graph := result.Graphs.Entries[0].Graph
+	if graph == nil {
+		t.Fatal("expected graph")
+	}
+	config, ok := graph.Package("com.typesafe:config@1.4.3")
+	if !ok {
+		t.Fatalf("expected config package, got %v", graph.Packages())
+	}
+	if config.PURL != "pkg:maven/com.typesafe/config@1.4.3" {
+		t.Fatalf("expected config PURL, got %q", config.PURL)
+	}
+	scalatest, ok := graph.Package("org.scalatest:scalatest@3.2.18")
+	if !ok {
+		t.Fatalf("expected scalatest package, got %v", graph.Packages())
+	}
+	if scalatest.Scope != string(model.ScopeDevelopment) {
+		t.Fatalf("expected scalatest development scope, got %q", scalatest.Scope)
+	}
+}

--- a/internal/detectors/sbt/testdata/project/build.sbt
+++ b/internal/detectors/sbt/testdata/project/build.sbt
@@ -1,0 +1,6 @@
+ThisBuild / scalaVersion := "3.3.3"
+
+libraryDependencies ++= Seq(
+  "com.typesafe" % "config" % "1.4.3",
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test
+)

--- a/internal/detectors/sbt/testdata/project/project/build.properties
+++ b/internal/detectors/sbt/testdata/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.0

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -1,0 +1,312 @@
+package swiftpm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/internal/system"
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Detector resolves Swift Package Manager dependency graphs from Package.resolved.
+type Detector struct {
+	Logger     *zap.Logger
+	WorkingDir string
+	Fallback   model.Detector
+}
+
+var evidencePatterns = []string{"Package.resolved", ".package.resolved", "Package.swift", "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"}
+
+type packageResolved struct {
+	Object struct {
+		Pins []resolvedPin `json:"pins"`
+	} `json:"object"`
+	Pins []resolvedPin `json:"pins"`
+}
+
+type resolvedPin struct {
+	Identity    string        `json:"identity"`
+	Package     string        `json:"package"`
+	Repository  string        `json:"repositoryURL"`
+	Location    string        `json:"location"`
+	State       resolvedState `json:"state"`
+	Description struct {
+		Identity string `json:"identity"`
+	} `json:"description"`
+}
+
+type resolvedState struct {
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+	Branch   string `json:"branch"`
+}
+
+type swiftPackage struct {
+	Name        string
+	Version     string
+	Repository  string
+	Revision    string
+	Requirement string
+	Direct      bool
+}
+
+var packageSwiftPattern = regexp.MustCompile(`\.package\s*\([^)]*(?:url:\s*"([^"]+)"|name:\s*"([^"]+)")[^)]*(?:from:|exact:|branch:|revision:)\s*"([^"]+)"`)
+
+// PackageManagerSupport returns SwiftPM package-manager discovery metadata.
+func (d Detector) PackageManagerSupport() []model.PackageManagerSupport {
+	return []model.PackageManagerSupport{model.Support(model.PackageManagerSwiftPM, evidencePatterns...)}
+}
+
+// Ready reports whether committed SwiftPM files can be parsed.
+func (d Detector) Ready() bool {
+	return true
+}
+
+// Applicable reports whether SwiftPM files are present.
+func (d Detector) Applicable(ctx context.Context, req model.DetectionRequest) (bool, error) {
+	_ = ctx
+	workingDir := d.workingDir(req.ProjectPath)
+	for _, name := range evidencePatterns {
+		if ok, err := system.FileExists(filepath.Join(workingDir, name)); ok || err != nil {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+// Descriptor describes the SwiftPM detector.
+func (d Detector) Descriptor() model.DetectorDescriptor {
+	return model.DetectorDescriptor{
+		Name:                detectors.NameSwiftPM,
+		Enabled:             true,
+		ComponentType:       model.NativeComponent,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemSwift},
+		SupportedManagers:   []model.PackageManager{model.PackageManagerSwiftPM},
+		SupportedModes:      []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		Capabilities:        []string{"graph-resolution", "component-targeting", "lockfile-parsing"},
+	}
+}
+
+// ResolveGraph resolves a SwiftPM dependency graph.
+func (d Detector) ResolveGraph(_ context.Context, req model.DetectionRequest) (model.DetectionResult, error) {
+	workingDir := d.workingDir(req.ProjectPath)
+	resolvedRaw, resolvedPath, err := readFirstExisting(workingDir, []string{"Package.resolved", ".package.resolved", "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"})
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+	manifestRaw, err := readOptional(filepath.Join(workingDir, "Package.swift"))
+	if err != nil {
+		return model.DetectionResult{}, fmt.Errorf("read Package.swift: %w", err)
+	}
+	g, err := depGraphFromSwiftPM(resolvedRaw, manifestRaw)
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+	metadataPatterns := evidencePatterns
+	if resolvedPath != "" {
+		metadataPatterns = append([]string{filepath.Base(resolvedPath)}, evidencePatterns...)
+	}
+	return model.DetectionResult{Graphs: model.SingleGraphContainer(g, detectors.InferManifestMetadata(req, metadataPatterns))}, nil
+}
+
+// FallbackDetector returns the configured fallback detector.
+func (d Detector) FallbackDetector() model.Detector {
+	return d.Fallback
+}
+
+func (d Detector) workingDir(projectPath string) string {
+	if d.WorkingDir != "" {
+		return d.WorkingDir
+	}
+	return projectPath
+}
+
+func depGraphFromSwiftPM(resolvedRaw, manifestRaw []byte) (*model.Graph, error) {
+	packages, err := parseResolved(resolvedRaw)
+	if err != nil {
+		return nil, err
+	}
+	for name, direct := range parsePackageSwift(string(manifestRaw)) {
+		pkg := packages[name]
+		if pkg.Name == "" {
+			pkg.Name = name
+		}
+		pkg.Direct = true
+		if direct.Requirement != "" {
+			pkg.Requirement = direct.Requirement
+		}
+		if direct.Repository != "" {
+			pkg.Repository = direct.Repository
+		}
+		packages[name] = pkg
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("SwiftPM files do not contain any dependencies")
+	}
+	g := model.New()
+	root := rootNode()
+	if err := g.AddPackage(root); err != nil {
+		return nil, fmt.Errorf("add root node: %w", err)
+	}
+	for _, name := range sortedNames(packages) {
+		pkg := packages[name]
+		node := packageNode(pkg)
+		if err := addNodeIfMissing(g, node); err != nil {
+			return nil, err
+		}
+		if pkg.Direct || len(manifestRaw) == 0 {
+			if err := g.AddDependency(root.ID, node.ID); err != nil {
+				return nil, fmt.Errorf("add SwiftPM root dependency %q: %w", node.ID, err)
+			}
+		}
+	}
+	return g, nil
+}
+
+func parseResolved(raw []byte) (map[string]swiftPackage, error) {
+	packages := make(map[string]swiftPackage)
+	if len(raw) == 0 {
+		return packages, nil
+	}
+	var resolved packageResolved
+	if err := json.Unmarshal(raw, &resolved); err != nil {
+		return nil, fmt.Errorf("parse Package.resolved: %w", err)
+	}
+	pins := resolved.Pins
+	if len(pins) == 0 {
+		pins = resolved.Object.Pins
+	}
+	for _, pin := range pins {
+		name := firstNonEmpty(pin.Identity, pin.Package, pin.Description.Identity, packageNameFromURL(firstNonEmpty(pin.Location, pin.Repository)))
+		if name == "" {
+			continue
+		}
+		packages[name] = swiftPackage{
+			Name:       name,
+			Version:    firstNonEmpty(pin.State.Version, pin.State.Branch, pin.State.Revision),
+			Repository: firstNonEmpty(pin.Location, pin.Repository),
+			Revision:   pin.State.Revision,
+		}
+	}
+	return packages, nil
+}
+
+func parsePackageSwift(raw string) map[string]swiftPackage {
+	packages := make(map[string]swiftPackage)
+	for _, match := range packageSwiftPattern.FindAllStringSubmatch(raw, -1) {
+		repo := strings.TrimSpace(match[1])
+		name := strings.TrimSpace(match[2])
+		if name == "" {
+			name = packageNameFromURL(repo)
+		}
+		if name == "" {
+			continue
+		}
+		packages[name] = swiftPackage{Name: name, Repository: repo, Requirement: strings.TrimSpace(match[3]), Direct: true}
+	}
+	return packages
+}
+
+func readFirstExisting(workingDir string, names []string) ([]byte, string, error) {
+	for _, name := range names {
+		path := filepath.Join(workingDir, name)
+		raw, err := readOptional(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("read %s: %w", name, err)
+		}
+		if len(raw) > 0 {
+			return raw, path, nil
+		}
+	}
+	return nil, "", nil
+}
+
+func readOptional(path string) ([]byte, error) {
+	ok, err := system.FileExists(path)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func rootNode() *model.Package {
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemSwift),
+		Name:        "root",
+		BuildSystem: model.PackageManagerSwiftPM.Name(),
+		Type:        "application",
+		Language:    "swift",
+	})
+}
+
+func packageNode(pkg swiftPackage) *model.Package {
+	metadata := map[string]any{}
+	if pkg.Repository != "" {
+		metadata["repository"] = pkg.Repository
+	}
+	if pkg.Revision != "" {
+		metadata["revision"] = pkg.Revision
+	}
+	if pkg.Requirement != "" {
+		metadata["requirement"] = pkg.Requirement
+	}
+	return model.NewPackage(model.Package{
+		Ecosystem:   string(model.EcosystemSwift),
+		Name:        strings.TrimSpace(pkg.Name),
+		Version:     strings.TrimSpace(pkg.Version),
+		BuildSystem: model.PackageManagerSwiftPM.Name(),
+		Type:        "package",
+		Language:    "swift",
+		PURL:        model.BuildPackageURL("swift", "", pkg.Name, pkg.Version),
+		ResolvedURL: strings.TrimSpace(pkg.Repository),
+		Metadata:    metadata,
+	})
+}
+
+func packageNameFromURL(value string) string {
+	value = strings.TrimSuffix(strings.TrimSpace(value), ".git")
+	value = strings.TrimRight(value, "/")
+	if value == "" {
+		return ""
+	}
+	if i := strings.LastIndex(value, "/"); i >= 0 {
+		return value[i+1:]
+	}
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sortedNames(packages map[string]swiftPackage) []string {
+	values := make([]string, 0, len(packages))
+	for name := range packages {
+		values = append(values, name)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func addNodeIfMissing(g *model.Graph, node *model.Package) error {
+	if _, ok := g.Package(node.ID); ok {
+		return nil
+	}
+	if err := g.AddPackage(node); err != nil {
+		return fmt.Errorf("add node %q: %w", node.ID, err)
+	}
+	return nil
+}

--- a/internal/detectors/swiftpm/detector_test.go
+++ b/internal/detectors/swiftpm/detector_test.go
@@ -1,0 +1,40 @@
+package swiftpm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestDetectorResolveGraphFromFixture(t *testing.T) {
+	projectDir := filepath.Join("testdata", "project")
+	detector := Detector{}
+	result, err := detector.ResolveGraph(context.Background(), model.DetectionRequest{
+		ProjectPath:    projectDir,
+		PackageManager: model.PackageManagerSwiftPM,
+		Ecosystem:      model.EcosystemSwift,
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph returned error: %v", err)
+	}
+	graph := result.Graphs.Entries[0].Graph
+	if graph == nil {
+		t.Fatal("expected graph")
+	}
+	pkg, ok := graph.Package("swift-argument-parser@1.3.0")
+	if !ok {
+		t.Fatalf("expected swift-argument-parser package, got %v", graph.Packages())
+	}
+	if pkg.PURL != "pkg:swift/swift-argument-parser@1.3.0" {
+		t.Fatalf("expected SwiftPM PURL, got %q", pkg.PURL)
+	}
+	deps, err := graph.Dependencies("root")
+	if err != nil {
+		t.Fatalf("root dependencies: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("expected one direct dependency, got %d", len(deps))
+	}
+}

--- a/internal/detectors/swiftpm/testdata/project/Package.resolved
+++ b/internal/detectors/swiftpm/testdata/project/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "abcdef",
+        "version" : "1.3.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/internal/detectors/swiftpm/testdata/project/Package.swift
+++ b/internal/detectors/swiftpm/testdata/project/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Demo",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0")
+    ],
+    targets: [
+        .executableTarget(name: "Demo", dependencies: [
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
+        ])
+    ]
+)

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -9,10 +9,12 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cargo"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cocoapods"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/composer"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/conan"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/githubactions"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/gomod"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/gradle"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/maven"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/mix"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/npm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/pnpm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/yarn"
@@ -21,6 +23,8 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/detectors/python"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/ruby"
 	sbomdetector "github.com/bomly-dev/bomly-cli/internal/detectors/sbom"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/sbt"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/swiftpm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/syft"
 	"github.com/bomly-dev/bomly-cli/internal/matchers/clearlydefined"
 	"github.com/bomly-dev/bomly-cli/internal/matchers/depsdev"
@@ -663,6 +667,10 @@ func builtInDetectorsByName(logger *zap.Logger) map[string]model.Detector {
 	cargoDetector := cargo.Detector{Logger: logger, Fallback: syftFallback}
 	pubDetector := pub.Detector{Logger: logger, Fallback: syftFallback}
 	cocoaPodsDetector := cocoapods.Detector{Logger: logger, Fallback: syftFallback}
+	swiftPMDetector := swiftpm.Detector{Logger: logger, Fallback: syftFallback}
+	mixDetector := mix.Detector{Logger: logger, Fallback: syftFallback}
+	conanDetector := conan.Detector{Logger: logger, Fallback: syftFallback}
+	sbtDetector := sbt.Detector{Logger: logger, Fallback: syftFallback}
 
 	return map[string]model.Detector{
 		sbomDetector.Descriptor().Name:          sbomDetector,
@@ -683,6 +691,10 @@ func builtInDetectorsByName(logger *zap.Logger) map[string]model.Detector {
 		cargoDetector.Descriptor().Name:         cargoDetector,
 		pubDetector.Descriptor().Name:           pubDetector,
 		cocoaPodsDetector.Descriptor().Name:     cocoaPodsDetector,
+		swiftPMDetector.Descriptor().Name:       swiftPMDetector,
+		mixDetector.Descriptor().Name:           mixDetector,
+		conanDetector.Descriptor().Name:         conanDetector,
+		sbtDetector.Descriptor().Name:           sbtDetector,
 		syftPrimary.Descriptor().Name:           syftPrimary,
 	}
 }

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -56,6 +56,10 @@ func TestBuildScanRegistryKeepsNativeDetectorFirstForNativeManagers(t *testing.T
 		{manager: model.PackageManagerCargo, detectorName: "cargo-detector"},
 		{manager: model.PackageManagerPub, detectorName: "pub-detector"},
 		{manager: model.PackageManagerCocoaPods, detectorName: "cocoapods-detector"},
+		{manager: model.PackageManagerSwiftPM, detectorName: "swiftpm-detector"},
+		{manager: model.PackageManagerMix, detectorName: "mix-detector"},
+		{manager: model.PackageManagerConan, detectorName: "conan-detector"},
+		{manager: model.PackageManagerSBT, detectorName: "sbt-detector"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/registry/support.go
+++ b/internal/registry/support.go
@@ -6,10 +6,12 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cargo"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cocoapods"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/composer"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/conan"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/githubactions"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/gomod"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/gradle"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/maven"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/mix"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/npm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/pnpm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/node/yarn"
@@ -18,6 +20,8 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/detectors/python"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/ruby"
 	sbomdetector "github.com/bomly-dev/bomly-cli/internal/detectors/sbom"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/sbt"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/swiftpm"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/syft"
 	model "github.com/bomly-dev/bomly-cli/sdk"
 )
@@ -80,6 +84,10 @@ func builtInSupportDetectors() []model.Detector {
 		cargo.Detector{},
 		pub.Detector{},
 		cocoapods.Detector{},
+		swiftpm.Detector{},
+		mix.Detector{},
+		conan.Detector{},
+		sbt.Detector{},
 		sbomdetector.Detector{},
 		syft.Detector{},
 	}

--- a/internal/registry/support_test.go
+++ b/internal/registry/support_test.go
@@ -19,6 +19,7 @@ func TestSupportCatalogEvidencePatterns(t *testing.T) {
 	if got := EvidencePatternsForPackageManager(model.PackageManagerGoMod); !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected evidence patterns to be copied, got %v", got)
 	}
+
 }
 
 func TestSupportCatalogDetectorChainOrdering(t *testing.T) {
@@ -46,6 +47,12 @@ func TestSupportCatalogDetectorChainOrdering(t *testing.T) {
 		t.Fatalf("expected cargo detector chain %v, got %v", want, chain)
 	}
 
+	chain = DetectorNamesForPackageManager(model.PackageManagerSBT)
+	want = []string{detectors.NameSBT}
+	if !reflect.DeepEqual(chain, want) {
+		t.Fatalf("expected sbt detector chain %v, got %v", want, chain)
+	}
+
 	for _, tc := range []struct {
 		manager model.PackageManager
 		native  string
@@ -53,6 +60,9 @@ func TestSupportCatalogDetectorChainOrdering(t *testing.T) {
 		{manager: model.PackageManagerNuGet, native: detectors.NameNuGet},
 		{manager: model.PackageManagerPub, native: detectors.NamePub},
 		{manager: model.PackageManagerCocoaPods, native: detectors.NameCocoaPods},
+		{manager: model.PackageManagerSwiftPM, native: detectors.NameSwiftPM},
+		{manager: model.PackageManagerMix, native: detectors.NameMix},
+		{manager: model.PackageManagerConan, native: detectors.NameConan},
 	} {
 		chain = DetectorNamesForPackageManager(tc.manager)
 		want = []string{tc.native, detectors.NameSyft}
@@ -78,6 +88,38 @@ func TestSupportEntriesForDetectorTypeFiltersEvidencePatterns(t *testing.T) {
 			wantDetectors:  []string{detectors.NameNPMNative},
 			wantEvidence:   []string{"package.json"},
 			rejectEvidence: []string{"package-lock.json"},
+		},
+		{
+			name:           "swiftpm native",
+			manager:        model.PackageManagerSwiftPM,
+			detectorType:   model.NativeComponent,
+			wantDetectors:  []string{detectors.NameSwiftPM},
+			wantEvidence:   []string{"Package.resolved", ".package.resolved", "Package.swift", "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"},
+			rejectEvidence: []string{},
+		},
+		{
+			name:           "mix native",
+			manager:        model.PackageManagerMix,
+			detectorType:   model.NativeComponent,
+			wantDetectors:  []string{detectors.NameMix},
+			wantEvidence:   []string{"mix.lock", "mix.exs"},
+			rejectEvidence: []string{},
+		},
+		{
+			name:           "conan native",
+			manager:        model.PackageManagerConan,
+			detectorType:   model.NativeComponent,
+			wantDetectors:  []string{detectors.NameConan},
+			wantEvidence:   []string{"conan.lock", "conanfile.txt", "conanfile.py", "conaninfo.txt"},
+			rejectEvidence: []string{},
+		},
+		{
+			name:           "sbt native",
+			manager:        model.PackageManagerSBT,
+			detectorType:   model.NativeComponent,
+			wantDetectors:  []string{detectors.NameSBT},
+			wantEvidence:   []string{"build.sbt", "project/plugins.sbt", "project/build.properties"},
+			rejectEvidence: []string{},
 		},
 		{
 			name:           "npm lockfile",

--- a/sdk/ecosystem.go
+++ b/sdk/ecosystem.go
@@ -38,6 +38,7 @@ const (
 	EcosystemRPM       Ecosystem = "rpm"
 	EcosystemRuby      Ecosystem = "ruby"
 	EcosystemRust      Ecosystem = "rust"
+	EcosystemScala     Ecosystem = "scala"
 	EcosystemSBOM      Ecosystem = "sbom"
 	EcosystemSnap      Ecosystem = "snap"
 	EcosystemSwift     Ecosystem = "swift"
@@ -107,6 +108,7 @@ var ecosystemRegistry = []ecosystemSupport{
 	{Ecosystem: EcosystemRPM},
 	{Ecosystem: EcosystemRuby},
 	{Ecosystem: EcosystemRust},
+	{Ecosystem: EcosystemScala},
 	{Ecosystem: EcosystemSBOM},
 	{Ecosystem: EcosystemSnap},
 	{Ecosystem: EcosystemSwift},

--- a/sdk/normalization.go
+++ b/sdk/normalization.go
@@ -137,6 +137,12 @@ func normEffectiveEcosystem(pkg *Package) string {
 			return string(EcosystemDart)
 		case string(EcosystemSwift), "cocoapods", "swiftpm":
 			return string(EcosystemSwift)
+		case string(EcosystemCPP), "conan":
+			return string(EcosystemCPP)
+		case string(EcosystemElixir), "mix", "hex":
+			return string(EcosystemElixir)
+		case string(EcosystemScala), "sbt":
+			return string(EcosystemScala)
 		}
 	}
 	return ""

--- a/sdk/package_manager.go
+++ b/sdk/package_manager.go
@@ -55,6 +55,7 @@ const (
 	PackageManagerWordPress
 	PackageManagerSetupPy
 	PackageManagerOther
+	PackageManagerSBT
 	PackageManagerCount
 )
 
@@ -111,6 +112,7 @@ var packageManagerInfoByID = [...]packageManagerInfo{
 	PackageManagerWordPress:     {Name: "wordpress", Ecosystem: EcosystemWordPress},
 	PackageManagerSetupPy:       {Name: "setuppy", Ecosystem: EcosystemPython},
 	PackageManagerOther:         {Name: "other", Ecosystem: EcosystemOther},
+	PackageManagerSBT:           {Name: "sbt", Ecosystem: EcosystemScala},
 }
 
 var allPackageManagers = []PackageManager{
@@ -158,6 +160,7 @@ var allPackageManagers = []PackageManager{
 	PackageManagerTerraform,
 	PackageManagerWordPress,
 	PackageManagerSetupPy,
+	PackageManagerSBT,
 	PackageManagerOther,
 }
 

--- a/sdk/package_manager_test.go
+++ b/sdk/package_manager_test.go
@@ -82,6 +82,34 @@ func TestOtherPackageManagerAndEcosystem(t *testing.T) {
 	}
 }
 
+func TestScalaPackageManagerAndEcosystem(t *testing.T) {
+	ecosystem, err := ParseEcosystem(" scala ")
+	if err != nil {
+		t.Fatalf("parse scala ecosystem: %v", err)
+	}
+	if ecosystem != EcosystemScala {
+		t.Fatalf("expected scala ecosystem, got %q", ecosystem)
+	}
+
+	manager, err := ParsePackageManager(" sbt ")
+	if err != nil {
+		t.Fatalf("parse sbt package manager: %v", err)
+	}
+	if manager != PackageManagerSBT {
+		t.Fatalf("expected sbt package manager, got %q", manager.Name())
+	}
+	if got := manager.Ecosystem(); got != EcosystemScala {
+		t.Fatalf("expected scala ecosystem, got %q", got)
+	}
+}
+
+func TestBuildPackageURLFallbackForSwift(t *testing.T) {
+	got := BuildPackageURL("swift", "", "async-kit", "1.15.0")
+	if got != "pkg:swift/async-kit@1.15.0" {
+		t.Fatalf("expected Swift package URL, got %q", got)
+	}
+}
+
 func TestAllPackageManagersReturnsCopy(t *testing.T) {
 	managers := AllPackageManagers()
 	if len(managers) == 0 {

--- a/sdk/purl.go
+++ b/sdk/purl.go
@@ -45,9 +45,26 @@ func BuildPackageURL(purlType, namespace, name, version string) string {
 		return ""
 	}
 	if err := purl.Normalize(); err != nil {
-		return ""
+		return buildPackageURLFallback(purlType, namespace, name, version)
 	}
 	return purl.ToString()
+}
+
+func buildPackageURLFallback(purlType, namespace, name, version string) string {
+	var builder strings.Builder
+	builder.WriteString("pkg:")
+	builder.WriteString(purlType)
+	builder.WriteString("/")
+	if namespace != "" {
+		builder.WriteString(namespace)
+		builder.WriteString("/")
+	}
+	builder.WriteString(name)
+	if version != "" {
+		builder.WriteString("@")
+		builder.WriteString(version)
+	}
+	return builder.String()
 }
 
 // PackageURLTypeForValues maps ecosystem/build-system values to a package-url type.
@@ -65,6 +82,12 @@ func PackageURLTypeForValues(values ...string) string {
 			return "cocoapods"
 		case "swiftpm":
 			return "swift"
+		case "conan":
+			return "conan"
+		case "mix", "hex":
+			return "hex"
+		case "sbt", "scala":
+			return "maven"
 		}
 	}
 	for _, value := range values {

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -136,6 +136,18 @@ func TestScan(t *testing.T) {
 			args: []string{"scan", "--url", "https://github.com/material-motion/motion-interchange-objc", "--ref", "835474053336d2004c079f7d6580f582a7a2b85a", "--format", "json", "--ecosystems", "swift"},
 		},
 		{
+			name: "scan-mix",
+			args: []string{"scan", "--url", "https://github.com/phoenixframework/phoenix", "--ref", "05e0b5b26a65124e768e0ab55b86bba30a531e14", "--format", "json", "--ecosystems", "elixir"},
+		},
+		{
+			name: "scan-swiftpm",
+			args: []string{"scan", "--url", "https://github.com/vapor/vapor", "--ref", "ebbe71c89aa1b76a0920277760b12be7a2ec7c70", "--format", "json", "--ecosystems", "swift"},
+		},
+		{
+			name: "scan-sbt",
+			args: []string{"scan", "--url", "https://github.com/ucb-bar/chiseltest", "--ref", "8315873827715841f75af9b2d73e49214a1373d6", "--format", "json", "--ecosystems", "scala"},
+		},
+		{
 			name:  "scan-npm-scope-runtime",
 			args:  []string{"scan", "--url", "https://github.com/ljharb/qs", "--ref", "v6.13.0", "--format", "json", "--scope", "runtime"},
 			tools: []string{"npm"},

--- a/test/smoke/testdata/golden/scan-mix.golden.json
+++ b/test/smoke/testdata/golden/scan-mix.golden.json
@@ -1,0 +1,560 @@
+{
+  "command": "scan",
+  "manifests": [
+    {
+      "detector": "mix-detector",
+      "ecosystem": "elixir",
+      "kind": "mix.lock",
+      "package_manager": "mix",
+      "packages": [
+        {
+          "dependencies": [
+            "pkg:hex/cowboy@2.10.0",
+            "pkg:hex/cowboy_telemetry@0.4.0",
+            "pkg:hex/cowlib@2.12.1",
+            "pkg:hex/db_connection@2.5.0",
+            "pkg:hex/decimal@2.1.1",
+            "pkg:hex/earmark_parser@1.4.39",
+            "pkg:hex/hpax@0.1.1",
+            "pkg:hex/makeup@1.1.2",
+            "pkg:hex/makeup_erlang@1.0.0",
+            "pkg:hex/makeup_html@0.1.1",
+            "pkg:hex/mime@2.0.5",
+            "pkg:hex/nimble_parsec@1.4.0",
+            "pkg:hex/ranch@1.8.0",
+            "pkg:hex/root",
+            "pkg:hex/websock@0.5.3"
+          ],
+          "id": "mix.lock",
+          "licenses": [],
+          "name": "mix.lock",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/castore@0.1.22",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "castore",
+          "purl": "pkg:hex/castore@0.1.22",
+          "scope": "runtime",
+          "version": "0.1.22",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/cowboy@2.10.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "cowboy",
+          "purl": "pkg:hex/cowboy@2.10.0",
+          "version": "2.10.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/cowboy_telemetry@0.4.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "cowboy_telemetry",
+          "purl": "pkg:hex/cowboy_telemetry@0.4.0",
+          "version": "0.4.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/cowlib@2.12.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "cowlib",
+          "purl": "pkg:hex/cowlib@2.12.1",
+          "version": "2.12.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/db_connection@2.5.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "db_connection",
+          "purl": "pkg:hex/db_connection@2.5.0",
+          "version": "2.5.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/decimal@2.1.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "decimal",
+          "purl": "pkg:hex/decimal@2.1.1",
+          "version": "2.1.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/earmark_parser@1.4.39",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "earmark_parser",
+          "purl": "pkg:hex/earmark_parser@1.4.39",
+          "version": "1.4.39",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/ecto@3.10.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "ecto",
+          "purl": "pkg:hex/ecto@3.10.1",
+          "scope": "runtime",
+          "version": "3.10.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/ecto_sql@3.10.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "ecto_sql",
+          "purl": "pkg:hex/ecto_sql@3.10.1",
+          "scope": "runtime",
+          "version": "3.10.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/esbuild@0.8.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "esbuild",
+          "purl": "pkg:hex/esbuild@0.8.1",
+          "scope": "development",
+          "version": "0.8.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/ex_doc@0.34.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "ex_doc",
+          "purl": "pkg:hex/ex_doc@0.34.0",
+          "scope": "runtime",
+          "version": "0.34.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/gettext@0.20.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "gettext",
+          "purl": "pkg:hex/gettext@0.20.0",
+          "scope": "runtime",
+          "version": "0.20.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/hpax@0.1.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "hpax",
+          "purl": "pkg:hex/hpax@0.1.1",
+          "version": "0.1.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/jason@1.4.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "jason",
+          "purl": "pkg:hex/jason@1.4.0",
+          "scope": "runtime",
+          "version": "1.4.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup@1.1.2",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup",
+          "purl": "pkg:hex/makeup@1.1.2",
+          "version": "1.1.2",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup_diff@0.1.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup_diff",
+          "purl": "pkg:hex/makeup_diff@0.1.0",
+          "scope": "runtime",
+          "version": "0.1.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup_eex@0.1.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup_eex",
+          "purl": "pkg:hex/makeup_eex@0.1.1",
+          "scope": "runtime",
+          "version": "0.1.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup_elixir@0.16.2",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup_elixir",
+          "purl": "pkg:hex/makeup_elixir@0.16.2",
+          "scope": "runtime",
+          "version": "0.16.2",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup_erlang@1.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup_erlang",
+          "purl": "pkg:hex/makeup_erlang@1.0.0",
+          "version": "1.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/makeup_html@0.1.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "makeup_html",
+          "purl": "pkg:hex/makeup_html@0.1.1",
+          "version": "0.1.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/mime@2.0.5",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "mime",
+          "purl": "pkg:hex/mime@2.0.5",
+          "version": "2.0.5",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/mint@1.4.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "mint",
+          "purl": "pkg:hex/mint@1.4.1",
+          "scope": "development",
+          "version": "1.4.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/mint_web_socket@1.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "mint_web_socket",
+          "purl": "pkg:hex/mint_web_socket@1.0.0",
+          "scope": "development",
+          "version": "1.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/nimble_parsec@1.4.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "nimble_parsec",
+          "purl": "pkg:hex/nimble_parsec@1.4.0",
+          "version": "1.4.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/phoenix_html@4.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "phoenix_html",
+          "purl": "pkg:hex/phoenix_html@4.0.0",
+          "scope": "development",
+          "version": "4.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/phoenix_pubsub@2.1.3",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "phoenix_pubsub",
+          "purl": "pkg:hex/phoenix_pubsub@2.1.3",
+          "scope": "runtime",
+          "version": "2.1.3",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/phoenix_template@1.0.4",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "phoenix_template",
+          "purl": "pkg:hex/phoenix_template@1.0.4",
+          "scope": "runtime",
+          "version": "1.0.4",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/phoenix_view@2.0.3",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "phoenix_view",
+          "purl": "pkg:hex/phoenix_view@2.0.3",
+          "scope": "runtime",
+          "version": "2.0.3",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/phx_new",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "phx_new",
+          "purl": "pkg:hex/phx_new",
+          "scope": "development",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/plug@1.15.3",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "plug",
+          "purl": "pkg:hex/plug@1.15.3",
+          "scope": "runtime",
+          "version": "1.15.3",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/plug_cowboy@2.7.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "plug_cowboy",
+          "purl": "pkg:hex/plug_cowboy@2.7.0",
+          "scope": "runtime",
+          "version": "2.7.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/plug_crypto@2.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "plug_crypto",
+          "purl": "pkg:hex/plug_crypto@2.0.0",
+          "scope": "runtime",
+          "version": "2.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/ranch@1.8.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "ranch",
+          "purl": "pkg:hex/ranch@1.8.0",
+          "version": "1.8.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [
+            "pkg:hex/castore@0.1.22",
+            "pkg:hex/ecto@3.10.1",
+            "pkg:hex/ecto_sql@3.10.1",
+            "pkg:hex/esbuild@0.8.1",
+            "pkg:hex/ex_doc@0.34.0",
+            "pkg:hex/gettext@0.20.0",
+            "pkg:hex/jason@1.4.0",
+            "pkg:hex/makeup_diff@0.1.0",
+            "pkg:hex/makeup_eex@0.1.1",
+            "pkg:hex/makeup_elixir@0.16.2",
+            "pkg:hex/mint@1.4.1",
+            "pkg:hex/mint_web_socket@1.0.0",
+            "pkg:hex/phoenix_html@4.0.0",
+            "pkg:hex/phoenix_pubsub@2.1.3",
+            "pkg:hex/phoenix_template@1.0.4",
+            "pkg:hex/phoenix_view@2.0.3",
+            "pkg:hex/phx_new",
+            "pkg:hex/plug@1.15.3",
+            "pkg:hex/plug_cowboy@2.7.0",
+            "pkg:hex/plug_crypto@2.0.0",
+            "pkg:hex/telemetry@1.2.1",
+            "pkg:hex/telemetry_metrics@1.0.0",
+            "pkg:hex/telemetry_poller@1.0.0",
+            "pkg:hex/websock_adapter@0.5.5"
+          ],
+          "id": "pkg:hex/root",
+          "licenses": [],
+          "name": "root",
+          "purl": "pkg:hex/root",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/telemetry@1.2.1",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "telemetry",
+          "purl": "pkg:hex/telemetry@1.2.1",
+          "scope": "runtime",
+          "version": "1.2.1",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/telemetry_metrics@1.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "telemetry_metrics",
+          "purl": "pkg:hex/telemetry_metrics@1.0.0",
+          "scope": "runtime",
+          "version": "1.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/telemetry_poller@1.0.0",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "telemetry_poller",
+          "purl": "pkg:hex/telemetry_poller@1.0.0",
+          "scope": "runtime",
+          "version": "1.0.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/websock@0.5.3",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "websock",
+          "purl": "pkg:hex/websock@0.5.3",
+          "version": "0.5.3",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:hex/websock_adapter@0.5.5",
+          "licenses": [],
+          "metadata": {
+            "source": "hex"
+          },
+          "name": "websock_adapter",
+          "purl": "pkg:hex/websock_adapter@0.5.5",
+          "scope": "runtime",
+          "version": "0.5.5",
+          "vulnerabilities": []
+        }
+      ],
+      "path": "mix.lock",
+      "subproject": "."
+    }
+  ],
+  "metadata": {
+    "duration_ms": 0
+  },
+  "project": {
+    "ecosystem": "elixir",
+    "name": "\u003cnormalized\u003e",
+    "package_manager": "mix",
+    "path": "\u003cnormalized\u003e"
+  },
+  "schema_version": "1.0"
+}

--- a/test/smoke/testdata/golden/scan-sbt.golden.json
+++ b/test/smoke/testdata/golden/scan-sbt.golden.json
@@ -1,0 +1,78 @@
+{
+  "command": "scan",
+  "manifests": [
+    {
+      "detector": "sbt-detector",
+      "ecosystem": "scala",
+      "kind": "build.sbt",
+      "package_manager": "sbt",
+      "packages": [
+        {
+          "dependencies": [],
+          "id": "pkg:maven/com.github.sbt/sbt-ci-release@1.5.12",
+          "licenses": [],
+          "name": "com.github.sbt:sbt-ci-release",
+          "purl": "pkg:maven/com.github.sbt/sbt-ci-release@1.5.12",
+          "scope": "runtime",
+          "version": "1.5.12",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:maven/net.java.dev.jna/jna@5.14.0",
+          "licenses": [],
+          "name": "net.java.dev.jna:jna",
+          "purl": "pkg:maven/net.java.dev.jna/jna@5.14.0",
+          "scope": "runtime",
+          "version": "5.14.0",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:maven/org.scalameta/sbt-scalafmt@2.5.2",
+          "licenses": [],
+          "name": "org.scalameta:sbt-scalafmt",
+          "purl": "pkg:maven/org.scalameta/sbt-scalafmt@2.5.2",
+          "scope": "runtime",
+          "version": "2.5.2",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:maven/org.scalatest/scalatest@3.2.17",
+          "licenses": [],
+          "name": "org.scalatest:scalatest",
+          "purl": "pkg:maven/org.scalatest/scalatest@3.2.17",
+          "scope": "runtime",
+          "version": "3.2.17",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [
+            "pkg:maven/com.github.sbt/sbt-ci-release@1.5.12",
+            "pkg:maven/net.java.dev.jna/jna@5.14.0",
+            "pkg:maven/org.scalameta/sbt-scalafmt@2.5.2",
+            "pkg:maven/org.scalatest/scalatest@3.2.17"
+          ],
+          "id": "pkg:maven/root",
+          "licenses": [],
+          "name": "root",
+          "purl": "pkg:maven/root",
+          "vulnerabilities": []
+        }
+      ],
+      "path": "build.sbt",
+      "subproject": "."
+    }
+  ],
+  "metadata": {
+    "duration_ms": 0
+  },
+  "project": {
+    "ecosystem": "scala",
+    "name": "\u003cnormalized\u003e",
+    "package_manager": "sbt",
+    "path": "\u003cnormalized\u003e"
+  },
+  "schema_version": "1.0"
+}

--- a/test/smoke/testdata/golden/scan-swiftpm.golden.json
+++ b/test/smoke/testdata/golden/scan-swiftpm.golden.json
@@ -1,0 +1,229 @@
+{
+  "command": "scan",
+  "manifests": [
+    {
+      "detector": "swiftpm-detector",
+      "ecosystem": "swift",
+      "kind": "Package.swift",
+      "package_manager": "swiftpm",
+      "packages": [
+        {
+          "dependencies": [],
+          "id": "pkg:swift/async-http-client",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/swift-server/async-http-client.git",
+            "requirement": "1.19.0"
+          },
+          "name": "async-http-client",
+          "purl": "pkg:swift/async-http-client",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/async-kit",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/vapor/async-kit.git",
+            "requirement": "1.15.0"
+          },
+          "name": "async-kit",
+          "purl": "pkg:swift/async-kit",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/console-kit",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/vapor/console-kit.git",
+            "requirement": "4.14.0"
+          },
+          "name": "console-kit",
+          "purl": "pkg:swift/console-kit",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/multipart-kit",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/vapor/multipart-kit.git",
+            "requirement": "4.2.1"
+          },
+          "name": "multipart-kit",
+          "purl": "pkg:swift/multipart-kit",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [
+            "pkg:swift/async-http-client",
+            "pkg:swift/async-kit",
+            "pkg:swift/console-kit",
+            "pkg:swift/multipart-kit",
+            "pkg:swift/routing-kit",
+            "pkg:swift/swift-algorithms",
+            "pkg:swift/swift-atomics",
+            "pkg:swift/swift-backtrace",
+            "pkg:swift/swift-log",
+            "pkg:swift/swift-metrics",
+            "pkg:swift/swift-nio",
+            "pkg:swift/swift-nio-extras",
+            "pkg:swift/swift-nio-http2",
+            "pkg:swift/swift-nio-ssl",
+            "pkg:swift/websocket-kit"
+          ],
+          "id": "pkg:swift/root",
+          "licenses": [],
+          "name": "root",
+          "purl": "pkg:swift/root",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/routing-kit",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/vapor/routing-kit.git",
+            "requirement": "4.9.0"
+          },
+          "name": "routing-kit",
+          "purl": "pkg:swift/routing-kit",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-algorithms",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-algorithms.git",
+            "requirement": "1.0.0"
+          },
+          "name": "swift-algorithms",
+          "purl": "pkg:swift/swift-algorithms",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-atomics",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-atomics.git",
+            "requirement": "1.1.0"
+          },
+          "name": "swift-atomics",
+          "purl": "pkg:swift/swift-atomics",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-backtrace",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/swift-server/swift-backtrace.git",
+            "requirement": "1.1.1"
+          },
+          "name": "swift-backtrace",
+          "purl": "pkg:swift/swift-backtrace",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-log",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-log.git",
+            "requirement": "1.0.0"
+          },
+          "name": "swift-log",
+          "purl": "pkg:swift/swift-log",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-metrics",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-metrics.git",
+            "requirement": "2.0.0"
+          },
+          "name": "swift-metrics",
+          "purl": "pkg:swift/swift-metrics",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-nio",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-nio.git",
+            "requirement": "2.67.0"
+          },
+          "name": "swift-nio",
+          "purl": "pkg:swift/swift-nio",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-nio-extras",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-nio-extras.git",
+            "requirement": "1.19.0"
+          },
+          "name": "swift-nio-extras",
+          "purl": "pkg:swift/swift-nio-extras",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-nio-http2",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-nio-http2.git",
+            "requirement": "1.28.0"
+          },
+          "name": "swift-nio-http2",
+          "purl": "pkg:swift/swift-nio-http2",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/swift-nio-ssl",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/apple/swift-nio-ssl.git",
+            "requirement": "2.8.0"
+          },
+          "name": "swift-nio-ssl",
+          "purl": "pkg:swift/swift-nio-ssl",
+          "vulnerabilities": []
+        },
+        {
+          "dependencies": [],
+          "id": "pkg:swift/websocket-kit",
+          "licenses": [],
+          "metadata": {
+            "repository": "https://github.com/vapor/websocket-kit.git",
+            "requirement": "2.13.0"
+          },
+          "name": "websocket-kit",
+          "purl": "pkg:swift/websocket-kit",
+          "vulnerabilities": []
+        }
+      ],
+      "path": "Package.swift",
+      "subproject": "."
+    }
+  ],
+  "metadata": {
+    "duration_ms": 0
+  },
+  "project": {
+    "ecosystem": "swift",
+    "name": "\u003cnormalized\u003e",
+    "package_manager": "swiftpm",
+    "path": "\u003cnormalized\u003e"
+  },
+  "schema_version": "1.0"
+}


### PR DESCRIPTION
## Summary

Adds the remaining native detector backlog from the mainstream SCA ecosystem expansion plan: Mix for Elixir, Conan for C/C++, Swift Package Manager for Swift, and sbt for Scala. These detectors keep Syft as the compatibility fallback while giving Bomly first-party graph and package metadata coverage for the prioritized ecosystems that were still Syft-only or missing explicit package-manager support.

## What changed

- Added native detector packages for:
  - `mix`: parses `mix.lock` plus `mix.exs` direct dependency declarations and environment hints.
  - `conan`: parses `conan.lock`, `conanfile.txt`, and `conanfile.py` references, including build/tool requirements as development-scope packages where identifiable.
  - `swiftpm`: parses `Package.resolved` and `Package.swift` dependency declarations, including Xcode-style resolved-file evidence paths.
  - `sbt`: parses `build.sbt` and `project/plugins.sbt` dependency declarations and records Scala package metadata.
- Added `scala` ecosystem and `sbt` package-manager support to the SDK catalog.
- Added package URL handling for Conan, Hex/Mix, SwiftPM, and sbt/Maven-style artifacts.
- Wired the new detectors through the built-in registry, support catalog, detector names, and generated support matrix.
- Added detector-level fixtures and unit tests for all four new detectors.
- Added smoke coverage and goldens for stable real repositories covering Mix, SwiftPM, and sbt.
- Updated the architecture docs with the native detector quality bar: package metadata, graph edges where available, scope inference where possible, PURLs, detector-package unit fixtures, and smoke coverage when a stable root-level real repo exists.

## Notes

Conan includes package-level fixture coverage for both lockfile and `conanfile.py` parsing. It does not add a smoke case in this PR because the current smoke harness discovers package-manager roots at repository root, and I did not find a stable small real-world repository with a root-level Conan manifest that fits that pattern. Syft remains the fallback for unsupported Conan project shapes.

The sbt detector introduces a new explicit `scala` ecosystem and `sbt` package-manager identifier because sbt was called out as a hard gap rather than an existing Syft-only manager in the previous catalog.

## Validation

- `make generate`
- `go test ./internal/support ./internal/registry ./internal/detectors/mix ./internal/detectors/conan ./internal/detectors/swiftpm ./internal/detectors/sbt ./sdk`
- `make test`
- `make smoke ARGS="-run 'TestScan/(scan-mix|scan-swiftpm|scan-sbt)'"`