### PR TITLE
[codex] Upgrade Go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,10 @@ jobs:
           cache-dependency-path: |
             go.sum
 
-      - name: Restore golangci-lint cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/golangci-lint
-            ~/go/bin
-          key: golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile', '.golangci.yml', 'go.mod', 'go.sum') }}
-          restore-keys: |
-            golangci-lint-${{ runner.os }}-
-
       - name: Run golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.0
 
       - name: Run unit and integration tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,33 @@
-run:
-  timeout: 5m
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - govet
     - ineffassign
     - staticcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY_NAME=bomly
 LITE_BUILD_TAGS=bomly_external_syft,bomly_external_grype
-GOLANGCI_LINT_VERSION=v1.64.8
+GOLANGCI_LINT_VERSION=v2.12.0
 GO_LICENSES_VERSION=v1.6.0
 GOPATH_BIN=$(shell go env GOPATH)/bin
 EXE_SUFFIX=$(if $(filter Windows_NT,$(OS)),.exe,)
@@ -23,7 +23,7 @@ fmt-check:
 	go run ./internal/tools/gofmtcheck
 
 $(GOLANGCI_LINT): Makefile
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -53,7 +53,7 @@ The repository also ships a pre-commit hook in `.githooks/pre-commit`. Run `make
 
 This repository is currently private, so the workflow set is intentionally lean:
 
-- `golangci-lint` runs inside the main `CI` workflow via `make lint`, with both its tool binary and analysis cache restored between runs.
+- `golangci-lint` runs inside the main `CI` workflow with the official action, pinned to the repository's lint version and using the action's built-in cache.
 - Standalone `go vet ./...` is not run separately in `CI` because `.golangci.yml` already enables `govet`.
 - `go test -race` is not enabled in CI because it adds runtime cost and is best reintroduced later if we need the extra concurrency diagnostics.
 - CodeQL is disabled for now because it is not available for the current private-repo setup. It can be restored when the repository goes public or the GitHub plan changes.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bomly-dev/bomly-cli
 
-go 1.25.8
+go 1.26.0
+
+toolchain go1.26.3
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.10.0

--- a/internal/cli/opts/filters.go
+++ b/internal/cli/opts/filters.go
@@ -189,9 +189,7 @@ func buildAuditorSelectorCatalog(reg *engine.Registry) catalog {
 		aliasToName[name] = name
 	}
 	simplified := make([]string, 0, len(available))
-	for _, name := range available {
-		simplified = append(simplified, name)
-	}
+	simplified = append(simplified, available...)
 	sort.Strings(available)
 	sort.Strings(simplified)
 	return catalog{Kind: "auditor", Available: available, AliasToName: aliasToName, Items: simplified}

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -1549,7 +1549,7 @@ func TestRoot_ScanCommand_TextReportOutput(t *testing.T) {
 	if rootIdx == -1 || directIdx == -1 || transitiveIdx == -1 {
 		t.Fatalf("expected root, direct, and transitive rows in output, got: %s", out)
 	}
-	if !(rootIdx < directIdx && directIdx < transitiveIdx) {
+	if rootIdx >= directIdx || directIdx >= transitiveIdx {
 		t.Fatalf("expected root/direct/transitive order, got: %s", out)
 	}
 }

--- a/internal/cli/scan_cmd_test.go
+++ b/internal/cli/scan_cmd_test.go
@@ -62,7 +62,7 @@ func TestRenderScanReportWithoutFindingsUsesCleanMessage(t *testing.T) {
 	if !strings.Contains(report, "Policy evaluation not enabled") {
 		t.Fatalf("expected not-audited message, got:\n%s", report)
 	}
-	if strings.Contains(report, "â€”") || strings.Contains(report, "Ã¢â‚¬â€") {
+	if strings.Contains(report, "\u00e2\u20ac\u201d") || strings.Contains(report, "\u00c3\u00a2\u00e2\u201a\u00ac\u00e2\u20ac\u009d") {
 		t.Fatalf("expected mojibake to be removed, got:\n%s", report)
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -68,7 +68,7 @@ func ApplyFileConfig(dst *Resolved, src File) {
 	t := srcVal.Type()
 	for i := 0; i < t.NumField(); i++ {
 		sf := srcVal.Field(i)
-		if sf.Kind() != reflect.Ptr || sf.IsNil() {
+		if sf.Kind() != reflect.Pointer || sf.IsNil() {
 			continue
 		}
 		df := dstVal.FieldByName(t.Field(i).Name)

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -309,11 +309,11 @@ type cargoManifest struct {
 func depGraphFromLock(lockRaw, manifestRaw []byte) (*sdk.Graph, error) {
 	packages := parseCargoLockPackages(string(lockRaw))
 	if len(packages) == 0 {
-		return nil, fmt.Errorf("Cargo.lock does not contain any packages")
+		return nil, fmt.Errorf("cargo.lock does not contain any packages")
 	}
 	manifest := parseCargoManifest(string(manifestRaw))
 	if manifest.Name == "" {
-		return nil, fmt.Errorf("Cargo.toml does not contain a package name")
+		return nil, fmt.Errorf("cargo.toml does not contain a package name")
 	}
 	g := sdk.New()
 	root := sdk.NewPackage(sdk.Package{

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -102,7 +102,7 @@ func depGraphFromLock(raw []byte) (*sdk.Graph, error) {
 	}
 	specs := parsePodSpecs(lock.Pods)
 	if len(specs) == 0 {
-		return nil, fmt.Errorf("Podfile.lock does not contain any pods")
+		return nil, fmt.Errorf("podfile.lock does not contain any pods")
 	}
 	g := sdk.New()
 	root := rootNode()

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -155,7 +155,7 @@ func depGraphFromJSON(raw []byte) (*sdk.Graph, error) {
 		}
 		return depGraphFromRefs(refs)
 	default:
-		return nil, fmt.Errorf("Conan JSON does not contain graph nodes or requirements")
+		return nil, fmt.Errorf("conan JSON does not contain graph nodes or requirements")
 	}
 }
 
@@ -221,7 +221,7 @@ func depGraphFromManifestFiles(workingDir string) (*sdk.Graph, error) {
 
 func depGraphFromRefs(refs []conanRef) (*sdk.Graph, error) {
 	if len(refs) == 0 {
-		return nil, fmt.Errorf("Conan files do not contain any dependencies")
+		return nil, fmt.Errorf("conan files do not contain any dependencies")
 	}
 	g := sdk.New()
 	root := rootNode()

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -124,7 +124,7 @@ func depGraphFromMix(lockRaw, manifestRaw []byte) (*sdk.Graph, error) {
 		packages[name] = pkg
 	}
 	if len(packages) == 0 {
-		return nil, fmt.Errorf("Mix files do not contain any dependencies")
+		return nil, fmt.Errorf("mix files do not contain any dependencies")
 	}
 
 	g := sdk.New()

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -76,10 +76,10 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 
 	doc, target, err := sbom.UnmarshalAutoJSON(data)
 	if err != nil {
-		switch {
-		case err == sbom.ErrMalformedJSON:
+		switch err {
+		case sbom.ErrMalformedJSON:
 			return sdk.DetectionResult{}, fmt.Errorf("parse sbom file %q: %w", sbomPath, err)
-		case err == sbom.ErrUnsupportedFormat:
+		case sbom.ErrUnsupportedFormat:
 			return sdk.DetectionResult{}, fmt.Errorf("detect sbom format for %q: %w", sbomPath, err)
 		default:
 			return sdk.DetectionResult{}, fmt.Errorf("decode sbom file %q: %w", sbomPath, err)

--- a/internal/engine/consolidation/consolidation_test.go
+++ b/internal/engine/consolidation/consolidation_test.go
@@ -196,7 +196,7 @@ func TestManifestDedupPriorityPrefersNativeOverSyft(t *testing.T) {
 	if got := ManifestDedupPriority(sdk.BundledOrigin, sdk.MultipleTechnique); got != 2 {
 		t.Fatalf("expected bundled multiple-technique detector priority 2, got %d", got)
 	}
-	if !(ManifestDedupPriority(sdk.CoreOrigin, sdk.BuildToolTechnique) < ManifestDedupPriority(sdk.BundledOrigin, sdk.MultipleTechnique)) {
+	if ManifestDedupPriority(sdk.CoreOrigin, sdk.BuildToolTechnique) >= ManifestDedupPriority(sdk.BundledOrigin, sdk.MultipleTechnique) {
 		t.Fatal("expected core detector to outrank bundled multiple-technique detector for manifest deduplication")
 	}
 }

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -109,7 +109,7 @@ func (p *Pipeline) runConsolidate(result *PipelineResult, req PipelineRequest) e
 }
 
 func (p *Pipeline) runMatch(ctx context.Context, result *PipelineResult, req PipelineRequest) {
-	if !(req.EnrichEnabled || req.MatchEnabled) || result.Graph == nil {
+	if (!req.EnrichEnabled && !req.MatchEnabled) || result.Graph == nil {
 		return
 	}
 	if req.Progress != nil {

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -33,28 +33,28 @@ func (r *Registry) registerDetector(detector sdk.Detector) {
 	if r == nil {
 		return
 	}
-	r.Registry.RegisterDetector(detector)
+	r.RegisterDetector(detector)
 }
 
 func (r *Registry) registerMatcher(matcher sdk.Matcher) {
 	if r == nil {
 		return
 	}
-	r.Registry.RegisterMatcher(matcher)
+	r.RegisterMatcher(matcher)
 }
 
 func (r *Registry) registerAuditor(auditor sdk.Auditor) {
 	if r == nil {
 		return
 	}
-	r.Registry.RegisterAuditor(auditor)
+	r.RegisterAuditor(auditor)
 }
 
 func (r *Registry) registerDetectorDiscoveryPlan(detectorName string, plan DetectorDiscoveryPlan) {
 	if r == nil {
 		return
 	}
-	r.Registry.RegisterDetectorDiscoveryPlan(detectorName, plan)
+	r.RegisterDetectorDiscoveryPlan(detectorName, plan)
 }
 
 // RegisterPreResolveHook adds a pre-resolve hook to the registry.

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bomly-dev/bomly-cli/internal/registry"
 	"github.com/bomly-dev/bomly-cli/sdk"
-	plugschema "github.com/bomly-dev/bomly-cli/sdk"
 )
 
 type registryWriter interface {
@@ -33,14 +32,14 @@ func RegisterRuntimePlugins(ctx context.Context, reg registryWriter, root string
 	}
 	for _, info := range infos {
 		switch info.Kind {
-		case plugschema.PluginKindDetector:
+		case sdk.PluginKindDetector:
 			reg.RegisterDetector(newExternalDetector(info, ctx))
 			if plan, ok := detectorDiscoveryPlan(info.Manifest); ok {
 				reg.RegisterDetectorDiscoveryPlan(info.ID, plan)
 			}
-		case plugschema.PluginKindMatcher:
+		case sdk.PluginKindMatcher:
 			reg.RegisterMatcher(newExternalMatcher(info, ctx))
-		case plugschema.PluginKindAuditor:
+		case sdk.PluginKindAuditor:
 			reg.RegisterAuditor(newExternalAuditor(info, ctx))
 		}
 	}
@@ -52,7 +51,7 @@ type externalDetector struct {
 	launchCtx context.Context
 }
 
-func (d externalDetector) Metadata(context.Context) (*plugschema.PluginMetadata, error) {
+func (d externalDetector) Metadata(context.Context) (*sdk.PluginMetadata, error) {
 	return metadataFromPluginInfo(d.info), nil
 }
 
@@ -66,10 +65,10 @@ func (d externalDetector) Descriptor() sdk.DetectorDescriptor {
 }
 
 func (d externalDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
-	if d.info.Manifest.DetectorDescriptor == nil {
+	if d.info.DetectorDescriptor == nil {
 		return nil
 	}
-	return clonePackageManagerSupport(d.info.Manifest.DetectorDescriptor.PackageManagerSupport)
+	return clonePackageManagerSupport(d.info.DetectorDescriptor.PackageManagerSupport)
 }
 
 func (d externalDetector) Ready() bool {
@@ -140,7 +139,7 @@ type externalMatcher struct {
 	launchCtx context.Context
 }
 
-func (m externalMatcher) Metadata(context.Context) (*plugschema.PluginMetadata, error) {
+func (m externalMatcher) Metadata(context.Context) (*sdk.PluginMetadata, error) {
 	return metadataFromPluginInfo(m.info), nil
 }
 
@@ -199,7 +198,7 @@ type externalAuditor struct {
 	launchCtx context.Context
 }
 
-func (a externalAuditor) Metadata(context.Context) (*plugschema.PluginMetadata, error) {
+func (a externalAuditor) Metadata(context.Context) (*sdk.PluginMetadata, error) {
 	return metadataFromPluginInfo(a.info), nil
 }
 
@@ -266,8 +265,8 @@ func launchContext(ctx context.Context, fallback context.Context) context.Contex
 	return WithLaunchOptions(ctx, LaunchOptions{})
 }
 
-func metadataFromPluginInfo(info PluginInfo) *plugschema.PluginMetadata {
-	return &plugschema.PluginMetadata{
+func metadataFromPluginInfo(info PluginInfo) *sdk.PluginMetadata {
+	return &sdk.PluginMetadata{
 		ID:                     info.ID,
 		Name:                   info.Name,
 		Version:                info.Version,

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/registry"
-	"github.com/bomly-dev/bomly-cli/sdk"
 	plugschema "github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -409,12 +408,12 @@ func detectorDiscoveryPlan(manifest Manifest) (registry.DetectorDiscoveryPlan, b
 		return registry.DetectorDiscoveryPlan{}, false
 	}
 	descriptor := manifest.DetectorDescriptor
-	managers := make([]sdk.PackageManager, 0, len(descriptor.PackageManagerSupport))
-	ecosystems := make([]sdk.Ecosystem, 0, len(manifest.DetectorDescriptor.SupportedEcosystems))
+	managers := make([]plugschema.PackageManager, 0, len(descriptor.PackageManagerSupport))
+	ecosystems := make([]plugschema.Ecosystem, 0, len(manifest.DetectorDescriptor.SupportedEcosystems))
 	patterns := make([]string, 0)
 	seenPatterns := make(map[string]struct{})
 	for _, support := range descriptor.PackageManagerSupport {
-		manager, err := sdk.ParsePackageManager(support.PackageManager.Name())
+		manager, err := plugschema.ParsePackageManager(support.PackageManager.Name())
 		if err != nil {
 			continue
 		}
@@ -443,12 +442,12 @@ func detectorDiscoveryPlan(manifest Manifest) (registry.DetectorDiscoveryPlan, b
 		}
 	}
 	for _, raw := range manifest.DetectorDescriptor.SupportedEcosystems {
-		eco, err := sdk.ParseEcosystem(string(raw))
+		eco, err := plugschema.ParseEcosystem(string(raw))
 		if err == nil && !slices.Contains(ecosystems, eco) {
 			ecosystems = append(ecosystems, eco)
 		}
 	}
-	targetKinds := []sdk.ExecutionTargetKind{sdk.ExecutionTargetFilesystem, sdk.ExecutionTargetGitRepository}
+	targetKinds := []plugschema.ExecutionTargetKind{plugschema.ExecutionTargetFilesystem, plugschema.ExecutionTargetGitRepository}
 	if len(ecosystems) == 0 && len(managers) > 0 {
 		for _, manager := range managers {
 			eco := manager.Ecosystem()
@@ -457,7 +456,7 @@ func detectorDiscoveryPlan(manifest Manifest) (registry.DetectorDiscoveryPlan, b
 			}
 		}
 	}
-	if len(patterns) == 0 && !slices.Contains(targetKinds, sdk.ExecutionTargetContainerImage) {
+	if len(patterns) == 0 && !slices.Contains(targetKinds, plugschema.ExecutionTargetContainerImage) {
 		return registry.DetectorDiscoveryPlan{}, false
 	}
 	return registry.DetectorDiscoveryPlan{

--- a/internal/support/config_reference.go
+++ b/internal/support/config_reference.go
@@ -197,7 +197,7 @@ func renderConfigMarkdown(fields []configField) string {
 			if envVar == "" {
 				envVar = "-"
 			}
-			builder.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s | %s |\n", field.YAMLKey, envVar, field.GoType, defaultVal, field.Doc))
+			fmt.Fprintf(&builder, "| `%s` | `%s` | `%s` | %s | %s |\n", field.YAMLKey, envVar, field.GoType, defaultVal, field.Doc)
 		}
 		builder.WriteString("\n")
 	}
@@ -223,8 +223,8 @@ func renderConfigMarkdown(fields []configField) string {
 					value = "\"\""
 				}
 			}
-			builder.WriteString(fmt.Sprintf("# %s\n", field.Doc))
-			builder.WriteString(fmt.Sprintf("# %s: %s\n", field.YAMLKey, value))
+			fmt.Fprintf(&builder, "# %s\n", field.Doc)
+			fmt.Fprintf(&builder, "# %s: %s\n", field.YAMLKey, value)
 		}
 	}
 	builder.WriteString("```\n")

