### PR TITLE
refactor: consolidate config loading into internal/config and reduce boilerplate

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/config"
 	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // resolvedConfig and fileConfig are cli-side aliases for the canonical config
@@ -34,36 +33,8 @@ func (o *globalOptions) current() resolvedConfig {
 	if o.resolved != nil {
 		return *o.resolved
 	}
-	cfg := resolvedConfig{
-		Path:         o.Path,
-		Container:    o.Container,
-		URL:          o.URL,
-		Ref:          o.Ref,
-		SBOM:         o.SBOM,
-		Enrich:       o.Enrich,
-		Audit:        o.Audit,
-		FailOn:       o.FailOn,
-		Format:       o.Format,
-		Interactive:  o.Interactive,
-		Ecosystems:   o.Ecosystems,
-		Detectors:    o.Detectors,
-		Auditors:     o.Auditors,
-		Matchers:     o.Matchers,
-		InstallFirst: o.InstallFirst,
-		InstallArgs:  append([]string(nil), o.InstallArgs...),
-		Config:       o.Config,
-		Quiet:        o.Quiet,
-		Verbosity:    o.Verbosity,
-		OsvAPIBase:   o.OsvAPIBase,
-		OsvCacheDir:  o.OsvCacheDir,
-		OsvCacheTTL:  o.OsvCacheTTL,
-		KEVCacheDir:  o.KEVCacheDir,
-		KEVCacheTTL:  o.KEVCacheTTL,
-		EOLAPIBase:   o.EOLAPIBase,
-		EOLCacheDir:  o.EOLCacheDir,
-		EOLCacheTTL:  o.EOLCacheTTL,
-	}
-	applyResolvedConfigDefaults(&cfg)
+	cfg := o.Resolved
+	config.ApplyDefaults(&cfg)
 	return cfg
 }
 
@@ -75,22 +46,22 @@ func (o *globalOptions) loadResolvedConfig(cmd *cobra.Command) (resolvedConfig, 
 		return resolvedConfig{}, err
 	}
 	for _, path := range configPaths {
-		fileCfg, err := loadConfigFile(path)
+		fileCfg, err := config.LoadFile(path)
 		if err != nil {
 			return resolvedConfig{}, invalidInputf("load config %q: %v", path, err)
 		}
 		if fileCfg == nil {
 			continue
 		}
-		applyFileConfig(&resolved, *fileCfg)
+		config.ApplyFileConfig(&resolved, *fileCfg)
 		resolved.LoadedFiles = append(resolved.LoadedFiles, path)
 	}
 
-	applyEnvOverrides(&resolved)
+	config.ApplyEnvOverrides(&resolved)
 	applyFlagOverrides(&resolved, o, cmd)
-	applyResolvedConfigDefaults(&resolved)
-	if err := validateResolvedConfig(resolved); err != nil {
-		return resolvedConfig{}, err
+	config.ApplyDefaults(&resolved)
+	if err := config.Validate(resolved); err != nil {
+		return resolvedConfig{}, invalidInputf("%v", err)
 	}
 	return resolved, nil
 }
