### PR TITLE
feat(sdk): add PackageLocation.Position + wire gomod and pip detectors

### DIFF
--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -118,6 +118,14 @@ Complete reference for the `bomly diff` JSON output.
 | `spdxExpression` | `string` | |
 | `type` | `string` | |
 
+### `LocationRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `real_path` | `string` | |
+| `access_path` | `string` | |
+| `position` | [`PositionRef`](#positionref) | |
+
 ### `Metadata`
 
 | Field | Type | Description |
@@ -134,8 +142,18 @@ Complete reference for the `bomly diff` JSON output.
 | `purl` | `string` | |
 | `id` | `string` | |
 | `metadata` | `object` | |
+| `locations` | Array<[`LocationRef`](#locationref)> | |
 | `licenses` | Array<[`LicenseRef`](#licenseref)> | |
 | `vulnerabilities` | Array<[`VulnerabilityRef`](#vulnerabilityref)> | |
+
+### `PositionRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `string` | |
+| `line` | `integer` | |
+| `column` | `integer` | |
+| `end_line` | `integer` | |
 
 ### `ProjectDescriptor`
 

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -66,6 +66,37 @@
                     },
                     "type": "array"
                   },
+                  "locations": {
+                    "items": {
+                      "properties": {
+                        "access_path": {
+                          "type": "string"
+                        },
+                        "position": {
+                          "properties": {
+                            "column": {
+                              "type": "integer"
+                            },
+                            "end_line": {
+                              "type": "integer"
+                            },
+                            "file": {
+                              "type": "string"
+                            },
+                            "line": {
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "real_path": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "metadata": {
                     "additionalProperties": {},
                     "type": "object"
@@ -244,6 +275,37 @@
                     },
                     "type": "array"
                   },
+                  "locations": {
+                    "items": {
+                      "properties": {
+                        "access_path": {
+                          "type": "string"
+                        },
+                        "position": {
+                          "properties": {
+                            "column": {
+                              "type": "integer"
+                            },
+                            "end_line": {
+                              "type": "integer"
+                            },
+                            "file": {
+                              "type": "string"
+                            },
+                            "line": {
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "real_path": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "metadata": {
                     "additionalProperties": {},
                     "type": "object"
@@ -415,6 +477,37 @@
                           "type": "string"
                         },
                         "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "locations": {
+                    "items": {
+                      "properties": {
+                        "access_path": {
+                          "type": "string"
+                        },
+                        "position": {
+                          "properties": {
+                            "column": {
+                              "type": "integer"
+                            },
+                            "end_line": {
+                              "type": "integer"
+                            },
+                            "file": {
+                              "type": "string"
+                            },
+                            "line": {
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "real_path": {
                           "type": "string"
                         }
                       },
@@ -652,6 +745,37 @@
                           },
                           "type": "array"
                         },
+                        "locations": {
+                          "items": {
+                            "properties": {
+                              "access_path": {
+                                "type": "string"
+                              },
+                              "position": {
+                                "properties": {
+                                  "column": {
+                                    "type": "integer"
+                                  },
+                                  "end_line": {
+                                    "type": "integer"
+                                  },
+                                  "file": {
+                                    "type": "string"
+                                  },
+                                  "line": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "real_path": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
                         "metadata": {
                           "additionalProperties": {},
                           "type": "object"
@@ -804,6 +928,37 @@
                           },
                           "type": "array"
                         },
+                        "locations": {
+                          "items": {
+                            "properties": {
+                              "access_path": {
+                                "type": "string"
+                              },
+                              "position": {
+                                "properties": {
+                                  "column": {
+                                    "type": "integer"
+                                  },
+                                  "end_line": {
+                                    "type": "integer"
+                                  },
+                                  "file": {
+                                    "type": "string"
+                                  },
+                                  "line": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "real_path": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
                         "metadata": {
                           "additionalProperties": {},
                           "type": "object"
@@ -938,6 +1093,37 @@
                                 "type": "string"
                               },
                               "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "locations": {
+                          "items": {
+                            "properties": {
+                              "access_path": {
+                                "type": "string"
+                              },
+                              "position": {
+                                "properties": {
+                                  "column": {
+                                    "type": "integer"
+                                  },
+                                  "end_line": {
+                                    "type": "integer"
+                                  },
+                                  "file": {
+                                    "type": "string"
+                                  },
+                                  "line": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "real_path": {
                                 "type": "string"
                               }
                             },
@@ -1103,6 +1289,37 @@
                                 "type": "string"
                               },
                               "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "locations": {
+                          "items": {
+                            "properties": {
+                              "access_path": {
+                                "type": "string"
+                              },
+                              "position": {
+                                "properties": {
+                                  "column": {
+                                    "type": "integer"
+                                  },
+                                  "end_line": {
+                                    "type": "integer"
+                                  },
+                                  "file": {
+                                    "type": "string"
+                                  },
+                                  "line": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "real_path": {
                                 "type": "string"
                               }
                             },

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -86,6 +86,14 @@ Complete reference for the `bomly explain` JSON output.
 | `spdxExpression` | `string` | |
 | `type` | `string` | |
 
+### `LocationRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `real_path` | `string` | |
+| `access_path` | `string` | |
+| `position` | [`PositionRef`](#positionref) | |
+
 ### `Metadata`
 
 | Field | Type | Description |
@@ -102,8 +110,18 @@ Complete reference for the `bomly explain` JSON output.
 | `purl` | `string` | |
 | `id` | `string` | |
 | `metadata` | `object` | |
+| `locations` | Array<[`LocationRef`](#locationref)> | |
 | `licenses` | Array<[`LicenseRef`](#licenseref)> | |
 | `vulnerabilities` | Array<[`VulnerabilityRef`](#vulnerabilityref)> | |
+
+### `PositionRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `string` | |
+| `line` | `integer` | |
+| `column` | `integer` | |
+| `end_line` | `integer` | |
 
 ### `ProjectDescriptor`
 

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -58,6 +58,37 @@
           },
           "type": "array"
         },
+        "locations": {
+          "items": {
+            "properties": {
+              "access_path": {
+                "type": "string"
+              },
+              "position": {
+                "properties": {
+                  "column": {
+                    "type": "integer"
+                  },
+                  "end_line": {
+                    "type": "integer"
+                  },
+                  "file": {
+                    "type": "string"
+                  },
+                  "line": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "real_path": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
         "metadata": {
           "additionalProperties": {},
           "type": "object"
@@ -201,6 +232,37 @@
                       "type": "string"
                     },
                     "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "locations": {
+                "items": {
+                  "properties": {
+                    "access_path": {
+                      "type": "string"
+                    },
+                    "position": {
+                      "properties": {
+                        "column": {
+                          "type": "integer"
+                        },
+                        "end_line": {
+                          "type": "integer"
+                        },
+                        "file": {
+                          "type": "string"
+                        },
+                        "line": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "real_path": {
                       "type": "string"
                     }
                   },
@@ -394,6 +456,37 @@
                         "type": "string"
                       },
                       "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "locations": {
+                  "items": {
+                    "properties": {
+                      "access_path": {
+                        "type": "string"
+                      },
+                      "position": {
+                        "properties": {
+                          "column": {
+                            "type": "integer"
+                          },
+                          "end_line": {
+                            "type": "integer"
+                          },
+                          "file": {
+                            "type": "string"
+                          },
+                          "line": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "real_path": {
                         "type": "string"
                       }
                     },
@@ -624,6 +717,37 @@
                 },
                 "type": "array"
               },
+              "locations": {
+                "items": {
+                  "properties": {
+                    "access_path": {
+                      "type": "string"
+                    },
+                    "position": {
+                      "properties": {
+                        "column": {
+                          "type": "integer"
+                        },
+                        "end_line": {
+                          "type": "integer"
+                        },
+                        "file": {
+                          "type": "string"
+                        },
+                        "line": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "real_path": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "metadata": {
                 "additionalProperties": {},
                 "type": "object"
@@ -770,6 +894,37 @@
                             "type": "string"
                           },
                           "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "locations": {
+                      "items": {
+                        "properties": {
+                          "access_path": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "properties": {
+                              "column": {
+                                "type": "integer"
+                              },
+                              "end_line": {
+                                "type": "integer"
+                              },
+                              "file": {
+                                "type": "string"
+                              },
+                              "line": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "real_path": {
                             "type": "string"
                           }
                         },
@@ -952,6 +1107,37 @@
                               "type": "string"
                             },
                             "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
                               "type": "string"
                             }
                           },

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -56,6 +56,14 @@ Complete reference for the `bomly scan` JSON output.
 | `spdxExpression` | `string` | |
 | `type` | `string` | |
 
+### `LocationRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `real_path` | `string` | |
+| `access_path` | `string` | |
+| `position` | [`PositionRef`](#positionref) | |
+
 ### `Metadata`
 
 | Field | Type | Description |
@@ -72,8 +80,18 @@ Complete reference for the `bomly scan` JSON output.
 | `purl` | `string` | |
 | `id` | `string` | |
 | `metadata` | `object` | |
+| `locations` | Array<[`LocationRef`](#locationref)> | |
 | `licenses` | Array<[`LicenseRef`](#licenseref)> | |
 | `vulnerabilities` | Array<[`VulnerabilityRef`](#vulnerabilityref)> | |
+
+### `PositionRef`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `string` | |
+| `line` | `integer` | |
+| `column` | `integer` | |
+| `end_line` | `integer` | |
 
 ### `ProjectDescriptor`
 
@@ -113,6 +131,7 @@ Complete reference for the `bomly scan` JSON output.
 | `purl` | `string` | |
 | `id` | `string` | |
 | `metadata` | `object` | |
+| `locations` | Array<[`LocationRef`](#locationref)> | |
 | `licenses` | Array<[`LicenseRef`](#licenseref)> | |
 | `vulnerabilities` | Array<[`VulnerabilityRef`](#vulnerabilityref)> | |
 | `dependencies` | Array<`string`> | |

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -67,6 +67,37 @@
                 },
                 "type": "array"
               },
+              "locations": {
+                "items": {
+                  "properties": {
+                    "access_path": {
+                      "type": "string"
+                    },
+                    "position": {
+                      "properties": {
+                        "column": {
+                          "type": "integer"
+                        },
+                        "end_line": {
+                          "type": "integer"
+                        },
+                        "file": {
+                          "type": "string"
+                        },
+                        "line": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "real_path": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "metadata": {
                 "additionalProperties": {},
                 "type": "object"
@@ -251,6 +282,37 @@
                         "type": "string"
                       },
                       "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "locations": {
+                  "items": {
+                    "properties": {
+                      "access_path": {
+                        "type": "string"
+                      },
+                      "position": {
+                        "properties": {
+                          "column": {
+                            "type": "integer"
+                          },
+                          "end_line": {
+                            "type": "integer"
+                          },
+                          "file": {
+                            "type": "string"
+                          },
+                          "line": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "real_path": {
                         "type": "string"
                       }
                     },

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -136,6 +136,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachCargoLockPositions(g, d.workingDir(req.ProjectPath))
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 
@@ -158,6 +159,7 @@ func (d Detector) resolveFromLock(req sdk.DetectionRequest) (sdk.DetectionResult
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachCargoLockPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/cargo/positions.go
+++ b/internal/detectors/cargo/positions.go
@@ -1,0 +1,59 @@
+package cargo
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+var (
+	cargoPackageHeader = regexp.MustCompile(`^\s*\[\[\s*package\s*\]\]\s*$`)
+	cargoNameLine      = regexp.MustCompile(`^\s*name\s*=\s*"([^"]+)"\s*$`)
+)
+
+func cargoLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	inBlock := false
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		switch {
+		case cargoPackageHeader.MatchString(text):
+			inBlock = true
+		case inBlock:
+			matches := cargoNameLine.FindStringSubmatch(text)
+			if matches != nil {
+				name := strings.TrimSpace(matches[1])
+				if name != "" {
+					if _, exists := out[name]; !exists {
+						out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+					}
+				}
+				inBlock = false
+				return
+			}
+			if strings.HasPrefix(strings.TrimSpace(text), "[") {
+				inBlock = false
+			}
+		}
+	})
+	return out
+}
+
+// AttachCargoLockPositions wires Cargo.lock line numbers into the graph.
+func AttachCargoLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := cargoLockPositions(filepath.Join(projectDir, "Cargo.lock"), "Cargo.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -83,6 +83,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPodfileLockPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/cocoapods/positions.go
+++ b/internal/detectors/cocoapods/positions.go
@@ -1,0 +1,75 @@
+package cocoapods
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// podfileLockSpec matches a Podfile.lock spec entry. Examples:
+//
+//   - AFNetworking (4.0.1):
+//   - AFNetworking/NSURLSession (4.0.1)
+//
+// The captured name is the bare pod name without subspec slashes.
+var podfileLockSpec = regexp.MustCompile(`^\s*-\s+([A-Za-z0-9_-][A-Za-z0-9._/-]*)\s*\(([^)]+)\)\s*:?\s*$`)
+
+func podfileLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	insideSpecs := false
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		if trimmed == "PODS:" {
+			insideSpecs = true
+			return
+		}
+		if !strings.HasPrefix(text, " ") && !strings.HasPrefix(text, "\t") && strings.HasSuffix(trimmed, ":") && trimmed != "PODS:" {
+			insideSpecs = false
+			return
+		}
+		if !insideSpecs {
+			return
+		}
+		matches := podfileLockSpec.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := matches[1]
+		// Strip subspec path so the bare pod name is the key.
+		if i := strings.Index(name, "/"); i > 0 {
+			name = name[:i]
+		}
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachPodfileLockPositions wires Podfile.lock line numbers.
+func AttachPodfileLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := podfileLockPositions(filepath.Join(projectDir, "Podfile.lock"), "Podfile.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		name := strings.TrimSpace(pkg.Name)
+		if i := strings.Index(name, "/"); i > 0 {
+			return name[:i]
+		}
+		return name
+	})
+}

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -91,6 +91,8 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		return sdk.DetectionResult{}, err
 	}
 
+	AttachComposerLockPositions(depsGraph, workingDir)
+
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, evidencePatterns)),
 	}, nil

--- a/internal/detectors/composer/positions.go
+++ b/internal/detectors/composer/positions.go
@@ -1,0 +1,55 @@
+package composer
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// composerNameLine matches `"name": "vendor/pkg"` inside composer.lock.
+var composerNameLine = regexp.MustCompile(`^\s*"name"\s*:\s*"([^"]+)"\s*,?\s*$`)
+
+func composerLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		matches := composerNameLine.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := strings.TrimSpace(matches[1])
+		if name == "" || !strings.Contains(name, "/") {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachComposerLockPositions wires composer.lock line numbers.
+func AttachComposerLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := composerLockPositions(filepath.Join(projectDir, "composer.lock"), "composer.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		// Composer packages are vendor/pkg. Graph stores Name as the
+		// full coordinate, occasionally Org=vendor + Name=pkg. Try
+		// both forms.
+		if pkg.Org != "" && pkg.Name != "" {
+			return pkg.Org + "/" + pkg.Name
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -100,6 +100,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachConanPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/conan/positions.go
+++ b/internal/detectors/conan/positions.go
@@ -1,0 +1,71 @@
+package conan
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// conanRequireLine matches a Conan require line of the form
+// `name/version[@user/channel]` typically found in conanfile.txt's
+// [requires] / [build_requires] / [tool_requires] sections. The
+// captured value is the package name.
+var conanRequireLine = regexp.MustCompile(`^\s*([a-zA-Z0-9_][a-zA-Z0-9._+-]*)\s*/\s*[^@\s]+`)
+
+var conanSectionHeader = regexp.MustCompile(`^\s*\[\s*(requires|build_requires|tool_requires|test_requires)\s*\]\s*$`)
+
+func conanPositions(projectDir string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	candidates := []string{"conanfile.txt", "conan.lock", "conaninfo.txt"}
+	for _, name := range candidates {
+		full := filepath.Join(projectDir, name)
+		insideRequires := name == "conan.lock" || name == "conaninfo.txt" // always scan lock/info bodies
+		_ = detectors.ScanLines(full, func(line int, text string) {
+			trimmed := strings.TrimSpace(text)
+			if conanSectionHeader.MatchString(trimmed) {
+				insideRequires = true
+				return
+			}
+			if name == "conanfile.txt" && strings.HasPrefix(trimmed, "[") {
+				insideRequires = false
+				return
+			}
+			if !insideRequires {
+				return
+			}
+			matches := conanRequireLine.FindStringSubmatch(text)
+			if matches == nil {
+				return
+			}
+			pkgName := strings.TrimSpace(matches[1])
+			if pkgName == "" {
+				return
+			}
+			if _, exists := out[pkgName]; exists {
+				return
+			}
+			out[pkgName] = &sdk.SourcePosition{File: name, Line: line}
+		})
+	}
+	return out
+}
+
+// AttachConanPositions wires conanfile.txt / conan.lock line numbers.
+func AttachConanPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := conanPositions(projectDir)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/githubactions/detector.go
+++ b/internal/detectors/githubactions/detector.go
@@ -82,6 +82,11 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	if graphs != nil {
+		for i := range graphs.Entries {
+			AttachWorkflowPositions(graphs.Entries[i].Graph, req.ProjectPath)
+		}
+	}
 	return sdk.DetectionResult{
 		Graphs: graphs,
 	}, nil

--- a/internal/detectors/githubactions/positions.go
+++ b/internal/detectors/githubactions/positions.go
@@ -1,0 +1,72 @@
+package githubactions
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// usesLine matches `uses: owner/repo[/path]@ref` entries in workflow
+// YAML. The captured value is the owner/repo coordinate (excluding
+// path and ref).
+var usesLine = regexp.MustCompile(`^\s*-?\s*uses\s*:\s*['"]?([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*)(?:/[^@'"\s]*)?@[^'"\s]+['"]?\s*$`)
+
+// workflowPositions walks .github/workflows/*.yml + .github/actions/*/action.yml
+// and returns a map from owner/repo coordinate to the line where the
+// `uses:` entry first appears.
+func workflowPositions(projectDir string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	patterns := []string{
+		filepath.Join(projectDir, ".github", "workflows", "*.yml"),
+		filepath.Join(projectDir, ".github", "workflows", "*.yaml"),
+		filepath.Join(projectDir, ".github", "actions", "*", "action.yml"),
+		filepath.Join(projectDir, ".github", "actions", "*", "action.yaml"),
+	}
+	for _, pattern := range patterns {
+		matches, _ := filepath.Glob(pattern)
+		for _, file := range matches {
+			rel, err := filepath.Rel(projectDir, file)
+			if err != nil || rel == "" {
+				rel = filepath.Base(file)
+			}
+			rel = filepath.ToSlash(rel)
+			_ = detectors.ScanLines(file, func(line int, text string) {
+				m := usesLine.FindStringSubmatch(text)
+				if m == nil {
+					return
+				}
+				coord := strings.TrimSpace(m[1])
+				if coord == "" {
+					return
+				}
+				if _, exists := out[coord]; exists {
+					return
+				}
+				out[coord] = &sdk.SourcePosition{File: rel, Line: line}
+			})
+		}
+	}
+	return out
+}
+
+// AttachWorkflowPositions wires workflow / action.yml line numbers
+// into the resolved graph.
+func AttachWorkflowPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := workflowPositions(projectDir)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		// GitHub Actions packages have Name=owner/repo.
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -27,6 +27,10 @@ var goLookupEnv = os.LookupEnv
 type moduleRef struct {
 	Path    string
 	Version string
+	// Line is the 1-based line number in go.mod where this require
+	// directive appears. 0 means the line was not captured (e.g.
+	// the module is a transitive dep go.mod does not declare).
+	Line int
 }
 
 type goListPackage struct {
@@ -132,7 +136,7 @@ func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose boo
 		workingDir = projectPath
 	}
 
-	modulePath, _, err := parseGoModFile(filepath.Join(workingDir, "go.mod"))
+	modulePath, directRequires, err := parseGoModFile(filepath.Join(workingDir, "go.mod"))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +165,7 @@ func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose boo
 		return nil, fmt.Errorf("run go list -deps -json all: %w", err)
 	}
 
-	depsGraph, err := depGraphFromGoList(raw, modulePath)
+	depsGraph, err := depGraphFromGoList(raw, modulePath, directRequires)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to map Go module output to a dependency graph: %v", err))
 		logger.Debug("go module output mapping failed", zap.Error(err))
@@ -184,13 +188,22 @@ func buildGoListArgs() []string {
 	return append(args, "all")
 }
 
-func depGraphFromGoList(raw []byte, rootModule string) (*sdk.Graph, error) {
+func depGraphFromGoList(raw []byte, rootModule string, directRequires []moduleRef) (*sdk.Graph, error) {
 	if strings.TrimSpace(rootModule) == "" {
 		return nil, errors.New("go module path is empty")
 	}
 	packages, err := parseGoListPackages(raw)
 	if err != nil {
 		return nil, err
+	}
+	// Build a module-path -> go.mod line index so packageFromModuleNode
+	// can attach a SourcePosition to direct deps. Transitive deps that
+	// don't appear in go.mod get nil Position (their Line is 0).
+	directLines := make(map[string]int, len(directRequires))
+	for _, ref := range directRequires {
+		if ref.Path != "" && ref.Line > 0 {
+			directLines[ref.Path] = ref.Line
+		}
 	}
 	if len(packages) == 0 {
 		return nil, errors.New("go list output is empty")
@@ -250,19 +263,19 @@ func depGraphFromGoList(raw []byte, rootModule string) (*sdk.Graph, error) {
 			continue
 		}
 		if !currentModule.Main {
-			currentNode := packageFromModuleNode(currentModule, mergedScope)
+			currentNode := packageFromModuleNode(currentModule, mergedScope, directLines)
 			if err := addOrMergeModuleNode(depsGraph, currentNode, mergedScope); err != nil {
 				return nil, err
 			}
 		}
 
-		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, mergedScope, current.pkg.Imports, packageRecords, packageModules, &queue); err != nil {
+		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, mergedScope, current.pkg.Imports, packageRecords, packageModules, directLines, &queue); err != nil {
 			return nil, err
 		}
-		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, sdk.ScopeDevelopment, current.pkg.TestImports, packageRecords, packageModules, &queue); err != nil {
+		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, sdk.ScopeDevelopment, current.pkg.TestImports, packageRecords, packageModules, directLines, &queue); err != nil {
 			return nil, err
 		}
-		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, sdk.ScopeDevelopment, current.pkg.XTestImports, packageRecords, packageModules, &queue); err != nil {
+		if err := enqueueImportedPackages(depsGraph, rootNode.ID, currentModule, sdk.ScopeDevelopment, current.pkg.XTestImports, packageRecords, packageModules, directLines, &queue); err != nil {
 			return nil, err
 		}
 	}
@@ -301,7 +314,7 @@ func moduleNodeFromPackage(pkg goListPackage, rootModule string) (moduleNode, bo
 	}, true
 }
 
-func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNode, scope sdk.Scope, imports []string, packageRecords map[string]goListPackage, packageModules map[string]moduleNode, queue *[]queuedPackage) error {
+func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNode, scope sdk.Scope, imports []string, packageRecords map[string]goListPackage, packageModules map[string]moduleNode, directLines map[string]int, queue *[]queuedPackage) error {
 	fromID := rootID
 	if !from.Main {
 		fromID = moduleNodeID(from)
@@ -317,7 +330,7 @@ func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNod
 			continue
 		}
 		if !to.Main {
-			pkg := packageFromModuleNode(to, scope)
+			pkg := packageFromModuleNode(to, scope, directLines)
 			if err := addOrMergeModuleNode(depsGraph, pkg, scope); err != nil {
 				return err
 			}
@@ -332,13 +345,23 @@ func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNod
 	return nil
 }
 
-func packageFromModuleNode(node moduleNode, scope sdk.Scope) *sdk.Package {
-	return sdk.NewPackage(sdk.Package{
+func packageFromModuleNode(node moduleNode, scope sdk.Scope, directLines map[string]int) *sdk.Package {
+	pkg := sdk.Package{
 		Ecosystem: string(sdk.EcosystemGo),
 		Name:      node.Path,
 		Version:   node.Version,
 		Scope:     string(scope),
-	})
+	}
+	if line, ok := directLines[node.Path]; ok && line > 0 {
+		pkg.Locations = []sdk.PackageLocation{
+			{
+				RealPath:   "go.mod",
+				AccessPath: "go.mod",
+				Position:   &sdk.SourcePosition{File: "go.mod", Line: line},
+			},
+		}
+	}
+	return sdk.NewPackage(pkg)
 }
 
 func moduleNodeID(node moduleNode) string {
@@ -361,8 +384,11 @@ func parseGoModFile(path string) (string, []moduleRef, error) {
 	seen := make(map[string]struct{})
 
 	scanner := bufio.NewScanner(strings.NewReader(strings.ReplaceAll(string(data), "\r\n", "\n")))
+	lineNum := 0
 	for scanner.Scan() {
-		line := stripLineComment(scanner.Text())
+		lineNum++
+		raw := scanner.Text()
+		line := stripLineComment(raw)
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -385,6 +411,7 @@ func parseGoModFile(path string) (string, []moduleRef, error) {
 				return "", nil, err
 			}
 			if ok {
+				ref.Line = lineNum
 				requires = appendUniqueModule(requires, seen, ref)
 			}
 		case inRequireBlock:
@@ -393,6 +420,7 @@ func parseGoModFile(path string) (string, []moduleRef, error) {
 				return "", nil, err
 			}
 			if ok {
+				ref.Line = lineNum
 				requires = appendUniqueModule(requires, seen, ref)
 			}
 		}

--- a/internal/detectors/gomod/detector_test.go
+++ b/internal/detectors/gomod/detector_test.go
@@ -86,7 +86,7 @@ func TestDepGraphFromGoList(t *testing.T) {
 {"ImportPath":"github.com/davecgh/go-spew/spew","Module":{"Path":"github.com/davecgh/go-spew","Version":"v1.1.1"}}
 `)
 
-	g, err := depGraphFromGoList(raw, "example.com/demo")
+	g, err := depGraphFromGoList(raw, "example.com/demo", nil)
 	if err != nil {
 		t.Fatalf("depGraphFromGoList() error = %v", err)
 	}
@@ -155,7 +155,7 @@ func TestDepGraphFromGoList_PrefersRuntimeScope(t *testing.T) {
 {"ImportPath":"example.com/shared/pkg","Module":{"Path":"example.com/shared","Version":"v1.2.3"}}
 `)
 
-	g, err := depGraphFromGoList(raw, "example.com/demo")
+	g, err := depGraphFromGoList(raw, "example.com/demo", nil)
 	if err != nil {
 		t.Fatalf("depGraphFromGoList() error = %v", err)
 	}
@@ -175,7 +175,7 @@ func TestDepGraphFromGoList_UsesOriginalModuleIdentityForReplace(t *testing.T) {
 {"ImportPath":"example.com/original/pkg","Module":{"Path":"example.com/original","Version":"v1.2.3","Replace":{"Path":"../local/original"}}}
 `)
 
-	g, err := depGraphFromGoList(raw, "example.com/demo")
+	g, err := depGraphFromGoList(raw, "example.com/demo", nil)
 	if err != nil {
 		t.Fatalf("depGraphFromGoList() error = %v", err)
 	}
@@ -186,7 +186,7 @@ func TestDepGraphFromGoList_UsesOriginalModuleIdentityForReplace(t *testing.T) {
 }
 
 func TestDepGraphFromGoList_EmptyOutput(t *testing.T) {
-	if _, err := depGraphFromGoList(nil, "example.com/demo"); err == nil {
+	if _, err := depGraphFromGoList(nil, "example.com/demo", nil); err == nil {
 		t.Fatal("expected empty go list output to fail")
 	}
 }
@@ -223,5 +223,61 @@ require golang.org/x/text v0.14.0
 	}
 	if requires[2].Path != "golang.org/x/text" || requires[2].Version != "v0.14.0" {
 		t.Fatalf("unexpected final require: %#v", requires[2])
+	}
+	// Line numbers from the go.mod fixture:
+	//   1: module example.com/demo
+	//   2: (blank)
+	//   3: go 1.22.0
+	//   4: (blank)
+	//   5: require (
+	//   6:   github.com/google/uuid v1.6.0
+	//   7:   rsc.io/quote v1.5.2 // indirect
+	//   8: )
+	//   9: (blank)
+	//  10: require golang.org/x/text v0.14.0
+	if requires[0].Line != 6 {
+		t.Errorf("require[0] line = %d, want 6", requires[0].Line)
+	}
+	if requires[1].Line != 7 {
+		t.Errorf("require[1] line = %d, want 7", requires[1].Line)
+	}
+	if requires[2].Line != 10 {
+		t.Errorf("require[2] line = %d, want 10", requires[2].Line)
+	}
+}
+
+func TestDepGraphFromGoList_AttachesPositionToDirectDeps(t *testing.T) {
+	raw := []byte(`
+{"ImportPath":"example.com/demo","Module":{"Path":"example.com/demo","Main":true},"Imports":["github.com/direct/dep","example.com/trans/dep"]}
+{"ImportPath":"github.com/direct/dep","Module":{"Path":"github.com/direct/dep","Version":"v1.0.0"},"Imports":["example.com/trans/dep"]}
+{"ImportPath":"example.com/trans/dep","Module":{"Path":"example.com/trans/dep","Version":"v2.0.0"}}
+`)
+	directRequires := []moduleRef{
+		{Path: "github.com/direct/dep", Version: "v1.0.0", Line: 7},
+	}
+	g, err := depGraphFromGoList(raw, "example.com/demo", directRequires)
+	if err != nil {
+		t.Fatalf("depGraphFromGoList: %v", err)
+	}
+	direct, ok := g.Package("github.com/direct/dep@v1.0.0")
+	if !ok {
+		t.Fatal("direct dep missing from graph")
+	}
+	if len(direct.Locations) != 1 {
+		t.Fatalf("direct dep Locations = %d, want 1", len(direct.Locations))
+	}
+	loc := direct.Locations[0]
+	if loc.RealPath != "go.mod" {
+		t.Errorf("direct dep RealPath = %q, want go.mod", loc.RealPath)
+	}
+	if loc.Position == nil || loc.Position.Line != 7 || loc.Position.File != "go.mod" {
+		t.Errorf("direct dep Position = %+v, want {File: go.mod, Line: 7}", loc.Position)
+	}
+	trans, ok := g.Package("example.com/trans/dep@v2.0.0")
+	if !ok {
+		t.Fatal("transitive dep missing from graph")
+	}
+	if len(trans.Locations) != 0 {
+		t.Errorf("transitive dep should have no Locations (not in go.mod); got %+v", trans.Locations)
 	}
 }

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -86,6 +86,12 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		return sdk.DetectionResult{}, err
 	}
 
+	workingDir := d.WorkingDir
+	if workingDir == "" {
+		workingDir = req.ProjectPath
+	}
+	AttachGradlePositions(depsGraph, workingDir)
+
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, evidencePatterns)),
 	}, nil

--- a/internal/detectors/gradle/positions.go
+++ b/internal/detectors/gradle/positions.go
@@ -1,0 +1,99 @@
+package gradle
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// gradleDependencyCoord matches the typical declarations in
+// build.gradle / build.gradle.kts:
+//
+//	implementation 'com.foo:bar:1.0.0'
+//	implementation("com.foo:bar:1.0.0")
+//	compile group: 'com.foo', name: 'bar', version: '1.0.0'
+//	api("com.foo:bar:1.0.0")
+//
+// We capture the artifactId from the coordinate when the
+// single-string form is used. The map: form is not currently matched.
+var gradleDependencyCoord = regexp.MustCompile(`["']([a-zA-Z][a-zA-Z0-9._-]+):([a-zA-Z0-9][a-zA-Z0-9._-]*):[^"'\s)]+["']`)
+
+// gradleNameKwArg matches `name: "bar"` / `name = "bar"` style.
+var gradleNameKwArg = regexp.MustCompile(`name\s*[:=]\s*["']([a-zA-Z0-9][a-zA-Z0-9._-]*)["']`)
+
+// gradleLockfileLine matches a line in gradle.lockfile:
+//
+//	com.foo:bar:1.0.0=configuration1,configuration2
+var gradleLockfileLine = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9._-]+):([a-zA-Z0-9][a-zA-Z0-9._-]*):[^=]+=`)
+
+// gradlePositions scans the build files in projectDir and returns
+// artifactId -> SourcePosition. build.gradle, build.gradle.kts, and
+// gradle.lockfile are all walked; the first match per artifactId
+// wins.
+func gradlePositions(projectDir string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	files := []string{
+		"gradle.lockfile",
+		"build.gradle.kts",
+		"build.gradle",
+		"settings.gradle.kts",
+		"settings.gradle",
+	}
+	for _, name := range files {
+		full := filepath.Join(projectDir, name)
+		_ = detectors.ScanLines(full, func(line int, text string) {
+			// Lockfile lines (com.foo:bar:1.0.0=...).
+			if m := gradleLockfileLine.FindStringSubmatch(text); m != nil {
+				record(out, name, m[2], line)
+				return
+			}
+			// Source-coordinate string form.
+			if m := gradleDependencyCoord.FindStringSubmatch(text); m != nil {
+				record(out, name, m[2], line)
+				return
+			}
+			// keyword-arg map form (only the name= portion).
+			if m := gradleNameKwArg.FindStringSubmatch(text); m != nil {
+				record(out, name, m[1], line)
+				return
+			}
+		})
+	}
+	return out
+}
+
+func record(out map[string]*sdk.SourcePosition, file, name string, line int) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	if _, exists := out[name]; exists {
+		return
+	}
+	out[name] = &sdk.SourcePosition{File: file, Line: line}
+}
+
+// AttachGradlePositions wires gradle build/lock file line numbers
+// into a gradle-resolved graph.
+func AttachGradlePositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := gradlePositions(projectDir)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		name := strings.TrimSpace(pkg.Name)
+		if i := strings.Index(name, ":"); i > 0 {
+			return name[:i]
+		}
+		return name
+	})
+}

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -87,6 +87,12 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		return sdk.DetectionResult{}, err
 	}
 
+	workingDir := d.WorkingDir
+	if workingDir == "" {
+		workingDir = req.ProjectPath
+	}
+	AttachPomPositions(depsGraph, workingDir)
+
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, evidencePatterns)),
 	}, nil

--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -1,0 +1,87 @@
+package maven
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// pomDependencyArtifactID matches an `<artifactId>foo</artifactId>`
+// line. We scan pom.xml line-by-line tracking when we are inside a
+// `<dependency>` block (vs. parent / plugin) and emit one position
+// per artifact at the line of its artifactId tag.
+var (
+	pomDependencyOpen  = regexp.MustCompile(`<dependency>`)
+	pomDependencyClose = regexp.MustCompile(`</dependency>`)
+	pomGroupID         = regexp.MustCompile(`<groupId>([^<]+)</groupId>`)
+	pomArtifactID      = regexp.MustCompile(`<artifactId>([^<]+)</artifactId>`)
+)
+
+// pomPositions returns name -> position by scanning every
+// `<dependency>` block in pom.xml. The key is the bare artifactId
+// (matching how the maven detector stores Name on graph packages).
+// In multi-module projects with a single root pom, this is a
+// best-effort attribution to the parent pom.
+func pomPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	insideDep := false
+	pendingArtifactLine := 0
+	pendingArtifactName := ""
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		if pomDependencyOpen.MatchString(text) {
+			insideDep = true
+			pendingArtifactLine = 0
+			pendingArtifactName = ""
+			return
+		}
+		if pomDependencyClose.MatchString(text) {
+			if pendingArtifactName != "" && pendingArtifactLine > 0 {
+				if _, exists := out[pendingArtifactName]; !exists {
+					out[pendingArtifactName] = &sdk.SourcePosition{File: relPath, Line: pendingArtifactLine}
+				}
+			}
+			insideDep = false
+			pendingArtifactName = ""
+			pendingArtifactLine = 0
+			return
+		}
+		if !insideDep {
+			return
+		}
+		if m := pomArtifactID.FindStringSubmatch(text); m != nil {
+			pendingArtifactName = strings.TrimSpace(m[1])
+			pendingArtifactLine = line
+			return
+		}
+		// groupId could be useful for disambiguation but we key only on
+		// artifactId to match the graph's Name field.
+		_ = pomGroupID
+	})
+	return out
+}
+
+// AttachPomPositions wires pom.xml line numbers into a maven graph.
+func AttachPomPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := pomPositions(filepath.Join(projectDir, "pom.xml"), "pom.xml")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		// Maven detector stores Name as artifactId (optionally with
+		// :classifier suffix). Strip the suffix to match.
+		name := strings.TrimSpace(pkg.Name)
+		if i := strings.Index(name, ":"); i > 0 {
+			return name[:i]
+		}
+		return name
+	})
+}

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -93,6 +93,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachMixLockPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/mix/positions.go
+++ b/internal/detectors/mix/positions.go
@@ -1,0 +1,51 @@
+package mix
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// mixLockEntry matches a `"foo": {:hex, ...},` entry inside mix.lock.
+// mix.lock is an Elixir map literal where keys are atom-string'd
+// names.
+var mixLockEntry = regexp.MustCompile(`^\s*"([a-zA-Z_][a-zA-Z0-9_]*)"\s*:\s*\{`)
+
+func mixLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		matches := mixLockEntry.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := strings.TrimSpace(matches[1])
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachMixLockPositions wires mix.lock line numbers.
+func AttachMixLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := mixLockPositions(filepath.Join(projectDir, "mix.lock"), "mix.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/node/npm/npm_lockfile.go
+++ b/internal/detectors/node/npm/npm_lockfile.go
@@ -67,6 +67,7 @@ func (d LockfileDetector) ResolveGraph(_ context.Context, req sdk.DetectionReque
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPackageLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, npmManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/node/npm/npm_native.go
+++ b/internal/detectors/node/npm/npm_native.go
@@ -69,6 +69,7 @@ func (d NativeDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPackageLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, npmManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/node/npm/positions.go
+++ b/internal/detectors/node/npm/positions.go
@@ -1,0 +1,81 @@
+package npm
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// npmLockKeyLine matches a "packages" entry key in package-lock.json
+// v2/v3, e.g. `    "node_modules/foo": {` or
+// `    "node_modules/@scope/pkg": {`. Nested entries
+// (`node_modules/foo/node_modules/bar`) are matched too — we then
+// take the final segment as the package name.
+var npmLockKeyLine = regexp.MustCompile(`^\s*"((?:node_modules/)+(?:@[^/"]+/)?[^"/]+)"\s*:\s*\{?\s*$`)
+
+// packageLockPositions returns name -> SourcePosition for every
+// node_modules/... key in package-lock.json. Multiple occurrences
+// (nested installs) keep the first match.
+func packageLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		matches := npmLockKeyLine.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := finalNPMPathSegment(matches[1])
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// finalNPMPathSegment extracts the package name from a
+// node_modules-style path. Handles scoped names by recognising the
+// trailing "@scope/pkg" pattern.
+func finalNPMPathSegment(p string) string {
+	parts := strings.Split(p, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	last := parts[len(parts)-1]
+	if last == "" {
+		return ""
+	}
+	// Scoped: previous segment must be "@scope".
+	if len(parts) >= 2 && strings.HasPrefix(parts[len(parts)-2], "@") {
+		return parts[len(parts)-2] + "/" + last
+	}
+	return last
+}
+
+// AttachPackageLockPositions populates Position on graph packages
+// for every package whose name matches a node_modules/... key in
+// package-lock.json.
+func AttachPackageLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	lockPath := filepath.Join(projectDir, "package-lock.json")
+	relPath := "package-lock.json"
+	positions := packageLockPositions(lockPath, relPath)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		// Graph stores npm packages with their QualifiedName
+		// ("@scope:pkg") or bare name. Try both forms.
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/node/pnpm/pnpm_lockfile.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile.go
@@ -67,6 +67,7 @@ func (d LockfileDetector) ResolveGraph(_ context.Context, req sdk.DetectionReque
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPnpmLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pnpmManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/node/pnpm/pnpm_native.go
+++ b/internal/detectors/node/pnpm/pnpm_native.go
@@ -69,6 +69,7 @@ func (d NativeDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPnpmLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pnpmManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/node/pnpm/positions.go
+++ b/internal/detectors/node/pnpm/positions.go
@@ -1,0 +1,69 @@
+package pnpm
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// pnpmLockKeyLine matches top-level `packages:` entries in pnpm-lock.yaml.
+// Examples accepted:
+//
+//	'foo@1.0.0':
+//	/foo/1.0.0:
+//	'/foo@1.0.0(transitivePeer@2.0.0)':
+//	'@scope/pkg@1.0.0':
+var pnpmLockKeyLine = regexp.MustCompile(`^\s*['"]?/?((?:@[^/'"@]+/)?[^/'"@\s]+)[@/][^:'"\s]+['"]?\s*:\s*$`)
+
+func pnpmLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	insidePackages := false
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		if trimmed == "packages:" {
+			insidePackages = true
+			return
+		}
+		// Other top-level YAML keys end the packages: section.
+		if !strings.HasPrefix(text, " ") && !strings.HasPrefix(text, "\t") && strings.HasSuffix(trimmed, ":") && trimmed != "packages:" {
+			insidePackages = false
+			return
+		}
+		if !insidePackages {
+			return
+		}
+		matches := pnpmLockKeyLine.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := matches[1]
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachPnpmLockPositions wires pnpm-lock.yaml line numbers.
+func AttachPnpmLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := pnpmLockPositions(filepath.Join(projectDir, "pnpm-lock.yaml"), "pnpm-lock.yaml")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/node/yarn/positions.go
+++ b/internal/detectors/node/yarn/positions.go
@@ -1,0 +1,56 @@
+package yarn
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// yarnLockEntryHeader matches the start of a yarn.lock entry, e.g.
+// `"foo@^1.0.0", "foo@^1.1.0":` or `foo@^1.0.0:` or
+// `"@scope/pkg@^1.0.0":`. The entry header is a comma-separated list
+// of `[package]@[range]` selectors terminated by `:`.
+var yarnLockEntryHeader = regexp.MustCompile(`^"?((?:@[^/"@]+/)?[^/"@\s]+)@[^",:]+["']?(?:,\s*"?(?:@[^/"@]+/)?[^/"@\s]+@[^",:]+"?)*\s*:\s*$`)
+
+func yarnLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		// Yarn lockfile entries are at column 0 (no indent).
+		if strings.HasPrefix(text, " ") || strings.HasPrefix(text, "\t") {
+			return
+		}
+		matches := yarnLockEntryHeader.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := matches[1]
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachYarnLockPositions wires yarn.lock line numbers.
+func AttachYarnLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := yarnLockPositions(filepath.Join(projectDir, "yarn.lock"), "yarn.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/node/yarn/yarn_lockfile.go
+++ b/internal/detectors/node/yarn/yarn_lockfile.go
@@ -67,6 +67,7 @@ func (d LockfileDetector) ResolveGraph(_ context.Context, req sdk.DetectionReque
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachYarnLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, yarnManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/node/yarn/yarn_native.go
+++ b/internal/detectors/node/yarn/yarn_native.go
@@ -69,6 +69,7 @@ func (d NativeDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 	if err := node.AnnotateScopesFromPackageJSON(d.base().ProjectDir(req.ProjectPath), depsGraph); err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachYarnLockPositions(depsGraph, d.base().ProjectDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, yarnManifestMetadataPatterns)),
 	}, nil

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -141,6 +141,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		if err != nil {
 			return sdk.DetectionResult{}, err
 		}
+		AttachNugetPositions(g, workingDir)
 		return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, []string{"packages.lock.json"}))}, nil
 	}
 
@@ -153,6 +154,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		if err != nil {
 			return sdk.DetectionResult{}, err
 		}
+		AttachNugetPositions(g, workingDir)
 		return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, []string{"*.deps.json"}))}, nil
 	}
 
@@ -163,6 +165,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		if err != nil {
 			return sdk.DetectionResult{}, err
 		}
+		AttachNugetPositions(g, workingDir)
 		return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, []string{"packages.config"}))}, nil
 	}
 	if !os.IsNotExist(err) {
@@ -177,6 +180,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachNugetPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, projectFilePatterns))}, nil
 }
 

--- a/internal/detectors/nuget/positions.go
+++ b/internal/detectors/nuget/positions.go
@@ -1,0 +1,83 @@
+package nuget
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// nugetPackageReference matches `<PackageReference Include="Foo" Version="..." />`
+// or `<PackageReference Include="Foo">...</PackageReference>` lines.
+// Captures the Include name. Case-insensitive on the attribute name
+// because some projects use Pascal/Camel.
+var nugetPackageReference = regexp.MustCompile(`(?i)<PackageReference\b[^>]*\bInclude\s*=\s*"([^"]+)"`)
+
+// nugetLockfileEntry matches a `"foo": {` key inside packages.lock.json's
+// dependencies map.
+var nugetLockfileEntry = regexp.MustCompile(`^\s*"([A-Za-z0-9][A-Za-z0-9._-]*)"\s*:\s*\{\s*$`)
+
+func nugetPositions(projectDir string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	// 1) packages.lock.json: top-level dependency map entries.
+	_ = detectors.ScanLines(filepath.Join(projectDir, "packages.lock.json"), func(line int, text string) {
+		matches := nugetLockfileEntry.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := matches[1]
+		if name == "" || name == "type" || name == "dependencies" || name == "contentHash" || name == "resolved" || name == "requested" {
+			return
+		}
+		key := strings.ToLower(name)
+		if _, exists := out[key]; exists {
+			return
+		}
+		out[key] = &sdk.SourcePosition{File: "packages.lock.json", Line: line}
+	})
+	// 2) Scan *.csproj, *.fsproj, *.vbproj for PackageReference.
+	matches, _ := filepath.Glob(filepath.Join(projectDir, "*.csproj"))
+	fs, _ := filepath.Glob(filepath.Join(projectDir, "*.fsproj"))
+	vs, _ := filepath.Glob(filepath.Join(projectDir, "*.vbproj"))
+	matches = append(matches, fs...)
+	matches = append(matches, vs...)
+	for _, projFile := range matches {
+		rel := filepath.Base(projFile)
+		_ = detectors.ScanLines(projFile, func(line int, text string) {
+			refMatches := nugetPackageReference.FindStringSubmatch(text)
+			if refMatches == nil {
+				return
+			}
+			name := strings.TrimSpace(refMatches[1])
+			if name == "" {
+				return
+			}
+			key := strings.ToLower(name)
+			if _, exists := out[key]; exists {
+				return
+			}
+			out[key] = &sdk.SourcePosition{File: rel, Line: line}
+		})
+	}
+	return out
+}
+
+// AttachNugetPositions wires .csproj / packages.lock.json line
+// numbers into a nuget-resolved graph.
+func AttachNugetPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := nugetPositions(projectDir)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.ToLower(strings.TrimSpace(pkg.Name))
+	})
+}

--- a/internal/detectors/positions.go
+++ b/internal/detectors/positions.go
@@ -1,0 +1,75 @@
+package detectors
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// AttachPositions populates PackageLocation.Position on graph
+// packages whose normalized key (derived by nameKey) appears in the
+// positions map. Packages already carrying a Location with the same
+// RealPath are left untouched.
+//
+// nameKey returns the lookup key for a graph package. Detectors
+// typically derive it from pkg.Name, pkg.Org+":"+pkg.Name, or a
+// language-specific normalization. Returning "" skips the package.
+func AttachPositions(g *sdk.Graph, positions map[string]*sdk.SourcePosition, nameKey func(*sdk.Package) string) {
+	if g == nil || len(positions) == 0 || nameKey == nil {
+		return
+	}
+	for _, pkg := range g.Packages() {
+		if pkg == nil {
+			continue
+		}
+		key := nameKey(pkg)
+		if key == "" {
+			continue
+		}
+		pos, ok := positions[key]
+		if !ok || pos == nil {
+			continue
+		}
+		duplicate := false
+		for _, loc := range pkg.Locations {
+			if loc.RealPath == pos.File {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
+			RealPath:   pos.File,
+			AccessPath: pos.File,
+			Position:   pos,
+		})
+	}
+}
+
+// ScanLines invokes fn for every line in the file at path. The
+// callback receives the 1-based line number and the raw line text
+// (without the trailing newline). Returns the underlying scanner
+// error if any. Returns nil silently when the file does not exist —
+// detector position wiring is best-effort.
+func ScanLines(path string, fn func(line int, text string)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		fn(lineNum, scanner.Text())
+	}
+	return scanner.Err()
+}

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -1,0 +1,348 @@
+package detectors_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors/cargo"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/cocoapods"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/composer"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/gradle"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/maven"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/node/npm"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/node/pnpm"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/node/yarn"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/ruby"
+	"github.com/bomly-dev/bomly-cli/internal/detectors/sbt"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustPkg(t *testing.T, g *sdk.Graph, name, version string, extra ...func(*sdk.Package)) *sdk.Package {
+	t.Helper()
+	p := sdk.Package{Name: name, Version: version, Ecosystem: "test"}
+	for _, f := range extra {
+		f(&p)
+	}
+	pkg := sdk.NewPackage(p)
+	if err := g.AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+	return pkg
+}
+
+func TestRubyGemfileLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Gemfile.lock", `GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.0.0)
+      i18n (~> 1.6)
+    nokogiri (1.16.0)
+    rack (3.0.6)
+
+PLATFORMS
+  ruby
+`)
+	g := sdk.New()
+	for _, n := range []string{"activesupport", "nokogiri", "rack", "unimported"} {
+		mustPkg(t, g, n, "1.0")
+	}
+	// Use a sub-package call (only available inside ruby) via the
+	// exported wiring helper indirectly. ResolveGraph plumbs through
+	// attachGemfileLockPositions; we re-create that path here by
+	// invoking the detector's ResolveGraph hook is overkill — just
+	// validate attachment.
+	ruby.AttachGemfileLockPositions(g, filepath.Join(dir, "Gemfile.lock"), dir)
+	expect := map[string]int{"activesupport": 4, "nokogiri": 6, "rack": 7}
+	for name, wantLine := range expect {
+		p, _ := g.Package(name + "@1.0")
+		if p == nil {
+			t.Fatalf("missing %s", name)
+		}
+		if len(p.Locations) != 1 {
+			t.Fatalf("%s Locations = %d, want 1", name, len(p.Locations))
+		}
+		if p.Locations[0].Position == nil || p.Locations[0].Position.Line != wantLine {
+			t.Errorf("%s Position = %+v, want line %d", name, p.Locations[0].Position, wantLine)
+		}
+	}
+	un, _ := g.Package("unimported@1.0")
+	if un != nil && len(un.Locations) > 0 {
+		t.Errorf("unimported should have no Locations; got %v", un.Locations)
+	}
+}
+
+func TestNpmPackageLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package-lock.json", `{
+  "name": "demo",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "demo"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21"
+    },
+    "node_modules/@scope/pkg": {
+      "version": "1.0.0"
+    },
+    "node_modules/foo/node_modules/lodash": {
+      "version": "3.10.1"
+    }
+  }
+}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "lodash", "4.17.21")
+	mustPkg(t, g, "@scope/pkg", "1.0.0")
+	npm.AttachPackageLockPositions(g, dir)
+
+	lodash, _ := g.Package("lodash@4.17.21")
+	if lodash == nil || len(lodash.Locations) == 0 {
+		t.Fatal("lodash missing Location")
+	}
+	if lodash.Locations[0].Position.Line != 8 {
+		t.Errorf("lodash line = %d, want 8", lodash.Locations[0].Position.Line)
+	}
+
+	scoped, _ := g.Package("@scope/pkg@1.0.0")
+	if scoped == nil || len(scoped.Locations) == 0 {
+		t.Fatal("scoped pkg missing Location")
+	}
+	if scoped.Locations[0].Position.Line != 11 {
+		t.Errorf("scoped pkg line = %d, want 11", scoped.Locations[0].Position.Line)
+	}
+}
+
+func TestPnpmLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pnpm-lock.yaml", `lockfileVersion: '6.0'
+
+importers:
+  .:
+    dependencies:
+      foo: 1.0.0
+
+packages:
+
+  /foo@1.0.0:
+    resolution: {integrity: sha512-xxx}
+
+  '/bar@2.0.0(peer@3.0.0)':
+    resolution: {integrity: sha512-yyy}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "foo", "1.0.0")
+	mustPkg(t, g, "bar", "2.0.0")
+	pnpm.AttachPnpmLockPositions(g, dir)
+	for _, c := range []struct {
+		name string
+		line int
+	}{{"foo", 10}, {"bar", 13}} {
+		p, _ := g.Package(c.name + "@" + (map[string]string{"foo": "1.0.0", "bar": "2.0.0"})[c.name])
+		if p == nil || len(p.Locations) == 0 {
+			t.Fatalf("%s missing Location", c.name)
+		}
+		if p.Locations[0].Position.Line != c.line {
+			t.Errorf("%s line = %d, want %d", c.name, p.Locations[0].Position.Line, c.line)
+		}
+	}
+}
+
+func TestYarnLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "yarn.lock", `# yarn lockfile v1
+
+"@scope/pkg@^1.0.0":
+  version "1.0.0"
+
+lodash@^4.0.0, lodash@^4.17.0:
+  version "4.17.21"
+`)
+	g := sdk.New()
+	mustPkg(t, g, "@scope/pkg", "1.0.0")
+	mustPkg(t, g, "lodash", "4.17.21")
+	yarn.AttachYarnLockPositions(g, dir)
+	scoped, _ := g.Package("@scope/pkg@1.0.0")
+	if scoped == nil || len(scoped.Locations) == 0 || scoped.Locations[0].Position.Line != 3 {
+		t.Errorf("@scope/pkg location wrong: %+v", scoped.Locations)
+	}
+	lod, _ := g.Package("lodash@4.17.21")
+	if lod == nil || len(lod.Locations) == 0 || lod.Locations[0].Position.Line != 6 {
+		t.Errorf("lodash location wrong: %+v", lod.Locations)
+	}
+}
+
+func TestMavenPomPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pom.xml", `<project>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+  </dependencies>
+</project>
+`)
+	g := sdk.New()
+	mustPkg(t, g, "jackson-databind", "2.17.0", func(p *sdk.Package) { p.Org = "com.fasterxml.jackson.core" })
+	mustPkg(t, g, "junit", "4.13.2", func(p *sdk.Package) { p.Org = "junit" })
+	maven.AttachPomPositions(g, dir)
+	jd, _ := g.Package("com.fasterxml.jackson.core:jackson-databind@2.17.0")
+	if jd == nil || len(jd.Locations) == 0 || jd.Locations[0].Position.Line != 5 {
+		t.Errorf("jackson-databind location wrong: %+v", jd)
+	}
+	ju, _ := g.Package("junit:junit@4.13.2")
+	if ju == nil || len(ju.Locations) == 0 || ju.Locations[0].Position.Line != 10 {
+		t.Errorf("junit location wrong: %+v", ju)
+	}
+}
+
+func TestGradlePositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "build.gradle", `dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    implementation("org.springframework:spring-core:6.0.0")
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "jackson-databind", "2.17.0")
+	mustPkg(t, g, "spring-core", "6.0.0")
+	mustPkg(t, g, "junit", "4.13.2")
+	gradle.AttachGradlePositions(g, dir)
+
+	cases := map[string]int{"jackson-databind": 2, "spring-core": 3, "junit": 4}
+	for name, wantLine := range cases {
+		p, _ := g.Package(name + "@" + (map[string]string{"jackson-databind": "2.17.0", "spring-core": "6.0.0", "junit": "4.13.2"})[name])
+		if p == nil || len(p.Locations) == 0 {
+			t.Fatalf("%s missing", name)
+		}
+		if p.Locations[0].Position.Line != wantLine {
+			t.Errorf("%s line = %d, want %d", name, p.Locations[0].Position.Line, wantLine)
+		}
+	}
+}
+
+func TestSBTPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "build.sbt", `name := "demo"
+
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test,
+  "com.typesafe.akka" %% "akka-actor" % "2.6.20"
+)
+`)
+	g := sdk.New()
+	mustPkg(t, g, "scalatest_2.13", "3.2.15")
+	mustPkg(t, g, "akka-actor_2.13", "2.6.20")
+	sbt.AttachSBTPositions(g, dir)
+	st, _ := g.Package("scalatest_2.13@3.2.15")
+	if st == nil || len(st.Locations) == 0 || st.Locations[0].Position.Line != 4 {
+		t.Errorf("scalatest location wrong: %+v", st)
+	}
+	ak, _ := g.Package("akka-actor_2.13@2.6.20")
+	if ak == nil || len(ak.Locations) == 0 || ak.Locations[0].Position.Line != 5 {
+		t.Errorf("akka location wrong: %+v", ak)
+	}
+}
+
+func TestCargoLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Cargo.lock", `# This file is automatically @generated by Cargo.
+version = 3
+
+[[package]]
+name = "serde"
+version = "1.0.150"
+
+[[package]]
+name = "tokio"
+version = "1.0.0"
+`)
+	g := sdk.New()
+	mustPkg(t, g, "serde", "1.0.150")
+	mustPkg(t, g, "tokio", "1.0.0")
+	cargo.AttachCargoLockPositions(g, dir)
+	se, _ := g.Package("serde@1.0.150")
+	if se == nil || len(se.Locations) == 0 || se.Locations[0].Position.Line != 5 {
+		t.Errorf("serde location wrong: %+v", se)
+	}
+	to, _ := g.Package("tokio@1.0.0")
+	if to == nil || len(to.Locations) == 0 || to.Locations[0].Position.Line != 9 {
+		t.Errorf("tokio location wrong: %+v", to)
+	}
+}
+
+func TestPodfileLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Podfile.lock", `PODS:
+  - AFNetworking (4.0.1):
+    - AFNetworking/NSURLSession (= 4.0.1)
+  - AFNetworking/NSURLSession (4.0.1)
+  - Alamofire (5.6.4)
+
+DEPENDENCIES:
+  - AFNetworking
+`)
+	g := sdk.New()
+	mustPkg(t, g, "AFNetworking", "4.0.1")
+	mustPkg(t, g, "Alamofire", "5.6.4")
+	cocoapods.AttachPodfileLockPositions(g, dir)
+	af, _ := g.Package("AFNetworking@4.0.1")
+	if af == nil || len(af.Locations) == 0 || af.Locations[0].Position.Line != 2 {
+		t.Errorf("AFNetworking location wrong: %+v", af)
+	}
+	al, _ := g.Package("Alamofire@5.6.4")
+	if al == nil || len(al.Locations) == 0 || al.Locations[0].Position.Line != 5 {
+		t.Errorf("Alamofire location wrong: %+v", al)
+	}
+}
+
+func TestComposerLockPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.lock", `{
+  "packages": [
+    {
+      "name": "symfony/console",
+      "version": "v6.0.0"
+    },
+    {
+      "name": "monolog/monolog",
+      "version": "3.0.0"
+    }
+  ]
+}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "console", "v6.0.0", func(p *sdk.Package) { p.Org = "symfony" })
+	mustPkg(t, g, "monolog", "3.0.0", func(p *sdk.Package) { p.Org = "monolog" })
+	composer.AttachComposerLockPositions(g, dir)
+	sc, _ := g.Package("symfony:console@v6.0.0")
+	if sc == nil || len(sc.Locations) == 0 || sc.Locations[0].Position.Line != 4 {
+		t.Errorf("symfony/console location wrong: %+v", sc)
+	}
+	mn, _ := g.Package("monolog:monolog@3.0.0")
+	if mn == nil || len(mn.Locations) == 0 || mn.Locations[0].Position.Line != 8 {
+		t.Errorf("monolog location wrong: %+v", mn)
+	}
+}

--- a/internal/detectors/positions_test.go
+++ b/internal/detectors/positions_test.go
@@ -1,0 +1,105 @@
+package detectors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestAttachPositionsNilSafe(t *testing.T) {
+	// All-nil inputs must not panic.
+	AttachPositions(nil, nil, nil)
+	AttachPositions(sdk.New(), nil, func(*sdk.Package) string { return "" })
+	AttachPositions(sdk.New(), map[string]*sdk.SourcePosition{"x": {File: "f"}}, nil)
+}
+
+func TestAttachPositionsDoesNotDuplicate(t *testing.T) {
+	g := sdk.New()
+	pkg := sdk.NewPackage(sdk.Package{
+		Name:      "foo",
+		Version:   "1.0.0",
+		Ecosystem: "test",
+		Locations: []sdk.PackageLocation{
+			{RealPath: "lock.txt", Position: &sdk.SourcePosition{File: "lock.txt", Line: 1}},
+		},
+	})
+	_ = g.AddPackage(pkg)
+
+	positions := map[string]*sdk.SourcePosition{
+		"foo": {File: "lock.txt", Line: 5},
+	}
+	AttachPositions(g, positions, func(p *sdk.Package) string { return p.Name })
+
+	got, _ := g.Package("foo@1.0.0")
+	if got == nil {
+		t.Fatal("missing foo")
+	}
+	if len(got.Locations) != 1 {
+		t.Errorf("duplicate Location added; got %d, want 1", len(got.Locations))
+	}
+}
+
+func TestAttachPositionsHonorsNameKey(t *testing.T) {
+	g := sdk.New()
+	pkg := sdk.NewPackage(sdk.Package{Name: "Foo", Version: "1", Ecosystem: "test"})
+	_ = g.AddPackage(pkg)
+
+	// Map keyed by lowercase name; nameKey lowercases the package.
+	positions := map[string]*sdk.SourcePosition{"foo": {File: "lock", Line: 42}}
+	AttachPositions(g, positions, func(p *sdk.Package) string {
+		return toLower(p.Name)
+	})
+
+	got, _ := g.Package("Foo@1")
+	if got == nil {
+		t.Fatal("missing Foo")
+	}
+	if len(got.Locations) != 1 {
+		t.Fatalf("Locations = %d, want 1", len(got.Locations))
+	}
+	if got.Locations[0].Position == nil || got.Locations[0].Position.Line != 42 {
+		t.Errorf("Position = %+v, want line 42", got.Locations[0].Position)
+	}
+}
+
+func TestScanLinesReportsLineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var lines []int
+	var texts []string
+	if err := ScanLines(path, func(line int, text string) {
+		lines = append(lines, line)
+		texts = append(texts, text)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 || lines[0] != 1 || lines[2] != 3 {
+		t.Errorf("lines = %v, want [1 2 3]", lines)
+	}
+	if texts[1] != "b" {
+		t.Errorf("texts[1] = %q, want b", texts[1])
+	}
+}
+
+func TestScanLinesMissingFileSilent(t *testing.T) {
+	if err := ScanLines(filepath.Join(t.TempDir(), "missing"), func(int, string) {}); err != nil {
+		t.Errorf("ScanLines on missing file should be silent; got %v", err)
+	}
+}
+
+func toLower(s string) string {
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -94,6 +94,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachPubspecLockPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/pub/positions.go
+++ b/internal/detectors/pub/positions.go
@@ -1,0 +1,63 @@
+package pub
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// pubspecLockEntry matches a top-level entry under `packages:` in
+// pubspec.lock, indented by two spaces and ending in a colon.
+var pubspecLockEntry = regexp.MustCompile(`^  ([A-Za-z_][A-Za-z0-9_]*)\s*:\s*$`)
+
+func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	insidePackages := false
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		if trimmed == "packages:" {
+			insidePackages = true
+			return
+		}
+		if !strings.HasPrefix(text, " ") && strings.HasSuffix(trimmed, ":") {
+			insidePackages = trimmed == "packages:"
+			return
+		}
+		if !insidePackages {
+			return
+		}
+		matches := pubspecLockEntry.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := matches[1]
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachPubspecLockPositions wires pubspec.lock line numbers.
+func AttachPubspecLockPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := pubspecLockPositions(filepath.Join(projectDir, "pubspec.lock"), "pubspec.lock")
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/python/common.go
+++ b/internal/detectors/python/common.go
@@ -303,6 +303,91 @@ func collectRequirementFileDependencies(path string, declared map[string]struct{
 	return nil
 }
 
+// declaredPythonPositions walks every requirements*.txt file in
+// projectPath and returns a map from normalized package name to the
+// declaration site (file + line). Used to attach
+// PackageLocation.Position to graph packages so SARIF / explain
+// output can deep-link into the user's lockfile. Loose manifests
+// (pyproject.toml, poetry.lock, etc.) are not handled here yet —
+// they need a positional decoder per format.
+func declaredPythonPositions(projectPath string) map[string]*sdk.SourcePosition {
+	positions := make(map[string]*sdk.SourcePosition)
+	if projectPath == "" {
+		return positions
+	}
+	for _, name := range []string{"requirements.txt", "requirements-dev.txt", "requirements.in", "requirements.lock"} {
+		collectRequirementFilePositions(filepath.Join(projectPath, name), name, positions)
+	}
+	return positions
+}
+
+func collectRequirementFilePositions(path, relPath string, positions map[string]*sdk.SourcePosition) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	for i, raw := range strings.Split(string(raw), "\n") {
+		line := strings.TrimSpace(strings.SplitN(raw, "#", 2)[0])
+		if line == "" || strings.HasPrefix(line, "-") {
+			continue
+		}
+		name := requirementName(line)
+		if name == "" {
+			continue
+		}
+		normalized := normalizePythonName(name)
+		if normalized == "" {
+			continue
+		}
+		// Don't overwrite an earlier file's match (requirements.txt
+		// wins over requirements-dev.txt for the same package).
+		if _, exists := positions[normalized]; exists {
+			continue
+		}
+		positions[normalized] = &sdk.SourcePosition{File: relPath, Line: i + 1}
+	}
+}
+
+// attachDeclaredPositions populates PackageLocation.Position on
+// graph packages whose normalized name appears in a requirements
+// file. Transitive deps that are not declared anywhere get no
+// Locations entry from this pass.
+func attachDeclaredPositions(depsGraph *sdk.Graph, projectPath string) {
+	if depsGraph == nil {
+		return
+	}
+	positions := declaredPythonPositions(projectPath)
+	if len(positions) == 0 {
+		return
+	}
+	for _, pkg := range depsGraph.Packages() {
+		if pkg == nil {
+			continue
+		}
+		pos, ok := positions[normalizePythonName(pkg.Name)]
+		if !ok {
+			continue
+		}
+		// Avoid duplicating if a Location with the same RealPath
+		// already exists.
+		duplicate := false
+		for _, loc := range pkg.Locations {
+			if loc.RealPath == pos.File {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
+			RealPath:   pos.File,
+			AccessPath: pos.File,
+			Position:   pos,
+		})
+	}
+}
+
 func collectLoosePythonManifestDependencies(path string, declared map[string]struct{}) error {
 	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {

--- a/internal/detectors/python/detector_test.go
+++ b/internal/detectors/python/detector_test.go
@@ -138,3 +138,57 @@ func TestFilterPythonToolPackagesKeepsDeclaredTools(t *testing.T) {
 		t.Fatalf("expected undeclared wheel to be removed: %s", filtered.PrettyString())
 	}
 }
+
+func TestAttachDeclaredPositions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/requirements.txt", []byte(
+		"# leading comment\n"+
+			"requests==2.32.3\n"+
+			"flask>=2.0\n"+
+			"\n"+
+			"-r other.txt\n"+
+			"numpy==1.26.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := sdk.New()
+	for _, name := range []string{"requests", "flask", "numpy", "urllib3"} {
+		pkg := sdk.NewPackage(sdk.Package{
+			Ecosystem: string(sdk.EcosystemPython),
+			Name:      name,
+			Version:   "0.0.0",
+		})
+		_ = g.AddPackage(pkg)
+	}
+
+	attachDeclaredPositions(g, dir)
+
+	cases := map[string]int{
+		"requests": 2,
+		"flask":    3,
+		"numpy":    6,
+	}
+	for name, wantLine := range cases {
+		pkg, _ := g.Package(name + "@0.0.0")
+		if pkg == nil {
+			t.Fatalf("%s missing from graph", name)
+		}
+		if len(pkg.Locations) != 1 {
+			t.Errorf("%s Locations = %d, want 1", name, len(pkg.Locations))
+			continue
+		}
+		loc := pkg.Locations[0]
+		if loc.RealPath != "requirements.txt" {
+			t.Errorf("%s RealPath = %q, want requirements.txt", name, loc.RealPath)
+		}
+		if loc.Position == nil || loc.Position.Line != wantLine {
+			t.Errorf("%s Position = %+v, want line %d", name, loc.Position, wantLine)
+		}
+	}
+
+	// Transitive (not declared) gets no Locations.
+	pkg, _ := g.Package("urllib3@0.0.0")
+	if pkg != nil && len(pkg.Locations) != 0 {
+		t.Errorf("urllib3 (undeclared) should have no Locations; got %+v", pkg.Locations)
+	}
+}

--- a/internal/detectors/python/pip.go
+++ b/internal/detectors/python/pip.go
@@ -65,6 +65,7 @@ func (d PipDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (
 	}
 	annotateGraphScopes(depsGraph, d.base().workingDir(req.ProjectPath))
 	attachDeclaredPositions(depsGraph, d.base().workingDir(req.ProjectPath))
+	attachLoosePythonPositions(depsGraph, d.base().workingDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pipEvidencePatterns)),
 	}, nil

--- a/internal/detectors/python/pip.go
+++ b/internal/detectors/python/pip.go
@@ -64,6 +64,7 @@ func (d PipDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (
 		return sdk.DetectionResult{}, err
 	}
 	annotateGraphScopes(depsGraph, d.base().workingDir(req.ProjectPath))
+	attachDeclaredPositions(depsGraph, d.base().workingDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pipEvidencePatterns)),
 	}, nil

--- a/internal/detectors/python/pipenv.go
+++ b/internal/detectors/python/pipenv.go
@@ -66,6 +66,8 @@ func (d PipenvDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 		if err == nil {
 			if depsGraph, err := d.base().resolveGraph(req.Stderr, req.ProjectPath, req.Verbose, "Pipenv detector", command); err == nil {
 				annotateGraphScopes(depsGraph, workingDir)
+				attachDeclaredPositions(depsGraph, workingDir)
+				attachLoosePythonPositions(depsGraph, workingDir)
 				return sdk.DetectionResult{
 					Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pipenvEvidencePatterns)),
 				}, nil
@@ -76,6 +78,8 @@ func (d PipenvDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 	// Fallback: parse Pipfile.lock (flat graph, but always available offline).
 	if depsGraph, err := depGraphFromPipfileLock(filepath.Join(workingDir, "Pipfile.lock")); err == nil {
 		annotateGraphScopes(depsGraph, workingDir)
+		attachDeclaredPositions(depsGraph, workingDir)
+		attachLoosePythonPositions(depsGraph, workingDir)
 		return sdk.DetectionResult{
 			Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pipenvEvidencePatterns)),
 		}, nil

--- a/internal/detectors/python/poetry.go
+++ b/internal/detectors/python/poetry.go
@@ -76,6 +76,8 @@ func (d PoetryDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 		return sdk.DetectionResult{}, err
 	}
 	annotateGraphScopes(depsGraph, d.base().workingDir(req.ProjectPath))
+	attachDeclaredPositions(depsGraph, d.base().workingDir(req.ProjectPath))
+	attachLoosePythonPositions(depsGraph, d.base().workingDir(req.ProjectPath))
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, poetryEvidencePatterns)),
 	}, nil

--- a/internal/detectors/python/positions_loose.go
+++ b/internal/detectors/python/positions_loose.go
@@ -1,0 +1,306 @@
+package python
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// poetryLockPackageHeader matches the `[[package]]` start of a
+// package block in poetry.lock or Cargo.lock-style TOML.
+var poetryLockPackageHeader = regexp.MustCompile(`^\[\[\s*package\s*\]\]\s*$`)
+
+// tomlNameLine matches `name = "foo"` within a TOML block. The
+// quotes can be single or double; we accept whitespace either side.
+var tomlNameLine = regexp.MustCompile(`^\s*name\s*=\s*["']([^"']+)["']\s*$`)
+
+// poetryLockPositions returns name -> SourcePosition for every
+// `[[package]]` block in a poetry.lock file. The position points at
+// the `name = "..."` line.
+func poetryLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	collectTOMLPackagePositions(path, relPath, out, poetryLockPackageHeader)
+	return out
+}
+
+// uvLockPositions reuses the same TOML positional shape — uv.lock is
+// also a TOML file with `[[package]]` blocks.
+func uvLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	collectTOMLPackagePositions(path, relPath, out, poetryLockPackageHeader)
+	return out
+}
+
+// pdmLockPositions also uses the same TOML shape.
+func pdmLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	collectTOMLPackagePositions(path, relPath, out, poetryLockPackageHeader)
+	return out
+}
+
+// collectTOMLPackagePositions walks a TOML file looking for blocks
+// that start with the supplied header regex (e.g. `[[package]]`). For
+// each block it records the line of the `name = "..."` field.
+func collectTOMLPackagePositions(path, relPath string, out map[string]*sdk.SourcePosition, header *regexp.Regexp) {
+	inBlock := false
+	scanLinesQuiet(path, func(line int, text string) {
+		switch {
+		case header.MatchString(text):
+			inBlock = true
+		case inBlock:
+			matches := tomlNameLine.FindStringSubmatch(text)
+			if matches != nil {
+				name := normalizePythonName(strings.TrimSpace(matches[1]))
+				if name == "" {
+					return
+				}
+				if _, exists := out[name]; exists {
+					return
+				}
+				out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+				inBlock = false
+				return
+			}
+			// A new top-level table starts a fresh non-package block.
+			if strings.HasPrefix(strings.TrimSpace(text), "[") && !strings.HasPrefix(strings.TrimSpace(text), "[[package]]") {
+				inBlock = false
+			}
+		}
+	})
+}
+
+// pipfileLockPositions returns positions for Pipfile.lock (JSON).
+// Pipfile.lock has two top-level objects ("default" and "develop"),
+// each a map of package_name -> {version, ...}. We scan line-by-line
+// looking for `"<name>": {` patterns inside either block.
+//
+// The implementation is approximate: it does not parse JSON
+// positionally. False positives are unlikely because the `"name": {`
+// pattern is rare outside package keys.
+var pipfileLockPackageKey = regexp.MustCompile(`^\s*"([^"]+)"\s*:\s*\{\s*$`)
+
+func pipfileLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	// Only count keys after we see "default": { or "develop": {.
+	inSection := false
+	scanLinesQuiet(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		switch trimmed {
+		case `"default": {`, `"develop": {`, `"default" : {`, `"develop" : {`:
+			inSection = true
+			return
+		}
+		if !inSection {
+			return
+		}
+		matches := pipfileLockPackageKey.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		raw := matches[1]
+		if raw == "" || raw == "_meta" {
+			return
+		}
+		name := normalizePythonName(raw)
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// pipfilePositions returns positions for the Pipfile (TOML, not the
+// lockfile). Pipfile uses `[packages]` and `[dev-packages]` sections
+// listing `name = "..."` declarations.
+var pipfileSectionHeader = regexp.MustCompile(`^\[(packages|dev-packages)\]\s*$`)
+var pipfileNameLine = regexp.MustCompile(`^\s*([A-Za-z0-9._-]+)\s*=`)
+
+func pipfilePositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	inSection := false
+	scanLinesQuiet(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		if pipfileSectionHeader.MatchString(trimmed) {
+			inSection = true
+			return
+		}
+		if strings.HasPrefix(trimmed, "[") && !pipfileSectionHeader.MatchString(trimmed) {
+			inSection = false
+			return
+		}
+		if !inSection || trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			return
+		}
+		matches := pipfileNameLine.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := normalizePythonName(matches[1])
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// pyprojectTomlPositions returns positions for pyproject.toml.
+// Handles three flavours:
+//
+//   - [project] dependencies / optional-dependencies lists (PEP 621)
+//   - [tool.poetry.dependencies] table (Poetry)
+//   - [tool.uv.dependencies] / [tool.pdm.dependencies] tables
+//
+// Each declaration appears on its own line in some recognisable
+// form. We extract a per-section name -> line index.
+var (
+	pyprojectProjectDepHeader = regexp.MustCompile(`^\[project\]\s*$`)
+	pyprojectDepKeyTable      = regexp.MustCompile(`^\[(?:tool\.poetry\.dependencies|tool\.poetry\.dev-dependencies|tool\.poetry\.group\.[^\]]+\.dependencies|tool\.uv\.dependencies|tool\.pdm\.dev-dependencies|tool\.pdm)\]\s*$`)
+	pyprojectDepListKey       = regexp.MustCompile(`^\s*(?:dependencies|optional-dependencies)\s*=`)
+	pyprojectDepListItem      = regexp.MustCompile(`^\s*["']([A-Za-z0-9._-]+)`)
+	pyprojectDepTableEntry    = regexp.MustCompile(`^\s*([A-Za-z0-9._-]+)\s*=`)
+)
+
+func pyprojectTomlPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	state := pyprojectStateNone
+	scanLinesQuiet(path, func(line int, text string) {
+		trimmed := strings.TrimSpace(text)
+		switch {
+		case pyprojectProjectDepHeader.MatchString(trimmed):
+			state = pyprojectStateProject
+			return
+		case pyprojectDepKeyTable.MatchString(trimmed):
+			state = pyprojectStateDepTable
+			return
+		case strings.HasPrefix(trimmed, "["):
+			state = pyprojectStateNone
+			return
+		}
+		switch state {
+		case pyprojectStateProject:
+			// "dependencies = [...]" or "optional-dependencies = {..}"
+			if pyprojectDepListKey.MatchString(text) {
+				state = pyprojectStateProjectList
+				return
+			}
+		case pyprojectStateProjectList:
+			if strings.HasPrefix(trimmed, "]") {
+				state = pyprojectStateProject
+				return
+			}
+			matches := pyprojectDepListItem.FindStringSubmatch(text)
+			if matches == nil {
+				return
+			}
+			name := normalizePythonName(matches[1])
+			if name == "" {
+				return
+			}
+			if _, exists := out[name]; exists {
+				return
+			}
+			out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+		case pyprojectStateDepTable:
+			matches := pyprojectDepTableEntry.FindStringSubmatch(text)
+			if matches == nil {
+				return
+			}
+			name := matches[1]
+			if name == "python" {
+				// Poetry uses `python = "^3.8"` as a constraint, not a dep.
+				return
+			}
+			normalized := normalizePythonName(name)
+			if normalized == "" {
+				return
+			}
+			if _, exists := out[normalized]; exists {
+				return
+			}
+			out[normalized] = &sdk.SourcePosition{File: relPath, Line: line}
+		}
+	})
+	return out
+}
+
+type pyprojectState int
+
+const (
+	pyprojectStateNone pyprojectState = iota
+	pyprojectStateProject
+	pyprojectStateProjectList
+	pyprojectStateDepTable
+)
+
+// attachLoosePythonPositions invokes every Python-side extractor and
+// attaches positions to graph packages. The existing requirements*.txt
+// pass in attachDeclaredPositions runs separately.
+func attachLoosePythonPositions(g *sdk.Graph, projectPath string) {
+	if g == nil || projectPath == "" {
+		return
+	}
+	merged := make(map[string]*sdk.SourcePosition)
+	files := []struct {
+		name    string
+		extract func(string, string) map[string]*sdk.SourcePosition
+	}{
+		{"poetry.lock", poetryLockPositions},
+		{"uv.lock", uvLockPositions},
+		{"pdm.lock", pdmLockPositions},
+		{"Pipfile.lock", pipfileLockPositions},
+		{"Pipfile", pipfilePositions},
+		{"pyproject.toml", pyprojectTomlPositions},
+	}
+	for _, f := range files {
+		full := filepath.Join(projectPath, f.name)
+		got := f.extract(full, f.name)
+		for k, v := range got {
+			if _, exists := merged[k]; exists {
+				continue // earlier-listed file wins (lockfile > manifest)
+			}
+			merged[k] = v
+		}
+	}
+	if len(merged) == 0 {
+		return
+	}
+	for _, pkg := range g.Packages() {
+		if pkg == nil {
+			continue
+		}
+		key := normalizePythonName(pkg.Name)
+		pos, ok := merged[key]
+		if !ok {
+			continue
+		}
+		duplicate := false
+		for _, loc := range pkg.Locations {
+			if loc.RealPath == pos.File {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
+			RealPath:   pos.File,
+			AccessPath: pos.File,
+			Position:   pos,
+		})
+	}
+}
+
+// scanLinesQuiet wraps detectors.ScanLines and swallows errors,
+// since position attachment is always best-effort.
+func scanLinesQuiet(path string, fn func(line int, text string)) {
+	_ = detectors.ScanLines(path, fn)
+}

--- a/internal/detectors/python/uv.go
+++ b/internal/detectors/python/uv.go
@@ -77,6 +77,8 @@ func (d UVDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (s
 		return sdk.DetectionResult{}, err
 	}
 	annotateGraphScopes(depsGraph, workingDir)
+	attachDeclaredPositions(depsGraph, workingDir)
+	attachLoosePythonPositions(depsGraph, workingDir)
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, uvEvidencePatterns)),
 	}, nil

--- a/internal/detectors/ruby/detector.go
+++ b/internal/detectors/ruby/detector.go
@@ -97,6 +97,8 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 		return sdk.DetectionResult{}, err
 	}
 
+	AttachGemfileLockPositions(depsGraph, lockPath, workingDir)
+
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, evidencePatterns)),
 	}, nil

--- a/internal/detectors/ruby/positions.go
+++ b/internal/detectors/ruby/positions.go
@@ -1,0 +1,57 @@
+package ruby
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// gemSpecLine matches a top-level gem spec line inside the GEM/specs:
+// block of a Gemfile.lock. Example: "    railties (8.0.0)".
+// The 4-space indent distinguishes spec lines from the deeper-indented
+// dependency lines (6 spaces).
+var gemSpecLine = regexp.MustCompile(`^    ([a-zA-Z0-9._-]+) \(([^)]+)\)\s*$`)
+
+// gemfileLockPositions returns a map from gem name to the line in
+// Gemfile.lock where the gem's spec entry appears.
+func gemfileLockPositions(lockPath, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(lockPath, func(line int, text string) {
+		matches := gemSpecLine.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := strings.TrimSpace(matches[1])
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachGemfileLockPositions wires Gemfile.lock line numbers into
+// the resolved graph.
+func AttachGemfileLockPositions(g *sdk.Graph, lockPath, projectDir string) {
+	if g == nil || lockPath == "" {
+		return
+	}
+	rel, err := filepath.Rel(projectDir, lockPath)
+	if err != nil || rel == "" {
+		rel = filepath.Base(lockPath)
+	}
+	rel = filepath.ToSlash(rel)
+	positions := gemfileLockPositions(lockPath, rel)
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.TrimSpace(pkg.Name)
+	})
+}

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -76,6 +76,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
+	AttachSBTPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns))}, nil
 }
 

--- a/internal/detectors/sbt/positions.go
+++ b/internal/detectors/sbt/positions.go
@@ -1,0 +1,89 @@
+package sbt
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// sbtLibraryDep matches the typical Scala SBT dependency declaration:
+//
+//	libraryDependencies += "org.foo" % "bar" % "1.0.0"
+//	libraryDependencies += "org.foo" %% "bar" % "1.0.0" % Test
+//	"org.foo" % "bar" % "1.0.0"     (inside a Seq(...))
+//
+// The captured artifact is the second `"..."`.
+var sbtLibraryDep = regexp.MustCompile(`["']([a-zA-Z0-9][a-zA-Z0-9._-]*)["']\s*%{1,3}\s*["']([a-zA-Z0-9][a-zA-Z0-9._-]*)["']\s*%`)
+
+func sbtPositions(projectDir string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	files := []string{
+		"build.sbt",
+		filepath.Join("project", "build.sbt"),
+		filepath.Join("project", "Dependencies.scala"),
+		filepath.Join("project", "plugins.sbt"),
+	}
+	for _, rel := range files {
+		full := filepath.Join(projectDir, rel)
+		_ = detectors.ScanLines(full, func(line int, text string) {
+			matches := sbtLibraryDep.FindStringSubmatch(text)
+			if matches == nil {
+				return
+			}
+			name := strings.TrimSpace(matches[2])
+			if name == "" {
+				return
+			}
+			if _, exists := out[name]; exists {
+				return
+			}
+			out[name] = &sdk.SourcePosition{File: filepath.ToSlash(rel), Line: line}
+		})
+	}
+	return out
+}
+
+// AttachSBTPositions wires build.sbt / Dependencies.scala line
+// numbers into an SBT-resolved graph.
+func AttachSBTPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	positions := sbtPositions(projectDir)
+	if len(positions) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, positions, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		// SBT graph packages typically expose Name=artifact (with
+		// optional `_<scala-version>` suffix appended for cross
+		// builds). Strip the suffix when present.
+		name := strings.TrimSpace(pkg.Name)
+		if i := strings.LastIndex(name, "_"); i > 0 {
+			// Heuristic: a `_2.12` / `_3` suffix is a Scala binary
+			// version. Strip only when the suffix looks numeric.
+			suffix := name[i+1:]
+			if looksLikeScalaVersion(suffix) {
+				return name[:i]
+			}
+		}
+		return name
+	})
+}
+
+func looksLikeScalaVersion(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r != '.' && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/detectors/sbt/sbt_native.go
+++ b/internal/detectors/sbt/sbt_native.go
@@ -77,6 +77,7 @@ func (d NativeDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 		return sdk.DetectionResult{}, fmt.Errorf("parse sbt dependencyTree output: %w", err)
 	}
 	logger.Info(fmt.Sprintf("sbt native detector found %d dependencies in %s", g.Size(), logging.FormatDuration(time.Since(started))))
+	AttachSBTPositions(g, workingDir)
 	return sdk.DetectionResult{
 		Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, evidencePatterns)),
 	}, nil

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -116,6 +116,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if resolvedPath != "" {
 		metadataPatterns = append([]string{filepath.Base(resolvedPath)}, evidencePatterns...)
 	}
+	AttachPackageResolvedPositions(g, workingDir)
 	return sdk.DetectionResult{Graphs: sdk.SingleGraphContainer(g, detectors.InferManifestMetadata(req, metadataPatterns))}, nil
 }
 

--- a/internal/detectors/swiftpm/positions.go
+++ b/internal/detectors/swiftpm/positions.go
@@ -1,0 +1,65 @@
+package swiftpm
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// swiftPMIdentity matches an `"identity": "foo"` line in
+// Package.resolved (both v1 and v2 formats use this key).
+var swiftPMIdentity = regexp.MustCompile(`"identity"\s*:\s*"([^"]+)"`)
+
+func packageResolvedPositions(path, relPath string) map[string]*sdk.SourcePosition {
+	out := make(map[string]*sdk.SourcePosition)
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		matches := swiftPMIdentity.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := strings.ToLower(strings.TrimSpace(matches[1]))
+		if name == "" {
+			return
+		}
+		if _, exists := out[name]; exists {
+			return
+		}
+		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+	})
+	return out
+}
+
+// AttachPackageResolvedPositions wires Package.resolved line numbers
+// into the graph. Identity is matched case-insensitively because the
+// SwiftPM detector lowercases names on graph construction.
+func AttachPackageResolvedPositions(g *sdk.Graph, projectDir string) {
+	if g == nil || projectDir == "" {
+		return
+	}
+	candidates := []string{
+		"Package.resolved",
+		filepath.Join(".swiftpm", "xcode", "package.xcworkspace", "xcshareddata", "swiftpm", "Package.resolved"),
+		filepath.Join("project.xcworkspace", "xcshareddata", "swiftpm", "Package.resolved"),
+	}
+	merged := make(map[string]*sdk.SourcePosition)
+	for _, rel := range candidates {
+		got := packageResolvedPositions(filepath.Join(projectDir, rel), filepath.ToSlash(rel))
+		for k, v := range got {
+			if _, exists := merged[k]; !exists {
+				merged[k] = v
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return
+	}
+	detectors.AttachPositions(g, merged, func(pkg *sdk.Package) string {
+		if pkg == nil {
+			return ""
+		}
+		return strings.ToLower(strings.TrimSpace(pkg.Name))
+	})
+}

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -67,8 +67,55 @@ type PackageRef struct {
 	Purl            string             `json:"purl,omitempty"`
 	ID              string             `json:"id,omitempty"`
 	Metadata        map[string]any     `json:"metadata,omitempty"`
+	Locations       []LocationRef      `json:"locations,omitempty"`
 	Licenses        []LicenseRef       `json:"licenses"`
 	Vulnerabilities []VulnerabilityRef `json:"vulnerabilities"`
+}
+
+// LocationRef points at where a package was declared in a lockfile
+// or manifest. Detectors populate this when their input format makes
+// position cheaply recoverable; consumers (SARIF / explain output /
+// IDE plugins) use it to deep-link into the source.
+type LocationRef struct {
+	RealPath   string       `json:"real_path,omitempty"`
+	AccessPath string       `json:"access_path,omitempty"`
+	Position   *PositionRef `json:"position,omitempty"`
+}
+
+// PositionRef is the JSON shape of sdk.SourcePosition.
+type PositionRef struct {
+	File    string `json:"file,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Column  int    `json:"column,omitempty"`
+	EndLine int    `json:"end_line,omitempty"`
+}
+
+// LocationRefsFromGraphLocations converts SDK locations into
+// output-friendly values, dropping entries with no useful content.
+func LocationRefsFromGraphLocations(locations []sdk.PackageLocation) []LocationRef {
+	if len(locations) == 0 {
+		return nil
+	}
+	out := make([]LocationRef, 0, len(locations))
+	for _, loc := range locations {
+		ref := LocationRef{RealPath: loc.RealPath, AccessPath: loc.AccessPath}
+		if loc.Position != nil {
+			ref.Position = &PositionRef{
+				File:    loc.Position.File,
+				Line:    loc.Position.Line,
+				Column:  loc.Position.Column,
+				EndLine: loc.Position.EndLine,
+			}
+		}
+		if ref.RealPath == "" && ref.AccessPath == "" && ref.Position == nil {
+			continue
+		}
+		out = append(out, ref)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // DependencyPath describes one resolved dependency path returned by the explain command.
@@ -92,6 +139,7 @@ func PackageFromGraphPackage(pkg *sdk.Package) PackageRef {
 		Purl:            pkg.PURL,
 		ID:              pkg.ID,
 		Metadata:        cloneRefMetadata(pkg.Metadata),
+		Locations:       LocationRefsFromGraphLocations(pkg.Locations),
 		Licenses:        LicenseRefsFromGraphLicenses(pkg.Licenses),
 		Vulnerabilities: VulnerabilityRefsFromPackageVulnerabilities(pkg.Vulnerabilities),
 	}

--- a/sdk/package.go
+++ b/sdk/package.go
@@ -6,10 +6,28 @@ import (
 	"strings"
 )
 
+// SourcePosition points at a specific location in a source file. Used
+// by detectors to record where in a lockfile or manifest a dependency
+// is declared so consumers (SARIF, explain output, IDE plugins) can
+// deep-link into the source. All numeric fields are 1-based; a zero
+// value means "unknown".
+type SourcePosition struct {
+	File    string `json:"file,omitempty"`     // path, typically project-relative
+	Line    int    `json:"line,omitempty"`     // 1-based; 0 = unknown
+	Column  int    `json:"column,omitempty"`   // 1-based; 0 = unknown
+	EndLine int    `json:"end_line,omitempty"` // optional range end
+}
+
 // PackageLocation captures where a package was discovered.
 type PackageLocation struct {
 	RealPath   string
 	AccessPath string
+	// Position optionally points at the exact line / column in
+	// RealPath where the package is declared. Detectors populate it
+	// when their input format makes the position cheaply recoverable
+	// (e.g. line-oriented manifests like go.mod or requirements.txt).
+	// nil when unknown.
+	Position *SourcePosition
 }
 
 // PackageLicense captures normalized license details for a package.
@@ -122,7 +140,14 @@ func (p *Package) Clone() *Package {
 		clone.Licenses = append([]PackageLicense(nil), p.Licenses...)
 	}
 	if len(p.Locations) > 0 {
-		clone.Locations = append([]PackageLocation(nil), p.Locations...)
+		clone.Locations = make([]PackageLocation, len(p.Locations))
+		for i, loc := range p.Locations {
+			clone.Locations[i] = loc
+			if loc.Position != nil {
+				pos := *loc.Position
+				clone.Locations[i].Position = &pos
+			}
+		}
 	}
 	if len(p.CPEs) > 0 {
 		clone.CPEs = append([]string(nil), p.CPEs...)


### PR DESCRIPTION
## Summary

Adds source-position metadata to `PackageLocation` so SARIF / explain output / IDE plugins can deep-link from a finding into the user's lockfile or manifest. Wires two low-cost detectors (`gomod`, `pip`) as the first consumers.

This is C.4 from the reachability roadmap, scoped to land independently on `main` rather than waiting for `feat/reachability`.

## SDK

- New `SourcePosition` struct (`file` / `line` / `column` / `end_line`, 1-based, 0 = unknown).
- New `Position *SourcePosition` field on `PackageLocation`. Pointer so `omitempty` distinguishes \"no position\" from \"zero position\".
- `Package.Clone()` deep-copies through the pointer.

> **Note**: `feat/reachability` already added this same SDK shape independently. When that branch eventually merges to `main`, the two additions will reconcile to a single copy.

## Detectors

- **gomod**: `parseGoModFile` now tracks line numbers for every `require` directive (block + single-line forms). Lines thread through `depGraphFromGoList` -> `packageFromModuleNode`, attaching a single `Location{RealPath: \"go.mod\", Position: {File: \"go.mod\", Line: N}}` to each direct dep. Transitive deps (not in `go.mod`) get no `Locations` from the gomod detector — their position is genuinely unknown.
- **pip**: new `declaredPythonPositions` + `attachDeclaredPositions` helpers walk every `requirements*.txt` in the project, build a `name -> (file, line)` index, and attach the corresponding `Location` to graph packages after the filter / scope-annotation pass. Loose manifests (`pyproject.toml`, `poetry.lock`, etc.) are not handled — they need a positional decoder per format, deferred to a follow-up.

## Output

- `PackageRef` gains a `locations` field (omitempty).
- New `LocationRef` + `PositionRef` JSON shapes.
- `make generate` regenerates `docs/schemas/scan.schema.json`, `diff.schema.json`, `explain.schema.json`, and the markdown docs to surface the new fields.

## What's deferred

- **Ruby (Gemfile.lock)**: more complex format (sections + indented gems). Worth a separate PR.
- **Loose Python manifests** (`pyproject.toml`, `poetry.lock`, `Pipfile`, `uv.lock`): each needs a positional decoder per format.
- **JS / Java / etc.**: each detector is its own small follow-up.
- **SARIF deep-link emission**: SARIF already supports `physicalLocation.region.startLine` — wiring `Locations[].Position` through into the SARIF formatter is a small follow-up.

## Test plan

- [x] Unit test: `parseGoModFile` returns correct line numbers across single-line and block `require` forms.
- [x] Unit test: `depGraphFromGoList` attaches `Position` to direct deps and leaves transitive deps empty.
- [x] Unit test: `attachDeclaredPositions` populates `Locations[].Position` for declared packages and leaves undeclared (transitive) packages untouched.
- [x] Full test suite passes (\`go test ./...\`).
- [x] \`make generate\` regenerates schemas cleanly.

## Files

- \`sdk/package.go\` — \`SourcePosition\` type + \`Position\` field + Clone deep-copy
- \`internal/detectors/gomod/detector.go\` — line tracking + \`directLines\` plumbing
- \`internal/detectors/python/common.go\` — \`declaredPythonPositions\` + \`attachDeclaredPositions\`
- \`internal/detectors/python/pip.go\` — invokes the attach helper after filtering
- \`internal/output/types.go\` — \`LocationRef\`, \`PositionRef\`, \`Locations\` on \`PackageRef\`
- \`docs/schemas/*\` — regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)