### PR TITLE
Upgrade Go and reduce CI validation minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,12 @@ jobs:
             go.sum
 
       - name: Run golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
 
       - name: Run unit and integration tests
         run: make test
-
-      - name: Run go vet
-        run: go vet ./...
 
       - name: Build default Bomly binary
         run: go build -o /tmp/bomly ./cmd/bomly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,16 @@ jobs:
           cache-dependency-path: |
             go.sum
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+      - name: Restore golangci-lint cache
+        uses: actions/cache@v4
         with:
-          version: v1.64.8
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('.golangci.yml', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
+
+      - name: Run golangci-lint
+        run: make lint
 
       - name: Run unit and integration tests
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           path: |
             ~/.cache/golangci-lint
-            .tools/bin
-          key: golangci-lint-${{ runner.os }}-${{ hashFiles('.golangci.yml', 'go.mod', 'go.sum') }}
+            ~/go/bin
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile', '.golangci.yml', 'go.mod', 'go.sum') }}
           restore-keys: |
             golangci-lint-${{ runner.os }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Restore golangci-lint cache
         uses: actions/cache@v4
         with:
-          path: ~/.cache/golangci-lint
+          path: |
+            ~/.cache/golangci-lint
+            .tools/bin
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('.golangci.yml', 'go.mod', 'go.sum') }}
           restore-keys: |
             golangci-lint-${{ runner.os }}-

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Ignore build files
 /bin
 
-# Ignore locally installed development tools
-/.tools
-
 # Ignore generated third-party license notices (bundled into release archives)
 /licenses
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore build files
 /bin
 
+# Ignore locally installed development tools
+/.tools
+
 # Ignore generated third-party license notices (bundled into release archives)
 /licenses
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,22 @@ BINARY_NAME=bomly
 LITE_BUILD_TAGS=bomly_external_syft,bomly_external_grype
 GOLANGCI_LINT_VERSION=v1.64.8
 GO_LICENSES_VERSION=v1.6.0
+LOCAL_BIN=$(CURDIR)/.tools/bin
+EXE_SUFFIX=$(if $(filter Windows_NT,$(OS)),.exe,)
+GOLANGCI_LINT=$(LOCAL_BIN)/golangci-lint$(EXE_SUFFIX)
+GOLANGCI_LINT_STAMP=$(LOCAL_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)
+
+ifeq ($(OS),Windows_NT)
+LOCAL_BIN_PATH=$(subst /,\,$(LOCAL_BIN))
+GOLANGCI_LINT_STAMP_PATH=$(subst /,\,$(GOLANGCI_LINT_STAMP))
+MKDIR_LOCAL_BIN=if not exist "$(LOCAL_BIN_PATH)" mkdir "$(LOCAL_BIN_PATH)"
+INSTALL_GOLANGCI_LINT=set "GOBIN=$(LOCAL_BIN)"&& go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+TOUCH_GOLANGCI_LINT_STAMP=type nul > "$(GOLANGCI_LINT_STAMP_PATH)"
+else
+MKDIR_LOCAL_BIN=mkdir -p "$(LOCAL_BIN)"
+INSTALL_GOLANGCI_LINT=GOBIN="$(LOCAL_BIN)" go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+TOUCH_GOLANGCI_LINT_STAMP=touch "$(GOLANGCI_LINT_STAMP)"
+endif
 
 .PHONY: build build-full build-lite fmt fmt-check lint install-hooks test run generate docs-config docs-schema docs-schema-md docs-support-matrix smoke licenses
 
@@ -19,8 +35,13 @@ fmt:
 fmt-check:
 	go run ./internal/tools/gofmtcheck
 
-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+$(GOLANGCI_LINT_STAMP):
+	$(MKDIR_LOCAL_BIN)
+	$(INSTALL_GOLANGCI_LINT)
+	$(TOUCH_GOLANGCI_LINT_STAMP)
+
+lint: $(GOLANGCI_LINT_STAMP)
+	$(GOLANGCI_LINT) run
 
 install-hooks:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,9 @@ BINARY_NAME=bomly
 LITE_BUILD_TAGS=bomly_external_syft,bomly_external_grype
 GOLANGCI_LINT_VERSION=v1.64.8
 GO_LICENSES_VERSION=v1.6.0
-LOCAL_BIN=$(CURDIR)/.tools/bin
+GOPATH_BIN=$(shell go env GOPATH)/bin
 EXE_SUFFIX=$(if $(filter Windows_NT,$(OS)),.exe,)
-GOLANGCI_LINT=$(LOCAL_BIN)/golangci-lint$(EXE_SUFFIX)
-GOLANGCI_LINT_STAMP=$(LOCAL_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)
-
-ifeq ($(OS),Windows_NT)
-LOCAL_BIN_PATH=$(subst /,\,$(LOCAL_BIN))
-GOLANGCI_LINT_STAMP_PATH=$(subst /,\,$(GOLANGCI_LINT_STAMP))
-MKDIR_LOCAL_BIN=if not exist "$(LOCAL_BIN_PATH)" mkdir "$(LOCAL_BIN_PATH)"
-INSTALL_GOLANGCI_LINT=set "GOBIN=$(LOCAL_BIN)"&& go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-TOUCH_GOLANGCI_LINT_STAMP=type nul > "$(GOLANGCI_LINT_STAMP_PATH)"
-else
-MKDIR_LOCAL_BIN=mkdir -p "$(LOCAL_BIN)"
-INSTALL_GOLANGCI_LINT=GOBIN="$(LOCAL_BIN)" go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-TOUCH_GOLANGCI_LINT_STAMP=touch "$(GOLANGCI_LINT_STAMP)"
-endif
+GOLANGCI_LINT=$(GOPATH_BIN)/golangci-lint$(EXE_SUFFIX)
 
 .PHONY: build build-full build-lite fmt fmt-check lint install-hooks test run generate docs-config docs-schema docs-schema-md docs-support-matrix smoke licenses
 
