### PR TITLE
feat(analyzers): Tier-3 pyreach reachability analyzer for Python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,11 @@ internal/registry/               Support/discovery registry; built-in wiring in 
 internal/matchers/*              External enrichment: osv, grype, deps.dev, ClearlyDefined, eol
 internal/matchers/cache          File-based cache shared by matchers
 internal/analyzers/*             Reachability analyzers (govulncheck — Go;
-                                 jsreach — JavaScript/TypeScript). Each is
-                                 backed by a single vendored library (no
-                                 builtin/external build-tag split). Run
-                                 after matchers; annotate
+                                 jsreach — JavaScript/TypeScript;
+                                 pyreach — Python). Each is backed by
+                                 a single in-process implementation
+                                 (no builtin/external build-tag split).
+                                 Run after matchers; annotate
                                  PackageVulnerability.Reachability and
                                  never abort the pipeline on failure
 internal/auditors/*              Policy evaluators (policy, noop)

--- a/docs/REACHABILITY.md
+++ b/docs/REACHABILITY.md
@@ -59,8 +59,9 @@ degrade to `Status: unknown` with a stable, machine-readable `Reason`
 | -------------------- | ------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Go                   | `govulncheck` | `symbol`  | Backed by the vendored `golang.org/x/vuln/scan` library; runs in-process so users never need a `govulncheck` binary on PATH.                                                                                                                                     |
 | JavaScript / TypeScript | `jsreach`     | `package` | Backed by the vendored `github.com/evanw/esbuild/pkg/api` library. Walks app source from `package.json` entry points (`main`, `module`, `browser`, `exports`, `bin`, plus implicit `index.*` / `app.js` / `server.js` / `main.js` fallbacks) and reports each npm package as reachable iff it appears in the import set. |
+| Python               | `pyreach`     | `package` | In-process line-oriented import scanner. Walks every `.py` file under the project root (`pyproject.toml` / `setup.py` / `requirements*.txt` / `Pipfile` / `poetry.lock` / `pdm.lock` / `uv.lock`), records each top-level module from `import` and `from … import` statements, and maps module names to PyPI distribution names through a static override map (e.g. `yaml` → `PyYAML`) plus PEP 503 normalization. |
 
-Other ecosystems (Python, Java, Rust) are tracked for follow-up phases.
+Other ecosystems (Java, Rust) are tracked for follow-up phases.
 When `--reachability` is set on a project that has no applicable
 analyzer for the languages present, the pipeline still runs cleanly:
 vulnerabilities just keep their default `nil` reachability.
@@ -108,6 +109,56 @@ Three important caveats:
    graph is incomplete (e.g. a package was installed locally but
    never recorded in the lockfile, or a package was installed via
    `npm link`), the closure can't reach it. The npm / pnpm / yarn
+   detectors are the source of truth for what edges exist.
+
+### A note on `pyreach` and Tier 3
+
+`pyreach` reports at the **package tier** today using the same
+"directly-imported set + transitive closure" approach as `jsreach`.
+The analyzer walks every `.py` file under the project root, scans for
+`import x` / `from x import …` statements, maps top-level module names
+to PyPI distribution names, and then expands the resulting set
+transitively through the Python detector's dep graph (via
+`Graph.Dependencies`).
+
+The module-to-distribution mapping is the part Python forces on every
+static analyzer: imports use module names (`import yaml`,
+`from PIL import Image`), but PyPI uses distribution names (`PyYAML`,
+`Pillow`). The analyzer applies a layered mapping:
+
+1. A small static override table for the well-known mismatches
+   (`yaml → pyyaml`, `cv2 → opencv-python`, `sklearn → scikit-learn`,
+   `bs4 → beautifulsoup4`, `PIL → pillow`, `jwt → pyjwt`, …).
+2. PEP 503 identity normalization (lowercase, `_` / `.` → `-`) for
+   everything else, which catches the bulk of PyPI (`requests`,
+   `flask`, `numpy`, `pandas`, …).
+3. Stdlib modules (`os`, `sys`, `json`, …) are dropped from the
+   import set so they never affect the closure.
+
+The same three caveats from `jsreach` apply, with two extra Python
+specifics:
+
+1. **"Unreachable" is not "safe".** `importlib.import_module(…)` on
+   user input, plugin discovery via entry points, Django's
+   `INSTALLED_APPS` strings, and conditional `__import__` calls are
+   all invisible to a static scanner. Tier-3 unreachable is useful
+   for prioritizing dev-only / unused dependencies, not as a fix
+   substitute.
+2. **Submodule imports collapse to the distribution.** `from
+   urllib3.util import retry` attributes the whole `urllib3`
+   distribution as reachable, even if a CVE only affects a
+   different submodule. Symbol-tier resolution for Python is a
+   future phase.
+3. **A missing static-override entry produces a false negative for
+   direct imports.** If a project does `import some_obscure_module`
+   and the override map doesn't know it maps to `some-other-dist`,
+   the analyzer reports the distribution as unreachable when it
+   actually was imported. The BFS through the dep graph usually
+   recovers the case via a transitive edge from a correctly-mapped
+   neighbour. Adding an override is a one-line PR.
+4. **The closure is only as accurate as the lockfile.** Same as
+   `jsreach`: if the dep graph is incomplete, the closure can't
+   reach what isn't there. The pip / poetry / pipenv / uv / pdm
    detectors are the source of truth for what edges exist.
 
 ## Composing with `--fail-on`
@@ -179,6 +230,15 @@ Reachability data appears in three places:
   analyzer treats the directory containing `package.json` as a single
   project. Workspace-aware traversal (each workspace as its own
   project root with its own entry points) is a follow-up.
+- **`pyreach` does not follow dynamic imports.**
+  `importlib.import_module(name)` on user input, plugin discovery via
+  entry points, Django `INSTALLED_APPS` strings, conditional
+  `__import__` — none of these are visible to a static scanner. The
+  analyzer is a lower bound on what's actually reachable.
+- **`pyreach`'s module-to-distribution map is hand-curated.** Missing
+  an entry produces a false-negative for direct top-level imports.
+  PRs to extend `internal/analyzers/pyreach/moduletodist.go` are
+  welcome.
 
 ## Selecting analyzers
 
@@ -202,6 +262,8 @@ library:
 
 - `govulncheck` runs in-process via `golang.org/x/vuln/scan`.
 - `jsreach` runs in-process via `github.com/evanw/esbuild/pkg/api`.
+- `pyreach` runs in-process via an in-tree line-oriented import
+  scanner (no external dependency).
 
 Both libraries are small enough that vendoring them outweighs the
 maintenance cost of supporting an external/lite variant. Lite builds

--- a/internal/analyzers/pyreach/analyzer.go
+++ b/internal/analyzers/pyreach/analyzer.go
@@ -1,0 +1,451 @@
+package pyreach
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Name is the analyzer's stable identifier (used in selectors and output).
+const Name = "pyreach"
+
+// Analyzer is a Tier-3 (package-level) reachability analyzer for
+// Python packages. It groups Python packages in the input graph by
+// project root, runs the configured Runner once per project, and
+// annotates each PackageVulnerability on Python packages with a
+// Reachability result.
+//
+// Tier-3 caveat: "unreachable" here means "the application source
+// does not import this distribution, neither directly nor indirectly
+// through app code". It does NOT mean "the vulnerability cannot be
+// triggered". Python is highly dynamic — importlib.import_module on
+// user input, plugin discovery via entry points, Django
+// INSTALLED_APPS strings — and none of those are visible to a static
+// scanner. docs/REACHABILITY.md is the authoritative source on this.
+type Analyzer struct {
+	// Runner is the underlying scanner. Defaults to
+	// NewRunner(Logger) when nil.
+	Runner Runner
+	Logger *zap.Logger
+	// CacheDir overrides the default per-project result cache
+	// location. Empty means "use the OS user cache directory under
+	// bomly/analyzers/pyreach".
+	CacheDir string
+	// CacheTTL overrides the default 24h cache lifetime. Zero means
+	// use the default.
+	CacheTTL time.Duration
+	// DisableCache turns off the on-disk result cache entirely.
+	// Useful in CI smoke runs where freshness matters more than
+	// speed.
+	DisableCache bool
+}
+
+// Descriptor returns the registration metadata for the pyreach analyzer.
+func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
+	return model.AnalyzerDescriptor{
+		Name:                Name,
+		Enabled:             true,
+		Origin:              model.BundledOrigin,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemPython},
+		SupportedManagers: []model.PackageManager{
+			model.PackageManagerPip,
+			model.PackageManagerPipenv,
+			model.PackageManagerPoetry,
+			model.PackageManagerUV,
+			model.PackageManagerPDM,
+			model.PackageManagerSetupPy,
+		},
+		SupportedLanguages: []model.Language{model.LanguagePython},
+		SupportedModes:     []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		SupportedTiers:     []model.ReachabilityTier{model.TierPackage},
+	}
+}
+
+// Ready reports whether the analyzer is callable. Always true; the
+// runner surfaces missing-source / parse errors at Run time as
+// Status=Unknown rather than blocking applicability.
+func (a Analyzer) Ready() bool { return true }
+
+// Applicable reports whether the request graph contains at least one
+// Python package with attached vulnerabilities.
+func (a Analyzer) Applicable(_ context.Context, req model.AnalyzeRequest) (bool, error) {
+	if req.Graph == nil {
+		return false, nil
+	}
+	for _, pkg := range req.Graph.Packages() {
+		if pkg == nil || len(pkg.Vulnerabilities) == 0 {
+			continue
+		}
+		if isPythonPackage(pkg) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Analyze runs the configured Runner per discovered Python project
+// root and writes Reachability onto every Python PackageVulnerability
+// in the graph. Errors degrade to Status=Unknown with a stable Reason
+// — the engine relies on this to keep the pipeline running.
+func (a Analyzer) Analyze(ctx context.Context, req model.AnalyzeRequest) (model.AnalyzeResult, error) {
+	logger := a.logger()
+	if req.Graph == nil {
+		return model.AnalyzeResult{}, nil
+	}
+	runner := a.Runner
+	if runner == nil {
+		runner = NewRunner(logger)
+	}
+
+	overallStart := time.Now()
+	projectRoots := discoverProjectRoots(req)
+	if len(projectRoots) == 0 {
+		logger.Info("pyreach: no Python project roots discovered; marking all Python vulnerabilities as unknown")
+		annotateAllUnknown(req.Graph, "no-project-root-discovered", time.Now())
+		return resultFromGraph(req.Graph), nil
+	}
+
+	logger.Info("pyreach: starting reachability analysis",
+		zap.String("runner", runner.Name()),
+		zap.String("runner_version", runner.Version()),
+		zap.Int("project_roots", len(projectRoots)),
+		zap.Bool("cache_enabled", !a.DisableCache),
+	)
+	logger.Debug("pyreach: discovered project roots", zap.Strings("paths", projectRoots))
+
+	cache := a.cache()
+	stats := model.ReachabilityStats{}
+	cacheHits, cacheMisses := 0, 0
+	for _, root := range projectRoots {
+		select {
+		case <-ctx.Done():
+			logger.Info("pyreach: context cancelled; skipping project",
+				zap.String("project_root", root))
+			annotateProjectUnknown(req.Graph, root, "cancelled", time.Now())
+			continue
+		default:
+		}
+
+		projectStart := time.Now()
+		runResult, fromCache, err := a.runWithCache(ctx, runner, cache, root, logger)
+		if err != nil {
+			logger.Warn("pyreach: runner failed",
+				zap.String("project_root", root),
+				zap.String("runner", runner.Name()),
+				zap.Duration("duration", time.Since(projectStart)),
+				zap.Error(err))
+			reason := failureReason(err)
+			added := annotateProjectUnknown(req.Graph, root, reason, time.Now())
+			stats.Unknown += added
+			continue
+		}
+		if fromCache {
+			cacheHits++
+		} else {
+			cacheMisses++
+		}
+		applied := applyRunnerResult(req.Graph, root, runResult, time.Now())
+		stats.Reachable += applied.reachable
+		stats.Unreachable += applied.unreachable
+		stats.Unknown += applied.unknown
+		logger.Info("pyreach: completed project",
+			zap.String("project_root", root),
+			zap.String("runner", runner.Name()),
+			zap.Bool("cache_hit", fromCache),
+			zap.Int("source_files", runResult.SourceFiles),
+			zap.Int("imported_distributions", len(runResult.ImportedDistributions)),
+			zap.Int("reachable", applied.reachable),
+			zap.Int("unreachable", applied.unreachable),
+			zap.Duration("duration", time.Since(projectStart)),
+		)
+	}
+
+	logger.Info("pyreach: completed reachability analysis",
+		zap.String("runner", runner.Name()),
+		zap.Int("projects", len(projectRoots)),
+		zap.Int("cache_hits", cacheHits),
+		zap.Int("cache_misses", cacheMisses),
+		zap.Int("reachable", stats.Reachable),
+		zap.Int("unreachable", stats.Unreachable),
+		zap.Int("unknown", stats.Unknown),
+		zap.Duration("duration", time.Since(overallStart)),
+	)
+
+	out := resultFromGraph(req.Graph)
+	out.AnalyzerStats = map[string]model.ReachabilityStats{Name: stats}
+	return out, nil
+}
+
+func (a Analyzer) logger() *zap.Logger { return ensureLogger(a.Logger) }
+
+// runWithCache returns (result, fromCache, error) for one project.
+// Cache failures are non-fatal — the runner still gets a chance to
+// produce fresh output. Cache writes after successful runs are also
+// non-fatal.
+func (a Analyzer) runWithCache(
+	ctx context.Context,
+	runner Runner,
+	cache *resultCache,
+	projectDir string,
+	logger *zap.Logger,
+) (RunnerResult, bool, error) {
+	if cache != nil {
+		if cached, ok := cache.get(projectDir, runner.Name(), runner.Version()); ok {
+			logger.Debug("pyreach: cache hit",
+				zap.String("project_root", projectDir),
+				zap.String("runner", runner.Name()),
+				zap.Int("imported_distributions", len(cached.ImportedDistributions)))
+			return cached, true, nil
+		}
+		logger.Debug("pyreach: cache miss",
+			zap.String("project_root", projectDir),
+			zap.String("runner", runner.Name()))
+	}
+	result, err := runner.Run(ctx, projectDir)
+	if err != nil {
+		return RunnerResult{}, false, err
+	}
+	if cache != nil {
+		if err := cache.set(projectDir, runner.Name(), runner.Version(), result); err != nil {
+			logger.Debug("pyreach: cache write failed (non-fatal)",
+				zap.String("project_root", projectDir),
+				zap.Error(err))
+		}
+	}
+	return result, false, nil
+}
+
+// cache returns the configured result cache, or nil when caching is
+// disabled. Cache construction errors are swallowed deliberately —
+// they degrade to "no cache" rather than failing the analyzer.
+func (a Analyzer) cache() *resultCache {
+	if a.DisableCache {
+		return nil
+	}
+	return newResultCache(a.CacheDir, a.CacheTTL)
+}
+
+func resultFromGraph(g *model.Graph) model.AnalyzeResult {
+	return model.AnalyzeResult{Graph: g, AnalyzerRuns: []string{Name}}
+}
+
+// applyOutcome reports per-vuln Reachability outcomes for telemetry.
+type applyOutcome struct {
+	reachable, unreachable, unknown int
+}
+
+// applyRunnerResult annotates every Python vulnerability whose
+// owning package is attributable to projectRoot. A package is
+// "reachable" iff it is in the transitive closure of the runner's
+// imported-distribution set walked through the dep graph; otherwise
+// it is marked Unreachable at TierPackage.
+//
+// The transitive closure is essential — the import scanner only
+// captures distributions whose top-level module appears in app
+// source. A CVE in a transitive dep (e.g. urllib3 pulled in by
+// requests) would be missed otherwise. The closure follows
+// Graph.Dependencies edges, so it sees exactly the dep tree the
+// Python detector resolved from the lockfile.
+func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, now time.Time) applyOutcome {
+	var outcome applyOutcome
+	timestamp := now.UTC().Format(time.RFC3339)
+	reachableIDs := computeReachablePackageIDs(g, runRes.ImportedDistributions)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isPythonPackage(pkg) {
+			continue
+		}
+		if !packageBelongsToProjectRoot(pkg, projectRoot) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			vuln := &pkg.Vulnerabilities[i]
+			if vuln.Reachability != nil && vuln.Reachability.Analyzer == Name {
+				continue
+			}
+			r := &model.Reachability{
+				Analyzer:   Name,
+				AnalyzedAt: timestamp,
+				Tier:       model.TierPackage,
+			}
+			if _, ok := reachableIDs[pkg.ID]; ok {
+				r.Status = model.ReachabilityReachable
+				outcome.reachable++
+			} else {
+				r.Status = model.ReachabilityUnreachable
+				r.Reason = "package-not-imported"
+				outcome.unreachable++
+			}
+			vuln.Reachability = r
+		}
+	}
+	return outcome
+}
+
+// computeReachablePackageIDs returns the set of graph package IDs
+// reachable from the imported-distribution set, expanded transitively
+// through the dep graph. Working in IDs (rather than names) keeps the
+// attribution honest when multiple versions of the same distribution
+// coexist in the resolved lockfile.
+func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map[string]struct{} {
+	reachable := make(map[string]struct{})
+	if g == nil || len(imports) == 0 {
+		return reachable
+	}
+	queue := make([]string, 0)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isPythonPackage(pkg) {
+			continue
+		}
+		if !isPackageImported(pkg, imports) {
+			continue
+		}
+		if _, ok := reachable[pkg.ID]; ok {
+			continue
+		}
+		reachable[pkg.ID] = struct{}{}
+		queue = append(queue, pkg.ID)
+	}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		deps, err := g.Dependencies(id)
+		if err != nil {
+			continue
+		}
+		for _, dep := range deps {
+			if dep == nil {
+				continue
+			}
+			if _, ok := reachable[dep.ID]; ok {
+				continue
+			}
+			reachable[dep.ID] = struct{}{}
+			queue = append(queue, dep.ID)
+		}
+	}
+	return reachable
+}
+
+// isPackageImported reports whether pkg's distribution name (in any
+// of its known forms) appears in the runner's import set. Names are
+// compared in PEP 503 normalized form so that hyphens, underscores,
+// and case differences don't cause mismatches.
+func isPackageImported(pkg *model.Package, imports map[string]struct{}) bool {
+	if pkg == nil || len(imports) == 0 {
+		return false
+	}
+	candidates := []string{pkg.QualifiedName(), pkg.Name}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := imports[canonicalDistName(candidate)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func annotateProjectUnknown(g *model.Graph, projectRoot, reason string, now time.Time) int {
+	timestamp := now.UTC().Format(time.RFC3339)
+	count := 0
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isPythonPackage(pkg) {
+			continue
+		}
+		if !packageBelongsToProjectRoot(pkg, projectRoot) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			if pkg.Vulnerabilities[i].Reachability != nil {
+				continue
+			}
+			pkg.Vulnerabilities[i].Reachability = &model.Reachability{
+				Analyzer:   Name,
+				Status:     model.ReachabilityUnknown,
+				Tier:       model.TierNone,
+				Reason:     reason,
+				AnalyzedAt: timestamp,
+			}
+			count++
+		}
+	}
+	return count
+}
+
+func annotateAllUnknown(g *model.Graph, reason string, now time.Time) {
+	timestamp := now.UTC().Format(time.RFC3339)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isPythonPackage(pkg) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			if pkg.Vulnerabilities[i].Reachability != nil {
+				continue
+			}
+			pkg.Vulnerabilities[i].Reachability = &model.Reachability{
+				Analyzer:   Name,
+				Status:     model.ReachabilityUnknown,
+				Tier:       model.TierNone,
+				Reason:     reason,
+				AnalyzedAt: timestamp,
+			}
+		}
+	}
+}
+
+// packageBelongsToProjectRoot is a best-effort attribution. pyreach
+// runs per-project, so any Python package physically located under
+// projectRoot (or with no recorded location) is treated as belonging
+// to it.
+func packageBelongsToProjectRoot(pkg *model.Package, projectRoot string) bool {
+	if pkg == nil {
+		return false
+	}
+	if len(pkg.Locations) == 0 {
+		return true
+	}
+	for _, loc := range pkg.Locations {
+		path := loc.RealPath
+		if path == "" {
+			continue
+		}
+		if pathContainsRoot(path, projectRoot) {
+			return true
+		}
+	}
+	return true
+}
+
+func pathContainsRoot(path, root string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanRoot := filepath.Clean(root)
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}
+
+// failureReason maps runner errors to stable machine-readable codes.
+func failureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not implemented"), strings.Contains(msg, "not on path"), strings.Contains(msg, "not found"):
+		return "missing-toolchain"
+	case strings.Contains(msg, "not accessible"), strings.Contains(msg, "no recognised lockfile"):
+		return "no-project-root"
+	case strings.Contains(msg, "context"), strings.Contains(msg, "cancel"):
+		return "cancelled"
+	default:
+		return "runner-error"
+	}
+}

--- a/internal/analyzers/pyreach/analyzer_test.go
+++ b/internal/analyzers/pyreach/analyzer_test.go
@@ -1,0 +1,390 @@
+package pyreach
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// fakeRunner returns a canned RunnerResult or error for tests.
+type fakeRunner struct {
+	result RunnerResult
+	err    error
+	called int
+	last   string
+}
+
+func (f *fakeRunner) Name() string { return "fake" }
+
+func (f *fakeRunner) Version() string { return "fake-1.0" }
+
+func (f *fakeRunner) Run(_ context.Context, projectDir string) (RunnerResult, error) {
+	f.called++
+	f.last = projectDir
+	return f.result, f.err
+}
+
+// newPythonProjectDir creates a temp directory that looks like a
+// Python project (pyproject.toml + a tiny app.py). The fixture is
+// intentionally minimal — most pyreach tests inject a fake runner
+// so the disk-walking scanner is exercised separately.
+func newPythonProjectDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	pyproject := []byte("[project]\nname = \"fixture\"\nversion = \"0.0.0\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), pyproject, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte("import os\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// newPyGraph builds a single-package graph rooted at projectDir with
+// the supplied vulnerabilities attached.
+func newPyGraph(t *testing.T, projectDir, name string, vulns ...model.PackageVulnerability) *model.Graph {
+	t.Helper()
+	g := model.New()
+	pkg := model.NewPackage(model.Package{
+		Name:            name,
+		Version:         "1.0.0",
+		Ecosystem:       string(model.EcosystemPython),
+		BuildSystem:     "pip",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Vulnerabilities: vulns,
+	})
+	if err := g.AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+func TestAnalyzerMarksReachableWhenPackageIsImported(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newPyGraph(t, projectDir, "requests", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedDistributions: map[string]struct{}{"requests": {}, "flask": {}},
+				SourceFiles:           1,
+			},
+		},
+	}
+
+	res, err := a.Analyze(context.Background(), model.AnalyzeRequest{
+		Graph:       g,
+		ProjectPath: projectDir,
+	})
+	if err != nil {
+		t.Fatalf("Analyze err: %v", err)
+	}
+	r := res.Graph.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil {
+		t.Fatal("expected Reachability to be set")
+	}
+	if r.Status != model.ReachabilityReachable {
+		t.Errorf("status = %q, want reachable", r.Status)
+	}
+	if r.Tier != model.TierPackage {
+		t.Errorf("tier = %q, want package", r.Tier)
+	}
+	if res.AnalyzerStats[Name].Reachable != 1 {
+		t.Errorf("stats.Reachable = %d, want 1", res.AnalyzerStats[Name].Reachable)
+	}
+}
+
+func TestAnalyzerMarksUnreachableWhenPackageNotImported(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newPyGraph(t, projectDir, "left-pad", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedDistributions: map[string]struct{}{"flask": {}},
+				SourceFiles:           1,
+			},
+		},
+	}
+
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{
+		Graph:       g,
+		ProjectPath: projectDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r.Status != model.ReachabilityUnreachable || r.Tier != model.TierPackage || r.Reason != "package-not-imported" {
+		t.Errorf("unexpected reachability: %+v", r)
+	}
+}
+
+func TestAnalyzerDegradesToUnknownOnRunnerError(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newPyGraph(t, projectDir, "requests", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner:       &fakeRunner{err: errors.New("project dir not accessible: not found")},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{
+		Graph:       g,
+		ProjectPath: projectDir,
+	})
+	if err != nil {
+		t.Fatalf("Analyze should not error on runner failure: %v", err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r.Status != model.ReachabilityUnknown {
+		t.Errorf("status = %q, want unknown", r.Status)
+	}
+	if r.Reason != "missing-toolchain" {
+		t.Errorf("reason = %q, want missing-toolchain", r.Reason)
+	}
+}
+
+// TestAnalyzerNormalisesDistributionNames covers the case where the
+// import set is normalized but the graph package name is not — both
+// sides go through canonicalDistName before comparison so PEP 503
+// equivalents (PyYAML / pyyaml, my_pkg / my-pkg) match.
+func TestAnalyzerNormalisesDistributionNames(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newPyGraph(t, projectDir, "PyYAML", vuln)
+
+	// Runner emits the canonicalised "pyyaml" form (which is what
+	// moduleToDistribution would produce for `import yaml`).
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedDistributions: map[string]struct{}{"pyyaml": {}},
+				SourceFiles:           1,
+			},
+		},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityReachable {
+		t.Errorf("PyYAML / pyyaml not matched: %+v", r)
+	}
+}
+
+func TestAnalyzerApplicableRequiresPythonVulns(t *testing.T) {
+	a := Analyzer{}
+
+	g := model.New()
+	goPkg := model.NewPackage(model.Package{Name: "lib", Ecosystem: "go", Vulnerabilities: []model.PackageVulnerability{{ID: "x"}}})
+	_ = g.AddPackage(goPkg)
+	ok, err := a.Applicable(context.Background(), model.AnalyzeRequest{Graph: g})
+	if err != nil || ok {
+		t.Errorf("Applicable on go-only graph = (%v, %v); want (false, nil)", ok, err)
+	}
+
+	g = model.New()
+	pyPkg := model.NewPackage(model.Package{Name: "requests", Ecosystem: string(model.EcosystemPython), Vulnerabilities: []model.PackageVulnerability{{ID: "x"}}})
+	_ = g.AddPackage(pyPkg)
+	ok, err = a.Applicable(context.Background(), model.AnalyzeRequest{Graph: g})
+	if err != nil || !ok {
+		t.Errorf("Applicable on python-with-vulns graph = (%v, %v); want (true, nil)", ok, err)
+	}
+
+	g = model.New()
+	pyNoVulns := model.NewPackage(model.Package{Name: "requests", Ecosystem: string(model.EcosystemPython)})
+	_ = g.AddPackage(pyNoVulns)
+	ok, err = a.Applicable(context.Background(), model.AnalyzeRequest{Graph: g})
+	if err != nil || ok {
+		t.Errorf("Applicable on python-without-vulns graph = (%v, %v); want (false, nil)", ok, err)
+	}
+}
+
+// TestAnalyzerMarksTransitiveDepReachable is the headline correctness
+// test for the closure expansion. The import scanner only returns
+// the top-level distributions imported in app source. Transitively
+// reachable distributions (urllib3 pulled in by requests) must still
+// be reported as reachable.
+func TestAnalyzerMarksTransitiveDepReachable(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	requestsVuln := model.PackageVulnerability{ID: "GHSA-direct", Source: "osv", Severity: "high"}
+	urllib3Vuln := model.PackageVulnerability{ID: "GHSA-transitive", Source: "osv", Severity: "high"}
+
+	g := model.New()
+	requests := model.NewPackage(model.Package{
+		Name:            "requests",
+		Version:         "2.32.3",
+		Ecosystem:       string(model.EcosystemPython),
+		BuildSystem:     "pip",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Vulnerabilities: []model.PackageVulnerability{requestsVuln},
+	})
+	urllib3 := model.NewPackage(model.Package{
+		Name:            "urllib3",
+		Version:         "2.2.1",
+		Ecosystem:       string(model.EcosystemPython),
+		BuildSystem:     "pip",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Vulnerabilities: []model.PackageVulnerability{urllib3Vuln},
+	})
+	if err := g.AddPackage(requests); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddPackage(urllib3); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(requests.ID, urllib3.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				// App source only imports requests directly.
+				ImportedDistributions: map[string]struct{}{"requests": {}},
+				SourceFiles:           1,
+			},
+		},
+	}
+
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pkg := range g.Packages() {
+		r := pkg.Vulnerabilities[0].Reachability
+		if r == nil {
+			t.Fatalf("%s: missing Reachability", pkg.Name)
+		}
+		if r.Status != model.ReachabilityReachable {
+			t.Errorf("%s: status = %q, want reachable", pkg.Name, r.Status)
+		}
+	}
+}
+
+// TestAnalyzerDoesNotExpandThroughUnimportedRoots ensures the
+// closure only walks from the directly-imported seed set. A
+// vulnerable transitive dep that is NOT reachable from any imported
+// distribution should stay unreachable.
+func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	pytestVuln := model.PackageVulnerability{ID: "GHSA-devtool", Source: "osv", Severity: "high"}
+	transVuln := model.PackageVulnerability{ID: "GHSA-trans", Source: "osv", Severity: "high"}
+
+	g := model.New()
+	pytest := model.NewPackage(model.Package{
+		Name:            "pytest",
+		Version:         "8.0.0",
+		Ecosystem:       string(model.EcosystemPython),
+		BuildSystem:     "pip",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Vulnerabilities: []model.PackageVulnerability{pytestVuln},
+	})
+	pluggy := model.NewPackage(model.Package{
+		Name:            "pluggy",
+		Version:         "1.0.0",
+		Ecosystem:       string(model.EcosystemPython),
+		BuildSystem:     "pip",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Vulnerabilities: []model.PackageVulnerability{transVuln},
+	})
+	if err := g.AddPackage(pytest); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddPackage(pluggy); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(pytest.ID, pluggy.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				// Unrelated import; pytest is dev-only and not seen.
+				ImportedDistributions: map[string]struct{}{"flask": {}},
+				SourceFiles:           1,
+			},
+		},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pkg := range g.Packages() {
+		r := pkg.Vulnerabilities[0].Reachability
+		if r == nil {
+			t.Fatalf("%s: missing Reachability", pkg.Name)
+		}
+		if r.Status != model.ReachabilityUnreachable {
+			t.Errorf("%s: status = %q, want unreachable", pkg.Name, r.Status)
+		}
+	}
+}
+
+// TestComputeReachablePackageIDsHandlesCycles guards against the
+// classic BFS pitfall: a → b → a should not loop.
+func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
+	g := model.New()
+	a := model.NewPackage(model.Package{Name: "a", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
+	b := model.NewPackage(model.Package{Name: "b", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
+	if err := g.AddPackage(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddPackage(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(a.ID, b.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(b.ID, a.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	got := computeReachablePackageIDs(g, map[string]struct{}{"a": {}})
+	if _, ok := got[a.ID]; !ok {
+		t.Errorf("expected a in reachable set: %v", got)
+	}
+	if _, ok := got[b.ID]; !ok {
+		t.Errorf("expected b (transitive of a) in reachable set: %v", got)
+	}
+}
+
+func TestAnalyzerMarksUnknownWhenNoProjectRootDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	g := model.New()
+	pkg := model.NewPackage(model.Package{
+		Name:            "requests",
+		Ecosystem:       string(model.EcosystemPython),
+		Vulnerabilities: []model.PackageVulnerability{{ID: "x"}},
+	})
+	_ = g.AddPackage(pkg)
+
+	a := Analyzer{DisableCache: true, Runner: &fakeRunner{}}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityUnknown {
+		t.Errorf("expected Unknown status, got %+v", r)
+	}
+	if r.Reason != "no-project-root-discovered" {
+		t.Errorf("reason = %q, want no-project-root-discovered", r.Reason)
+	}
+}

--- a/internal/analyzers/pyreach/cache.go
+++ b/internal/analyzers/pyreach/cache.go
@@ -1,0 +1,170 @@
+package pyreach
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	cachepkg "github.com/bomly-dev/bomly-cli/internal/matchers/cache"
+)
+
+// cacheSchemaVersion bumps whenever the on-disk cache layout changes
+// in a way that would silently produce wrong results. Bumping
+// invalidates every previously cached entry.
+const cacheSchemaVersion = "v1"
+
+// defaultCacheTTL matches the OSV / EOL / govulncheck / jsreach
+// matchers. pyreach output changes whenever the project's lockfile
+// or source tree changes; the lockfile hash in the key catches the
+// lockfile case but not editor-time source edits, so we keep TTL
+// short enough that stale entries don't survive long.
+const defaultCacheTTL = 24 * time.Hour
+
+// resultCache wraps cachepkg.FileCache with the pyreach-specific key
+// construction and value type. A nil resultCache is a valid no-op
+// that always reports cache miss.
+type resultCache struct {
+	store *cachepkg.FileCache
+}
+
+// cachedRunnerResult is the JSON-serializable form of RunnerResult.
+type cachedRunnerResult struct {
+	ImportedDistributions []string `json:"imported_distributions,omitempty"`
+	SourceFiles           int      `json:"source_files,omitempty"`
+	SkippedDirs           []string `json:"skipped_dirs,omitempty"`
+}
+
+// newResultCache constructs a result cache rooted at dir. If dir is
+// empty, the OS user cache directory is used. Errors creating the
+// cache directory are non-fatal — they return a nil resultCache that
+// the caller can use without checks.
+func newResultCache(dir string, ttl time.Duration) *resultCache {
+	if ttl <= 0 {
+		ttl = defaultCacheTTL
+	}
+	root := dir
+	if root == "" {
+		root = defaultCacheRoot()
+	}
+	if root == "" {
+		return nil
+	}
+	store, err := cachepkg.NewFileCache(root, ttl)
+	if err != nil {
+		return nil
+	}
+	return &resultCache{store: store}
+}
+
+// defaultCacheRoot returns the platform-appropriate cache directory
+// for pyreach analyzer results, or "" if the user cache directory
+// cannot be determined.
+func defaultCacheRoot() string {
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		return ""
+	}
+	return filepath.Join(base, "bomly", "analyzers", "pyreach")
+}
+
+// keyFor builds a stable cache key for one project pass. Folds every
+// input that materially changes the runner output: the project
+// directory, a content hash of the lockfile (or pyproject / setup.py
+// when no lockfile is present), the runner name and version, and
+// the analyzer's cache schema version.
+func keyFor(projectDir, runnerName, runnerVersion string) (cachepkg.Key, error) {
+	checksum, err := projectChecksum(projectDir)
+	if err != nil {
+		return cachepkg.Key{}, err
+	}
+	parts := fmt.Sprintf("pyreach|%s|%s|%s|%s|%s",
+		cacheSchemaVersion, runnerName, runnerVersion, projectDir, checksum)
+	return cachepkg.NewKey(parts, "pyreach", "python", cacheSchemaVersion), nil
+}
+
+// lockfileCandidates lists the files we hash to fingerprint the
+// project, in priority order. The first one that exists wins. The
+// list mirrors projectFileMarkers minus loose source files.
+var lockfileCandidates = []string{
+	"poetry.lock",
+	"pdm.lock",
+	"uv.lock",
+	"Pipfile.lock",
+	"requirements.txt",
+	"requirements-dev.txt",
+	"pyproject.toml",
+	"Pipfile",
+	"setup.py",
+	"setup.cfg",
+}
+
+// projectChecksum returns a short hex digest of the project's
+// lockfile equivalent. A change there means the dependency closure
+// changed, so the import graph could change too. Source-only edits
+// don't move the cache key — that's why TTL is 24h, not infinity.
+func projectChecksum(projectDir string) (string, error) {
+	for _, name := range lockfileCandidates {
+		path := filepath.Join(projectDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("read %s: %w", name, err)
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:8]), nil
+	}
+	return "", fmt.Errorf("project %q has no recognised lockfile or manifest", projectDir)
+}
+
+// get returns the cached RunnerResult for projectDir + runner, or
+// (zero value, false) on cache miss / cache failure.
+func (c *resultCache) get(projectDir, runnerName, runnerVersion string) (RunnerResult, bool) {
+	if c == nil {
+		return RunnerResult{}, false
+	}
+	key, err := keyFor(projectDir, runnerName, runnerVersion)
+	if err != nil {
+		return RunnerResult{}, false
+	}
+	cached, ok := cachepkg.Get[cachedRunnerResult](c.store, key)
+	if !ok {
+		return RunnerResult{}, false
+	}
+	imports := make(map[string]struct{}, len(cached.ImportedDistributions))
+	for _, m := range cached.ImportedDistributions {
+		imports[m] = struct{}{}
+	}
+	return RunnerResult{
+		ImportedDistributions: imports,
+		SourceFiles:           cached.SourceFiles,
+		SkippedDirs:           append([]string(nil), cached.SkippedDirs...),
+	}, true
+}
+
+// set writes the runner result to the cache. A non-nil error is
+// non-fatal; callers should log it at debug level and continue.
+func (c *resultCache) set(projectDir, runnerName, runnerVersion string, result RunnerResult) error {
+	if c == nil {
+		return nil
+	}
+	key, err := keyFor(projectDir, runnerName, runnerVersion)
+	if err != nil {
+		return err
+	}
+	imports := make([]string, 0, len(result.ImportedDistributions))
+	for m := range result.ImportedDistributions {
+		imports = append(imports, m)
+	}
+	cached := cachedRunnerResult{
+		ImportedDistributions: imports,
+		SourceFiles:           result.SourceFiles,
+		SkippedDirs:           append([]string(nil), result.SkippedDirs...),
+	}
+	return cachepkg.Set(c.store, key, cached)
+}

--- a/internal/analyzers/pyreach/cache_test.go
+++ b/internal/analyzers/pyreach/cache_test.go
@@ -1,0 +1,142 @@
+package pyreach
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestResultCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cache := newResultCache(dir, 0)
+	if cache == nil {
+		t.Fatal("newResultCache returned nil for a writable dir")
+	}
+
+	projectDir := newPythonProjectDir(t)
+	want := RunnerResult{
+		ImportedDistributions: map[string]struct{}{"requests": {}, "flask": {}},
+		SourceFiles:           4,
+		SkippedDirs:           []string{".venv"},
+	}
+	if err := cache.set(projectDir, "fake", "1.0", want); err != nil {
+		t.Fatalf("cache.set: %v", err)
+	}
+	got, ok := cache.get(projectDir, "fake", "1.0")
+	if !ok {
+		t.Fatal("cache.get reported miss right after set")
+	}
+	if len(got.ImportedDistributions) != 2 {
+		t.Errorf("imports = %v, want 2 entries", got.ImportedDistributions)
+	}
+	if got.SourceFiles != 4 {
+		t.Errorf("source files = %d, want 4", got.SourceFiles)
+	}
+	if _, ok := got.ImportedDistributions["requests"]; !ok {
+		t.Errorf("missing requests in cached imports: %+v", got.ImportedDistributions)
+	}
+}
+
+func TestResultCacheIsolatesByRunnerVersion(t *testing.T) {
+	dir := t.TempDir()
+	cache := newResultCache(dir, 0)
+	projectDir := newPythonProjectDir(t)
+
+	if err := cache.set(projectDir, "library", "1.0", RunnerResult{ImportedDistributions: map[string]struct{}{"a": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.get(projectDir, "library", "2.0"); ok {
+		t.Errorf("cache lookup should miss when runner version differs")
+	}
+}
+
+func TestResultCacheInvalidatesOnLockfileChange(t *testing.T) {
+	dir := t.TempDir()
+	cache := newResultCache(dir, 0)
+	projectDir := newPythonProjectDir(t)
+
+	lockfile := filepath.Join(projectDir, "requirements.txt")
+	if err := os.WriteFile(lockfile, []byte("requests==2.32.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.set(projectDir, "fake", "1.0", RunnerResult{ImportedDistributions: map[string]struct{}{"a": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.get(projectDir, "fake", "1.0"); !ok {
+		t.Fatal("cache.get reported miss right after set with lockfile present")
+	}
+
+	// Mutate the lockfile — should invalidate.
+	if err := os.WriteFile(lockfile, []byte("requests==2.31.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.get(projectDir, "fake", "1.0"); ok {
+		t.Errorf("cache should miss after lockfile content change")
+	}
+}
+
+func TestAnalyzerWithCacheServesSecondCallFromCache(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	if err := os.WriteFile(filepath.Join(projectDir, "requirements.txt"), []byte("requests==2.32.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newPyGraph(t, projectDir, "requests", vuln)
+
+	runner := &fakeRunner{
+		result: RunnerResult{
+			ImportedDistributions: map[string]struct{}{"requests": {}},
+			SourceFiles:           1,
+		},
+	}
+	a := Analyzer{Runner: runner, CacheDir: t.TempDir()}
+
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.called != 1 {
+		t.Fatalf("first Analyze should call runner once, got %d", runner.called)
+	}
+
+	g2 := newPyGraph(t, projectDir, "requests", vuln)
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g2, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.called != 1 {
+		t.Errorf("second Analyze should hit cache; runner.called = %d, want 1", runner.called)
+	}
+	r := g2.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityReachable {
+		t.Errorf("cached path did not produce a reachable annotation: %+v", r)
+	}
+}
+
+func TestAnalyzerDisableCacheAlwaysRunsRunner(t *testing.T) {
+	projectDir := newPythonProjectDir(t)
+	if err := os.WriteFile(filepath.Join(projectDir, "requirements.txt"), []byte("requests==2.32.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+
+	runner := &fakeRunner{
+		result: RunnerResult{
+			ImportedDistributions: map[string]struct{}{"requests": {}},
+			SourceFiles:           1,
+		},
+	}
+	a := Analyzer{Runner: runner, CacheDir: t.TempDir(), DisableCache: true}
+
+	g1 := newPyGraph(t, projectDir, "requests", vuln)
+	g2 := newPyGraph(t, projectDir, "requests", vuln)
+	for _, g := range []*model.Graph{g1, g2} {
+		if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if runner.called != 2 {
+		t.Errorf("DisableCache should re-run runner per call; got %d calls", runner.called)
+	}
+}

--- a/internal/analyzers/pyreach/discover.go
+++ b/internal/analyzers/pyreach/discover.go
@@ -1,0 +1,149 @@
+package pyreach
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// discoverProjectRoots returns the Python project roots derivable
+// from the request, in priority order:
+//
+//  1. Each Python package's PackageLocation.RealPath: walk upward to
+//     the nearest directory containing a recognised project file
+//     (pyproject.toml, setup.py, requirements.txt, …). Skip
+//     directories inside venv/, site-packages/, etc. — those describe
+//     installed dependencies, not project roots.
+//  2. The request's ProjectPath / ExecutionTarget.Location, when it
+//     itself contains a project file.
+//
+// Paths are normalized with filepath.Clean. Duplicates are removed
+// and results are sorted for deterministic ordering.
+func discoverProjectRoots(req model.AnalyzeRequest) []string {
+	seen := make(map[string]struct{})
+	roots := make([]string, 0)
+
+	add := func(dir string) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return
+		}
+		clean := filepath.Clean(dir)
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		roots = append(roots, clean)
+	}
+
+	if req.Graph != nil {
+		for _, pkg := range req.Graph.Packages() {
+			if pkg == nil || !isPythonPackage(pkg) {
+				continue
+			}
+			for _, loc := range pkg.Locations {
+				if loc.RealPath == "" {
+					continue
+				}
+				if root := findProjectRoot(loc.RealPath); root != "" {
+					add(root)
+				}
+			}
+		}
+	}
+
+	for _, candidate := range []string{req.ProjectPath, req.ExecutionTarget.Location} {
+		if candidate == "" {
+			continue
+		}
+		if root := findProjectRoot(candidate); root != "" {
+			add(root)
+		}
+	}
+
+	sort.Strings(roots)
+	return roots
+}
+
+// findProjectRoot walks upward from start until it finds a directory
+// that looks like a Python project root (contains any recognised
+// project file). Returns "" when none is found before reaching the
+// filesystem root or hitting a path that is itself inside a venv /
+// site-packages tree.
+func findProjectRoot(start string) string {
+	dir := start
+	info, err := os.Stat(dir)
+	if err == nil && !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+	for {
+		if dir == "" {
+			return ""
+		}
+		if isInsideVendoredTree(dir) {
+			// Walking through a venv / site-packages would attribute
+			// dep source to the project. Bail out when we recognise
+			// we're below such a directory.
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				return ""
+			}
+			dir = parent
+			continue
+		}
+		if hasProjectMarker(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// isInsideVendoredTree reports whether dir is itself inside a venv,
+// site-packages, or similar dependency tree. We must skip these
+// because their pyproject.toml / setup.py describe installed
+// dependencies, not the application.
+func isInsideVendoredTree(dir string) bool {
+	normalized := filepath.ToSlash(dir)
+	markers := []string{
+		"/site-packages/",
+		"/venv/",
+		"/.venv/",
+		"/node_modules/",
+		"/__pycache__/",
+		"/.tox/",
+		"/.nox/",
+	}
+	for _, m := range markers {
+		if strings.Contains(normalized, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPythonPackage reports whether pkg's ecosystem or build system
+// identifies it as a Python (PyPI) package. Mirrors the equivalent
+// helpers in govulncheck and jsreach.
+func isPythonPackage(pkg *model.Package) bool {
+	if pkg == nil {
+		return false
+	}
+	if strings.EqualFold(pkg.Ecosystem, string(model.EcosystemPython)) {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(pkg.BuildSystem)) {
+	case "pip", "pipenv", "poetry", "uv", "pdm", "setuppy", "setup.py":
+		return true
+	}
+	if strings.EqualFold(pkg.Language, string(model.LanguagePython)) {
+		return true
+	}
+	return false
+}

--- a/internal/analyzers/pyreach/importscanner.go
+++ b/internal/analyzers/pyreach/importscanner.go
@@ -1,0 +1,215 @@
+package pyreach
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// scanImports reads Python source and returns the set of top-level
+// module names that appear in `import x` and `from x import …`
+// statements. Relative imports (`from .foo import bar`,
+// `from ..pkg import …`) are skipped — they refer to local app
+// packages, never to PyPI distributions. Imports inside string
+// literals, comments, and triple-quoted blocks are also skipped.
+//
+// The scanner is line-oriented and handles:
+//
+//   - "import x"                       -> {"x"}
+//   - "import x.y"                     -> {"x"}
+//   - "import x, y, z"                 -> {"x", "y", "z"}
+//   - "import x as a, y as b"          -> {"x", "y"}
+//   - "from x import y"                -> {"x"}
+//   - "from x.y import z"              -> {"x"}
+//   - "from . import foo"              -> {} (relative)
+//   - "from .foo import bar"           -> {} (relative)
+//   - "    import x"                   -> {"x"} (indented; conditional / function-local)
+//   - "import x  # noqa"               -> {"x"} (trailing comment)
+//   - "import x; import y"             -> {"x"} (semicolons not split — rare in real code)
+//
+// What it deliberately skips:
+//
+//   - Multi-line imports inside parens (`from x import (\n  a,\n  b\n)`).
+//     Only the first line is scanned; the analyzer doesn't need the
+//     imported symbols anyway, just the source module.
+//   - String-literal imports passed to importlib.import_module(...).
+//     Those are the entire reason Tier-3 "unreachable" is not "safe".
+//   - Imports inside triple-quoted strings or docstrings — the scanner
+//     keeps a trivial state machine to skip those. The scanner does
+//     NOT attempt to handle every edge case of Python's lexical
+//     grammar; false positives (an import-looking line inside a
+//     comment block) are acceptable since the BFS through the dep
+//     graph then maps them to a no-op.
+func scanImports(r io.Reader) (map[string]struct{}, error) {
+	imports := make(map[string]struct{})
+	scanner := bufio.NewScanner(r)
+	// Allow up to 1 MB per line — Python source rarely has long
+	// lines but pathological generated code can.
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	inTripleQuote := false
+	tripleQuoteStr := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		stripped := stripComment(line)
+		// Triple-quoted block tracking. Cheap and approximate — we
+		// only check whether a """ or ''' appears on the line,
+		// without tracking column position. Imports buried inside
+		// docstrings are vanishingly rare.
+		if inTripleQuote {
+			if strings.Contains(line, tripleQuoteStr) {
+				inTripleQuote = false
+			}
+			continue
+		}
+		// Detect opening triple-quote on this line.
+		if i := indexAny(line, `"""`, `'''`); i >= 0 {
+			marker := line[i : i+3]
+			rest := line[i+3:]
+			// If the closing triple-quote appears on the same line,
+			// it's a single-line docstring — not a block. Ignore it
+			// unless it's the only content; in either case, do not
+			// flip into block mode.
+			if !strings.Contains(rest, marker) {
+				inTripleQuote = true
+				tripleQuoteStr = marker
+				// fall through and still scan the prefix before
+				// the triple quote, in case the line is something
+				// like `import x  # docstring follows """`.
+			}
+		}
+		trimmed := strings.TrimSpace(stripped)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "import "):
+			for _, mod := range parseImportTargets(trimmed[len("import "):]) {
+				if mod != "" {
+					imports[mod] = struct{}{}
+				}
+			}
+		case strings.HasPrefix(trimmed, "from "):
+			mod := parseFromTarget(trimmed[len("from "):])
+			if mod != "" {
+				imports[mod] = struct{}{}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return imports, nil
+}
+
+// stripComment returns line with any trailing "# …" comment removed.
+// It is intentionally naive — it does not track string literals — so
+// "x = '#'  # comment" becomes "x = '". This is fine for the import
+// scanner because real `import` and `from` lines never contain string
+// literals before the comment marker.
+func stripComment(line string) string {
+	if i := strings.Index(line, "#"); i >= 0 {
+		return line[:i]
+	}
+	return line
+}
+
+// parseImportTargets splits the operand of an `import` statement into
+// the top-level module names being imported. Handles aliases ("as x")
+// and comma-separated lists.
+func parseImportTargets(operand string) []string {
+	parts := strings.Split(operand, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Drop "as <alias>" suffix.
+		if i := strings.Index(p, " as "); i >= 0 {
+			p = p[:i]
+		}
+		p = strings.TrimSpace(p)
+		// Take the top-level segment.
+		if i := strings.Index(p, "."); i >= 0 {
+			p = p[:i]
+		}
+		// Skip relative-import dots and empty.
+		if p == "" || strings.HasPrefix(p, ".") {
+			continue
+		}
+		// Reject anything that looks non-identifier (semicolons, colons).
+		if !isLikelyIdentifier(p) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// parseFromTarget extracts the source-module of a `from x import …`
+// statement, returning the top-level segment. Returns "" for relative
+// imports (`from .` / `from ..`) and for malformed input.
+func parseFromTarget(operand string) string {
+	operand = strings.TrimSpace(operand)
+	if operand == "" {
+		return ""
+	}
+	// Find the " import " separator. We look for the keyword
+	// surrounded by whitespace on both sides to avoid false matches
+	// like "from importlib import …".
+	idx := strings.Index(operand, " import ")
+	if idx < 0 {
+		return ""
+	}
+	src := strings.TrimSpace(operand[:idx])
+	// Relative imports start with one or more dots.
+	if src == "" || strings.HasPrefix(src, ".") {
+		return ""
+	}
+	if i := strings.Index(src, "."); i >= 0 {
+		src = src[:i]
+	}
+	if !isLikelyIdentifier(src) {
+		return ""
+	}
+	return src
+}
+
+// isLikelyIdentifier reports whether s is a plausible Python identifier
+// (letters, digits, underscore, with a non-digit first character). The
+// scanner uses it as a sanity check on what it parsed; non-identifier
+// junk is dropped silently.
+func isLikelyIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+			// always ok
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// indexAny returns the first index where any of the provided
+// substrings is found, or -1 when none of them appear. Used to
+// approximate triple-quote detection without scanning twice.
+func indexAny(line string, opts ...string) int {
+	first := -1
+	for _, opt := range opts {
+		if i := strings.Index(line, opt); i >= 0 {
+			if first < 0 || i < first {
+				first = i
+			}
+		}
+	}
+	return first
+}

--- a/internal/analyzers/pyreach/importscanner_test.go
+++ b/internal/analyzers/pyreach/importscanner_test.go
@@ -1,0 +1,132 @@
+package pyreach
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanImports(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "single import",
+			src:  "import requests\n",
+			want: []string{"requests"},
+		},
+		{
+			name: "dotted import keeps top-level only",
+			src:  "import os.path\n",
+			want: []string{"os"},
+		},
+		{
+			name: "comma-separated imports",
+			src:  "import os, sys, requests\n",
+			want: []string{"os", "sys", "requests"},
+		},
+		{
+			name: "import as alias",
+			src:  "import numpy as np\nimport pandas as pd\n",
+			want: []string{"numpy", "pandas"},
+		},
+		{
+			name: "from import",
+			src:  "from flask import Flask\n",
+			want: []string{"flask"},
+		},
+		{
+			name: "from dotted import",
+			src:  "from urllib3.util import retry\n",
+			want: []string{"urllib3"},
+		},
+		{
+			name: "relative imports skipped",
+			src:  "from . import utils\nfrom .foo import bar\nfrom ..pkg import baz\n",
+			want: nil,
+		},
+		{
+			name: "trailing comment ignored",
+			src:  "import requests  # noqa: F401\n",
+			want: []string{"requests"},
+		},
+		{
+			name: "indented import (function-local)",
+			src:  "def f():\n    import lazy_dep\n    return lazy_dep.value\n",
+			want: []string{"lazy_dep"},
+		},
+		{
+			name: "from-importlib is not a relative import",
+			src:  "from importlib import import_module\n",
+			want: []string{"importlib"},
+		},
+		{
+			name: "triple-quoted block hides imports",
+			src:  "\"\"\"\nimport secret\n\"\"\"\nimport real\n",
+			want: []string{"real"},
+		},
+		{
+			name: "single-line docstring does not flip block",
+			src:  "\"\"\"oneliner\"\"\"\nimport real\n",
+			want: []string{"real"},
+		},
+		{
+			name: "blank lines and comments are ignored",
+			src:  "# coding: utf-8\n\nimport os\n\n# trailing comment\n",
+			want: []string{"os"},
+		},
+		{
+			name: "ignore non-identifier junk",
+			src:  "import 123foo\nimport bar\n",
+			want: []string{"bar"},
+		},
+		{
+			name: "from-only list (multi-import on one line)",
+			src:  "from typing import List, Dict, Optional\n",
+			want: []string{"typing"},
+		},
+		{
+			name: "empty source",
+			src:  "",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := scanImports(strings.NewReader(tc.src))
+			if err != nil {
+				t.Fatalf("scanImports returned error: %v", err)
+			}
+			gotSlice := mapKeys(got)
+			if !equalAsSets(gotSlice, tc.want) {
+				t.Errorf("scanImports = %v, want %v", gotSlice, tc.want)
+			}
+		})
+	}
+}
+
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func equalAsSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		seen[v] = struct{}{}
+	}
+	for _, v := range a {
+		if _, ok := seen[v]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/analyzers/pyreach/moduletodist.go
+++ b/internal/analyzers/pyreach/moduletodist.go
@@ -1,0 +1,205 @@
+package pyreach
+
+import "strings"
+
+// moduleToDistOverrides maps Python top-level module names to their
+// canonical PyPI distribution names where the two differ. The lookup
+// is case-sensitive on the module side because Python imports are
+// (e.g. `from PIL import Image` is distinct from `from pil import …`).
+// Distribution names are stored lowercase + hyphenated — the canonical
+// form per PEP 503 normalization.
+//
+// Identity normalization (lowercase + underscore-to-hyphen) handles
+// the common case (~70% of PyPI). This map covers well-known names
+// that don't follow the identity rule. Missing an entry produces a
+// false negative (the analyzer reports the package as unreachable
+// when it actually was imported); the BFS through the dep graph
+// usually catches it via a transitive edge from a correctly-mapped
+// neighbour, but for top-level direct imports it is a real blind
+// spot. PRs welcome.
+var moduleToDistOverrides = map[string]string{
+	// Common mismatches drawn from the most-downloaded PyPI packages.
+	"PIL":                      "pillow",
+	"bs4":                      "beautifulsoup4",
+	"yaml":                     "pyyaml",
+	"cv2":                      "opencv-python",
+	"sklearn":                  "scikit-learn",
+	"skimage":                  "scikit-image",
+	"crypto":                   "pycryptodome",
+	"Crypto":                   "pycryptodome",
+	"OpenSSL":                  "pyopenssl",
+	"git":                      "gitpython",
+	"github":                   "pygithub",
+	"jwt":                      "pyjwt",
+	"dateutil":                 "python-dateutil",
+	"dotenv":                   "python-dotenv",
+	"magic":                    "python-magic",
+	"slugify":                  "python-slugify",
+	"serial":                   "pyserial",
+	"usb":                      "pyusb",
+	"docx":                     "python-docx",
+	"pptx":                     "python-pptx",
+	"google":                   "google-api-python-client",
+	"googleapiclient":          "google-api-python-client",
+	"googleapis_common_protos": "googleapis-common-protos",
+	"grpc":                     "grpcio",
+	"grpc_tools":               "grpcio-tools",
+	"attr":                     "attrs",
+	"attrs":                    "attrs",
+	"win32api":                 "pywin32",
+	"win32com":                 "pywin32",
+	"pywintypes":               "pywin32",
+	"Levenshtein":              "python-levenshtein",
+	"MySQLdb":                  "mysqlclient",
+	"psycopg2":                 "psycopg2-binary",
+	"discord":                  "discord-py",
+	"telegram":                 "python-telegram-bot",
+	"jose":                     "python-jose",
+	"socks":                    "pysocks",
+	"OpenGL":                   "pyopengl",
+	"snakemake":                "snakemake",
+	"speech_recognition":       "speechrecognition",
+	"prompt_toolkit":           "prompt-toolkit",
+	"setuptools":               "setuptools",
+	"pkg_resources":            "setuptools",
+	"_pytest":                  "pytest",
+	"IPython":                  "ipython",
+	"backports":                "backports",
+	"absl":                     "absl-py",
+	"PyQt5":                    "pyqt5",
+	"PyQt6":                    "pyqt6",
+	"PySide2":                  "pyside2",
+	"PySide6":                  "pyside6",
+	"sqlalchemy":               "sqlalchemy",
+	"flask_sqlalchemy":         "flask-sqlalchemy",
+	"flask_login":              "flask-login",
+	"flask_wtf":                "flask-wtf",
+	"flask_migrate":            "flask-migrate",
+	"flask_restful":            "flask-restful",
+	"flask_cors":               "flask-cors",
+	"djangorestframework":      "djangorestframework",
+	"rest_framework":           "djangorestframework",
+}
+
+// stdlibModules is a conservative set of Python standard-library
+// top-level modules. Imports of these are dropped from the runner's
+// distribution set since stdlib is never a PyPI dependency. The list
+// is not exhaustive (Python 3.12 has ~200 stdlib modules) but covers
+// the most common ones; missing a stdlib module just produces a
+// false-positive distribution name that the dep graph BFS will
+// silently ignore (since no graph package will match), so this map
+// is a performance optimization, not a correctness requirement.
+var stdlibModules = map[string]struct{}{
+	"abc": {}, "argparse": {}, "array": {}, "ast": {}, "asyncio": {},
+	"base64": {}, "binascii": {}, "bisect": {}, "builtins": {}, "bz2": {},
+	"calendar": {}, "cgi": {}, "cmath": {}, "cmd": {}, "codecs": {},
+	"collections": {}, "colorsys": {}, "concurrent": {}, "configparser": {},
+	"contextlib": {}, "contextvars": {}, "copy": {}, "copyreg": {}, "csv": {},
+	"ctypes": {}, "curses": {}, "dataclasses": {}, "datetime": {}, "decimal": {},
+	"difflib": {}, "dis": {}, "doctest": {}, "email": {}, "encodings": {},
+	"enum": {}, "errno": {}, "faulthandler": {}, "fcntl": {}, "filecmp": {},
+	"fileinput": {}, "fnmatch": {}, "fractions": {}, "ftplib": {}, "functools": {},
+	"gc": {}, "getopt": {}, "getpass": {}, "gettext": {}, "glob": {}, "graphlib": {},
+	"grp": {}, "gzip": {}, "hashlib": {}, "heapq": {}, "hmac": {}, "html": {},
+	"http": {}, "imaplib": {}, "imghdr": {}, "imp": {}, "importlib": {}, "inspect": {},
+	"io": {}, "ipaddress": {}, "itertools": {}, "json": {}, "keyword": {},
+	"linecache": {}, "locale": {}, "logging": {}, "lzma": {}, "mailbox": {},
+	"mailcap": {}, "marshal": {}, "math": {}, "mimetypes": {}, "mmap": {},
+	"modulefinder": {}, "msilib": {}, "msvcrt": {}, "multiprocessing": {},
+	"netrc": {}, "nis": {}, "nntplib": {}, "numbers": {}, "operator": {},
+	"optparse": {}, "os": {}, "ossaudiodev": {}, "parser": {}, "pathlib": {},
+	"pdb": {}, "pickle": {}, "pickletools": {}, "pipes": {}, "pkgutil": {},
+	"platform": {}, "plistlib": {}, "poplib": {}, "posix": {}, "posixpath": {},
+	"pprint": {}, "profile": {}, "pstats": {}, "pty": {}, "pwd": {}, "py_compile": {},
+	"pyclbr": {}, "pydoc": {}, "queue": {}, "quopri": {}, "random": {}, "re": {},
+	"readline": {}, "reprlib": {}, "resource": {}, "rlcompleter": {}, "runpy": {},
+	"sched": {}, "secrets": {}, "select": {}, "selectors": {}, "shelve": {},
+	"shlex": {}, "shutil": {}, "signal": {}, "site": {}, "smtpd": {}, "smtplib": {},
+	"sndhdr": {}, "socket": {}, "socketserver": {}, "spwd": {}, "sqlite3": {},
+	"ssl": {}, "stat": {}, "statistics": {}, "string": {}, "stringprep": {},
+	"struct": {}, "subprocess": {}, "sunau": {}, "symtable": {}, "sys": {},
+	"sysconfig": {}, "syslog": {}, "tabnanny": {}, "tarfile": {}, "telnetlib": {},
+	"tempfile": {}, "termios": {}, "test": {}, "textwrap": {}, "threading": {},
+	"time": {}, "timeit": {}, "tkinter": {}, "token": {}, "tokenize": {}, "tomllib": {},
+	"trace": {}, "traceback": {}, "tracemalloc": {}, "tty": {}, "turtle": {},
+	"types": {}, "typing": {}, "unicodedata": {}, "unittest": {}, "urllib": {},
+	"uu": {}, "uuid": {}, "venv": {}, "warnings": {}, "wave": {}, "weakref": {},
+	"webbrowser": {}, "winreg": {}, "winsound": {}, "wsgiref": {}, "xdrlib": {},
+	"xml": {}, "xmlrpc": {}, "zipapp": {}, "zipfile": {}, "zipimport": {},
+	"zlib": {}, "zoneinfo": {},
+	// Special / pseudo modules:
+	"__future__": {}, "__main__": {},
+}
+
+// isStdlibModule reports whether the given top-level module name is
+// part of the Python standard library. Conservative — see stdlibModules.
+func isStdlibModule(top string) bool {
+	_, ok := stdlibModules[top]
+	return ok
+}
+
+// moduleToDistribution maps a Python top-level module name to its
+// canonical PyPI distribution name (lowercase, hyphenated). Returns
+// "" for stdlib modules, relative imports, or anything that should
+// be skipped.
+//
+// Order:
+//  1. Skip stdlib.
+//  2. Look up a static override (covers the well-known mismatches).
+//  3. Identity normalize: lowercase + replace "_" with "-".
+//
+// Inputs that look like dotted module paths are reduced to the
+// top-level segment first ("foo.bar.baz" -> "foo").
+func moduleToDistribution(module string) string {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return ""
+	}
+	// Drop relative-import dots (handled by caller, but defensive).
+	module = strings.TrimLeft(module, ".")
+	if module == "" {
+		return ""
+	}
+	if i := strings.Index(module, "."); i >= 0 {
+		module = module[:i]
+	}
+	if isStdlibModule(module) {
+		return ""
+	}
+	if dist, ok := moduleToDistOverrides[module]; ok {
+		return dist
+	}
+	return canonicalDistName(module)
+}
+
+// canonicalDistName normalizes a raw distribution name per PEP 503:
+// lowercase and replace runs of [-_.] with a single "-".
+func canonicalDistName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	out := make([]byte, 0, len(name))
+	prevSep := false
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c == '-' || c == '_' || c == '.':
+			if !prevSep && len(out) > 0 {
+				out = append(out, '-')
+			}
+			prevSep = true
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+('a'-'A'))
+			prevSep = false
+		default:
+			out = append(out, c)
+			prevSep = false
+		}
+	}
+	// Trim trailing separator if any.
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	return string(out)
+}

--- a/internal/analyzers/pyreach/moduletodist_test.go
+++ b/internal/analyzers/pyreach/moduletodist_test.go
@@ -1,0 +1,66 @@
+package pyreach
+
+import "testing"
+
+func TestModuleToDistribution(t *testing.T) {
+	cases := []struct {
+		module string
+		want   string
+	}{
+		// Identity normalization.
+		{"requests", "requests"},
+		{"flask", "flask"},
+		{"NumPy", "numpy"},
+		{"my_underscore_pkg", "my-underscore-pkg"},
+		// Static overrides.
+		{"yaml", "pyyaml"},
+		{"PIL", "pillow"},
+		{"cv2", "opencv-python"},
+		{"sklearn", "scikit-learn"},
+		{"bs4", "beautifulsoup4"},
+		{"jwt", "pyjwt"},
+		// Stdlib drops to "".
+		{"os", ""},
+		{"sys", ""},
+		{"typing", ""},
+		// Dotted modules reduce to top-level segment.
+		{"urllib3.util", "urllib3"},
+		{"flask.cli", "flask"},
+		// Relative-import dots are stripped.
+		{".foo", "foo"},
+		// Empty input.
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.module, func(t *testing.T) {
+			got := moduleToDistribution(tc.module)
+			if got != tc.want {
+				t.Errorf("moduleToDistribution(%q) = %q, want %q", tc.module, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalDistName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Requests", "requests"},
+		{"my_pkg", "my-pkg"},
+		{"my.pkg", "my-pkg"},
+		{"My-Pkg", "my-pkg"},
+		{"my___pkg", "my-pkg"},
+		{"_leading", "leading"},
+		{"trailing_", "trailing"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := canonicalDistName(tc.in); got != tc.want {
+				t.Errorf("canonicalDistName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/analyzers/pyreach/runner.go
+++ b/internal/analyzers/pyreach/runner.go
@@ -1,0 +1,88 @@
+// Package pyreach implements a Tier-3 (package-level) reachability
+// analyzer for Python packages. It walks application source files
+// rooted at a Python project (pyproject.toml / setup.py / requirements.txt
+// / Pipfile / poetry.lock / pdm.lock / uv.lock), scans every reachable
+// .py file for top-level import statements, maps the imported module
+// names to PyPI distribution names, and reports each PackageVulnerability
+// as Reachable / Unreachable / Unknown depending on whether the
+// distribution appears in the import set (expanded transitively through
+// the dep graph).
+//
+// Tier-3 caveat: "unreachable" here means "the application source does
+// not import this package, neither directly nor indirectly through app
+// code". It does NOT mean "the vulnerability cannot be triggered" —
+// Python is highly dynamic (importlib.import_module on user input,
+// plugin discovery via entry points, Django INSTALLED_APPS strings,
+// __import__ inside conditional branches). See docs/REACHABILITY.md
+// for the full set of caveats.
+//
+// The runner reads source in-process so users never need a Python
+// interpreter or third-party tool on PATH. The Runner interface is
+// preserved (rather than calling the scanner directly from the
+// analyzer) so unit tests can inject a fake runner for deterministic
+// behaviour.
+package pyreach
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// Runner walks a Python project rooted at projectDir and returns the
+// set of PyPI distribution names imported anywhere in its reachable
+// source tree. Implementations must NEVER panic and should map missing
+// inputs, parse errors, and other recoverable conditions to a
+// (RunnerResult, error) pair where the error is descriptive but does
+// not abort the pipeline.
+type Runner interface {
+	// Name returns a stable identifier (e.g. "library") used in
+	// telemetry and Reason fields.
+	Name() string
+	// Version returns the runner schema version. The result cache
+	// folds it into its key so scanner upgrades invalidate prior
+	// entries automatically.
+	Version() string
+	// Run walks projectDir and returns the imported-distribution set.
+	// projectDir must contain at least one of pyproject.toml,
+	// setup.py, setup.cfg, requirements*.txt, Pipfile, poetry.lock,
+	// pdm.lock, or uv.lock.
+	Run(ctx context.Context, projectDir string) (RunnerResult, error)
+}
+
+// RunnerResult is the parsed output of one runner pass over a project.
+// It carries enough information for the analyzer to map advisories to
+// reachable / unreachable / unknown without re-reading any source.
+type RunnerResult struct {
+	// ImportedDistributions is the set of PyPI distribution names
+	// (lowercase, hyphenated form — the canonical form of
+	// distribution names) imported anywhere in the project's
+	// reachable source tree. Module names are normalized to
+	// distribution names through a layered strategy: a static map
+	// of well-known mismatches (e.g. yaml -> PyYAML), then the
+	// identity normalization (lowercase, "_" -> "-").
+	ImportedDistributions map[string]struct{}
+	// SourceFiles is the count of project .py files the runner
+	// visited (for telemetry).
+	SourceFiles int
+	// SkippedDirs lists the directory names skipped during the walk
+	// (venv/, __pycache__/, etc.) for debug logging.
+	SkippedDirs []string
+}
+
+// hasResult reports whether the runner produced anything actionable.
+// Zero source files means the runner found no project structure to
+// analyse and the analyzer should mark every Python vulnerability
+// Unknown.
+func (r RunnerResult) hasResult() bool {
+	return r.SourceFiles > 0
+}
+
+// ensureLogger guarantees a non-nil zap.Logger so call sites can drop
+// the standard nil-check boilerplate.
+func ensureLogger(l *zap.Logger) *zap.Logger {
+	if l != nil {
+		return l
+	}
+	return zap.NewNop()
+}

--- a/internal/analyzers/pyreach/runner_library.go
+++ b/internal/analyzers/pyreach/runner_library.go
@@ -1,0 +1,99 @@
+package pyreach
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+// runnerSchemaVersion is the runner's stable identifier for cache
+// invalidation. Bumping it invalidates every previously cached entry
+// the next time the cache key is built. Reserve bumps for changes to
+// the import scanner or the module-to-distribution mapping that
+// would silently change reachability outcomes.
+const runnerSchemaVersion = "v1"
+
+// NewRunner returns the analyzer's Runner implementation, an
+// in-process scanner that walks the project's .py source files and
+// records every top-level module imported. Module names are mapped
+// to PyPI distribution names through moduleToDistribution; the
+// resulting set is what downstream BFS through the dep graph
+// expands into the full reachable set.
+func NewRunner(logger *zap.Logger) Runner {
+	return libraryRunner{logger: ensureLogger(logger)}
+}
+
+// libraryRunner is the in-process implementation of Runner. It
+// reads source straight off disk; there is no Python interpreter or
+// third-party tool involved. The scanner is line-oriented and
+// deliberately does not fully parse Python — see importscanner.go
+// for the supported subset and the tradeoff.
+type libraryRunner struct {
+	logger *zap.Logger
+}
+
+func (libraryRunner) Name() string { return "library" }
+
+func (libraryRunner) Version() string { return runnerSchemaVersion }
+
+func (r libraryRunner) Run(ctx context.Context, projectDir string) (RunnerResult, error) {
+	if info, err := os.Stat(projectDir); err != nil || !info.IsDir() {
+		return RunnerResult{}, fmt.Errorf("project dir not accessible: %w", err)
+	}
+
+	r.logger.Debug("pyreach: executing in-process runner",
+		zap.String("project_dir", projectDir),
+		zap.String("schema_version", runnerSchemaVersion))
+
+	imports := make(map[string]struct{})
+	sourceFiles := 0
+	skipped, walkErr := walkSourceFiles(projectDir, func(path string) error {
+		// Cheap cancellation check between files. The walker reads
+		// every file synchronously, so this is the natural boundary.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			r.logger.Debug("pyreach: skipping unreadable source",
+				zap.String("path", path),
+				zap.Error(err))
+			return nil
+		}
+		defer f.Close()
+		fileImports, scanErr := scanImports(f)
+		if scanErr != nil {
+			r.logger.Debug("pyreach: scan failed for source file (continuing)",
+				zap.String("path", path),
+				zap.Error(scanErr))
+			return nil
+		}
+		sourceFiles++
+		for module := range fileImports {
+			dist := moduleToDistribution(module)
+			if dist == "" {
+				continue
+			}
+			imports[dist] = struct{}{}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		// Cancellation is the only error walkSourceFiles propagates.
+		return RunnerResult{}, walkErr
+	}
+
+	r.logger.Debug("pyreach: in-process runner completed",
+		zap.String("project_dir", projectDir),
+		zap.Int("source_files", sourceFiles),
+		zap.Int("imported_distributions", len(imports)),
+		zap.Strings("skipped_dirs", skipped))
+
+	return RunnerResult{
+		ImportedDistributions: imports,
+		SourceFiles:           sourceFiles,
+		SkippedDirs:           skipped,
+	}, nil
+}

--- a/internal/analyzers/pyreach/runner_library_test.go
+++ b/internal/analyzers/pyreach/runner_library_test.go
@@ -1,0 +1,67 @@
+package pyreach
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLibraryRunnerWalksProjectAndExtractsDistributions exercises the
+// real in-process runner against a tiny on-disk fixture. It checks
+// the end-to-end path: walk source → scan imports → map modules to
+// PEP-503 distribution names → drop stdlib and venv content.
+func TestLibraryRunnerWalksProjectAndExtractsDistributions(t *testing.T) {
+	dir := t.TempDir()
+
+	must := func(path string, body string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	must("pyproject.toml", "[project]\nname = \"fixture\"\n")
+	must("app.py", "import os\nimport requests\nimport yaml\nfrom flask import Flask\n")
+	must("pkg/__init__.py", "from . import sub\n")
+	must("pkg/sub.py", "import numpy as np\n")
+	// Should be skipped: lives inside .venv/, so its imports must
+	// not leak into the result.
+	must(".venv/lib/python3.11/site-packages/django/__init__.py", "import django_internal\n")
+	// Should be skipped: build artefact.
+	must("build/lib/app.py", "import never_seen\n")
+
+	r := NewRunner(nil)
+	got, err := r.Run(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+
+	wantPresent := []string{"requests", "pyyaml", "flask", "numpy"}
+	for _, dist := range wantPresent {
+		if _, ok := got.ImportedDistributions[dist]; !ok {
+			t.Errorf("missing %q in imported set: %v", dist, got.ImportedDistributions)
+		}
+	}
+	wantAbsent := []string{"os", "django_internal", "never_seen"}
+	for _, dist := range wantAbsent {
+		if _, ok := got.ImportedDistributions[dist]; ok {
+			t.Errorf("unexpected %q in imported set", dist)
+		}
+	}
+	if got.SourceFiles == 0 {
+		t.Errorf("source files = 0; want > 0")
+	}
+}
+
+func TestLibraryRunnerErrorsOnMissingDir(t *testing.T) {
+	r := NewRunner(nil)
+	_, err := r.Run(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing dir, got nil")
+	}
+}

--- a/internal/analyzers/pyreach/sources.go
+++ b/internal/analyzers/pyreach/sources.go
@@ -1,0 +1,124 @@
+package pyreach
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// projectFileMarkers names every file whose presence at a directory
+// makes that directory a Python project root. The list is the union
+// of the manifests recognised by Bomly's Python detectors (pip,
+// pipenv, poetry, uv, pdm, setuppy) plus the most common loose
+// requirements layouts.
+var projectFileMarkers = []string{
+	"pyproject.toml",
+	"setup.py",
+	"setup.cfg",
+	"Pipfile",
+	"Pipfile.lock",
+	"poetry.lock",
+	"pdm.lock",
+	"uv.lock",
+	"requirements.txt",
+	"requirements-dev.txt",
+}
+
+// hasProjectMarker returns true when dir contains any of the recognised
+// Python project files. Used to filter out source-only subdirectories
+// when walking up from a package location.
+func hasProjectMarker(dir string) bool {
+	for _, name := range projectFileMarkers {
+		path := filepath.Join(dir, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	// Also accept any requirements*.txt variant (requirements-prod.txt,
+	// requirements/base.txt etc. — the latter lives in a subdir, so we
+	// only catch top-level variants here).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, "requirements") && strings.HasSuffix(name, ".txt") {
+			return true
+		}
+	}
+	return false
+}
+
+// walkSourceFiles invokes fn for every .py file under root, skipping
+// directories whose names appear in skipDirs. Returns the list of
+// directory names actually skipped (for telemetry) and any walk error.
+//
+// The walker stops on context cancellation indirectly: callers pass
+// a cancellable filepath.WalkDir-style function or check ctx.Err()
+// inside fn. We don't take a context here directly because the runner
+// already does so at a coarser granularity (per-project), which is the
+// right place to be responsive on a typical project.
+func walkSourceFiles(root string, fn func(path string) error) (skipped []string, err error) {
+	skippedSet := make(map[string]struct{})
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Permission errors and similar issues skip the offending
+			// entry without aborting the whole walk. Returning err
+			// here would propagate; we want best-effort coverage.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path == root {
+				return nil
+			}
+			if shouldSkipDir(name) {
+				skippedSet[name] = struct{}{}
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".py") {
+			return nil
+		}
+		return fn(path)
+	})
+	for name := range skippedSet {
+		skipped = append(skipped, name)
+	}
+	return skipped, walkErr
+}
+
+// shouldSkipDir reports whether the named subdirectory should be
+// pruned during the walk. The list includes virtualenv layouts,
+// common build outputs, and editor / VCS directories. Skipping
+// site-packages is essential — it would otherwise scan installed
+// dependency source as if it were the application.
+func shouldSkipDir(name string) bool {
+	switch name {
+	case "venv", ".venv", "env", ".env",
+		"__pycache__",
+		"node_modules",
+		".tox", ".nox",
+		"build", "dist",
+		".eggs",
+		"site-packages",
+		".git", ".hg", ".svn",
+		".mypy_cache", ".pytest_cache", ".ruff_cache",
+		".idea", ".vscode",
+		"htmlcov", "coverage":
+		return true
+	}
+	if strings.HasSuffix(name, ".egg-info") {
+		return true
+	}
+	return false
+}

--- a/internal/registry/analyzers_pyreach.go
+++ b/internal/registry/analyzers_pyreach.go
@@ -1,0 +1,12 @@
+package registry
+
+import (
+	"github.com/bomly-dev/bomly-cli/internal/analyzers/pyreach"
+)
+
+// registerPyReachAnalyzer wires the Python Tier-3 reachability
+// analyzer. The runner is an in-process line-oriented import scanner
+// that walks the project's .py source tree.
+func (r *Registry) registerPyReachAnalyzer() {
+	r.RegisterAnalyzer(pyreach.Analyzer{Logger: r.logger})
+}

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -246,6 +246,7 @@ func (r *Registry) RegisterMatcher(matcher sdk.Matcher) {
 func (r *Registry) registerAnalyzers() {
 	r.registerGovulncheckAnalyzer()
 	r.registerJSReachAnalyzer()
+	r.registerPyReachAnalyzer()
 }
 
 // registerGovulncheckAnalyzer is provided by analyzers_govulncheck.go so the

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -132,6 +132,21 @@ func TestScan(t *testing.T) {
 			tools: []string{"pip"},
 		},
 		{
+			// pyreach smoke pinned to veracode/example-python3-pip,
+			// a deliberately-vulnerable demo. main.py imports
+			// jwt / django / rsa / requests directly; requirements.txt
+			// pins ten more deps that are either unimported (feedparser,
+			// sgmllib3k) or reachable only transitively (urllib3, idna,
+			// chardet, certifi, pyasn1, pytz). Exercises the
+			// directly-imported, transitively-reachable, and
+			// unreachable branches plus the module-to-distribution
+			// override (jwt → pyjwt). Goldens scrub timestamps via
+			// normalizeReachability.
+			name:  "scan-python-pip-reachability",
+			args:  []string{"scan", "--url", "https://github.com/veracode/example-python3-pip", "--ref", "e19d10938caf3e06730c23047ae118cd59638e41", "--enrich", "--reachability", "--format", "json"},
+			tools: []string{"pip"},
+		},
+		{
 			name: "scan-composer",
 			args: []string{"scan", "--url", "https://github.com/guzzle/guzzle", "--ref", "7.9.2", "--format", "json"},
 			//tools: []string{"composer"},


### PR DESCRIPTION
## Summary

Phase C kickoff. Adds `pyreach`, the third reachability analyzer and the first non-vendored one — Python has no esbuild equivalent in Go, so the runner is an in-tree line-oriented import scanner. Behaviour mirrors `jsreach`:

- Walks every `.py` file under a Python project root (`pyproject.toml` / `setup.py` / `setup.cfg` / `requirements*.txt` / `Pipfile` / `poetry.lock` / `pdm.lock` / `uv.lock`)
- Records every top-level module from `import x` and `from x import …` statements (handles aliases, dotted paths, comma-separated lists, indented / function-local imports, triple-quoted docstrings)
- Maps module names to PyPI distribution names through a layered strategy: drop stdlib → static override map (`yaml → pyyaml`, `cv2 → opencv-python`, `sklearn → scikit-learn`, `bs4 → beautifulsoup4`, `PIL → pillow`, `jwt → pyjwt`, … ~50 entries) → PEP 503 identity normalization (lowercase, `_`/`.` → `-`)
- Expands the resulting set transitively through `Graph.Dependencies` so a CVE in `urllib3` (pulled in by `requests`) still flips reachable when `requests` is the only direct import
- Per-project `FileCache` invalidating on lockfile / pyproject content change; cache key folds runner schema version
- INFO/DEBUG/WARN structured logging mirroring jsreach
- Plugin command picks `pyreach` up automatically through the `AnalyzerDescriptors` registry surface — no plugin_cmd.go changes needed
- Skips `venv/`, `.venv/`, `site-packages/`, `__pycache__/`, `build/`, `dist/`, `.tox/`, `.nox/`, VCS dirs, `*.egg-info`

### Tier-3 caveats (documented in REACHABILITY.md)

The new analyzer ships with a prominent caveat section. The Python-specific traps:

- \"Unreachable\" is not \"safe\". `importlib.import_module(name)` on user input, plugin discovery via entry points, Django `INSTALLED_APPS` strings, and conditional `__import__` — all invisible to a static scanner.
- Submodule imports collapse to the distribution. `from urllib3.util import retry` attributes the whole `urllib3` distribution as reachable.
- A missing static-override entry produces a false negative for direct top-level imports. Adding an entry to `moduletodist.go` is a one-line PR.
- The closure is only as accurate as the lockfile (same as jsreach).

## Smoke fixture

Pinned to [veracode/example-python3-pip@e19d109](https://github.com/veracode/example-python3-pip/tree/e19d10938caf3e06730c23047ae118cd59638e41) — a small, stable Veracode demo with a deliberately-vulnerable `requirements.txt`. The fixture exercises every pyreach branch in one project:

- **Directly imported** (`requests`, `django`, `rsa`, `jwt`)
- **Transitively reachable** (`urllib3` ← `requests`, `pytz` ← `django`, `idna` / `chardet` / `certifi` ← `requests`, `pyasn1` ← `rsa`)
- **Unreachable** (`feedparser`, `sgmllib3k` — pinned but never imported)
- **Module-to-distribution override** (`import jwt` → `pyjwt`)

Goldens need to be seeded once via `make smoke ARGS=\"-update\"` on a machine with network + `pip` after this lands.

## Test plan

- [x] Unit tests for the import scanner (15 cases covering every supported syntactic form)
- [x] Unit tests for module-to-distribution mapping (overrides, identity normalization, stdlib drops, PEP 503 canonicalization)
- [x] Cache round-trip + invalidation on lockfile change + isolation by runner version
- [x] Analyzer integration tests: reachable / unreachable / unknown / runner-error / missing-project-root
- [x] Headline correctness tests: transitive expansion, BFS doesn't expand through unimported roots, cycle handling
- [x] Library-runner end-to-end test against on-disk fixture (verifies venv / build / __pycache__ are skipped, stdlib is dropped, override map applies, source files counted)
- [x] `bomly plugin list --analyzers` shows pyreach with the python language column
- [x] `make build` and `make build-lite` both clean
- [ ] Smoke goldens: regenerate via `make smoke ARGS=\"-update\"` after merge

## Files

- `internal/analyzers/pyreach/` — new package (analyzer, runner, scanner, mapping, cache, sources, discover + tests)
- `internal/registry/analyzers_pyreach.go` — registration shim
- `internal/registry/builder.go` — wires `registerPyReachAnalyzer()` into `registerAnalyzers()`
- `test/smoke/smoke_test.go` — adds `scan-python-pip-reachability` case
- `docs/REACHABILITY.md` — pyreach row in the ecosystem table, full Tier-3 caveat section, build-layout note
- `CLAUDE.md` — analyzer tree comment lists the third analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)