@@ -98,7 +69,7 @@ func (o *globalOptions) loadResolvedConfig(cmd *cobra.Command) (resolvedConfig, 
 func (o *globalOptions) configLoadPaths() ([]string, error) {
 	paths := make([]string, 0, 3)
 
-	homePath, err := userConfigPath()
+	homePath, err := config.UserConfigPath()
 	if err != nil {
 		return nil, err
 	}
@@ -127,20 +98,6 @@ func (o *globalOptions) configLoadPaths() ([]string, error) {
 	return paths, nil
 }
 
-func userConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		if strings.TrimSpace(err.Error()) == "" {
-			return "", nil
-		}
-		return "", fmt.Errorf("resolve user home: %w", err)
-	}
-	if strings.TrimSpace(home) == "" {
-		return "", nil
-	}
-	return filepath.Join(home, ".bomly", "config.yaml"), nil
-}
-
 func (o *globalOptions) projectConfigPathForLoading() (string, error) {
 	if strings.TrimSpace(o.URL) != "" || strings.TrimSpace(o.Container) != "" {
 		return "", nil
@@ -164,132 +121,6 @@ func (o *globalOptions) projectConfigPathForLoading() (string, error) {
 		absPath = filepath.Dir(absPath)
 	}
 	return filepath.Join(absPath, ".bomly", "config.yaml"), nil
-}
-
-func loadConfigFile(path string) (*fileConfig, error) {
-	if strings.TrimSpace(path) == "" {
-		return nil, nil
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var cfg fileConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse YAML: %w", err)
-	}
-
-	baseDir := filepath.Dir(path)
-	normalizeFileConfigPaths(&cfg, baseDir)
-	return &cfg, nil
-}
-
-func normalizeFileConfigPaths(cfg *fileConfig, baseDir string) {
-	if cfg == nil {
-		return
-	}
-	for _, target := range []*string{cfg.Path, cfg.Config} {
-		if target == nil || strings.TrimSpace(*target) == "" {
-			continue
-		}
-		if filepath.IsAbs(*target) {
-			continue
-		}
-		*target = filepath.Clean(filepath.Join(baseDir, *target))
-	}
-}
-
-func applyFileConfig(dst *resolvedConfig, src fileConfig) {
-	if dst == nil {
-		return
-	}
-	if src.Path != nil {
-		dst.Path = *src.Path
-	}
-	if src.Container != nil {
-		dst.Container = *src.Container
-	}
-	if src.URL != nil {
-		dst.URL = *src.URL
-	}
-	if src.Ref != nil {
-		dst.Ref = *src.Ref
-	}
-	if src.SBOM != nil {
-		dst.SBOM = *src.SBOM
-	}
-	if src.Enrich != nil {
-		dst.Enrich = *src.Enrich
-	}
-	if src.Audit != nil {
-		dst.Audit = *src.Audit
-	}
-	if src.FailOn != nil {
-		dst.FailOn = *src.FailOn
-	}
-	if src.Format != nil {
-		dst.Format = *src.Format
-	}
-	if src.Interactive != nil {
-		dst.Interactive = *src.Interactive
-	}
-	if src.Ecosystems != nil {
-		dst.Ecosystems = *src.Ecosystems
-	}
-	if src.Detectors != nil {
-		dst.Detectors = *src.Detectors
-	}
-	if src.Auditors != nil {
-		dst.Auditors = *src.Auditors
-	}
-	if src.Matchers != nil {
-		dst.Matchers = *src.Matchers
-	}
-	if src.InstallFirst != nil {
-		dst.InstallFirst = *src.InstallFirst
-	}
-	if len(src.InstallArgs) > 0 {
-		dst.InstallArgs = append([]string(nil), src.InstallArgs...)
-	}
-	if src.Config != nil {
-		dst.Config = *src.Config
-	}
-	if src.Quiet != nil {
-		dst.Quiet = *src.Quiet
-	}
-	if src.Verbosity != nil {
-		dst.Verbosity = *src.Verbosity
-	}
-	if src.Verbose != nil && *src.Verbose && dst.Verbosity == 0 {
-		dst.Verbosity = 1
-	}
-	if src.OsvAPIBase != nil {
-		dst.OsvAPIBase = *src.OsvAPIBase
-	}
-	if src.OsvCacheDir != nil {
-		dst.OsvCacheDir = *src.OsvCacheDir
-	}
-	if src.OsvCacheTTL != nil {
-		dst.OsvCacheTTL = *src.OsvCacheTTL
-	}
-	if src.KEVCacheDir != nil {
-		dst.KEVCacheDir = *src.KEVCacheDir
-	}
-	if src.KEVCacheTTL != nil {
-		dst.KEVCacheTTL = *src.KEVCacheTTL
-	}
-	if src.EOLAPIBase != nil {
-		dst.EOLAPIBase = *src.EOLAPIBase
-	}
-	if src.EOLCacheDir != nil {
-		dst.EOLCacheDir = *src.EOLCacheDir
-	}
-	if src.EOLCacheTTL != nil {
-		dst.EOLCacheTTL = *src.EOLCacheTTL
-	}
 }
 
 func applyFlagOverrides(dst *resolvedConfig, src *globalOptions, cmd *cobra.Command) {
@@ -330,91 +161,6 @@ func applyFlagOverrides(dst *resolvedConfig, src *globalOptions, cmd *cobra.Comm
 	if flagChanged(cmd, "verbose") {
 		dst.Verbosity = src.Verbosity
 	}
-}
-
-func applyEnvOverrides(dst *resolvedConfig) {
-	if dst == nil {
-		return
-	}
-	overrideString := func(key string, target *string) {
-		if value, ok := os.LookupEnv(key); ok {
-			*target = value
-		}
-	}
-	overrideBool := func(key string, target *bool) {
-		value, ok := os.LookupEnv(key)
-		if !ok {
-			return
-		}
-		switch strings.ToLower(strings.TrimSpace(value)) {
-		case "1", "true", "yes", "on":
-			*target = true
-		case "0", "false", "no", "off":
-			*target = false
-		}
-	}
-
-	overrideString("BOMLY_PATH", &dst.Path)
-	overrideString("BOMLY_CONTAINER", &dst.Container)
-	overrideString("BOMLY_URL", &dst.URL)
-	overrideString("BOMLY_REF", &dst.Ref)
-	overrideBool("BOMLY_SBOM", &dst.SBOM)
-	overrideBool("BOMLY_ENRICH", &dst.Enrich)
-	overrideBool("BOMLY_AUDIT", &dst.Audit)
-	overrideString("BOMLY_FAIL_ON", &dst.FailOn)
-	overrideString("BOMLY_FORMAT", &dst.Format)
-	overrideBool("BOMLY_INTERACTIVE", &dst.Interactive)
-	overrideString("BOMLY_ECOSYSTEMS", &dst.Ecosystems)
-	overrideString("BOMLY_DETECTORS", &dst.Detectors)
-	overrideString("BOMLY_AUDITORS", &dst.Auditors)
-	overrideString("BOMLY_MATCHERS", &dst.Matchers)
-	overrideBool("BOMLY_INSTALL_FIRST", &dst.InstallFirst)
-	if value, ok := os.LookupEnv("BOMLY_INSTALL_ARGS"); ok {
-		dst.InstallArgs = parseCSV(value)
-	}
-	overrideString("BOMLY_CONFIG", &dst.Config)
-	overrideBool("BOMLY_QUIET", &dst.Quiet)
-	if value, ok := os.LookupEnv("BOMLY_VERBOSE"); ok {
-		switch strings.ToLower(strings.TrimSpace(value)) {
-		case "1", "true", "yes", "on":
-			if dst.Verbosity == 0 {
-				dst.Verbosity = 1
-			}
-		case "2":
-			dst.Verbosity = 2
-		case "3":
-			dst.Verbosity = 3
-		case "0", "false", "no", "off":
-			dst.Verbosity = 0
-		}
-	}
-	overrideString("BOMLY_OSV_API_BASE", &dst.OsvAPIBase)
-	overrideString("BOMLY_OSV_CACHE_DIR", &dst.OsvCacheDir)
-	overrideString("BOMLY_OSV_CACHE_TTL", &dst.OsvCacheTTL)
-	overrideString("BOMLY_KEV_CACHE_DIR", &dst.KEVCacheDir)
-	overrideString("BOMLY_KEV_CACHE_TTL", &dst.KEVCacheTTL)
-	overrideString("BOMLY_EOL_API_BASE", &dst.EOLAPIBase)
-	overrideString("BOMLY_EOL_CACHE_DIR", &dst.EOLCacheDir)
-	overrideString("BOMLY_EOL_CACHE_TTL", &dst.EOLCacheTTL)
-}
-
-func applyResolvedConfigDefaults(cfg *resolvedConfig) {
-	if cfg == nil {
-		return
-	}
-	if strings.TrimSpace(cfg.FailOn) == "" {
-		cfg.FailOn = "any"
-	}
-}
-
-func validateResolvedConfig(cfg resolvedConfig) error {
-	if cfg.Interactive && strings.TrimSpace(cfg.Format) != "" {
-		return invalidInputf("--interactive cannot be combined with --format")
-	}
-	if cfg.Quiet && cfg.Verbosity > 0 {
-		return invalidInputf("--quiet cannot be combined with --verbose")
-	}
-	return nil
 }
 
 func flagChanged(cmd *cobra.Command, name string) bool {

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/config"
 	"github.com/bomly-dev/bomly-cli/internal/git"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	managedplugin "github.com/bomly-dev/bomly-cli/internal/plugin"
@@ -22,34 +23,8 @@ import (
 )
 
 type globalOptions struct {
-	Path         string
-	Container    string
-	URL          string
-	Ref          string
-	SBOM         bool
-	Enrich       bool
-	Audit        bool
-	FailOn       string
-	Format       string
-	Interactive  bool
-	Ecosystems   string
-	Detectors    string
-	Auditors     string
-	Matchers     string
-	InstallFirst bool
-	InstallArgs  []string
-	Config       string
-	Quiet        bool
-	Verbosity    int
-	OsvAPIBase   string
-	OsvCacheDir  string
-	OsvCacheTTL  string
-	KEVCacheDir  string
-	KEVCacheTTL  string
-	EOLAPIBase   string
-	EOLCacheDir  string
-	EOLCacheTTL  string
-	resolved     *resolvedConfig
+	config.Resolved
+	resolved *resolvedConfig
 }
 
 type commandContext struct {

--- a/internal/cli/options_test.go
+++ b/internal/cli/options_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bomly-dev/bomly-cli/internal/config"
 	"github.com/bomly-dev/bomly-cli/internal/registry"
 	model "github.com/bomly-dev/bomly-cli/sdk"
 	"github.com/spf13/cobra"
@@ -45,7 +46,7 @@ func TestGlobalOptionsResolveSubprojects_AppliesEcosystemFilter(t *testing.T) {
 		t.Fatalf("write go.mod: %v", err)
 	}
 
-	options := globalOptions{Ecosystems: "go,npm"}
+	options := globalOptions{Resolved: config.Resolved{Ecosystems: "go,npm"}}
 	subprojects, err := options.resolveSubprojects(model.ExecutionTarget{Kind: model.ExecutionTargetWorkingDirectory, Location: projectDir})
 	if err != nil {
 		t.Fatalf("resolveSubprojects() error = %v", err)
@@ -54,7 +55,7 @@ func TestGlobalOptionsResolveSubprojects_AppliesEcosystemFilter(t *testing.T) {
 		t.Fatalf("expected 2 filtered subprojects, got %d", len(subprojects))
 	}
 
-	options = globalOptions{Ecosystems: "go"}
+	options = globalOptions{Resolved: config.Resolved{Ecosystems: "go"}}
 	subprojects, err = options.resolveSubprojects(model.ExecutionTarget{Kind: model.ExecutionTargetWorkingDirectory, Location: projectDir})
 	if err != nil {
 		t.Fatalf("resolveSubprojects() error = %v", err)
@@ -68,7 +69,7 @@ func TestGlobalOptionsResolveSubprojects_AppliesEcosystemFilter(t *testing.T) {
 }
 
 func TestGlobalOptionsResolveExecutionTarget_Container(t *testing.T) {
-	options := globalOptions{Container: "alpine:3.20"}
+	options := globalOptions{Resolved: config.Resolved{Container: "alpine:3.20"}}
 
 	target, location, cleanup, err := options.resolveExecutionTarget(nil)
 	if err != nil {
@@ -86,7 +87,7 @@ func TestGlobalOptionsResolveExecutionTarget_Container(t *testing.T) {
 }
 
 func TestGlobalOptionsResolveExecutionTarget_RejectsMultipleTargets(t *testing.T) {
-	options := globalOptions{Path: ".", Container: "alpine:3.20"}
+	options := globalOptions{Resolved: config.Resolved{Path: ".", Container: "alpine:3.20"}}
 
 	_, _, _, err := options.resolveExecutionTarget(nil)
 	if err == nil {
@@ -103,7 +104,7 @@ func TestGlobalOptionsResolveSubprojects_SingleFileUsesRegistryIndexedManager(t 
 		t.Fatalf("write Cargo.lock: %v", err)
 	}
 
-	options := globalOptions{Path: projectFile}
+	options := globalOptions{Resolved: config.Resolved{Path: projectFile}}
 	subprojects, err := options.resolveSubprojects(model.ExecutionTarget{Kind: model.ExecutionTargetFilesystem, Location: projectFile})
 	if err != nil {
 		t.Fatalf("resolveSubprojects() error = %v", err)
@@ -134,7 +135,7 @@ func TestGlobalOptionsResolveSubprojects_ContainerUsesGenericDiscoveryTarget(t *
 }
 
 func TestGlobalOptionsResolveSubprojects_ContainerAppliesEcosystemFilter(t *testing.T) {
-	options := globalOptions{Ecosystems: "rpm"}
+	options := globalOptions{Resolved: config.Resolved{Ecosystems: "rpm"}}
 	subprojects, err := options.resolveSubprojects(model.ExecutionTarget{Kind: model.ExecutionTargetContainerImage, Location: "alpine:3.20"})
 	if err != nil {
 		t.Fatalf("resolveSubprojects() error = %v", err)
@@ -363,8 +364,10 @@ func TestGlobalOptionsInitialize_LoadsConfigHierarchy(t *testing.T) {
 	})
 
 	options := &globalOptions{
-		Config:     explicitConfig,
-		Ecosystems: "python",
+		Resolved: config.Resolved{
+			Config:     explicitConfig,
+			Ecosystems: "python",
+		},
 	}
 	root := newTestRootCommand(t)
 	if err := options.bind(root); err != nil {
@@ -426,7 +429,7 @@ func TestGlobalOptionsInitialize_LoadsQuietFromConfig(t *testing.T) {
 }
 
 func TestGlobalOptionsInitialize_RejectsQuietAndVerboseTogether(t *testing.T) {
-	options := &globalOptions{Quiet: true, Verbosity: 1}
+	options := &globalOptions{Resolved: config.Resolved{Quiet: true, Verbosity: 1}}
 	root := newTestRootCommand(t)
 	if err := options.bind(root); err != nil {
 		t.Fatalf("bind() error = %v", err)
@@ -456,7 +459,7 @@ func TestGlobalOptionsInitialize_ProjectConfigUsesSelectedPath(t *testing.T) {
 		"ecosystems": "go",
 	})
 
-	options := &globalOptions{Path: projectDir}
+	options := &globalOptions{Resolved: config.Resolved{Path: projectDir}}
 	root := newTestRootCommand(t)
 	if err := options.bind(root); err != nil {
 		t.Fatalf("bind() error = %v", err)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UserConfigPath returns the path to the user-level config file (~/.bomly/config.yaml).
+// Returns an empty string (no error) when the home directory cannot be determined.
+func UserConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		if strings.TrimSpace(err.Error()) == "" {
+			return "", nil
+		}
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", nil
+	}
+	return filepath.Join(home, ".bomly", "config.yaml"), nil
+}
+
+// LoadFile reads and parses a YAML config file at path. Returns nil with no
+// error when the file does not exist or path is empty. Relative path/config
+// fields inside the file are resolved relative to the file's directory.
+func LoadFile(path string) (*File, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var cfg File
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	normalizeFilePaths(&cfg, filepath.Dir(path))
+	return &cfg, nil
+}
+
+func normalizeFilePaths(cfg *File, baseDir string) {
+	for _, target := range []*string{cfg.Path, cfg.Config} {
+		if target == nil || strings.TrimSpace(*target) == "" || filepath.IsAbs(*target) {
+			continue
+		}
+		*target = filepath.Clean(filepath.Join(baseDir, *target))
+	}
+}
+
+// ApplyFileConfig merges non-nil src fields into dst. File fields are pointers;
+// nil means the user did not set the field, so dst is left unchanged.
+func ApplyFileConfig(dst *Resolved, src File) {
+	if dst == nil {
+		return
+	}
+	dstVal := reflect.ValueOf(dst).Elem()
+	srcVal := reflect.ValueOf(src)
+	t := srcVal.Type()
+	for i := 0; i < t.NumField(); i++ {
+		sf := srcVal.Field(i)
+		if sf.Kind() != reflect.Ptr || sf.IsNil() {
+			continue
+		}
+		df := dstVal.FieldByName(t.Field(i).Name)
+		if df.IsValid() && df.CanSet() {
+			df.Set(sf.Elem())
+		}
+	}
+	// InstallArgs is a slice (not a pointer) — replace when provided.
+	if len(src.InstallArgs) > 0 {
+		dst.InstallArgs = append([]string(nil), src.InstallArgs...)
+	}
+	// Verbose is a legacy shorthand; map it to Verbosity=1 if not already set.
+	if src.Verbose != nil && *src.Verbose && dst.Verbosity == 0 {
+		dst.Verbosity = 1
+	}
+}
+
+// ApplyEnvOverrides reads the environment variables named in Resolved's env
+// struct tags and overwrites the corresponding dst fields.
+func ApplyEnvOverrides(dst *Resolved) {
+	if dst == nil {
+		return
+	}
+	v := reflect.ValueOf(dst).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		key := t.Field(i).Tag.Get("env")
+		if key == "" {
+			continue
+		}
+		val, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+		fv := v.Field(i)
+		switch fv.Kind() {
+		case reflect.String:
+			fv.SetString(val)
+		case reflect.Bool:
+			if b, ok := parseBool(val); ok {
+				fv.SetBool(b)
+			}
+		case reflect.Int:
+			applyVerbosityEnv(fv, val)
+		case reflect.Slice:
+			fv.Set(reflect.ValueOf(parseCSV(val)))
+		}
+	}
+}
+
+// ApplyDefaults fills in zero-value fields with their documented defaults.
+func ApplyDefaults(cfg *Resolved) {
+	if cfg == nil {
+		return
+	}
+	if strings.TrimSpace(cfg.FailOn) == "" {
+		cfg.FailOn = "any"
+	}
+}
+
+// Validate returns an error if cfg contains mutually exclusive options.
+func Validate(cfg Resolved) error {
+	if cfg.Interactive && strings.TrimSpace(cfg.Format) != "" {
+		return fmt.Errorf("--interactive cannot be combined with --format")
+	}
+	if cfg.Quiet && cfg.Verbosity > 0 {
+		return fmt.Errorf("--quiet cannot be combined with --verbose")
+	}
+	return nil
+}
+
+func parseBool(s string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// applyVerbosityEnv applies a BOMLY_VERBOSE env var value to the Verbosity field.
+// It accepts numeric levels (0–3) and bool-style truthy/falsy strings.
+func applyVerbosityEnv(fv reflect.Value, val string) {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "1", "true", "yes", "on":
+		if fv.Int() == 0 {
+			fv.SetInt(1)
+		}
+	case "2":
+		fv.SetInt(2)
+	case "3":
+		fv.SetInt(3)
+	case "0", "false", "no", "off":
+		fv.SetInt(0)
+	}
+}
+
+func parseCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	items := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		normalized := strings.ToLower(strings.TrimSpace(part))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		items = append(items, normalized)
+	}
+	return items
+}


### PR DESCRIPTION
## Summary
- **New `internal/config/load.go`**: moves all non-Cobra config logic (file loading, env overrides, defaults, validation) out of `internal/cli` and into the config package, making it self-contained
- **Reflection-driven `ApplyFileConfig`**: replaces 89 lines of `if src.X != nil { dst.X = *src.X }` with a reflect loop over `File`'s pointer fields — adding a new config field no longer requires touching this function
- **Tag-driven `ApplyEnvOverrides`**: replaces 65 lines of hardcoded `os.LookupEnv("BOMLY_X")` calls with a reflect loop that reads the `env` struct tags already declared on `Resolved` — new env-var fields are picked up automatically
- **`globalOptions` embeds `config.Resolved`**: removes the duplicate 27-field struct definition and the manual field-by-field copy in `current()`
Net reduction: ~140 lines. No behavior changes.
## What didn't change
- `config.Resolved` and `config.File` struct definitions and their tags — AST generators are unaffected (`make generate` produces identical output)
- `applyFlagOverrides` and `flagChanged` — Cobra-dependent, stay in `internal/cli`
- Precedence order: defaults → YAML files → env vars → flags
- Bool env var semantics (`"yes"/"on"` truthy, `"no"/"off"` falsy)
## Test plan
- [x] `go test ./...` — all packages pass
- [x] `make generate` — generators produce identical docs output
- [x] `TestGlobalOptionsInitialize_LoadsConfigHierarchy` covers three-file config hierarchy, `LoadedFiles` count, env override, and flag override