### PR TITLE
Shorten GitHub Actions artifact retention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           name: licenses
           path: licenses/
+          retention-days: 1
 
   package:
     needs: [validate, licenses]
@@ -162,6 +163,7 @@ jobs:
         with:
           name: release-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*
+          retention-days: 1
 
   publish:
     needs: package

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -128,6 +128,7 @@ jobs:
           path: |
             smoke-artifacts
           if-no-files-found: ignore
+          retention-days: 3
 
       - name: Fail job if smoke tests failed
         if: steps.smoke_tests.outcome == 'failure'


### PR DESCRIPTION
## Summary

- Set the release workflow `licenses` artifact retention to 1 day.
- Set packaged release artifact retention to 1 day since the publish job only needs them within the same workflow run.
- Set failed-smoke candidate golden artifact retention to 3 days so review artifacts remain briefly available without accumulating against storage quota.

## Why

GitHub Actions is failing uploads with `Artifact storage quota has been hit`, including the `licenses` artifact. Explicit short retention prevents transient CI handoff artifacts from lingering at the repository or organization default retention period.

## Validation

- `make test`
- commit hook: `gofmtcheck`
- commit hook: `golangci-lint`