### PR TITLE
Improve detector progress and debug logging

### DIFF
--- a/internal/engine/pipeline_resolve.go
+++ b/internal/engine/pipeline_resolve.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -45,6 +47,7 @@ func (p *Pipeline) resolveAll(ctx context.Context, req PipelineRequest) ([]sdk.D
 			defer wg.Done()
 			for idx := range jobs {
 				sub := req.Subprojects[idx]
+				reportProgressDetail(req.Progress, "Detecting dependencies", subprojectProgressDetail(sub))
 				subResults, err := p.resolveSubproject(ctx, req, sub)
 				ordered[idx] = subprojectResolution{results: subResults, err: err}
 				if req.Progress != nil {
@@ -125,10 +128,16 @@ func (p *Pipeline) resolveSubproject(ctx context.Context, req PipelineRequest, s
 	detectorNames := sub.PlannedDetectors
 	detectorList := p.Registry.PlannedDetectors(baseReq, detectorNames)
 	if len(detectorList) == 0 {
+		p.Logger.Warn("pipeline: no detector registered for subproject",
+			zap.String("path", sub.RelativePath),
+			zap.String("ecosystem", string(sub.Ecosystem)),
+			zap.String("package_manager", sub.PrimaryPackageManager().Name()),
+			zap.Strings("planned_detectors", detectorNames),
+		)
 		return nil, fmt.Errorf("no detector registered for ecosystem %q and package manager %q", sub.Ecosystem, sub.PrimaryPackageManager())
 	}
 
-	results, err := p.resolveDetectors(ctx, baseReq, detectorList[:1])
+	results, err := p.resolveDetectors(ctx, baseReq, detectorList[:1], req.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +149,7 @@ func (p *Pipeline) resolveSubproject(ctx context.Context, req PipelineRequest, s
 
 // resolveDetectors runs matched detectors in priority order. Detectors may
 // provide their own fallback detector when they cannot produce a result.
-func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionRequest, detectorList []sdk.Detector) ([]sdk.DetectionResult, error) {
+func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionRequest, detectorList []sdk.Detector, progress ProgressReporter) ([]sdk.DetectionResult, error) {
 	var results []sdk.DetectionResult
 	var errs []error
 	succeeded := make(map[string]struct{}, len(detectorList))
@@ -150,7 +159,7 @@ func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionReques
 		if _, ok := succeeded[descriptor.Name]; ok {
 			continue
 		}
-		detectorResults, err := p.resolveDetector(ctx, req, detector)
+		detectorResults, err := p.resolveDetector(ctx, req, detector, progress)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -169,48 +178,88 @@ func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionReques
 	return results, nil
 }
 
-func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector) ([]sdk.DetectionResult, error) {
+func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, progress ProgressReporter) ([]sdk.DetectionResult, error) {
 	descriptor := detector.Descriptor()
+	support := detector.PackageManagerSupport()
+	reportProgressDetail(progress, "Detecting dependencies", detectorProgressDetail(req.Subproject, descriptor.Name))
+	p.Logger.Debug("pipeline: detector starting",
+		zap.String("detector", descriptor.Name),
+		zap.String("subproject", req.Subproject.RelativePath),
+		zap.String("ecosystem", string(req.Ecosystem)),
+		zap.String("package_manager", req.PackageManager.Name()),
+		zap.Strings("evidence_patterns", evidencePatternsForSupport(support, req.PackageManager)),
+		zap.Bool("install_first_requested", req.InstallFirst),
+		zap.Bool("install_first_supported", descriptor.SupportsInstallFirst),
+	)
 
 	if !detector.Ready() {
-		p.Logger.Debug("pipeline: detector not ready", zap.String("detector", descriptor.Name))
-		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: not ready", descriptor.Name))
+		p.Logger.Debug("pipeline: detector not ready",
+			zap.String("detector", descriptor.Name),
+			zap.String("subproject", req.Subproject.RelativePath),
+		)
+		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: not ready", descriptor.Name), progress)
 	}
 
 	applicable, err := detector.Applicable(ctx, req)
 	if err != nil {
-		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: applicability check failed: %w", descriptor.Name, err))
+		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: applicability check failed: %w", descriptor.Name, err), progress)
 	}
 	if !applicable {
-		p.Logger.Debug("pipeline: detector not applicable", zap.String("detector", descriptor.Name))
-		return p.resolveFallback(ctx, req, detector, nil)
+		p.Logger.Debug("pipeline: detector not applicable",
+			zap.String("detector", descriptor.Name),
+			zap.String("subproject", req.Subproject.RelativePath),
+		)
+		return p.resolveFallback(ctx, req, detector, nil, progress)
 	}
 
 	if req.InstallFirst {
 		if installer, ok := detector.(sdk.InstallFirstDetector); ok {
+			p.Logger.Debug("pipeline: running detector install-first",
+				zap.String("detector", descriptor.Name),
+				zap.String("subproject", req.Subproject.RelativePath),
+				zap.Strings("install_args", req.InstallArgs),
+			)
 			if err := installer.Install(ctx, req); err != nil {
-				return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: install-first failed: %w", descriptor.Name, err))
+				return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: install-first failed: %w", descriptor.Name, err), progress)
 			}
+		} else {
+			p.Logger.Debug("pipeline: detector does not support install-first",
+				zap.String("detector", descriptor.Name),
+				zap.String("subproject", req.Subproject.RelativePath),
+			)
 		}
+	} else if descriptor.SupportsInstallFirst {
+		p.Logger.Debug("pipeline: detector supports install-first",
+			zap.String("detector", descriptor.Name),
+			zap.String("subproject", req.Subproject.RelativePath),
+			zap.String("hint", "use --install-first when dependencies must be installed before graph resolution"),
+		)
 	}
 
 	result, err := detector.ResolveGraph(ctx, req)
 	if err != nil {
-		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: %w", descriptor.Name, err))
+		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: %w", descriptor.Name, err), progress)
 	}
 	if result.Graphs == nil || result.Graphs.Len() == 0 {
-		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: no graph data", descriptor.Name))
+		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: no graph data", descriptor.Name), progress)
 	}
 
 	result.SubprojectInfo = req.Subproject
 	result.DetectorName = descriptor.Name
 	result.Origin = descriptor.Origin
 	result.Technique = descriptor.Technique
-	p.Logger.Debug("pipeline: detector succeeded", zap.String("detector", descriptor.Name))
+	packages, edges := graphContainerStats(result.Graphs)
+	p.Logger.Debug("pipeline: detector succeeded",
+		zap.String("detector", descriptor.Name),
+		zap.String("subproject", req.Subproject.RelativePath),
+		zap.Int("graphs", result.Graphs.Len()),
+		zap.Int("packages", packages),
+		zap.Int("edges", edges),
+	)
 	return []sdk.DetectionResult{result}, nil
 }
 
-func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, primaryErr error) ([]sdk.DetectionResult, error) {
+func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, primaryErr error, progress ProgressReporter) ([]sdk.DetectionResult, error) {
 	fallbackProvider, ok := detector.(sdk.FallbackDetector)
 	if !ok {
 		return nil, primaryErr
@@ -220,9 +269,20 @@ func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest
 		return nil, primaryErr
 	}
 	if !fallbackSelected(req.DetectorFilter, fallback.Descriptor()) {
+		p.Logger.Debug("pipeline: fallback detector skipped by filter",
+			zap.String("detector", detector.Descriptor().Name),
+			zap.String("fallback_detector", fallback.Descriptor().Name),
+			zap.String("subproject", req.Subproject.RelativePath),
+		)
 		return nil, primaryErr
 	}
-	results, fallbackErr := p.resolveDetector(ctx, req, fallback)
+	p.Logger.Debug("pipeline: trying fallback detector",
+		zap.String("detector", detector.Descriptor().Name),
+		zap.String("fallback_detector", fallback.Descriptor().Name),
+		zap.String("subproject", req.Subproject.RelativePath),
+		zap.Error(primaryErr),
+	)
+	results, fallbackErr := p.resolveDetector(ctx, req, fallback, progress)
 	if primaryErr == nil {
 		return results, fallbackErr
 	}
@@ -230,6 +290,85 @@ func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest
 		return results, nil
 	}
 	return nil, errors.Join(primaryErr, fallbackErr)
+}
+
+func reportProgressDetail(progress ProgressReporter, label, detail string) {
+	if reporter, ok := progress.(DetailProgressReporter); ok {
+		reporter.Detail(label, detail)
+	}
+}
+
+func subprojectProgressDetail(sub sdk.Subproject) string {
+	label := strings.TrimSpace(sub.RelativePath)
+	if label == "" || label == "." {
+		label = filepath.Base(sub.ExecutionTarget.Location)
+	}
+	if label == "" || label == "." {
+		label = "root"
+	}
+	manager := sub.PrimaryPackageManager().Name()
+	if manager == "" {
+		return label
+	}
+	return fmt.Sprintf("%s (%s)", label, manager)
+}
+
+func detectorProgressDetail(sub sdk.Subproject, detectorName string) string {
+	detail := subprojectProgressDetail(sub)
+	if detectorName == "" {
+		return detail
+	}
+	return detectorName + " - " + detail
+}
+
+func evidencePatternsForSupport(support []sdk.PackageManagerSupport, manager sdk.PackageManager) []string {
+	var values []string
+	for _, entry := range support {
+		if manager != sdk.PackageManagerUnknown && entry.PackageManager != manager {
+			continue
+		}
+		values = append(values, entry.EvidencePatterns...)
+	}
+	if len(values) == 0 {
+		for _, entry := range support {
+			values = append(values, entry.EvidencePatterns...)
+		}
+	}
+	return dedupeStrings(values)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func graphContainerStats(container *sdk.GraphContainer) (packages, edges int) {
+	if container == nil {
+		return 0, 0
+	}
+	for _, entry := range container.Entries {
+		if entry.Graph == nil {
+			continue
+		}
+		packages += entry.Graph.Size()
+		entry.Graph.WalkRelationships(func(_, _ *sdk.Package) bool {
+			edges++
+			return true
+		})
+	}
+	return packages, edges
 }
 
 func fallbackSelected(filter sdk.DetectorFilter, descriptor sdk.DetectorDescriptor) bool {

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -18,6 +18,17 @@ func (f fakeFallbackDetector) FallbackDetector() Detector {
 	return f.fallback
 }
 
+type recordingProgress struct {
+	details []string
+}
+
+func (p *recordingProgress) StartStage(string, int)        {}
+func (p *recordingProgress) AdvanceStage(string, int, int) {}
+func (p *recordingProgress) CompleteStage(string, int)     {}
+func (p *recordingProgress) Detail(label, detail string) {
+	p.details = append(p.details, label+": "+detail)
+}
+
 // ---------------------------------------------------------------------------
 // Detector resolution tests
 // ---------------------------------------------------------------------------
@@ -38,7 +49,7 @@ func TestResolveDetectors_RunsMatchingDetector(t *testing.T) {
 		PackageManager: PackageManagerNPM,
 		Mode:           TargetModeFullGraph,
 	}
-	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req))
+	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req), nil)
 	if err != nil {
 		t.Fatalf("resolveDetectors() error = %v", err)
 	}
