### PR TITLE
Make auto version workflow manual

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,9 +1,16 @@
 name: Auto Version
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   actions: write
@@ -15,7 +22,6 @@ concurrency:
 
 jobs:
   bump-tag-and-release:
-    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -23,19 +29,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Require main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Auto Version must be run from main, got ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
       - name: Compute next version
         id: version
         shell: bash
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
 
           latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
           if [[ -n "${latest_tag}" ]]; then
             current="${latest_tag#v}"
-            messages="$(git log --format=%B "${latest_tag}..HEAD")"
           else
             current="$(sed -nE 's/^var version = "([^"]+)"/\1/p' cmd/bomly/main.go | head -n 1)"
-            messages="$(git log --format=%B -n 1 HEAD)"
           fi
 
           if [[ ! "${current}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -44,16 +59,24 @@ jobs:
           fi
 
           IFS=. read -r major minor patch <<< "${current}"
-          if grep -Eq '(^[a-zA-Z]+(\([^)]+\))?!:|BREAKING CHANGE:)' <<< "${messages}"; then
-            major=$((major + 1))
-            minor=0
-            patch=0
-          elif grep -Eq '^feat(\([^)]+\))?:' <<< "${messages}"; then
-            minor=$((minor + 1))
-            patch=0
-          else
-            patch=$((patch + 1))
-          fi
+          case "${BUMP}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "Unsupported bump type ${BUMP}" >&2
+              exit 1
+              ;;
+          esac
 
           next="${major}.${minor}.${patch}"
           tag="v${next}"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -10,7 +10,7 @@ Bomly uses GitHub Actions for validation, security analysis, smoke coverage, and
 | `Dependency Review`    | Pull requests touching `go.mod` or `go.sum`    | Review dependency changes before merge                                                                                 |
 | `Smoke`                | Merge queue, nightly schedule, manual dispatch | Slow end-to-end coverage against real repositories, SBOMs, and containers before merge, plus scheduled drift detection |
 | `Update Smoke Goldens` | Manual dispatch                                | Regenerate golden files on a chosen ref and open a PR when the changes are intentional                                 |
-| `Auto Version`         | Pushes to `main`                               | Bump `cmd/bomly/main.go`, create a semver tag, and start the release workflow                                          |
+| `Auto Version`         | Manual dispatch                                | Bump `cmd/bomly/main.go`, create a semver tag, and start the release workflow                                          |
 | `Release`              | Semver tags like `v1.2.3`, manual dispatch     | Cross-platform packaging, checksum generation, and draft GitHub prerelease publication                                 |
 
 ## Required Checks
@@ -84,30 +84,28 @@ go build -tags "bomly_external_syft,bomly_external_grype" -o bin/bomly-lite ./cm
 ## Release Process
 
 1. Merge to `main`.
-2. The `Auto Version` workflow computes the next semantic version from commit messages, updates `cmd/bomly/main.go`, commits the bump, creates a tag such as `v0.2.0`, and starts the `Release` workflow.
-3. The `Release` workflow reruns validation and then cross-compiles `bomly` and `bomly-lite`.
-4. The workflow packages archives for:
+2. When ready to publish, a maintainer runs the `Auto Version` workflow from `main` and chooses a `patch`, `minor`, or `major` bump.
+3. The `Auto Version` workflow updates `cmd/bomly/main.go`, commits the bump, creates a tag such as `v0.2.0`, and starts the `Release` workflow.
+4. The `Release` workflow reruns validation and then cross-compiles `bomly` and `bomly-lite`.
+5. The workflow packages archives for:
    - `linux/amd64`
    - `linux/arm64`
    - `darwin/amd64`
    - `darwin/arm64`
    - `windows/amd64`
    - `windows/arm64`
-5. The workflow generates `SHA256SUMS`.
-6. The workflow creates a **draft prerelease** in GitHub Releases and uploads all archives plus checksums.
+6. The workflow generates `SHA256SUMS`.
+7. The workflow creates a **draft prerelease** in GitHub Releases and uploads all archives plus checksums.
 
-Version bump rules follow conventional commit text in commits since the last `vX.Y.Z` tag:
+Version bump rules are chosen explicitly when running `Auto Version`:
 
-| Desired outcome | Commit message pattern                              | Example                              | Result                           |
-|-----------------|-----------------------------------------------------|--------------------------------------|----------------------------------|
-| Skip release    | Include `[skip release]` in the head commit message | `docs: update README [skip release]` | No version bump, tag, or release |
-| Patch release   | Any non-breaking commit that is not `feat:`         | `fix: handle empty SBOM input`       | `0.2.3` -> `0.2.4`               |
-| Minor release   | `feat:` or `feat(scope):`                           | `feat: add npm workspace detection`  | `0.2.3` -> `0.3.0`               |
-| Major release   | `type!:` or `BREAKING CHANGE:`                      | `feat!: change JSON output schema`   | `0.2.3` -> `1.0.0`               |
+| Selected bump | Result             |
+|---------------|--------------------|
+| `patch`       | `0.2.3` -> `0.2.4` |
+| `minor`       | `0.2.3` -> `0.3.0` |
+| `major`       | `0.2.3` -> `1.0.0` |
 
-The workflow evaluates the commit messages between the latest `vX.Y.Z` tag and `HEAD`. If any message is breaking, the release is major. Otherwise, if any message starts with `feat:`, the release is minor. Otherwise, the release is patch.
-
-When using GitHub squash merge, the final squash commit title and body are the important inputs. Before merging, make sure the squash message contains the intended `feat:`, `feat!:`, `BREAKING CHANGE:`, or `[skip release]` marker.
+The workflow uses the latest `vX.Y.Z` tag as the current version. If no tag exists yet, it falls back to the version in `cmd/bomly/main.go`. Manual dispatch is restricted to `main` so release tags are cut from the release branch.
 
 Archive naming follows this pattern:
 


### PR DESCRIPTION
## Summary

- Change the Auto Version workflow from push-on-main to manual dispatch.
- Require a maintainer-selected `patch`, `minor`, or `major` bump input.
- Update CI release docs to describe the manual release flow and explicit bump rules.

## Validation

- `make test`
- pre-commit hook ran `gofmtcheck` and `golangci-lint` during commit