@@ -35,12 +22,10 @@ fmt:
 fmt-check:
 	go run ./internal/tools/gofmtcheck
 
-$(GOLANGCI_LINT_STAMP):
-	$(MKDIR_LOCAL_BIN)
-	$(INSTALL_GOLANGCI_LINT)
-	$(TOUCH_GOLANGCI_LINT_STAMP)
+$(GOLANGCI_LINT): Makefile
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
-lint: $(GOLANGCI_LINT_STAMP)
+lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run
 
 install-hooks:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -53,7 +53,7 @@ The repository also ships a pre-commit hook in `.githooks/pre-commit`. Run `make
 
 This repository is currently private, so the workflow set is intentionally lean:
 
-- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with its analysis cache restored between runs.
+- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with both its repo-local tool binary and analysis cache restored between runs.
 - Standalone `go vet ./...` is not run separately in `CI` because `.golangci.yml` already enables `govet`.
 - `go test -race` is not enabled in CI because it adds runtime cost and is best reintroduced later if we need the extra concurrency diagnostics.
 - CodeQL is disabled for now because it is not available for the current private-repo setup. It can be restored when the repository goes public or the GitHub plan changes.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -53,7 +53,7 @@ The repository also ships a pre-commit hook in `.githooks/pre-commit`. Run `make
 
 This repository is currently private, so the workflow set is intentionally lean:
 
-- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with both its repo-local tool binary and analysis cache restored between runs.
+- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with both its tool binary and analysis cache restored between runs.
 - Standalone `go vet ./...` is not run separately in `CI` because `.golangci.yml` already enables `govet`.
 - `go test -race` is not enabled in CI because it adds runtime cost and is best reintroduced later if we need the extra concurrency diagnostics.
 - CodeQL is disabled for now because it is not available for the current private-repo setup. It can be restored when the repository goes public or the GitHub plan changes.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -53,7 +53,7 @@ The repository also ships a pre-commit hook in `.githooks/pre-commit`. Run `make
 
 This repository is currently private, so the workflow set is intentionally lean:
 
-- `golangci-lint` runs inside the main `CI` workflow with its official action, which uses the pinned version and preserves the linter analysis cache between runs.
+- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with its analysis cache restored between runs.
 - Standalone `go vet ./...` is not run separately in `CI` because `.golangci.yml` already enables `govet`.
 - `go test -race` is not enabled in CI because it adds runtime cost and is best reintroduced later if we need the extra concurrency diagnostics.
 - CodeQL is disabled for now because it is not available for the current private-repo setup. It can be restored when the repository goes public or the GitHub plan changes.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -6,7 +6,7 @@ Bomly uses GitHub Actions for validation, security analysis, smoke coverage, and
 
 | Workflow               | Trigger                                        | Purpose                                                                                                                |
 |------------------------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| `CI`                   | Pull requests, pushes to `main`                | Fast validation: `golangci-lint`, `gofmt` drift checks, tests, `go vet`, build sanity, module drift, and generated-doc drift |
+| `CI`                   | Pull requests, pushes to `main`                | Fast validation: `golangci-lint`, `gofmt` drift checks, tests, build sanity, module drift, and generated-doc drift |
 | `Dependency Review`    | Pull requests touching `go.mod` or `go.sum`    | Review dependency changes before merge                                                                                 |
 | `Smoke`                | Merge queue, nightly schedule, manual dispatch | Slow end-to-end coverage against real repositories, SBOMs, and containers before merge, plus scheduled drift detection |
 | `Update Smoke Goldens` | Manual dispatch                                | Regenerate golden files on a chosen ref and open a PR when the changes are intentional                                 |
@@ -53,8 +53,8 @@ The repository also ships a pre-commit hook in `.githooks/pre-commit`. Run `make
 
 This repository is currently private, so the workflow set is intentionally lean:
 
-- `go vet` runs inside the main `CI` workflow instead of a separate quality workflow.
-- `golangci-lint` runs inside the main `CI` workflow via `make lint`, which uses the repository-pinned version and configuration from `.golangci.yml`.
+- `golangci-lint` runs inside the main `CI` workflow with its official action, which uses the pinned version and preserves the linter analysis cache between runs.
+- Standalone `go vet ./...` is not run separately in `CI` because `.golangci.yml` already enables `govet`.
 - `go test -race` is not enabled in CI because it adds runtime cost and is best reintroduced later if we need the extra concurrency diagnostics.
 - CodeQL is disabled for now because it is not available for the current private-repo setup. It can be restored when the repository goes public or the GitHub plan changes.
 


### PR DESCRIPTION
## Summary

- Upgrade the module to Go 1.26 language rules with `toolchain go1.26.3`, the latest stable Go patch release from the official Go downloads feed.
- Upgrade golangci-lint from v1.64.8 to v2.12.0 and migrate `.golangci.yml` to the v2 schema.
- Use `golangci/golangci-lint-action@v9` in CI so linting uses the current action with built-in caching instead of a hand-rolled cache step.
- Keep local `make lint` pinned to the same v2.12.0 linter binary through the v2 module path.
- Remove the standalone `go vet ./...` CI step because `.golangci.yml` already enables `govet`.
- Apply the new lint/formatting guidance surfaced by Go 1.26 and golangci-lint v2.

## Validation

- `golangci-lint config verify`
- `make fmt`
- `go mod tidy`
- `make lint`
- `make generate`
- `make test`
- `make build`
- pre-commit hook ran `gofmtcheck` and `make lint`