@@ -47,6 +58,43 @@ func TestResolveDetectors_RunsMatchingDetector(t *testing.T) {
 	}
 	if results[0].DetectorName != "npm-native" {
 		t.Fatalf("expected npm-native result, got %q", results[0].DetectorName)
+	}
+}
+
+func TestResolveDetectors_ReportsDetectorDetail(t *testing.T) {
+	registry := newTestRegistry()
+	graph := sdk.New()
+	if err := graph.AddPackage(sdk.NewPackageRef("app", "1.0.0")); err != nil {
+		t.Fatalf("add package: %v", err)
+	}
+
+	registry.registerDetector(fakeDetector{
+		descriptor: DetectorDescriptor{Name: "npm-native", Enabled: true, SupportedEcosystems: []Ecosystem{EcosystemNPM}, SupportedManagers: []PackageManager{PackageManagerNPM}, SupportedModes: []TargetMode{TargetModeFullGraph}},
+		result:     ResolveGraphResult{Graphs: SingleGraphContainer(graph, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"})},
+	})
+
+	progress := &recordingProgress{}
+	pipeline := NewPipeline(registry, zap.NewNop())
+	req := ResolveGraphRequest{
+		Ecosystem:      EcosystemNPM,
+		PackageManager: PackageManagerNPM,
+		Mode:           TargetModeFullGraph,
+		Subproject: Subproject{
+			ExecutionTarget:         ExecutionTarget{Kind: ExecutionTargetFilesystem, Location: "/repo/app"},
+			RelativePath:            ".",
+			DetectedPackageManagers: []PackageManager{PackageManagerNPM},
+			Ecosystem:               EcosystemNPM,
+		},
+	}
+
+	if _, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req), progress); err != nil {
+		t.Fatalf("resolveDetectors() error = %v", err)
+	}
+	if len(progress.details) == 0 {
+		t.Fatal("expected detector detail progress")
+	}
+	if got := progress.details[len(progress.details)-1]; got != "Detecting dependencies: npm-native - app (npm)" {
+		t.Fatalf("unexpected detector detail %q", got)
 	}
 }
 
