### PR TITLE
feat(analyzers): Tier-3 jvmreach reachability analyzer for JVM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,13 @@ internal/matchers/*              External enrichment: osv, grype, deps.dev, Clea
 internal/matchers/cache          File-based cache shared by matchers
 internal/analyzers/*             Reachability analyzers (govulncheck — Go;
                                  jsreach — JavaScript/TypeScript;
-                                 pyreach — Python). Each is backed by
-                                 a single in-process implementation
-                                 (no builtin/external build-tag split).
-                                 Run after matchers; annotate
-                                 PackageVulnerability.Reachability and
-                                 never abort the pipeline on failure
+                                 pyreach — Python;
+                                 jvmreach — Java/Kotlin/Scala/Groovy).
+                                 Each is backed by a single in-process
+                                 implementation (no builtin/external
+                                 build-tag split). Run after matchers;
+                                 annotate PackageVulnerability.Reachability
+                                 and never abort the pipeline on failure
 internal/auditors/*              Policy evaluators (policy, noop)
 internal/sbom/                   SPDX 2.3 / CycloneDX codec
 internal/output/                 Text, JSON, SARIF 2.1.0, SBOM rendering + schema generation

--- a/docs/REACHABILITY.md
+++ b/docs/REACHABILITY.md
@@ -60,6 +60,7 @@ degrade to `Status: unknown` with a stable, machine-readable `Reason`
 | Go                   | `govulncheck` | `symbol`  | Backed by the vendored `golang.org/x/vuln/scan` library; runs in-process so users never need a `govulncheck` binary on PATH.                                                                                                                                     |
 | JavaScript / TypeScript | `jsreach`     | `package` | Backed by the vendored `github.com/evanw/esbuild/pkg/api` library. Walks app source from `package.json` entry points (`main`, `module`, `browser`, `exports`, `bin`, plus implicit `index.*` / `app.js` / `server.js` / `main.js` fallbacks) and reports each npm package as reachable iff it appears in the import set. |
 | Python               | `pyreach`     | `package` | In-process line-oriented import scanner. Walks every `.py` file under the project root (`pyproject.toml` / `setup.py` / `requirements*.txt` / `Pipfile` / `poetry.lock` / `pdm.lock` / `uv.lock`), records each top-level module from `import` and `from … import` statements, and maps module names to PyPI distribution names through a static override map (e.g. `yaml` → `PyYAML`) plus PEP 503 normalization. |
+| Java / Kotlin / Scala / Groovy | `jvmreach`    | `package` | In-process line-oriented import scanner for JVM ecosystems (Maven, Gradle, SBT). Walks `.java` / `.kt` / `.kts` / `.scala` / `.groovy` source under the project root, scans top-of-file `import` statements (including Java `static`, Kotlin aliases, Scala selectors and wildcards), and maps Java/Kotlin/Scala package prefixes to Maven coordinates (`groupId:artifactId`) through a curated longest-prefix map. |
 
 Other ecosystems (Java, Rust) are tracked for follow-up phases.
 When `--reachability` is set on a project that has no applicable
@@ -161,6 +162,45 @@ specifics:
    reach what isn't there. The pip / poetry / pipenv / uv / pdm
    detectors are the source of truth for what edges exist.
 
+### A note on `jvmreach` and Tier 3
+
+`jvmreach` is the third Tier-3 analyzer and follows the same
+"directly-imported set + transitive closure" shape as `jsreach`
+and `pyreach`. It walks `.java` / `.kt` / `.kts` / `.scala` /
+`.groovy` files under the project root, parses each top-of-file
+`import` statement, and maps the FQN prefix to a Maven artifact
+coordinate (`groupId:artifactId`) via a curated longest-prefix
+map. The closure is then expanded transitively through
+`Graph.Dependencies`.
+
+The Java/Maven mapping problem is genuinely harder than Python's.
+Python's `module → distribution` relationship is usually identity
+modulo a small override table. The Java `package → Maven artifact`
+relationship has no naming convention at all — `org.apache.commons`
+covers ten different distributions, `com.google.common` is one
+specific distribution, and there is no rule that holds in general.
+Consequences:
+
+1. **"Unreachable" is not "safe".** All the standard caveats apply:
+   reflection, `ServiceLoader`, Spring component scanning, OSGi
+   bundles, JPMS layers, and class-loader gymnastics are invisible
+   to a static scanner. Annotation processors that generate code at
+   build time also escape detection.
+2. **The curated prefix map is small and biased toward popular
+   libraries.** A missing prefix produces a false-negative for
+   direct imports. The dep-graph BFS usually catches the case via
+   a transitive edge from a correctly-mapped neighbour, but unlike
+   Python there is no identity-normalization fallback. Adding a
+   prefix is a one-line PR in
+   `internal/analyzers/jvmreach/prefixmap.go`.
+3. **Sub-package imports collapse to the artifact.** Importing
+   `com.fasterxml.jackson.databind.ObjectMapper` flips the whole
+   `jackson-databind` artifact reachable, even if the advisory
+   affects only a different class in that artifact.
+4. **The closure is only as accurate as the build manifest.** Same
+   as `jsreach` / `pyreach`: if the Maven / Gradle / SBT detector
+   doesn't see an edge, the closure can't follow it.
+
 ## Composing with `--fail-on`
 
 `--fail-on` is repeatable; constraints AND together. Two kinds are
@@ -239,6 +279,18 @@ Reachability data appears in three places:
   an entry produces a false-negative for direct top-level imports.
   PRs to extend `internal/analyzers/pyreach/moduletodist.go` are
   welcome.
+- **`jvmreach` does not follow reflection or runtime class loading.**
+  Spring component scanning, `ServiceLoader`, OSGi, JPMS dynamic
+  layers, and annotation-processed code are invisible to a static
+  scanner.
+- **`jvmreach`'s package-prefix map is hand-curated.** The Java
+  `package → Maven artifact` relationship has no naming convention,
+  so missing prefixes do not have an identity fallback. PRs to
+  extend `internal/analyzers/jvmreach/prefixmap.go` are welcome.
+- **`jvmreach` does not handle Gradle / Maven multi-module projects
+  yet.** Each pom.xml / build.gradle root is treated as one
+  project; modules under a parent are detected separately but
+  attribution between modules is best-effort.
 
 ## Selecting analyzers
 
@@ -263,6 +315,8 @@ library:
 - `govulncheck` runs in-process via `golang.org/x/vuln/scan`.
 - `jsreach` runs in-process via `github.com/evanw/esbuild/pkg/api`.
 - `pyreach` runs in-process via an in-tree line-oriented import
+  scanner (no external dependency).
+- `jvmreach` runs in-process via an in-tree line-oriented import
   scanner (no external dependency).
 
 Both libraries are small enough that vendoring them outweighs the

--- a/internal/analyzers/jvmreach/analyzer.go
+++ b/internal/analyzers/jvmreach/analyzer.go
@@ -1,0 +1,413 @@
+package jvmreach
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
+)
+
+// Name is the analyzer's stable identifier (used in selectors and output).
+const Name = "jvmreach"
+
+// Analyzer is a Tier-3 (package-level) reachability analyzer for
+// JVM-ecosystem packages. It groups Maven artifacts in the input
+// graph by project root, runs the configured Runner once per
+// project, and annotates each PackageVulnerability on JVM packages
+// with a Reachability result.
+//
+// Tier-3 caveat: "unreachable" means "the application source does
+// not import this artifact, neither directly nor through any
+// dep-graph edge from a directly-imported neighbour". It does NOT
+// mean "the vulnerability cannot be triggered" — reflection,
+// ServiceLoader, Spring component scanning, OSGi, and JPMS dynamic
+// loading are all invisible to a static scanner. See
+// docs/REACHABILITY.md for the full caveat list.
+type Analyzer struct {
+	Runner       Runner
+	Logger       *zap.Logger
+	CacheDir     string
+	CacheTTL     time.Duration
+	DisableCache bool
+}
+
+// Descriptor returns the registration metadata for the jvmreach analyzer.
+func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
+	return model.AnalyzerDescriptor{
+		Name:                Name,
+		Enabled:             true,
+		Origin:              model.BundledOrigin,
+		SupportedEcosystems: []model.Ecosystem{model.EcosystemMaven, model.EcosystemScala},
+		SupportedManagers: []model.PackageManager{
+			model.PackageManagerMaven,
+			model.PackageManagerGradle,
+			model.PackageManagerSBT,
+		},
+		SupportedLanguages: []model.Language{
+			model.LanguageJava,
+			model.LanguageKotlin,
+			model.LanguageScala,
+			model.LanguageGroovy,
+		},
+		SupportedModes: []model.TargetMode{model.TargetModeFullGraph, model.TargetModeComponent},
+		SupportedTiers: []model.ReachabilityTier{model.TierPackage},
+	}
+}
+
+func (a Analyzer) Ready() bool { return true }
+
+func (a Analyzer) Applicable(_ context.Context, req model.AnalyzeRequest) (bool, error) {
+	if req.Graph == nil {
+		return false, nil
+	}
+	for _, pkg := range req.Graph.Packages() {
+		if pkg == nil || len(pkg.Vulnerabilities) == 0 {
+			continue
+		}
+		if isJVMPackage(pkg) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a Analyzer) Analyze(ctx context.Context, req model.AnalyzeRequest) (model.AnalyzeResult, error) {
+	logger := a.logger()
+	if req.Graph == nil {
+		return model.AnalyzeResult{}, nil
+	}
+	runner := a.Runner
+	if runner == nil {
+		runner = NewRunner(logger)
+	}
+
+	overallStart := time.Now()
+	projectRoots := discoverProjectRoots(req)
+	if len(projectRoots) == 0 {
+		logger.Info("jvmreach: no JVM project roots discovered; marking all JVM vulnerabilities as unknown")
+		annotateAllUnknown(req.Graph, "no-project-root-discovered", time.Now())
+		return resultFromGraph(req.Graph), nil
+	}
+
+	logger.Info("jvmreach: starting reachability analysis",
+		zap.String("runner", runner.Name()),
+		zap.String("runner_version", runner.Version()),
+		zap.Int("project_roots", len(projectRoots)),
+		zap.Bool("cache_enabled", !a.DisableCache),
+	)
+	logger.Debug("jvmreach: discovered project roots", zap.Strings("paths", projectRoots))
+
+	cache := a.cache()
+	stats := model.ReachabilityStats{}
+	cacheHits, cacheMisses := 0, 0
+	for _, root := range projectRoots {
+		select {
+		case <-ctx.Done():
+			logger.Info("jvmreach: context cancelled; skipping project",
+				zap.String("project_root", root))
+			annotateProjectUnknown(req.Graph, root, "cancelled", time.Now())
+			continue
+		default:
+		}
+
+		projectStart := time.Now()
+		runResult, fromCache, err := a.runWithCache(ctx, runner, cache, root, logger)
+		if err != nil {
+			logger.Warn("jvmreach: runner failed",
+				zap.String("project_root", root),
+				zap.String("runner", runner.Name()),
+				zap.Duration("duration", time.Since(projectStart)),
+				zap.Error(err))
+			reason := failureReason(err)
+			added := annotateProjectUnknown(req.Graph, root, reason, time.Now())
+			stats.Unknown += added
+			continue
+		}
+		if fromCache {
+			cacheHits++
+		} else {
+			cacheMisses++
+		}
+		applied := applyRunnerResult(req.Graph, root, runResult, time.Now())
+		stats.Reachable += applied.reachable
+		stats.Unreachable += applied.unreachable
+		stats.Unknown += applied.unknown
+		logger.Info("jvmreach: completed project",
+			zap.String("project_root", root),
+			zap.String("runner", runner.Name()),
+			zap.Bool("cache_hit", fromCache),
+			zap.Int("source_files", runResult.SourceFiles),
+			zap.Int("imported_artifacts", len(runResult.ImportedArtifacts)),
+			zap.Int("reachable", applied.reachable),
+			zap.Int("unreachable", applied.unreachable),
+			zap.Duration("duration", time.Since(projectStart)),
+		)
+	}
+
+	logger.Info("jvmreach: completed reachability analysis",
+		zap.String("runner", runner.Name()),
+		zap.Int("projects", len(projectRoots)),
+		zap.Int("cache_hits", cacheHits),
+		zap.Int("cache_misses", cacheMisses),
+		zap.Int("reachable", stats.Reachable),
+		zap.Int("unreachable", stats.Unreachable),
+		zap.Int("unknown", stats.Unknown),
+		zap.Duration("duration", time.Since(overallStart)),
+	)
+
+	out := resultFromGraph(req.Graph)
+	out.AnalyzerStats = map[string]model.ReachabilityStats{Name: stats}
+	return out, nil
+}
+
+func (a Analyzer) logger() *zap.Logger { return ensureLogger(a.Logger) }
+
+func (a Analyzer) runWithCache(
+	ctx context.Context,
+	runner Runner,
+	cache *resultCache,
+	projectDir string,
+	logger *zap.Logger,
+) (RunnerResult, bool, error) {
+	if cache != nil {
+		if cached, ok := cache.get(projectDir, runner.Name(), runner.Version()); ok {
+			logger.Debug("jvmreach: cache hit",
+				zap.String("project_root", projectDir),
+				zap.String("runner", runner.Name()),
+				zap.Int("imported_artifacts", len(cached.ImportedArtifacts)))
+			return cached, true, nil
+		}
+		logger.Debug("jvmreach: cache miss",
+			zap.String("project_root", projectDir),
+			zap.String("runner", runner.Name()))
+	}
+	result, err := runner.Run(ctx, projectDir)
+	if err != nil {
+		return RunnerResult{}, false, err
+	}
+	if cache != nil {
+		if err := cache.set(projectDir, runner.Name(), runner.Version(), result); err != nil {
+			logger.Debug("jvmreach: cache write failed (non-fatal)",
+				zap.String("project_root", projectDir),
+				zap.Error(err))
+		}
+	}
+	return result, false, nil
+}
+
+func (a Analyzer) cache() *resultCache {
+	if a.DisableCache {
+		return nil
+	}
+	return newResultCache(a.CacheDir, a.CacheTTL)
+}
+
+func resultFromGraph(g *model.Graph) model.AnalyzeResult {
+	return model.AnalyzeResult{Graph: g, AnalyzerRuns: []string{Name}}
+}
+
+type applyOutcome struct{ reachable, unreachable, unknown int }
+
+// applyRunnerResult annotates every JVM vulnerability whose owning
+// package is attributable to projectRoot. A package is "reachable"
+// iff its `groupId:artifactId` is in the transitive closure of the
+// runner's imported-artifact set, expanded through Graph.Dependencies.
+func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, now time.Time) applyOutcome {
+	var outcome applyOutcome
+	timestamp := now.UTC().Format(time.RFC3339)
+	reachableIDs := computeReachablePackageIDs(g, runRes.ImportedArtifacts)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isJVMPackage(pkg) {
+			continue
+		}
+		if !packageBelongsToProjectRoot(pkg, projectRoot) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			vuln := &pkg.Vulnerabilities[i]
+			if vuln.Reachability != nil && vuln.Reachability.Analyzer == Name {
+				continue
+			}
+			r := &model.Reachability{
+				Analyzer:   Name,
+				AnalyzedAt: timestamp,
+				Tier:       model.TierPackage,
+			}
+			if _, ok := reachableIDs[pkg.ID]; ok {
+				r.Status = model.ReachabilityReachable
+				outcome.reachable++
+			} else {
+				r.Status = model.ReachabilityUnreachable
+				r.Reason = "package-not-imported"
+				outcome.unreachable++
+			}
+			vuln.Reachability = r
+		}
+	}
+	return outcome
+}
+
+// computeReachablePackageIDs returns the set of graph package IDs
+// reachable from the imported-artifact set, expanded transitively
+// through Graph.Dependencies. The seed is every JVM package whose
+// `Org:Name` (groupId:artifactId) matches a coordinate in imports.
+func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map[string]struct{} {
+	reachable := make(map[string]struct{})
+	if g == nil || len(imports) == 0 {
+		return reachable
+	}
+	queue := make([]string, 0)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isJVMPackage(pkg) {
+			continue
+		}
+		if !isPackageImported(pkg, imports) {
+			continue
+		}
+		if _, ok := reachable[pkg.ID]; ok {
+			continue
+		}
+		reachable[pkg.ID] = struct{}{}
+		queue = append(queue, pkg.ID)
+	}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		deps, err := g.Dependencies(id)
+		if err != nil {
+			continue
+		}
+		for _, dep := range deps {
+			if dep == nil {
+				continue
+			}
+			if _, ok := reachable[dep.ID]; ok {
+				continue
+			}
+			reachable[dep.ID] = struct{}{}
+			queue = append(queue, dep.ID)
+		}
+	}
+	return reachable
+}
+
+// isPackageImported reports whether pkg's Maven coordinate (built
+// from Org / Name) appears in the runner's import set.
+func isPackageImported(pkg *model.Package, imports map[string]struct{}) bool {
+	if pkg == nil || len(imports) == 0 {
+		return false
+	}
+	coord := canonicalCoord(pkg.Org, baseArtifactName(pkg.Name))
+	if coord == "" {
+		return false
+	}
+	_, ok := imports[coord]
+	return ok
+}
+
+// baseArtifactName strips any trailing ":classifier" suffix that the
+// Maven detector appends to differentiate artifacts (e.g.
+// "jackson-databind:tests"). The reachability map keys on bare
+// artifact IDs.
+func baseArtifactName(name string) string {
+	if i := strings.Index(name, ":"); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+func annotateProjectUnknown(g *model.Graph, projectRoot, reason string, now time.Time) int {
+	timestamp := now.UTC().Format(time.RFC3339)
+	count := 0
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isJVMPackage(pkg) {
+			continue
+		}
+		if !packageBelongsToProjectRoot(pkg, projectRoot) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			if pkg.Vulnerabilities[i].Reachability != nil {
+				continue
+			}
+			pkg.Vulnerabilities[i].Reachability = &model.Reachability{
+				Analyzer:   Name,
+				Status:     model.ReachabilityUnknown,
+				Tier:       model.TierNone,
+				Reason:     reason,
+				AnalyzedAt: timestamp,
+			}
+			count++
+		}
+	}
+	return count
+}
+
+func annotateAllUnknown(g *model.Graph, reason string, now time.Time) {
+	timestamp := now.UTC().Format(time.RFC3339)
+	for _, pkg := range g.Packages() {
+		if pkg == nil || !isJVMPackage(pkg) {
+			continue
+		}
+		for i := range pkg.Vulnerabilities {
+			if pkg.Vulnerabilities[i].Reachability != nil {
+				continue
+			}
+			pkg.Vulnerabilities[i].Reachability = &model.Reachability{
+				Analyzer:   Name,
+				Status:     model.ReachabilityUnknown,
+				Tier:       model.TierNone,
+				Reason:     reason,
+				AnalyzedAt: timestamp,
+			}
+		}
+	}
+}
+
+func packageBelongsToProjectRoot(pkg *model.Package, projectRoot string) bool {
+	if pkg == nil {
+		return false
+	}
+	if len(pkg.Locations) == 0 {
+		return true
+	}
+	for _, loc := range pkg.Locations {
+		if loc.RealPath == "" {
+			continue
+		}
+		if pathContainsRoot(loc.RealPath, projectRoot) {
+			return true
+		}
+	}
+	return true
+}
+
+func pathContainsRoot(path, root string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanRoot := filepath.Clean(root)
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}
+
+func failureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not implemented"), strings.Contains(msg, "not on path"), strings.Contains(msg, "not found"):
+		return "missing-toolchain"
+	case strings.Contains(msg, "not accessible"), strings.Contains(msg, "no recognised build manifest"):
+		return "no-project-root"
+	case strings.Contains(msg, "context"), strings.Contains(msg, "cancel"):
+		return "cancelled"
+	default:
+		return "runner-error"
+	}
+}

--- a/internal/analyzers/jvmreach/analyzer_test.go
+++ b/internal/analyzers/jvmreach/analyzer_test.go
@@ -1,0 +1,313 @@
+package jvmreach
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+type fakeRunner struct {
+	result RunnerResult
+	err    error
+	called int
+	last   string
+}
+
+func (f *fakeRunner) Name() string    { return "fake" }
+func (f *fakeRunner) Version() string { return "fake-1.0" }
+func (f *fakeRunner) Run(_ context.Context, projectDir string) (RunnerResult, error) {
+	f.called++
+	f.last = projectDir
+	return f.result, f.err
+}
+
+func newJVMProjectDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	pom := []byte(`<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>fixture</artifactId>
+  <version>0.0.0</version>
+</project>
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), pom, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srcDir := filepath.Join(dir, "src", "main", "java", "com", "example")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := []byte("package com.example;\nimport com.fasterxml.jackson.databind.ObjectMapper;\nclass App {}\n")
+	if err := os.WriteFile(filepath.Join(srcDir, "App.java"), app, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func newJVMGraph(t *testing.T, projectDir, group, artifact string, vulns ...model.PackageVulnerability) *model.Graph {
+	t.Helper()
+	g := model.New()
+	pkg := model.NewPackage(model.Package{
+		Name:            artifact,
+		Org:             group,
+		Version:         "1.0.0",
+		Ecosystem:       string(model.EcosystemMaven),
+		BuildSystem:     "maven",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
+		Vulnerabilities: vulns,
+	})
+	if err := g.AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+func TestAnalyzerMarksReachableWhenArtifactIsImported(t *testing.T) {
+	projectDir := newJVMProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newJVMGraph(t, projectDir, "com.fasterxml.jackson.core", "jackson-databind", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedArtifacts: map[string]struct{}{
+					"com.fasterxml.jackson.core:jackson-databind": {},
+				},
+				SourceFiles: 1,
+			},
+		},
+	}
+	res, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatalf("Analyze err: %v", err)
+	}
+	r := res.Graph.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityReachable || r.Tier != model.TierPackage {
+		t.Errorf("unexpected reachability: %+v", r)
+	}
+	if res.AnalyzerStats[Name].Reachable != 1 {
+		t.Errorf("stats.Reachable = %d, want 1", res.AnalyzerStats[Name].Reachable)
+	}
+}
+
+func TestAnalyzerMarksUnreachableWhenArtifactNotImported(t *testing.T) {
+	projectDir := newJVMProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newJVMGraph(t, projectDir, "log4j", "log4j", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedArtifacts: map[string]struct{}{
+					"com.fasterxml.jackson.core:jackson-databind": {},
+				},
+				SourceFiles: 1,
+			},
+		},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r.Status != model.ReachabilityUnreachable || r.Reason != "package-not-imported" {
+		t.Errorf("unexpected reachability: %+v", r)
+	}
+}
+
+func TestAnalyzerDegradesToUnknownOnRunnerError(t *testing.T) {
+	projectDir := newJVMProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newJVMGraph(t, projectDir, "com.fasterxml.jackson.core", "jackson-databind", vuln)
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner:       &fakeRunner{err: errors.New("project dir not accessible: not found")},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatalf("Analyze should not error on runner failure: %v", err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r.Status != model.ReachabilityUnknown || r.Reason != "missing-toolchain" {
+		t.Errorf("unexpected: %+v", r)
+	}
+}
+
+// Transitive expansion is the headline correctness test: the
+// scanner only sees direct imports, but the BFS through the dep
+// graph must lift downstream artifacts to reachable too.
+func TestAnalyzerMarksTransitiveDepReachable(t *testing.T) {
+	projectDir := newJVMProjectDir(t)
+	directVuln := model.PackageVulnerability{ID: "GHSA-direct", Source: "osv", Severity: "high"}
+	transVuln := model.PackageVulnerability{ID: "GHSA-trans", Source: "osv", Severity: "high"}
+
+	g := model.New()
+	direct := model.NewPackage(model.Package{
+		Name:            "jackson-databind",
+		Org:             "com.fasterxml.jackson.core",
+		Version:         "2.17.0",
+		Ecosystem:       string(model.EcosystemMaven),
+		BuildSystem:     "maven",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
+		Vulnerabilities: []model.PackageVulnerability{directVuln},
+	})
+	trans := model.NewPackage(model.Package{
+		Name:            "jackson-core",
+		Org:             "com.fasterxml.jackson.core",
+		Version:         "2.17.0",
+		Ecosystem:       string(model.EcosystemMaven),
+		BuildSystem:     "maven",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
+		Vulnerabilities: []model.PackageVulnerability{transVuln},
+	})
+	if err := g.AddPackage(direct); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddPackage(trans); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(direct.ID, trans.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	a := Analyzer{
+		DisableCache: true,
+		Runner: &fakeRunner{
+			result: RunnerResult{
+				ImportedArtifacts: map[string]struct{}{
+					"com.fasterxml.jackson.core:jackson-databind": {},
+				},
+				SourceFiles: 1,
+			},
+		},
+	}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pkg := range g.Packages() {
+		r := pkg.Vulnerabilities[0].Reachability
+		if r == nil || r.Status != model.ReachabilityReachable {
+			t.Errorf("%s:%s: status = %v, want reachable", pkg.Org, pkg.Name, r)
+		}
+	}
+}
+
+func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
+	g := model.New()
+	a := model.NewPackage(model.Package{Name: "a", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
+	b := model.NewPackage(model.Package{Name: "b", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
+	if err := g.AddPackage(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddPackage(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(a.ID, b.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddDependency(b.ID, a.ID); err != nil {
+		t.Fatal(err)
+	}
+	got := computeReachablePackageIDs(g, map[string]struct{}{"g:a": {}})
+	if _, ok := got[a.ID]; !ok {
+		t.Errorf("a missing from reachable set")
+	}
+	if _, ok := got[b.ID]; !ok {
+		t.Errorf("b missing from reachable set")
+	}
+}
+
+func TestAnalyzerApplicableRequiresJVMVulns(t *testing.T) {
+	a := Analyzer{}
+	g := model.New()
+	pyPkg := model.NewPackage(model.Package{Name: "requests", Ecosystem: string(model.EcosystemPython), Vulnerabilities: []model.PackageVulnerability{{ID: "x"}}})
+	_ = g.AddPackage(pyPkg)
+	ok, _ := a.Applicable(context.Background(), model.AnalyzeRequest{Graph: g})
+	if ok {
+		t.Errorf("Applicable on python-only graph = true; want false")
+	}
+	g = model.New()
+	jvm := model.NewPackage(model.Package{Name: "jackson-databind", Org: "com.fasterxml.jackson.core", Ecosystem: string(model.EcosystemMaven), Vulnerabilities: []model.PackageVulnerability{{ID: "x"}}})
+	_ = g.AddPackage(jvm)
+	ok, _ = a.Applicable(context.Background(), model.AnalyzeRequest{Graph: g})
+	if !ok {
+		t.Errorf("Applicable on jvm-with-vulns graph = false; want true")
+	}
+}
+
+func TestAnalyzerMarksUnknownWhenNoProjectRootDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	g := model.New()
+	pkg := model.NewPackage(model.Package{
+		Name:            "jackson-databind",
+		Org:             "com.fasterxml.jackson.core",
+		Ecosystem:       string(model.EcosystemMaven),
+		Vulnerabilities: []model.PackageVulnerability{{ID: "x"}},
+	})
+	_ = g.AddPackage(pkg)
+	a := Analyzer{DisableCache: true, Runner: &fakeRunner{}}
+	_, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityUnknown || r.Reason != "no-project-root-discovered" {
+		t.Errorf("unexpected: %+v", r)
+	}
+}
+
+func TestLibraryRunnerWalksProjectAndResolvesArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	must := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("pom.xml", "<project></project>")
+	must("src/main/java/com/example/App.java",
+		"package com.example;\n"+
+			"import com.fasterxml.jackson.databind.ObjectMapper;\n"+
+			"import org.apache.logging.log4j.LogManager;\n"+
+			"import java.util.List;\n"+
+			"class App {}\n")
+	// Build outputs that must be skipped:
+	must("target/classes/com/decompiled/Junk.java",
+		"package com.decompiled;\nimport never.seen.Class;\n")
+
+	r := NewRunner(nil)
+	got, err := r.Run(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	expectPresent := []string{
+		"com.fasterxml.jackson.core:jackson-databind",
+		"org.apache.logging.log4j:log4j-api",
+		"org.apache.logging.log4j:log4j-core",
+	}
+	for _, coord := range expectPresent {
+		if _, ok := got.ImportedArtifacts[coord]; !ok {
+			t.Errorf("missing %q in imported set: %v", coord, got.ImportedArtifacts)
+		}
+	}
+	// Stdlib must not leak in.
+	if _, ok := got.ImportedArtifacts["java.util:list"]; ok {
+		t.Errorf("stdlib leaked into import set")
+	}
+	if got.SourceFiles == 0 {
+		t.Error("source files = 0; want > 0")
+	}
+}

--- a/internal/analyzers/jvmreach/cache.go
+++ b/internal/analyzers/jvmreach/cache.go
@@ -1,0 +1,135 @@
+package jvmreach
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	cachepkg "github.com/bomly-dev/bomly-cli/internal/matchers/cache"
+)
+
+const cacheSchemaVersion = "v1"
+const defaultCacheTTL = 24 * time.Hour
+
+type resultCache struct {
+	store *cachepkg.FileCache
+}
+
+type cachedRunnerResult struct {
+	ImportedArtifacts []string `json:"imported_artifacts,omitempty"`
+	SourceFiles       int      `json:"source_files,omitempty"`
+	SkippedDirs       []string `json:"skipped_dirs,omitempty"`
+}
+
+func newResultCache(dir string, ttl time.Duration) *resultCache {
+	if ttl <= 0 {
+		ttl = defaultCacheTTL
+	}
+	root := dir
+	if root == "" {
+		root = defaultCacheRoot()
+	}
+	if root == "" {
+		return nil
+	}
+	store, err := cachepkg.NewFileCache(root, ttl)
+	if err != nil {
+		return nil
+	}
+	return &resultCache{store: store}
+}
+
+func defaultCacheRoot() string {
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		return ""
+	}
+	return filepath.Join(base, "bomly", "analyzers", "jvmreach")
+}
+
+func keyFor(projectDir, runnerName, runnerVersion string) (cachepkg.Key, error) {
+	checksum, err := projectChecksum(projectDir)
+	if err != nil {
+		return cachepkg.Key{}, err
+	}
+	parts := fmt.Sprintf("jvmreach|%s|%s|%s|%s|%s",
+		cacheSchemaVersion, runnerName, runnerVersion, projectDir, checksum)
+	return cachepkg.NewKey(parts, "jvmreach", "maven", cacheSchemaVersion), nil
+}
+
+// lockfileCandidates lists the files hashed to fingerprint the
+// project. The first one that exists wins. Gradle's `dependencies`
+// task can produce a lockfile under `gradle/dependency-locks/` but
+// it isn't required, so we fall back to the build script itself.
+var lockfileCandidates = []string{
+	"gradle.lockfile",
+	"pom.xml",
+	"build.gradle.kts",
+	"build.gradle",
+	"build.sbt",
+	"settings.gradle.kts",
+	"settings.gradle",
+}
+
+func projectChecksum(projectDir string) (string, error) {
+	for _, name := range lockfileCandidates {
+		path := filepath.Join(projectDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("read %s: %w", name, err)
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:8]), nil
+	}
+	return "", fmt.Errorf("project %q has no recognised build manifest", projectDir)
+}
+
+func (c *resultCache) get(projectDir, runnerName, runnerVersion string) (RunnerResult, bool) {
+	if c == nil {
+		return RunnerResult{}, false
+	}
+	key, err := keyFor(projectDir, runnerName, runnerVersion)
+	if err != nil {
+		return RunnerResult{}, false
+	}
+	cached, ok := cachepkg.Get[cachedRunnerResult](c.store, key)
+	if !ok {
+		return RunnerResult{}, false
+	}
+	artifacts := make(map[string]struct{}, len(cached.ImportedArtifacts))
+	for _, a := range cached.ImportedArtifacts {
+		artifacts[a] = struct{}{}
+	}
+	return RunnerResult{
+		ImportedArtifacts: artifacts,
+		SourceFiles:       cached.SourceFiles,
+		SkippedDirs:       append([]string(nil), cached.SkippedDirs...),
+	}, true
+}
+
+func (c *resultCache) set(projectDir, runnerName, runnerVersion string, result RunnerResult) error {
+	if c == nil {
+		return nil
+	}
+	key, err := keyFor(projectDir, runnerName, runnerVersion)
+	if err != nil {
+		return err
+	}
+	artifacts := make([]string, 0, len(result.ImportedArtifacts))
+	for a := range result.ImportedArtifacts {
+		artifacts = append(artifacts, a)
+	}
+	cached := cachedRunnerResult{
+		ImportedArtifacts: artifacts,
+		SourceFiles:       result.SourceFiles,
+		SkippedDirs:       append([]string(nil), result.SkippedDirs...),
+	}
+	return cachepkg.Set(c.store, key, cached)
+}

--- a/internal/analyzers/jvmreach/cache_test.go
+++ b/internal/analyzers/jvmreach/cache_test.go
@@ -1,0 +1,85 @@
+package jvmreach
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestResultCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cache := newResultCache(dir, 0)
+	if cache == nil {
+		t.Fatal("newResultCache returned nil")
+	}
+	projectDir := newJVMProjectDir(t)
+	want := RunnerResult{
+		ImportedArtifacts: map[string]struct{}{"com.fasterxml.jackson.core:jackson-databind": {}},
+		SourceFiles:       3,
+	}
+	if err := cache.set(projectDir, "fake", "1.0", want); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, ok := cache.get(projectDir, "fake", "1.0")
+	if !ok {
+		t.Fatal("cache miss right after set")
+	}
+	if got.SourceFiles != 3 {
+		t.Errorf("source files = %d, want 3", got.SourceFiles)
+	}
+	if _, ok := got.ImportedArtifacts["com.fasterxml.jackson.core:jackson-databind"]; !ok {
+		t.Errorf("missing artifact in cached result")
+	}
+}
+
+func TestResultCacheInvalidatesOnBuildFileChange(t *testing.T) {
+	dir := t.TempDir()
+	cache := newResultCache(dir, 0)
+	projectDir := newJVMProjectDir(t)
+	pom := filepath.Join(projectDir, "pom.xml")
+	if err := cache.set(projectDir, "fake", "1.0", RunnerResult{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.get(projectDir, "fake", "1.0"); !ok {
+		t.Fatal("cache miss right after set")
+	}
+	if err := os.WriteFile(pom, []byte("<project>changed</project>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.get(projectDir, "fake", "1.0"); ok {
+		t.Errorf("cache should miss after pom.xml content change")
+	}
+}
+
+func TestAnalyzerWithCacheServesSecondCallFromCache(t *testing.T) {
+	projectDir := newJVMProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newJVMGraph(t, projectDir, "com.fasterxml.jackson.core", "jackson-databind", vuln)
+	runner := &fakeRunner{
+		result: RunnerResult{
+			ImportedArtifacts: map[string]struct{}{"com.fasterxml.jackson.core:jackson-databind": {}},
+			SourceFiles:       1,
+		},
+	}
+	a := Analyzer{Runner: runner, CacheDir: t.TempDir()}
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.called != 1 {
+		t.Fatalf("first Analyze should call runner once, got %d", runner.called)
+	}
+	g2 := newJVMGraph(t, projectDir, "com.fasterxml.jackson.core", "jackson-databind", vuln)
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g2, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.called != 1 {
+		t.Errorf("second Analyze should hit cache; runner.called = %d, want 1", runner.called)
+	}
+	r := g2.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityReachable {
+		t.Errorf("cached path did not produce a reachable annotation: %+v", r)
+	}
+}

--- a/internal/analyzers/jvmreach/discover.go
+++ b/internal/analyzers/jvmreach/discover.go
@@ -1,0 +1,104 @@
+package jvmreach
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	model "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// discoverProjectRoots returns the JVM project roots derivable from
+// the request.
+func discoverProjectRoots(req model.AnalyzeRequest) []string {
+	seen := make(map[string]struct{})
+	roots := make([]string, 0)
+
+	add := func(dir string) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return
+		}
+		clean := filepath.Clean(dir)
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		roots = append(roots, clean)
+	}
+
+	if req.Graph != nil {
+		for _, pkg := range req.Graph.Packages() {
+			if pkg == nil || !isJVMPackage(pkg) {
+				continue
+			}
+			for _, loc := range pkg.Locations {
+				if loc.RealPath == "" {
+					continue
+				}
+				if root := findProjectRoot(loc.RealPath); root != "" {
+					add(root)
+				}
+			}
+		}
+	}
+
+	for _, candidate := range []string{req.ProjectPath, req.ExecutionTarget.Location} {
+		if candidate == "" {
+			continue
+		}
+		if root := findProjectRoot(candidate); root != "" {
+			add(root)
+		}
+	}
+
+	sort.Strings(roots)
+	return roots
+}
+
+// findProjectRoot walks upward from start until it finds a directory
+// that contains a recognised JVM project file. Returns "" when none
+// is found.
+func findProjectRoot(start string) string {
+	dir := start
+	info, err := os.Stat(dir)
+	if err == nil && !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+	for {
+		if dir == "" {
+			return ""
+		}
+		if hasProjectMarker(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// isJVMPackage reports whether pkg's ecosystem, build system, or
+// language identifies it as a JVM (Maven/Gradle/SBT) package.
+func isJVMPackage(pkg *model.Package) bool {
+	if pkg == nil {
+		return false
+	}
+	switch strings.ToLower(pkg.Ecosystem) {
+	case string(model.EcosystemMaven), string(model.EcosystemScala):
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(pkg.BuildSystem)) {
+	case "maven", "gradle", "sbt":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(pkg.Language)) {
+	case string(model.LanguageJava), string(model.LanguageKotlin),
+		string(model.LanguageScala), string(model.LanguageGroovy):
+		return true
+	}
+	return false
+}

--- a/internal/analyzers/jvmreach/importscanner.go
+++ b/internal/analyzers/jvmreach/importscanner.go
@@ -1,0 +1,264 @@
+package jvmreach
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// scanImports reads JVM source (.java / .kt / .kts / .scala / .groovy)
+// and returns the set of fully-qualified imports. Each entry is a
+// dotted FQN — the import path as written by the user, before any
+// wildcard or selector expansion.
+//
+// Supported syntactic forms:
+//
+//	Java:
+//	  import com.foo.Bar;
+//	  import com.foo.*;
+//	  import static com.foo.Bar.baz;
+//
+//	Kotlin (.kt, .kts):
+//	  import com.foo.Bar
+//	  import com.foo.*
+//	  import com.foo.Bar as B
+//
+//	Scala:
+//	  import com.foo.Bar
+//	  import com.foo.{Bar, Baz}
+//	  import com.foo.{Bar => B, _}
+//	  import com.foo._
+//
+//	Groovy:
+//	  same shape as Java, optional semicolon
+//
+// The scanner is line-oriented. It tracks /* ... */ block comments
+// (but not nested) and skips // line comments. Triple-quoted Kotlin
+// raw strings and Scala interpolators are not modelled — false
+// positives there are harmless because the analyzer's downstream
+// prefix mapping won't have an entry for a string-literal FQN. The
+// scanner stops paying attention to imports after the first line
+// that does not look like an import, a comment, or whitespace; this
+// matches the JLS / Kotlin / Scala rule that imports come at the
+// top of the file.
+//
+// Returned FQNs are the "source path" only (everything before the
+// last segment for Java/Kotlin "import foo.bar.Baz;", or everything
+// inside `from x import ...`-like Scala selectors). The caller
+// (resolveArtifacts) decides what prefix to match.
+func scanImports(r io.Reader) (map[string]struct{}, error) {
+	imports := make(map[string]struct{})
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	inBlockComment := false
+	// sawNonImport tracks whether we've passed the import header of
+	// the file. After the first non-comment, non-blank, non-import
+	// line we stop looking — saves work on big source files.
+	sawNonImport := false
+	for scanner.Scan() {
+		raw := scanner.Text()
+		// Strip block comments straddling the line. We do not track
+		// strings; an import-looking substring inside a string
+		// literal at the top of a file is vanishingly rare in real
+		// JVM code.
+		line, stillInBlock := stripBlockComment(raw, inBlockComment)
+		inBlockComment = stillInBlock
+		// Strip a trailing line-comment.
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "package "):
+			// package declaration; keep scanning.
+		case strings.HasPrefix(trimmed, "import "):
+			for _, fqn := range parseImportLine(trimmed[len("import "):]) {
+				if fqn != "" {
+					imports[fqn] = struct{}{}
+				}
+			}
+		default:
+			// First substantive non-import line. Stop scanning.
+			sawNonImport = true
+		}
+		if sawNonImport {
+			break
+		}
+	}
+	// Drain the rest of the file so the scanner.Err() check below
+	// is meaningful for early-truncated readers.
+	for scanner.Scan() {
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return imports, nil
+}
+
+// stripBlockComment removes any /* ... */ block-comment content from
+// line. When inBlock is true on entry, the prefix of line is treated
+// as already inside a block. Returns the trimmed line and the new
+// "in-block" state.
+func stripBlockComment(line string, inBlock bool) (string, bool) {
+	out := ""
+	i := 0
+	for i < len(line) {
+		if inBlock {
+			end := strings.Index(line[i:], "*/")
+			if end < 0 {
+				return out, true
+			}
+			i += end + 2
+			inBlock = false
+			continue
+		}
+		start := strings.Index(line[i:], "/*")
+		if start < 0 {
+			out += line[i:]
+			break
+		}
+		out += line[i : i+start]
+		i += start + 2
+		inBlock = true
+	}
+	return out, inBlock
+}
+
+// parseImportLine takes the operand of an `import` statement (after
+// the keyword) and returns the set of source-side FQNs it implies.
+//
+// For Java: "static com.foo.Bar.baz;" -> "com.foo.Bar" (drop the
+// member). For Kotlin: "com.foo.Bar as B" -> "com.foo.Bar". For
+// Scala: "com.foo.{Bar, Baz}" -> {"com.foo.Bar", "com.foo.Baz"};
+// "com.foo._" -> "com.foo"; "com.foo.{Bar => B, _}" -> "com.foo.Bar".
+//
+// Returned FQNs include the import's full source path so the prefix
+// resolver can match the most specific prefix possible.
+func parseImportLine(operand string) []string {
+	operand = strings.TrimSpace(operand)
+	operand = strings.TrimSuffix(operand, ";")
+	operand = strings.TrimSpace(operand)
+	if operand == "" {
+		return nil
+	}
+	// Java "import static com.foo.Bar.baz" — drop the leading
+	// "static " keyword and the trailing member identifier (last
+	// segment after the package).
+	staticImport := false
+	if strings.HasPrefix(operand, "static ") {
+		operand = strings.TrimSpace(operand[len("static "):])
+		staticImport = true
+	}
+	// Kotlin "import com.foo.Bar as B" — drop the alias.
+	if i := strings.Index(operand, " as "); i >= 0 {
+		operand = operand[:i]
+	}
+	operand = strings.TrimSpace(operand)
+	if operand == "" {
+		return nil
+	}
+	// Scala selector: "com.foo.{A, B => C, _}"
+	if i := strings.Index(operand, "{"); i >= 0 {
+		j := strings.LastIndex(operand, "}")
+		if j < 0 || j < i {
+			return nil
+		}
+		prefix := strings.TrimSpace(operand[:i])
+		prefix = strings.TrimSuffix(prefix, ".")
+		inside := operand[i+1 : j]
+		parts := strings.Split(inside, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" || p == "_" {
+				if prefix != "" {
+					out = appendUnique(out, prefix)
+				}
+				continue
+			}
+			// "A => B" — keep A.
+			if k := strings.Index(p, "=>"); k >= 0 {
+				p = strings.TrimSpace(p[:k])
+			}
+			if !isIdentLike(p) {
+				continue
+			}
+			fqn := prefix
+			if fqn != "" {
+				fqn += "."
+			}
+			fqn += p
+			out = appendUnique(out, fqn)
+		}
+		return out
+	}
+	// Trailing wildcard `.*` or `._` => keep everything before the
+	// wildcard (Scala uses `_`, Java/Kotlin use `*`).
+	for _, suffix := range []string{".*", "._"} {
+		if strings.HasSuffix(operand, suffix) {
+			return []string{strings.TrimSuffix(operand, suffix)}
+		}
+	}
+	// Plain `import a.b.c.Class` form. Keep the full path. For
+	// `import static`, also strip the trailing member identifier so
+	// the prefix match sees the type, not the field.
+	if staticImport {
+		if i := strings.LastIndex(operand, "."); i >= 0 {
+			operand = operand[:i]
+		}
+	}
+	if !isDotIdent(operand) {
+		return nil
+	}
+	return []string{operand}
+}
+
+// isIdentLike reports whether s looks like a single Java/Kotlin/Scala
+// identifier (letters, digits, underscore, plus '$' which is legal
+// for inner-class references).
+func isIdentLike(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_', r == '$':
+			// ok
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isDotIdent reports whether s is a dot-separated chain of
+// identifiers. Used to drop garbage that doesn't look like a real
+// import path.
+func isDotIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, part := range strings.Split(s, ".") {
+		if !isIdentLike(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func appendUnique(out []string, v string) []string {
+	for _, x := range out {
+		if x == v {
+			return out
+		}
+	}
+	return append(out, v)
+}

--- a/internal/analyzers/jvmreach/importscanner_test.go
+++ b/internal/analyzers/jvmreach/importscanner_test.go
@@ -1,0 +1,121 @@
+package jvmreach
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanImports(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "java single import",
+			src:  "package com.example;\nimport com.fasterxml.jackson.databind.ObjectMapper;\n\nclass X {}\n",
+			want: []string{"com.fasterxml.jackson.databind.ObjectMapper"},
+		},
+		{
+			name: "java wildcard",
+			src:  "import com.foo.*;\n",
+			want: []string{"com.foo"},
+		},
+		{
+			name: "java static import drops member",
+			src:  "import static org.junit.jupiter.api.Assertions.assertEquals;\n",
+			want: []string{"org.junit.jupiter.api.Assertions"},
+		},
+		{
+			name: "kotlin import with alias",
+			src:  "import com.foo.Bar as B\n",
+			want: []string{"com.foo.Bar"},
+		},
+		{
+			name: "kotlin import wildcard",
+			src:  "import com.foo.*\n",
+			want: []string{"com.foo"},
+		},
+		{
+			name: "scala selector list",
+			src:  "import com.foo.{A, B, C}\n",
+			want: []string{"com.foo.A", "com.foo.B", "com.foo.C"},
+		},
+		{
+			name: "scala selector with rename",
+			src:  "import com.foo.{Bar => B, Baz}\n",
+			want: []string{"com.foo.Bar", "com.foo.Baz"},
+		},
+		{
+			name: "scala wildcard",
+			src:  "import com.foo._\n",
+			want: []string{"com.foo"},
+		},
+		{
+			name: "scala selector wildcard inside braces",
+			src:  "import com.foo.{Bar, _}\n",
+			want: []string{"com.foo.Bar", "com.foo"},
+		},
+		{
+			name: "scanner stops after first non-import line",
+			src:  "import com.a.A;\nclass X {}\nimport com.b.B;\n",
+			want: []string{"com.a.A"},
+		},
+		{
+			name: "block comment stripped",
+			src:  "/* preamble */\nimport com.a.A;\n",
+			want: []string{"com.a.A"},
+		},
+		{
+			name: "trailing line comment ignored",
+			src:  "import com.a.A; // why\n",
+			want: []string{"com.a.A"},
+		},
+		{
+			name: "multi-line block comment",
+			src:  "/*\n  banner\n*/\nimport com.a.A;\n",
+			want: []string{"com.a.A"},
+		},
+		{
+			name: "empty input",
+			src:  "",
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := scanImports(strings.NewReader(tc.src))
+			if err != nil {
+				t.Fatalf("scanImports err: %v", err)
+			}
+			gotSlice := mapKeys(got)
+			if !equalAsSets(gotSlice, tc.want) {
+				t.Errorf("scanImports = %v, want %v", gotSlice, tc.want)
+			}
+		})
+	}
+}
+
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func equalAsSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		seen[v] = struct{}{}
+	}
+	for _, v := range a {
+		if _, ok := seen[v]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/analyzers/jvmreach/prefixmap.go
+++ b/internal/analyzers/jvmreach/prefixmap.go
@@ -1,0 +1,271 @@
+package jvmreach
+
+import (
+	"sort"
+	"strings"
+)
+
+// packagePrefixToArtifacts maps fully-qualified Java/Kotlin/Scala
+// package prefixes to one or more Maven artifact coordinates that
+// publish into them. The map is hand-curated and covers the most
+// commonly-imported third-party libraries on the JVM.
+//
+// Resolution: each scanned import is matched against the **longest**
+// registered prefix that is a prefix of the import (component-wise:
+// `com.fasterxml.jackson.databind` is a prefix of
+// `com.fasterxml.jackson.databind.ObjectMapper` but not of
+// `com.fasterxml.jackson.databindfoo.X`). On a hit, every artifact
+// listed for that prefix is added to the imported-artifact set; the
+// BFS through Graph.Dependencies then expands the set transitively.
+//
+// Why a curated map. The Java package -> Maven artifact relationship
+// is genuinely arbitrary — there is no naming convention that holds
+// across vendors. Unlike Python (where `requests` the module almost
+// always lives in `requests` the dist), Java has no fallback. A
+// missing prefix produces a false-negative for direct imports; the
+// dep-graph BFS recovers it if any correctly-mapped neighbour is
+// imported.
+//
+// Coordinates are stored lowercase, in `group:artifact` form. PRs
+// extending the map are welcome.
+var packagePrefixToArtifacts = map[string][]string{
+	// Jackson — split across many artifacts.
+	"com.fasterxml.jackson.core":            {"com.fasterxml.jackson.core:jackson-core"},
+	"com.fasterxml.jackson.databind":        {"com.fasterxml.jackson.core:jackson-databind"},
+	"com.fasterxml.jackson.annotation":      {"com.fasterxml.jackson.core:jackson-annotations"},
+	"com.fasterxml.jackson.datatype.jsr310": {"com.fasterxml.jackson.datatype:jackson-datatype-jsr310"},
+	"com.fasterxml.jackson.datatype.jdk8":   {"com.fasterxml.jackson.datatype:jackson-datatype-jdk8"},
+	"com.fasterxml.jackson.module.kotlin":   {"com.fasterxml.jackson.module:jackson-module-kotlin"},
+	"com.fasterxml.jackson.module.scala":    {"com.fasterxml.jackson.module:jackson-module-scala"},
+	"com.fasterxml.jackson.dataformat.yaml": {"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"},
+	"com.fasterxml.jackson.dataformat.xml":  {"com.fasterxml.jackson.dataformat:jackson-dataformat-xml"},
+
+	// Spring Framework + Spring Boot. We keep these coarse; the
+	// real artifact split is at sub-package level (e.g. spring-web
+	// vs spring-webmvc) and over-attributing to the umbrella has
+	// a small false-positive cost vs missing real reachability.
+	"org.springframework.boot":               {"org.springframework.boot:spring-boot"},
+	"org.springframework.boot.autoconfigure": {"org.springframework.boot:spring-boot-autoconfigure"},
+	"org.springframework.boot.actuate":       {"org.springframework.boot:spring-boot-actuator"},
+	"org.springframework.web.servlet":        {"org.springframework:spring-webmvc"},
+	"org.springframework.web.reactive":       {"org.springframework:spring-webflux"},
+	"org.springframework.web":                {"org.springframework:spring-web"},
+	"org.springframework.context":            {"org.springframework:spring-context"},
+	"org.springframework.beans":              {"org.springframework:spring-beans"},
+	"org.springframework.core":               {"org.springframework:spring-core"},
+	"org.springframework.data.jpa":           {"org.springframework.data:spring-data-jpa"},
+	"org.springframework.data.mongodb":       {"org.springframework.data:spring-data-mongodb"},
+	"org.springframework.data.redis":         {"org.springframework.data:spring-data-redis"},
+	"org.springframework.security":           {"org.springframework.security:spring-security-core"},
+	"org.springframework.kafka":              {"org.springframework.kafka:spring-kafka"},
+
+	// Logging.
+	"org.apache.logging.log4j": {"org.apache.logging.log4j:log4j-api", "org.apache.logging.log4j:log4j-core"},
+	"org.slf4j":                {"org.slf4j:slf4j-api"},
+	"ch.qos.logback":           {"ch.qos.logback:logback-classic", "ch.qos.logback:logback-core"},
+	"java.util.logging":        nil, // stdlib, listed for clarity
+	"org.apache.log4j":         {"log4j:log4j"},
+
+	// Apache Commons.
+	"org.apache.commons.lang3":        {"org.apache.commons:commons-lang3"},
+	"org.apache.commons.lang":         {"commons-lang:commons-lang"},
+	"org.apache.commons.io":           {"commons-io:commons-io"},
+	"org.apache.commons.collections4": {"org.apache.commons:commons-collections4"},
+	"org.apache.commons.collections":  {"commons-collections:commons-collections"},
+	"org.apache.commons.codec":        {"commons-codec:commons-codec"},
+	"org.apache.commons.text":         {"org.apache.commons:commons-text"},
+	"org.apache.commons.cli":          {"commons-cli:commons-cli"},
+	"org.apache.commons.compress":     {"org.apache.commons:commons-compress"},
+	"org.apache.commons.csv":          {"org.apache.commons:commons-csv"},
+	"org.apache.commons.math3":        {"org.apache.commons:commons-math3"},
+	"org.apache.commons.pool2":        {"org.apache.commons:commons-pool2"},
+	"org.apache.commons.dbcp2":        {"org.apache.commons:commons-dbcp2"},
+	"org.apache.commons.beanutils":    {"commons-beanutils:commons-beanutils"},
+	"org.apache.commons.fileupload":   {"commons-fileupload:commons-fileupload"},
+	"org.apache.commons.fileupload2":  {"org.apache.commons:commons-fileupload2-core"},
+	"org.apache.xml.security":         {"org.apache.santuario:xmlsec"},
+	"org.mindrot.jbcrypt":             {"org.mindrot:jbcrypt"},
+	"org.mindrot":                     {"org.mindrot:jbcrypt"},
+
+	// Apache Struts 2.
+	"org.apache.struts2":      {"org.apache.struts:struts2-core"},
+	"com.opensymphony.xwork2": {"org.apache.struts.xwork:xwork-core"},
+
+	// Keycloak (SAML / common).
+	"org.keycloak.adapters": {"org.keycloak:keycloak-saml-core"},
+	"org.keycloak":          {"org.keycloak:keycloak-core"},
+
+	// H2 / Kafka / other widely-pinned demos.
+	"org.h2":                {"com.h2database:h2"},
+	"org.apache.kafka":      {"org.apache.kafka:kafka-clients"},
+	"kafka":                 {"org.apache.kafka:kafka_2.12"},
+	"net.bull.javamelody":   {"net.bull.javamelody:javamelody-core"},
+	"com.orientechnologies": {"com.orientechnologies:orientdb-core"},
+
+	// Apache Sling.
+	"org.apache.sling.engine": {"org.apache.sling:org.apache.sling.engine"},
+
+	// Google.
+	"com.google.common":     {"com.google.guava:guava"},
+	"com.google.gson":       {"com.google.code.gson:gson"},
+	"com.google.protobuf":   {"com.google.protobuf:protobuf-java"},
+	"com.google.inject":     {"com.google.inject:guice"},
+	"com.google.errorprone": {"com.google.errorprone:error_prone_annotations"},
+	"io.grpc":               {"io.grpc:grpc-core", "io.grpc:grpc-api"},
+
+	// Testing.
+	"org.junit.jupiter":  {"org.junit.jupiter:junit-jupiter-api", "org.junit.jupiter:junit-jupiter-engine"},
+	"org.junit.platform": {"org.junit.platform:junit-platform-launcher"},
+	"org.junit":          {"junit:junit"},
+	"junit.framework":    {"junit:junit"},
+	"org.assertj.core":   {"org.assertj:assertj-core"},
+	"org.mockito":        {"org.mockito:mockito-core"},
+	"org.testng":         {"org.testng:testng"},
+	"io.cucumber":        {"io.cucumber:cucumber-java"},
+	"org.hamcrest":       {"org.hamcrest:hamcrest"},
+
+	// Networking / HTTP clients.
+	"io.netty":              {"io.netty:netty-all"},
+	"okhttp3":               {"com.squareup.okhttp3:okhttp"},
+	"retrofit2":             {"com.squareup.retrofit2:retrofit"},
+	"org.apache.http":       {"org.apache.httpcomponents:httpclient"},
+	"org.apache.hc.client5": {"org.apache.httpcomponents.client5:httpclient5"},
+	"org.apache.hc.core5":   {"org.apache.httpcomponents.core5:httpcore5"},
+	"com.squareup.okio":     {"com.squareup.okio:okio"},
+
+	// Database / persistence.
+	"org.hibernate":       {"org.hibernate.orm:hibernate-core"},
+	"javax.persistence":   {"javax.persistence:javax.persistence-api"},
+	"jakarta.persistence": {"jakarta.persistence:jakarta.persistence-api"},
+	"org.postgresql":      {"org.postgresql:postgresql"},
+	"com.mysql.cj":        {"com.mysql:mysql-connector-j"},
+	"redis.clients.jedis": {"redis.clients:jedis"},
+	"com.mongodb":         {"org.mongodb:mongodb-driver-sync"},
+
+	// XML / JSON.
+	"org.dom4j":        {"org.dom4j:dom4j"},
+	"org.jdom2":        {"org.jdom:jdom2"},
+	"javax.xml.bind":   {"jakarta.xml.bind:jakarta.xml.bind-api"},
+	"jakarta.xml.bind": {"jakarta.xml.bind:jakarta.xml.bind-api"},
+
+	// Misc widely-used.
+	"org.yaml.snakeyaml":   {"org.yaml:snakeyaml"},
+	"com.zaxxer.hikari":    {"com.zaxxer:HikariCP"},
+	"io.swagger":           {"io.swagger:swagger-annotations"},
+	"io.swagger.v3":        {"io.swagger.core.v3:swagger-annotations"},
+	"org.eclipse.jetty":    {"org.eclipse.jetty:jetty-server"},
+	"org.glassfish.jersey": {"org.glassfish.jersey.core:jersey-server"},
+	"javax.servlet":        {"javax.servlet:javax.servlet-api"},
+	"jakarta.servlet":      {"jakarta.servlet:jakarta.servlet-api"},
+	"io.micrometer":        {"io.micrometer:micrometer-core"},
+	"io.opentelemetry":     {"io.opentelemetry:opentelemetry-api"},
+	"io.opentracing":       {"io.opentracing:opentracing-api"},
+
+	// Kotlin libraries.
+	"kotlinx.coroutines":        {"org.jetbrains.kotlinx:kotlinx-coroutines-core"},
+	"kotlinx.serialization":     {"org.jetbrains.kotlinx:kotlinx-serialization-core"},
+	"org.jetbrains.annotations": {"org.jetbrains:annotations"},
+
+	// Scala libraries.
+	"akka":   {"com.typesafe.akka:akka-actor"},
+	"cats":   {"org.typelevel:cats-core"},
+	"scalaz": {"org.scalaz:scalaz-core"},
+	"play":   {"com.typesafe.play:play"},
+	"slick":  {"com.typesafe.slick:slick"},
+
+	// Groovy.
+	"groovy": {"org.codehaus.groovy:groovy"},
+
+	// Build / annotation processors that appear in app source occasionally.
+	"lombok":             {"org.projectlombok:lombok"},
+	"javax.inject":       {"javax.inject:javax.inject"},
+	"jakarta.inject":     {"jakarta.inject:jakarta.inject-api"},
+	"javax.validation":   {"javax.validation:validation-api"},
+	"jakarta.validation": {"jakarta.validation:jakarta.validation-api"},
+}
+
+// stdlibPackagePrefixes lists package roots that are part of the JDK,
+// Kotlin, Scala, or Groovy standard libraries. Imports under these
+// roots are dropped from the import set before mapping.
+var stdlibPackagePrefixes = []string{
+	"java.",
+	"javax.crypto.",
+	"javax.naming.",
+	"javax.net.",
+	"javax.security.",
+	"javax.sound.",
+	"javax.sql.",
+	"javax.swing.",
+	"javax.tools.",
+	"javax.imageio.",
+	"javax.accessibility.",
+	"javax.activation.",
+	"javax.management.",
+	"javax.print.",
+	"javax.script.",
+	"javax.smartcardio.",
+	"javax.transaction.",
+	"jdk.",
+	"sun.",
+	"com.sun.",
+	"kotlin.",
+	"kotlinx.io.", // some kotlinx parts are stdlib-adjacent
+	"scala.",
+	"groovy.lang.",
+	"groovy.util.",
+}
+
+// isStdlibImport reports whether the given full import path lives in
+// a stdlib package root.
+func isStdlibImport(fqn string) bool {
+	for _, prefix := range stdlibPackagePrefixes {
+		if strings.HasPrefix(fqn, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveArtifacts returns the set of Maven coordinates that should
+// be added to the import set for one scanned import. Empty result
+// means: stdlib, unknown prefix, or empty input — caller drops it.
+//
+// The match is longest-prefix component-wise (so
+// `com.fasterxml.jackson.databind.foo` resolves the `databind`
+// artifact, not the broader `core`). The lookup never falls through
+// to a synthesised coordinate — Java packages and Maven coordinates
+// have no usable identity relationship.
+func resolveArtifacts(fqn string) []string {
+	fqn = strings.TrimSpace(fqn)
+	if fqn == "" || isStdlibImport(fqn) {
+		return nil
+	}
+	// Try every component prefix from longest to shortest.
+	parts := strings.Split(fqn, ".")
+	for i := len(parts); i > 0; i-- {
+		candidate := strings.Join(parts[:i], ".")
+		if artifacts, ok := packagePrefixToArtifacts[candidate]; ok {
+			out := make([]string, 0, len(artifacts))
+			for _, a := range artifacts {
+				if a == "" {
+					continue
+				}
+				out = append(out, strings.ToLower(a))
+			}
+			sort.Strings(out)
+			return out
+		}
+	}
+	return nil
+}
+
+// canonicalCoord normalizes a Maven coordinate to lowercase for
+// case-insensitive comparison against the import set.
+func canonicalCoord(group, artifact string) string {
+	g := strings.ToLower(strings.TrimSpace(group))
+	a := strings.ToLower(strings.TrimSpace(artifact))
+	if g == "" || a == "" {
+		return ""
+	}
+	return g + ":" + a
+}

--- a/internal/analyzers/jvmreach/prefixmap_test.go
+++ b/internal/analyzers/jvmreach/prefixmap_test.go
@@ -1,0 +1,63 @@
+package jvmreach
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveArtifacts(t *testing.T) {
+	cases := []struct {
+		fqn  string
+		want []string
+	}{
+		// Longest-prefix matching: databind beats jackson umbrella.
+		{"com.fasterxml.jackson.databind.ObjectMapper", []string{"com.fasterxml.jackson.core:jackson-databind"}},
+		{"com.fasterxml.jackson.core.JsonParser", []string{"com.fasterxml.jackson.core:jackson-core"}},
+		// Log4j publishes two artifacts under the same prefix.
+		{"org.apache.logging.log4j.LogManager", []string{"org.apache.logging.log4j:log4j-api", "org.apache.logging.log4j:log4j-core"}},
+		// Stdlib: dropped.
+		{"java.util.List", nil},
+		{"javax.crypto.Cipher", nil},
+		{"kotlin.collections.List", nil},
+		{"scala.collection.immutable.List", nil},
+		// Unknown prefix: dropped (no identity fallback).
+		{"com.example.app.Main", nil},
+		// Empty / whitespace.
+		{"", nil},
+		{"   ", nil},
+		// Junit5.
+		{"org.junit.jupiter.api.Test", []string{"org.junit.jupiter:junit-jupiter-api", "org.junit.jupiter:junit-jupiter-engine"}},
+		// Spring sub-package.
+		{"org.springframework.web.servlet.DispatcherServlet", []string{"org.springframework:spring-webmvc"}},
+		// Apache commons.
+		{"org.apache.commons.lang3.StringUtils", []string{"org.apache.commons:commons-lang3"}},
+		// Guava.
+		{"com.google.common.collect.ImmutableMap", []string{"com.google.guava:guava"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fqn, func(t *testing.T) {
+			got := resolveArtifacts(tc.fqn)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("resolveArtifacts(%q) = %v, want %v", tc.fqn, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalCoord(t *testing.T) {
+	cases := []struct {
+		group, artifact, want string
+	}{
+		{"com.fasterxml.jackson.core", "jackson-databind", "com.fasterxml.jackson.core:jackson-databind"},
+		{"Org.Mockito", "Mockito-Core", "org.mockito:mockito-core"},
+		{"", "jackson", ""},
+		{"org.example", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.group+":"+tc.artifact, func(t *testing.T) {
+			if got := canonicalCoord(tc.group, tc.artifact); got != tc.want {
+				t.Errorf("canonicalCoord(%q,%q) = %q, want %q", tc.group, tc.artifact, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/analyzers/jvmreach/runner.go
+++ b/internal/analyzers/jvmreach/runner.go
@@ -1,0 +1,72 @@
+// Package jvmreach implements a Tier-3 (package-level) reachability
+// analyzer for JVM-ecosystem packages (Maven, Gradle, SBT). It walks
+// application source files rooted at a JVM project, scans every
+// reachable .java / .kt / .kts / .scala / .groovy file for top-of-file
+// import statements, maps the imported FQN prefixes to Maven artifact
+// coordinates (`groupId:artifactId`), and reports each
+// PackageVulnerability as Reachable / Unreachable / Unknown depending
+// on whether the artifact appears in the import set (expanded
+// transitively through the dep graph).
+//
+// Tier-3 caveat: "unreachable" here means "the application source does
+// not import this artifact, neither directly nor indirectly through
+// app code". It does NOT mean "the vulnerability cannot be triggered"
+// — JVM apps use reflection, ServiceLoader, classpath scanning, Spring
+// component scanning, and OSGi/JPMS dynamic loading, all of which are
+// invisible to a static scanner. See docs/REACHABILITY.md for the
+// full set of caveats.
+//
+// The runner reads source in-process. The Runner interface is
+// preserved so unit tests can inject a fake runner for deterministic
+// behaviour.
+package jvmreach
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// Runner walks a JVM project rooted at projectDir and returns the set
+// of Maven artifact coordinates (`groupId:artifactId`) imported
+// anywhere in its reachable source tree. Implementations must NEVER
+// panic and should map missing inputs, parse errors, and other
+// recoverable conditions to a (RunnerResult, error) pair where the
+// error is descriptive but does not abort the pipeline.
+type Runner interface {
+	// Name returns a stable identifier (e.g. "library") used in
+	// telemetry and Reason fields.
+	Name() string
+	// Version returns the runner schema version. The result cache
+	// folds it into its key so scanner upgrades invalidate prior
+	// entries automatically.
+	Version() string
+	// Run walks projectDir and returns the imported-artifact set.
+	// projectDir must look like a JVM project root (pom.xml,
+	// build.gradle(.kts), build.sbt, or settings.gradle(.kts)).
+	Run(ctx context.Context, projectDir string) (RunnerResult, error)
+}
+
+// RunnerResult is the parsed output of one runner pass over a project.
+type RunnerResult struct {
+	// ImportedArtifacts is the set of Maven coordinates ("group:artifact",
+	// lowercase) that the prefix map resolved from source-level
+	// imports. The analyzer matches graph packages against this set
+	// before walking transitive deps.
+	ImportedArtifacts map[string]struct{}
+	// SourceFiles is the count of project source files visited
+	// (.java / .kt / .kts / .scala / .groovy).
+	SourceFiles int
+	// SkippedDirs lists directory names skipped during the walk
+	// (target/, build/, .gradle/, etc.) for debug logging.
+	SkippedDirs []string
+}
+
+func (r RunnerResult) hasResult() bool { return r.SourceFiles > 0 }
+
+func ensureLogger(l *zap.Logger) *zap.Logger {
+	if l != nil {
+		return l
+	}
+	return zap.NewNop()
+}

--- a/internal/analyzers/jvmreach/runner_library.go
+++ b/internal/analyzers/jvmreach/runner_library.go
@@ -1,0 +1,82 @@
+package jvmreach
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+// runnerSchemaVersion is the runner's stable identifier for cache
+// invalidation. Bump it when the import scanner or the prefix map
+// change in a way that would silently change reachability outcomes.
+const runnerSchemaVersion = "v1"
+
+// NewRunner returns the in-process Runner — a line-oriented scanner
+// that walks the project's JVM source tree and records every imported
+// FQN, resolving each through the prefix map to a Maven coordinate set.
+func NewRunner(logger *zap.Logger) Runner {
+	return libraryRunner{logger: ensureLogger(logger)}
+}
+
+type libraryRunner struct{ logger *zap.Logger }
+
+func (libraryRunner) Name() string { return "library" }
+
+func (libraryRunner) Version() string { return runnerSchemaVersion }
+
+func (r libraryRunner) Run(ctx context.Context, projectDir string) (RunnerResult, error) {
+	if info, err := os.Stat(projectDir); err != nil || !info.IsDir() {
+		return RunnerResult{}, fmt.Errorf("project dir not accessible: %w", err)
+	}
+
+	r.logger.Debug("jvmreach: executing in-process runner",
+		zap.String("project_dir", projectDir),
+		zap.String("schema_version", runnerSchemaVersion))
+
+	artifacts := make(map[string]struct{})
+	sourceFiles := 0
+	skipped, walkErr := walkSourceFiles(projectDir, func(path string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			r.logger.Debug("jvmreach: skipping unreadable source",
+				zap.String("path", path),
+				zap.Error(err))
+			return nil
+		}
+		defer f.Close()
+		imports, scanErr := scanImports(f)
+		if scanErr != nil {
+			r.logger.Debug("jvmreach: scan failed (continuing)",
+				zap.String("path", path),
+				zap.Error(scanErr))
+			return nil
+		}
+		sourceFiles++
+		for fqn := range imports {
+			for _, coord := range resolveArtifacts(fqn) {
+				artifacts[coord] = struct{}{}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return RunnerResult{}, walkErr
+	}
+
+	r.logger.Debug("jvmreach: in-process runner completed",
+		zap.String("project_dir", projectDir),
+		zap.Int("source_files", sourceFiles),
+		zap.Int("imported_artifacts", len(artifacts)),
+		zap.Strings("skipped_dirs", skipped))
+
+	return RunnerResult{
+		ImportedArtifacts: artifacts,
+		SourceFiles:       sourceFiles,
+		SkippedDirs:       skipped,
+	}, nil
+}

--- a/internal/analyzers/jvmreach/sources.go
+++ b/internal/analyzers/jvmreach/sources.go
@@ -1,0 +1,107 @@
+package jvmreach
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// projectFileMarkers names every file whose presence at a directory
+// makes that directory a JVM project root.
+var projectFileMarkers = []string{
+	"pom.xml",
+	"build.gradle",
+	"build.gradle.kts",
+	"settings.gradle",
+	"settings.gradle.kts",
+	"build.sbt",
+	"project.scala", // scala-cli
+}
+
+// hasProjectMarker returns true when dir contains any of the
+// recognised JVM project files.
+func hasProjectMarker(dir string) bool {
+	for _, name := range projectFileMarkers {
+		path := filepath.Join(dir, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// sourceFileExtensions are the file suffixes (lowercase) whose
+// contents the analyzer scans for imports. The scanner itself is
+// language-agnostic — Java / Kotlin / Scala / Groovy all share the
+// same `import ...` line shape.
+var sourceFileExtensions = []string{".java", ".kt", ".kts", ".scala", ".groovy"}
+
+// walkSourceFiles invokes fn for every JVM source file under root,
+// skipping common test / build / VCS / IDE / dependency-cache dirs.
+// Returns the list of directory names actually skipped (for
+// telemetry) and any walk error.
+//
+// Test sources are intentionally walked too: many real-world Java
+// projects keep integration / smoke tests under src/main/test/...
+// or use a non-standard layout, and reachability that's only
+// triggered from tests is still real reachability for an audit.
+// (A future refinement could separate runtime vs test reachability,
+// matching the scope flag.)
+func walkSourceFiles(root string, fn func(path string) error) (skipped []string, err error) {
+	skippedSet := make(map[string]struct{})
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if path == root {
+				return nil
+			}
+			name := d.Name()
+			if shouldSkipDir(name) {
+				skippedSet[name] = struct{}{}
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		lower := strings.ToLower(d.Name())
+		match := false
+		for _, ext := range sourceFileExtensions {
+			if strings.HasSuffix(lower, ext) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return nil
+		}
+		return fn(path)
+	})
+	for name := range skippedSet {
+		skipped = append(skipped, name)
+	}
+	return skipped, walkErr
+}
+
+// shouldSkipDir reports whether the named subdirectory should be
+// pruned during the walk. The list includes Maven/Gradle/SBT build
+// outputs, dependency caches, IDE state, and VCS dirs. Skipping
+// `target/`, `build/`, and `.gradle/` is essential — they may
+// contain decompiled or extracted dependency source that would
+// otherwise be misattributed as app code.
+func shouldSkipDir(name string) bool {
+	switch name {
+	case "target", "build", "out", "bin",
+		".gradle", ".m2", ".ivy2", ".sbt",
+		".idea", ".vscode", ".eclipse", ".settings",
+		".git", ".hg", ".svn",
+		"node_modules",
+		"generated", "generated-sources", "generated-test-sources":
+		return true
+	}
+	return false
+}

--- a/internal/registry/analyzers_jvmreach.go
+++ b/internal/registry/analyzers_jvmreach.go
@@ -1,0 +1,13 @@
+package registry
+
+import (
+	"github.com/bomly-dev/bomly-cli/internal/analyzers/jvmreach"
+)
+
+// registerJVMReachAnalyzer wires the JVM (Maven/Gradle/SBT) Tier-3
+// reachability analyzer. The runner is an in-process line-oriented
+// import scanner that walks the project's .java / .kt / .scala /
+// .groovy source tree.
+func (r *Registry) registerJVMReachAnalyzer() {
+	r.RegisterAnalyzer(jvmreach.Analyzer{Logger: r.logger})
+}

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -247,6 +247,7 @@ func (r *Registry) registerAnalyzers() {
 	r.registerGovulncheckAnalyzer()
 	r.registerJSReachAnalyzer()
 	r.registerPyReachAnalyzer()
+	r.registerJVMReachAnalyzer()
 }
 
 // registerGovulncheckAnalyzer is provided by analyzers_govulncheck.go so the

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -173,6 +173,21 @@ func TestScan(t *testing.T) {
 			tools: []string{"pip"},
 		},
 		{
+			// jvmreach smoke pinned to veracode/example-java-maven, a
+			// deliberately-vulnerable Maven demo. Main.java imports
+			// Apache Commons FileUpload, Apache XMLSec, jBCrypt, and
+			// Spring Web. requirements include Struts2, Keycloak,
+			// H2, Kafka, OrientDB, JavaMelody, Sling — most of which
+			// are unimported from app source but reachable through
+			// dep edges. Exercises directly-imported, transitively-
+			// reachable, and unreachable branches plus the
+			// package-prefix map. Goldens scrub timestamps via
+			// normalizeReachability.
+			name:  "scan-java-maven-reachability",
+			args:  []string{"scan", "--url", "https://github.com/veracode/example-java-maven", "--ref", "509948ba5a02ffab48e7260031d4a1e78d010891", "--enrich", "--reachability", "--format", "json"},
+			tools: []string{"mvn"},
+		},
+		{
 			name:  "scan-npm-scope-runtime",
 			args:  []string{"scan", "--url", "https://github.com/ljharb/qs", "--ref", "v6.13.0", "--format", "json", "--scope", "runtime"},
 			tools: []string{"npm"},


### PR DESCRIPTION
## Summary

Phase C.2. `jvmreach` is the fourth reachability analyzer, covering Maven, Gradle, and SBT projects across Java, Kotlin, Scala, and Groovy. Same in-process line-oriented scanner shape as `pyreach`, expanded transitively through `Graph.Dependencies`.

### What's covered

- **Scanner**: Java `import` (incl. `static`), Kotlin `import` (incl. `as` alias), Scala selectors / renames / wildcards, Groovy. Block-comment + line-comment stripping; scanner stops after the import header for bounded cost on big source files.
- **Curated longest-prefix `package -> Maven coordinate` map** covering ~80 of the most-imported JVM libraries: Jackson, Spring (Boot + Framework + Data + Security + Kafka), Log4j, SLF4J, Logback, Apache Commons (lang3, io, codec, text, fileupload, ...), Guava, JUnit (4 + 5), AssertJ, Mockito, TestNG, Netty, OkHttp, Retrofit, Apache HttpClient, Hibernate, Hikari, Snakeyaml, Jetty, Jersey, Micrometer, OpenTelemetry, kotlinx-coroutines, Akka, Cats, Play, Slick, Struts, Keycloak, H2, Kafka, JavaMelody, Sling, OrientDB, Lombok, javax/jakarta APIs.
- **Stdlib drops**: `java.*`, `javax.*`, `kotlin.*`, `scala.*`, `sun.*`, `jdk.*`, `com.sun.*`, `groovy.lang/util`.
- **Per-project FileCache** invalidating on `pom.xml` / `build.gradle*` / `build.sbt` content change; cache key folds runner schema version.
- **INFO/DEBUG/WARN structured logging** mirroring pyreach.
- **Plugin command** picks `jvmreach` up automatically via the `AnalyzerDescriptors` registry surface.

### Tier-3 caveats (documented in REACHABILITY.md)

Same shape as jsreach / pyreach, with the JVM-specific traps:

- Reflection, `ServiceLoader`, Spring component scanning, OSGi, JPMS dynamic layers, annotation-processed code — all invisible to a static scanner.
- The Java `package -> Maven artifact` relationship is genuinely arbitrary (no naming convention like Python's identity rule), so a missing prefix produces a false-negative for direct top-level imports. The dep-graph BFS usually recovers via a transitive edge from a correctly-mapped neighbour. Adding an entry to `internal/analyzers/jvmreach/prefixmap.go` is a one-line PR.
- Sub-package imports collapse to the artifact — `databind.ObjectMapper` flips the whole `jackson-databind` artifact reachable.
- Multi-module Maven / Gradle attribution is best-effort.

## Smoke fixture

Pinned to [veracode/example-java-maven@509948b](https://github.com/veracode/example-java-maven/tree/509948ba5a02ffab48e7260031d4a1e78d010891) — a deliberately-vulnerable Maven demo whose `Main.java` imports Apache Commons FileUpload, Apache XML Security, jBCrypt, and Spring Web (exercising the prefix-map's direct-hit path) while `pom.xml` pins Struts, Keycloak, H2, Kafka, JavaMelody, OrientDB, etc. that should resolve through the dep-graph BFS.

Goldens need to be seeded once via \`make smoke ARGS=\"-update\"\` after merge.

## Test plan

- [x] Scanner unit tests covering Java, Kotlin, Scala (selectors / renames / wildcards), Groovy, comments, multi-line block comments
- [x] Prefix-map unit tests: longest-prefix match, multi-artifact prefixes (log4j-api + log4j-core), stdlib drops, unknown-prefix dropped (no identity fallback), `canonicalCoord` normalization
- [x] Analyzer integration: reachable, unreachable, runner-error -> unknown, no-project-root -> unknown, applicability gate, transitive BFS, cycle handling
- [x] Library-runner end-to-end test against on-disk fixture (verifies target/ is skipped, stdlib dropped, prefix map applied)
- [x] Cache: round-trip, invalidates on \`pom.xml\` content change, second Analyze call hits cache
- [x] \`bomly plugin list --analyzers\` shows jvmreach with all four JVM languages + maven/scala ecosystems + maven/gradle/sbt managers
- [x] \`make build\` and \`make build-lite\` clean
- [ ] Smoke goldens: regenerate via \`make smoke ARGS=\"-update\"\` after merge

## Files

- \`internal/analyzers/jvmreach/\` — new package (analyzer, runner, scanner, prefix-map, cache, sources, discover + tests)
- \`internal/registry/analyzers_jvmreach.go\` — registration shim
- \`internal/registry/builder.go\` — wires \`registerJVMReachAnalyzer()\`
- \`test/smoke/smoke_test.go\` — adds \`scan-java-maven-reachability\` case
- \`docs/REACHABILITY.md\` — jvmreach row + Tier-3 caveat section + build-layout note + limitations
- \`CLAUDE.md\` — analyzer tree comment now lists the fourth analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)