--- a/internal/support/schema_docs.go
+++ b/internal/support/schema_docs.go
@@ -32,8 +32,8 @@ func WriteCommandSchemaDocs(outputDir string) ([]string, error) {
 func GenerateSchemaReferenceMarkdown(command string, root reflect.Type) string {
 	var builder strings.Builder
 	title := strings.ToUpper(command[:1]) + command[1:]
-	builder.WriteString(fmt.Sprintf("# Bomly %s JSON Schema Reference\n\n", title))
-	builder.WriteString(fmt.Sprintf("Complete reference for the `bomly %s` JSON output.\n\n", command))
+	fmt.Fprintf(&builder, "# Bomly %s JSON Schema Reference\n\n", title)
+	fmt.Fprintf(&builder, "Complete reference for the `bomly %s` JSON output.\n\n", command)
 
 	visited := map[reflect.Type]bool{}
 	collectStructTypes(root, visited)
@@ -53,7 +53,7 @@ func GenerateSchemaReferenceMarkdown(command string, root reflect.Type) string {
 
 		builder.WriteString("## Types\n\n")
 		for _, t := range types {
-			builder.WriteString(fmt.Sprintf("### `%s`\n\n", t.Name()))
+			fmt.Fprintf(&builder, "### `%s`\n\n", t.Name())
 			writeTypeTable(&builder, t)
 		}
 	}
@@ -79,7 +79,7 @@ func writeTypeTable(builder *strings.Builder, t reflect.Type) {
 		if jsonName == "" {
 			jsonName = field.Name
 		}
-		builder.WriteString(fmt.Sprintf("| `%s` | %s | |\n", jsonName, jsonTypeName(field.Type)))
+		fmt.Fprintf(builder, "| `%s` | %s | |\n", jsonName, jsonTypeName(field.Type))
 	}
 	builder.WriteString("\n")
 }
@@ -131,7 +131,7 @@ func jsonTypeName(t reflect.Type) string {
 func collectStructTypes(t reflect.Type, visited map[reflect.Type]bool) {
 	t = derefType(t)
 	if t.Kind() != reflect.Struct {
-		if t.Kind() == reflect.Slice || t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Slice || t.Kind() == reflect.Pointer {
 			collectStructTypes(t.Elem(), visited)
 		}
 		return

--- a/internal/support/schema_helpers.go
+++ b/internal/support/schema_helpers.go
@@ -25,7 +25,7 @@ func parseJSONTag(tag string) (string, jsonTagOptions) {
 }
 
 func derefType(t reflect.Type) reflect.Type {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t

--- a/internal/support/support_matrix.go
+++ b/internal/support/support_matrix.go
@@ -24,7 +24,7 @@ func RenderSupportMatrixMarkdown() string {
 	builder.WriteString("| Ecosystem | Package managers | Primary detector files | Fallback detector files | Detector |\n")
 	builder.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, entry := range groupedNativeEntries() {
-		builder.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s | %s |\n", entry.ecosystem, codeList(entry.managers), codeListOrDash(entry.primaryPatterns), codeListOrDash(entry.fallbackPatterns), nativeDetectorLabel(entry.ecosystem)))
+		fmt.Fprintf(&builder, "| `%s` | %s | %s | %s | %s |\n", entry.ecosystem, codeList(entry.managers), codeListOrDash(entry.primaryPatterns), codeListOrDash(entry.fallbackPatterns), nativeDetectorLabel(entry.ecosystem))
 	}
 	builder.WriteString("\n## Bundled Detectors\n\n")
 	builder.WriteString("The entries below show Syft-backed ecosystem coverage plus representative files Bomly uses during planning and discovery.\n\n")
@@ -32,7 +32,7 @@ func RenderSupportMatrixMarkdown() string {
 	builder.WriteString("| Ecosystem | Package managers | Representative file evidence |\n")
 	builder.WriteString("| --- | --- | --- |\n")
 	for _, entry := range groupedMultipleTechniqueEntries() {
-		builder.WriteString(fmt.Sprintf("| `%s` | %s | %s |\n", entry.ecosystem, codeList(entry.managers), codeList(entry.patterns)))
+		fmt.Fprintf(&builder, "| `%s` | %s | %s |\n", entry.ecosystem, codeList(entry.managers), codeList(entry.patterns))
 	}
 	builder.WriteString("\n## Notes\n\n")
 	builder.WriteString("- Bomly does not expose every Syft cataloger as a package manager.\n")
@@ -47,7 +47,7 @@ func RenderSupportMatrixMarkdown() string {
 		if len(item.Aliases) > 0 {
 			label = fmt.Sprintf("%s (%s)", item.Name, strings.Join(item.Aliases, ", "))
 		}
-		builder.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` |\n", label, item.Provider, item.VersionSource))
+		fmt.Fprintf(&builder, "| `%s` | `%s` | `%s` |\n", label, item.Provider, item.VersionSource)
 	}
 	return builder.String()
 }


### PR DESCRIPTION
## Summary

- Upgrade the module to Go 1.26 language rules with `toolchain go1.26.3`, the latest stable Go patch release from the official Go downloads feed.
- Upgrade golangci-lint from v1.64.8 to v2.12.0 and migrate `.golangci.yml` to the v2 schema.
- Use `golangci/golangci-lint-action@v9` in CI so linting uses the current action with built-in caching.
- Keep local `make lint` pinned to the same v2.12.0 linter binary through the v2 module path.
- Apply the new lint/formatting guidance surfaced by Go 1.26 and golangci-lint v2.

## Validation

- `golangci-lint config verify`
- `make fmt`
- `go mod tidy`
- `make lint`
- `make generate`
- `make test`
- `make build`
- pre-commit hook ran `gofmtcheck` and `make lint`