@@ -72,7 +120,7 @@ func TestResolveDetectors_FallsBackWhenPrimaryFails(t *testing.T) {
 		PackageManager: PackageManagerGoMod,
 		Mode:           TargetModeFullGraph,
 	}
-	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req))
+	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req), nil)
 	if err != nil {
 		t.Fatalf("resolveDetectors() error = %v", err)
 	}
@@ -107,7 +155,7 @@ func TestResolveDetectors_DoesNotRunExcludedFallback(t *testing.T) {
 		Mode:           TargetModeFullGraph,
 		DetectorFilter: DetectorFilter{Exclude: []string{"syft-detector"}},
 	}
-	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req))
+	results, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req), nil)
 	if err == nil {
 		t.Fatal("expected primary detector error when fallback is excluded")
 	}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -45,6 +45,13 @@ type ProgressReporter interface {
 	CompleteStage(label string, total int)
 }
 
+// DetailProgressReporter is optionally implemented by progress renderers that
+// can show the current subproject or detector without expanding the public
+// coarse progress contract.
+type DetailProgressReporter interface {
+	Detail(label, detail string)
+}
+
 // PipelineWarning is a structured warning captured during a pipeline stage.
 type PipelineWarning struct {
 	Source  string // detector, auditor, or matcher name

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -146,6 +146,20 @@ func (p *Progress) Stage(text string) {
 	p.mu.Unlock()
 }
 
+// Detail updates the active spinner with a concise current-operation hint.
+func (p *Progress) Detail(label, detail string) {
+	if !p.enabled {
+		return
+	}
+	p.mu.Lock()
+	if label != "" {
+		p.label = label
+	}
+	p.stage = strings.TrimSpace(detail)
+	p.mu.Unlock()
+	p.renderActive(spinnerFrames[0])
+}
+
 // StartStage / AdvanceStage / CompleteStage satisfy engine.ProgressReporter.
 func (p *Progress) StartStage(label string, total int) {
 	p.setStageProgress(label, 0, total)

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -73,3 +73,18 @@ func TestStageShowsBarAndPercent(t *testing.T) {
 		t.Fatalf("expected rendered percentage, got %q", rendered)
 	}
 }
+
+func TestDetailUpdatesActiveHint(t *testing.T) {
+	var buf bytes.Buffer
+	progress := &Progress{writer: &buf, enabled: true}
+
+	progress.Detail("Detecting dependencies", "go-detector - root (gomod)")
+
+	rendered := buf.String()
+	if !strings.Contains(rendered, "Detecting dependencies") {
+		t.Fatalf("expected detail label, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "go-detector - root (gomod)") {
+		t.Fatalf("expected detail text, got %q", rendered)
+	}
+}


### PR DESCRIPTION
## Summary
- Add optional detail progress updates without changing the coarse progress contract
- Show current subproject/detector hints during dependency detection
- Add structured debug logs for evidence patterns, install-first support, fallback decisions, and graph stats
- Add focused tests for detail progress and detector reporting

## Tests
- `go test ./internal/progress ./internal/engine`
- `make test`