### PR TITLE
feat(reachability): Tier-3 hops + confidence + dynamic-import detection; govulncheck reason refinements

### DIFF
--- a/docs/REACHABILITY.md
+++ b/docs/REACHABILITY.md
@@ -236,7 +236,20 @@ Reachability data appears in three places:
    `--audit` is set) `findings[].reachability`. The reachability object
    carries `status`, `tier`, `analyzer`, optional `reason`, optional
    list of confirmed `symbols`, and optional `call_paths` with frame
-   metadata (`function`, `package`, `file`, `line`, `column`).
+   metadata (`function`, `package`, `file`, `line`, `column`). Tier-3
+   analyzers additionally populate:
+   - `hops` — dep-graph distance from a directly-imported package.
+     `0` means directly imported; higher values are transitive.
+   - `confidence` — `high` (directly imported, no dynamic imports),
+     `medium` (1–3 hops, no dynamic imports), or `low` (4+ hops or
+     dynamic imports detected). Lets consumers triage long transitive
+     chains without parsing `hops` themselves.
+   - `dynamic_imports_detected` — `true` when the analyzer's scanner
+     observed dynamic-import constructs in app source (e.g.
+     `require(variable)`, `importlib.import_module(name)`,
+     `Class.forName(string)`). When `true`, an "unreachable" verdict
+     is necessarily incomplete; the confidence label is forced to
+     `low` for reachable results as a triage signal.
 
 2. **Text scan report** gains a "Reachability" line in the executive
    summary plus a `REACHABILITY` column in the findings table when
@@ -247,7 +260,9 @@ Reachability data appears in three places:
    `Reachability.CallPaths` (one threadFlow per path, one location per
    frame with file/line/column), and a top-level `result.properties`
    exposes `reachability`, `reachability_tier`, `reachability_reason`,
-   and `analyzer` for SARIF consumers that don't traverse codeFlows.
+   `analyzer`, `reachability_confidence`, `reachability_hops`, and
+   `reachability_dynamic_imports_detected` for SARIF consumers that
+   don't traverse codeFlows.
 
 ## Limitations
 
@@ -257,7 +272,19 @@ Reachability data appears in three places:
   does not mean the vulnerability has been mitigated. See the
   `jsreach` notes above for the npm-specific shape of this caveat.
 - **`govulncheck` requires a buildable Go module**. When the build
-  fails, the analyzer returns `unknown` with `Reason: build-failed`.
+  fails, the analyzer returns `unknown` with one of the following
+  stable `reason` codes so consumers can branch by failure mode:
+  - `missing-toolchain` — `go` not on `PATH`, govulncheck binary
+    missing, or runner not vendored.
+  - `no-go-packages` — target dir has no `.go` files, build
+    constraints exclude everything, or `go list` returns no matches.
+  - `module-resolution-failed` — `go.mod` not found, missing
+    `go.sum` entry, or `go: download` failed for a required module.
+  - `invalid-go-mod` — `go.mod` syntax error.
+  - `build-failed` — generic compile-stage failure (`syntax error`,
+    `undefined:`, `imported and not used`, non-zero exit).
+  - `cancelled` — context cancelled or deadline exceeded.
+  - `runner-error` — fallback when none of the above patterns match.
 - **Multi-module / multi-project repos**: Attribution is best-effort.
   Each vulnerability is annotated by the first module/project pass
   that owns its package; better multi-root attribution will improve

--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -185,6 +185,9 @@ Complete reference for the `bomly diff` JSON output.
 | `reason` | `string` | |
 | `symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `call_paths` | Array<[`CallPath`](#callpath)> | |
+| `hops` | `integer` | |
+| `confidence` | `string` | |
+| `dynamic_imports_detected` | `boolean` | |
 | `analyzed_at` | `string` | |
 
 ### `Reference`

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -256,6 +256,15 @@
                               },
                               "type": "array"
                             },
+                            "confidence": {
+                              "type": "string"
+                            },
+                            "dynamic_imports_detected": {
+                              "type": "boolean"
+                            },
+                            "hops": {
+                              "type": "integer"
+                            },
                             "reason": {
                               "type": "string"
                             },
@@ -447,6 +456,15 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "confidence": {
+                    "type": "string"
+                  },
+                  "dynamic_imports_detected": {
+                    "type": "boolean"
+                  },
+                  "hops": {
+                    "type": "integer"
                   },
                   "reason": {
                     "type": "string"
@@ -749,6 +767,15 @@
                               },
                               "type": "array"
                             },
+                            "confidence": {
+                              "type": "string"
+                            },
+                            "dynamic_imports_detected": {
+                              "type": "boolean"
+                            },
+                            "hops": {
+                              "type": "integer"
+                            },
                             "reason": {
                               "type": "string"
                             },
@@ -940,6 +967,15 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "confidence": {
+                    "type": "string"
+                  },
+                  "dynamic_imports_detected": {
+                    "type": "boolean"
+                  },
+                  "hops": {
+                    "type": "integer"
                   },
                   "reason": {
                     "type": "string"
@@ -1242,6 +1278,15 @@
                               },
                               "type": "array"
                             },
+                            "confidence": {
+                              "type": "string"
+                            },
+                            "dynamic_imports_detected": {
+                              "type": "boolean"
+                            },
+                            "hops": {
+                              "type": "integer"
+                            },
                             "reason": {
                               "type": "string"
                             },
@@ -1433,6 +1478,15 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "confidence": {
+                    "type": "string"
+                  },
+                  "dynamic_imports_detected": {
+                    "type": "boolean"
+                  },
+                  "hops": {
+                    "type": "integer"
                   },
                   "reason": {
                     "type": "string"
@@ -1813,6 +1867,15 @@
                                     },
                                     "type": "array"
                                   },
+                                  "confidence": {
+                                    "type": "string"
+                                  },
+                                  "dynamic_imports_detected": {
+                                    "type": "boolean"
+                                  },
+                                  "hops": {
+                                    "type": "integer"
+                                  },
                                   "reason": {
                                     "type": "string"
                                   },
@@ -2141,6 +2204,15 @@
                                     },
                                     "type": "array"
                                   },
+                                  "confidence": {
+                                    "type": "string"
+                                  },
+                                  "dynamic_imports_detected": {
+                                    "type": "boolean"
+                                  },
+                                  "hops": {
+                                    "type": "integer"
+                                  },
                                   "reason": {
                                     "type": "string"
                                   },
@@ -2457,6 +2529,15 @@
                                       "type": "object"
                                     },
                                     "type": "array"
+                                  },
+                                  "confidence": {
+                                    "type": "string"
+                                  },
+                                  "dynamic_imports_detected": {
+                                    "type": "boolean"
+                                  },
+                                  "hops": {
+                                    "type": "integer"
                                   },
                                   "reason": {
                                     "type": "string"
@@ -2798,6 +2879,15 @@
                                       "type": "object"
                                     },
                                     "type": "array"
+                                  },
+                                  "confidence": {
+                                    "type": "string"
+                                  },
+                                  "dynamic_imports_detected": {
+                                    "type": "boolean"
+                                  },
+                                  "hops": {
+                                    "type": "integer"
                                   },
                                   "reason": {
                                     "type": "string"

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -153,6 +153,9 @@ Complete reference for the `bomly explain` JSON output.
 | `reason` | `string` | |
 | `symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `call_paths` | Array<[`CallPath`](#callpath)> | |
+| `hops` | `integer` | |
+| `confidence` | `string` | |
+| `dynamic_imports_detected` | `boolean` | |
 | `analyzed_at` | `string` | |
 
 ### `Reference`

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -248,6 +248,15 @@
                     },
                     "type": "array"
                   },
+                  "confidence": {
+                    "type": "string"
+                  },
+                  "dynamic_imports_detected": {
+                    "type": "boolean"
+                  },
+                  "hops": {
+                    "type": "integer"
+                  },
                   "reason": {
                     "type": "string"
                   },
@@ -574,6 +583,15 @@
                           },
                           "type": "array"
                         },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "dynamic_imports_detected": {
+                          "type": "boolean"
+                        },
+                        "hops": {
+                          "type": "integer"
+                        },
                         "reason": {
                           "type": "string"
                         },
@@ -765,6 +783,15 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              "confidence": {
+                "type": "string"
+              },
+              "dynamic_imports_detected": {
+                "type": "boolean"
+              },
+              "hops": {
+                "type": "integer"
               },
               "reason": {
                 "type": "string"
@@ -1107,6 +1134,15 @@
                               "type": "object"
                             },
                             "type": "array"
+                          },
+                          "confidence": {
+                            "type": "string"
+                          },
+                          "dynamic_imports_detected": {
+                            "type": "boolean"
+                          },
+                          "hops": {
+                            "type": "integer"
                           },
                           "reason": {
                             "type": "string"
@@ -1507,6 +1543,15 @@
                           },
                           "type": "array"
                         },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "dynamic_imports_detected": {
+                          "type": "boolean"
+                        },
+                        "hops": {
+                          "type": "integer"
+                        },
                         "reason": {
                           "type": "string"
                         },
@@ -1836,6 +1881,15 @@
                                 },
                                 "type": "array"
                               },
+                              "confidence": {
+                                "type": "string"
+                              },
+                              "dynamic_imports_detected": {
+                                "type": "boolean"
+                              },
+                              "hops": {
+                                "type": "integer"
+                              },
                               "reason": {
                                 "type": "string"
                               },
@@ -2027,6 +2081,15 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "confidence": {
+                      "type": "string"
+                    },
+                    "dynamic_imports_detected": {
+                      "type": "boolean"
+                    },
+                    "hops": {
+                      "type": "integer"
                     },
                     "reason": {
                       "type": "string"
@@ -2332,6 +2395,15 @@
                                     "type": "object"
                                   },
                                   "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
                                 },
                                 "reason": {
                                   "type": "string"

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -123,6 +123,9 @@ Complete reference for the `bomly scan` JSON output.
 | `reason` | `string` | |
 | `symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `call_paths` | Array<[`CallPath`](#callpath)> | |
+| `hops` | `integer` | |
+| `confidence` | `string` | |
+| `dynamic_imports_detected` | `boolean` | |
 | `analyzed_at` | `string` | |
 
 ### `Reference`

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -257,6 +257,15 @@
                           },
                           "type": "array"
                         },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "dynamic_imports_detected": {
+                          "type": "boolean"
+                        },
+                        "hops": {
+                          "type": "integer"
+                        },
                         "reason": {
                           "type": "string"
                         },
@@ -448,6 +457,15 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              "confidence": {
+                "type": "string"
+              },
+              "dynamic_imports_detected": {
+                "type": "boolean"
+              },
+              "hops": {
+                "type": "integer"
               },
               "reason": {
                 "type": "string"
@@ -762,6 +780,15 @@
                               "type": "object"
                             },
                             "type": "array"
+                          },
+                          "confidence": {
+                            "type": "string"
+                          },
+                          "dynamic_imports_detected": {
+                            "type": "boolean"
+                          },
+                          "hops": {
+                            "type": "integer"
                           },
                           "reason": {
                             "type": "string"

--- a/internal/analyzers/govulncheck/analyzer.go
+++ b/internal/analyzers/govulncheck/analyzer.go
@@ -425,18 +425,62 @@ func packageImportedByModule(pkg *model.Package, importedModules map[string]stru
 }
 
 // failureReason maps runner errors to stable machine-readable codes.
+// Order matters: more-specific patterns are checked before the
+// generic build-failed/runner-error fallbacks so SARIF / JSON
+// consumers can branch on the exact failure mode.
 func failureReason(err error) string {
 	if err == nil {
 		return ""
 	}
 	msg := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(msg, "not found"), strings.Contains(msg, "not on path"), strings.Contains(msg, "not yet vendored"):
+	// Toolchain / executable missing — distinct from a build failure
+	// because the user can't act on it the same way (install Go, vs.
+	// fix their source).
+	case strings.Contains(msg, "not on path"),
+		strings.Contains(msg, "executable not found"),
+		strings.Contains(msg, "not yet vendored"):
 		return "missing-toolchain"
-	case strings.Contains(msg, "build failed"), strings.Contains(msg, "exit status 2"):
-		return "build-failed"
-	case strings.Contains(msg, "context"), strings.Contains(msg, "cancel"):
+	// Cancellation propagates through both context.Canceled and
+	// govulncheck's own wrapping.
+	case strings.Contains(msg, "context canceled"),
+		strings.Contains(msg, "context deadline"),
+		strings.Contains(msg, "cancel"):
 		return "cancelled"
+	// "no Go files in", "build constraints exclude all Go files", and
+	// "no packages matching" all mean the target dir is not a Go
+	// package — separate failure mode from a build that fails on
+	// real Go code.
+	case strings.Contains(msg, "no go files"),
+		strings.Contains(msg, "no packages matching"),
+		strings.Contains(msg, "build constraints exclude"):
+		return "no-go-packages"
+	// "missing go.sum entry" / "go: download" / "cannot find module"
+	// — module-resolution failures distinct from a compile-stage error.
+	case strings.Contains(msg, "missing go.sum"),
+		strings.Contains(msg, "cannot find module"),
+		strings.Contains(msg, "go.mod file not found"),
+		strings.Contains(msg, "no required module"),
+		strings.Contains(msg, "verifying module"):
+		return "module-resolution-failed"
+	// "go: parse" / "go.mod:" syntax errors.
+	case strings.Contains(msg, "go.mod:") && strings.Contains(msg, "syntax"),
+		strings.Contains(msg, "errors parsing go.mod"):
+		return "invalid-go-mod"
+	// Compile-stage errors: "build failed", "exit status 1/2",
+	// "syntax error", "undefined:". All actionable by the user
+	// fixing their source.
+	case strings.Contains(msg, "build failed"),
+		strings.Contains(msg, "exit status 1"),
+		strings.Contains(msg, "exit status 2"),
+		strings.Contains(msg, "syntax error"),
+		strings.Contains(msg, "undefined:"),
+		strings.Contains(msg, "imported and not used"):
+		return "build-failed"
+	// Generic fallback when we can't classify further; preserves the
+	// historical default.
+	case strings.Contains(msg, "not found"):
+		return "missing-toolchain"
 	default:
 		return "runner-error"
 	}

--- a/internal/analyzers/jsreach/analyzer.go
+++ b/internal/analyzers/jsreach/analyzer.go
@@ -245,7 +245,8 @@ type applyOutcome struct {
 func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, now time.Time) applyOutcome {
 	var outcome applyOutcome
 	timestamp := now.UTC().Format(time.RFC3339)
-	reachableIDs := computeReachablePackageIDs(g, runRes.ImportedPackages)
+	hopsByID := computeReachablePackageHops(g, runRes.ImportedPackages)
+	dynamicImports := runRes.DynamicImportsDetected
 	for _, pkg := range g.Packages() {
 		if pkg == nil || !isNPMPackage(pkg) {
 			continue
@@ -259,12 +260,16 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 				continue // already annotated by an earlier project pass
 			}
 			r := &model.Reachability{
-				Analyzer:   Name,
-				AnalyzedAt: timestamp,
-				Tier:       model.TierPackage,
+				Analyzer:               Name,
+				AnalyzedAt:             timestamp,
+				Tier:                   model.TierPackage,
+				DynamicImportsDetected: dynamicImports,
 			}
-			if _, ok := reachableIDs[pkg.ID]; ok {
+			if hops, ok := hopsByID[pkg.ID]; ok {
 				r.Status = model.ReachabilityReachable
+				h := hops
+				r.Hops = &h
+				r.Confidence = model.DeriveConfidence(&h, dynamicImports)
 				outcome.reachable++
 			} else {
 				r.Status = model.ReachabilityUnreachable
@@ -277,21 +282,21 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 	return outcome
 }
 
-// computeReachablePackageIDs returns the set of graph package IDs
-// reachable from the import set, expanded transitively through the
-// dep graph. The seed set is every npm package whose name (or
-// qualified scoped name) matches a bare specifier in imports; the
-// expansion walks Graph.Dependencies edges breadth-first.
+// computeReachablePackageHops returns a map from graph package ID to
+// the shortest dep-graph distance from any directly-imported package.
+// The seed set (hop 0) is every npm package whose name (or qualified
+// scoped name) matches a bare specifier in imports; the expansion
+// walks Graph.Dependencies edges breadth-first.
 //
 // The result is keyed by package ID rather than name because npm
 // allows multiple versions of the same package to coexist (a top-
 // level lodash@4 and a nested lodash@3 inside some dep), and the
 // lockfile-derived graph captures that. Working in IDs keeps the
 // attribution honest.
-func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map[string]struct{} {
-	reachable := make(map[string]struct{})
+func computeReachablePackageHops(g *model.Graph, imports map[string]struct{}) map[string]int {
+	hops := make(map[string]int)
 	if g == nil || len(imports) == 0 {
-		return reachable
+		return hops
 	}
 	queue := make([]string, 0)
 	// Seed: every npm package whose name matches the import set.
@@ -302,17 +307,18 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 		if !isPackageImported(pkg, imports) {
 			continue
 		}
-		if _, ok := reachable[pkg.ID]; ok {
+		if _, ok := hops[pkg.ID]; ok {
 			continue
 		}
-		reachable[pkg.ID] = struct{}{}
+		hops[pkg.ID] = 0
 		queue = append(queue, pkg.ID)
 	}
-	// BFS: every dep edge from a reachable package adds its target to
-	// the reachable set.
+	// BFS: every dep edge from a reachable package adds its target at
+	// hop+1 if it has not been seen yet (shortest-distance wins).
 	for len(queue) > 0 {
 		id := queue[0]
 		queue = queue[1:]
+		current := hops[id]
 		deps, err := g.Dependencies(id)
 		if err != nil {
 			continue
@@ -321,14 +327,14 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 			if dep == nil {
 				continue
 			}
-			if _, ok := reachable[dep.ID]; ok {
+			if _, ok := hops[dep.ID]; ok {
 				continue
 			}
-			reachable[dep.ID] = struct{}{}
+			hops[dep.ID] = current + 1
 			queue = append(queue, dep.ID)
 		}
 	}
-	return reachable
+	return hops
 }
 
 // isPackageImported reports whether pkg's npm name (or qualified

--- a/internal/analyzers/jsreach/analyzer_test.go
+++ b/internal/analyzers/jsreach/analyzer_test.go
@@ -338,9 +338,10 @@ func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
 	}
 }
 
-// TestComputeReachablePackageIDsHandlesCycles guards against the
-// classic BFS pitfall: a → b → a should not loop.
-func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
+// TestComputeReachablePackageHopsHandlesCycles guards against the
+// classic BFS pitfall: a → b → a should not loop, and the hop count
+// for a transitive dep should be the shortest distance.
+func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
 	a := model.NewPackage(model.Package{Name: "a", Version: "1.0.0", Ecosystem: "npm"})
 	b := model.NewPackage(model.Package{Name: "b", Version: "1.0.0", Ecosystem: "npm"})
@@ -357,12 +358,12 @@ func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := computeReachablePackageIDs(g, map[string]struct{}{"a": {}})
-	if _, ok := got[a.ID]; !ok {
-		t.Errorf("expected a in reachable set: %v", got)
+	got := computeReachablePackageHops(g, map[string]struct{}{"a": {}})
+	if h, ok := got[a.ID]; !ok || h != 0 {
+		t.Errorf("expected a at hop 0: got=%v ok=%v", h, ok)
 	}
-	if _, ok := got[b.ID]; !ok {
-		t.Errorf("expected b (transitive of a) in reachable set: %v", got)
+	if h, ok := got[b.ID]; !ok || h != 1 {
+		t.Errorf("expected b at hop 1 (transitive of a): got=%v ok=%v", h, ok)
 	}
 }
 
@@ -389,5 +390,139 @@ func TestAnalyzerMarksUnknownWhenNoProjectRootDiscovered(t *testing.T) {
 	}
 	if r.Reason != "no-project-root-discovered" {
 		t.Errorf("reason = %q, want no-project-root-discovered", r.Reason)
+	}
+}
+
+// TestAnalyzerPopulatesHopsAndConfidence verifies the Tier-3
+// improvements added in the reachability follow-up: each reachable
+// vulnerability carries the BFS hop count and a coarse confidence
+// label derived from it.
+func TestAnalyzerPopulatesHopsAndConfidence(t *testing.T) {
+	projectDir := newNPMProjectDir(t)
+
+	g := model.New()
+	directVuln := model.PackageVulnerability{ID: "GHSA-direct", Source: "osv", Severity: "high"}
+	transitiveVuln := model.PackageVulnerability{ID: "GHSA-trans", Source: "osv", Severity: "high"}
+	deepVuln := model.PackageVulnerability{ID: "GHSA-deep", Source: "osv", Severity: "high"}
+
+	express := model.NewPackage(model.Package{
+		Name:            "express",
+		Version:         "4.0.0",
+		Ecosystem:       "npm",
+		BuildSystem:     "npm",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
+		Vulnerabilities: []model.PackageVulnerability{directVuln},
+	})
+	bodyParser := model.NewPackage(model.Package{
+		Name:            "body-parser",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		BuildSystem:     "npm",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
+		Vulnerabilities: []model.PackageVulnerability{transitiveVuln},
+	})
+	// 5 hops deep — should land at low confidence even without
+	// dynamic imports.
+	deep1 := model.NewPackage(model.Package{Name: "deep1", Version: "1", Ecosystem: "npm", Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}}})
+	deep2 := model.NewPackage(model.Package{Name: "deep2", Version: "1", Ecosystem: "npm", Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}}})
+	deep3 := model.NewPackage(model.Package{Name: "deep3", Version: "1", Ecosystem: "npm", Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}}})
+	deep4 := model.NewPackage(model.Package{
+		Name:            "deep4",
+		Version:         "1",
+		Ecosystem:       "npm",
+		Locations:       []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
+		Vulnerabilities: []model.PackageVulnerability{deepVuln},
+	})
+
+	for _, pkg := range []*model.Package{express, bodyParser, deep1, deep2, deep3, deep4} {
+		if err := g.AddPackage(pkg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := g.AddDependency(express.ID, bodyParser.ID); err != nil {
+		t.Fatal(err)
+	}
+	for from, to := range map[string]string{
+		bodyParser.ID: deep1.ID,
+		deep1.ID:      deep2.ID,
+		deep2.ID:      deep3.ID,
+		deep3.ID:      deep4.ID,
+	} {
+		if err := g.AddDependency(from, to); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := Analyzer{DisableCache: true, Runner: &fakeRunner{
+		result: RunnerResult{
+			ImportedPackages: map[string]struct{}{"express": {}},
+			EntryPoints:      []string{filepath.Join(projectDir, "index.js")},
+			SourceFiles:      1,
+		},
+	}}
+
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	type expect struct {
+		hops       int
+		confidence model.ReachabilityConfidence
+	}
+	cases := map[string]expect{
+		"express@4.0.0":     {0, model.ConfidenceHigh},
+		"body-parser@1.0.0": {1, model.ConfidenceMedium},
+		"deep4@1":           {5, model.ConfidenceLow},
+	}
+	for id, want := range cases {
+		pkg, _ := g.Package(id)
+		if pkg == nil {
+			t.Fatalf("missing pkg %s", id)
+		}
+		r := pkg.Vulnerabilities[0].Reachability
+		if r == nil || r.Status != model.ReachabilityReachable {
+			t.Fatalf("%s: expected reachable, got %+v", id, r)
+		}
+		if r.Hops == nil || *r.Hops != want.hops {
+			t.Errorf("%s: hops = %v, want %d", id, r.Hops, want.hops)
+		}
+		if r.Confidence != want.confidence {
+			t.Errorf("%s: confidence = %q, want %q", id, r.Confidence, want.confidence)
+		}
+		if r.DynamicImportsDetected {
+			t.Errorf("%s: DynamicImportsDetected = true, want false (runner reported no dynamic imports)", id)
+		}
+	}
+}
+
+// TestAnalyzerHonorsRunnerDynamicImportFlag verifies that when the
+// runner reports dynamic imports detected, every reachable vuln is
+// downgraded to ConfidenceLow even when its hop count would normally
+// be ConfidenceHigh / ConfidenceMedium.
+func TestAnalyzerHonorsRunnerDynamicImportFlag(t *testing.T) {
+	projectDir := newNPMProjectDir(t)
+	vuln := model.PackageVulnerability{ID: "GHSA-test", Source: "osv", Severity: "high"}
+	g := newNPMGraph(t, projectDir, "lodash", vuln)
+
+	a := Analyzer{DisableCache: true, Runner: &fakeRunner{
+		result: RunnerResult{
+			ImportedPackages:       map[string]struct{}{"lodash": {}},
+			EntryPoints:            []string{filepath.Join(projectDir, "index.js")},
+			SourceFiles:            1,
+			DynamicImportsDetected: true,
+		},
+	}}
+	if _, err := a.Analyze(context.Background(), model.AnalyzeRequest{Graph: g, ProjectPath: projectDir}); err != nil {
+		t.Fatal(err)
+	}
+	r := g.Packages()[0].Vulnerabilities[0].Reachability
+	if r == nil || r.Status != model.ReachabilityReachable {
+		t.Fatalf("expected reachable, got %+v", r)
+	}
+	if !r.DynamicImportsDetected {
+		t.Error("DynamicImportsDetected should be true")
+	}
+	if r.Confidence != model.ConfidenceLow {
+		t.Errorf("confidence = %q, want low when dynamic imports detected", r.Confidence)
 	}
 }

--- a/internal/analyzers/jsreach/cache.go
+++ b/internal/analyzers/jsreach/cache.go
@@ -15,7 +15,7 @@ import (
 // cacheSchemaVersion bumps whenever the on-disk cache layout changes
 // in a way that would silently produce wrong results. Bumping
 // invalidates every previously cached entry.
-const cacheSchemaVersion = "v1"
+const cacheSchemaVersion = "v2"
 
 // defaultCacheTTL matches the OSV / EOL / govulncheck matchers.
 // jsreach output changes whenever the project's lockfile or source
@@ -38,9 +38,10 @@ type resultCache struct {
 // slice and rebuild the map on read. EntryPoints and SourceFiles
 // round-trip directly.
 type cachedRunnerResult struct {
-	ImportedPackages []string `json:"imported_packages,omitempty"`
-	EntryPoints      []string `json:"entry_points,omitempty"`
-	SourceFiles      int      `json:"source_files,omitempty"`
+	ImportedPackages       []string `json:"imported_packages,omitempty"`
+	EntryPoints            []string `json:"entry_points,omitempty"`
+	SourceFiles            int      `json:"source_files,omitempty"`
+	DynamicImportsDetected bool     `json:"dynamic_imports_detected,omitempty"`
 }
 
 // newResultCache constructs a result cache rooted at dir. If dir is
@@ -138,9 +139,10 @@ func (c *resultCache) get(projectDir, runnerName, runnerVersion string) (RunnerR
 		imports[m] = struct{}{}
 	}
 	return RunnerResult{
-		ImportedPackages: imports,
-		EntryPoints:      append([]string(nil), cached.EntryPoints...),
-		SourceFiles:      cached.SourceFiles,
+		ImportedPackages:       imports,
+		EntryPoints:            append([]string(nil), cached.EntryPoints...),
+		SourceFiles:            cached.SourceFiles,
+		DynamicImportsDetected: cached.DynamicImportsDetected,
 	}, true
 }
 
@@ -159,9 +161,10 @@ func (c *resultCache) set(projectDir, runnerName, runnerVersion string, result R
 		imports = append(imports, m)
 	}
 	cached := cachedRunnerResult{
-		ImportedPackages: imports,
-		EntryPoints:      append([]string(nil), result.EntryPoints...),
-		SourceFiles:      result.SourceFiles,
+		ImportedPackages:       imports,
+		EntryPoints:            append([]string(nil), result.EntryPoints...),
+		SourceFiles:            result.SourceFiles,
+		DynamicImportsDetected: result.DynamicImportsDetected,
 	}
 	return cachepkg.Set(c.store, key, cached)
 }

--- a/internal/analyzers/jsreach/dynamicimports.go
+++ b/internal/analyzers/jsreach/dynamicimports.go
@@ -1,0 +1,105 @@
+package jsreach
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// jsDynamicImport matches dynamic-import constructs in JavaScript /
+// TypeScript that the static scanner cannot follow:
+//
+//	require(variable)
+//	require(`literal ${interp}`)
+//	import(variable)
+//	await import(name)
+//	System.import(name)
+//
+// The pattern intentionally fires on any non-string argument inside
+// require()/import(). A bare string literal like require("react") is
+// excluded — those are statically resolved by the esbuild walk.
+var jsDynamicImport = regexp.MustCompile(`(?:\brequire\s*\(\s*(?:[^"'\s)]|` + "`" + `)|\bimport\s*\(\s*(?:[^"'\s)]|` + "`" + `)|\bSystem\.import\s*\(\s*(?:[^"'\s)]|` + "`" + `))`)
+
+// detectDynamicImports walks .js/.jsx/.ts/.tsx/.mjs/.cjs files under
+// projectDir and returns true on the first match of a dynamic-import
+// construct. Returns false if the walk completes without finding one.
+// Skips node_modules and common build outputs to avoid false positives
+// from third-party bundled code.
+func detectDynamicImports(projectDir string) bool {
+	found := false
+	_ = filepath.WalkDir(projectDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if shouldSkipJSDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isJSSource(d.Name()) {
+			return nil
+		}
+		if fileContainsDynamicImport(path) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// fileContainsDynamicImport reads path line-by-line and returns true
+// on the first match of jsDynamicImport. The line iterator is bounded
+// so a pathologically long line cannot stall the scan.
+func fileContainsDynamicImport(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Cheap pre-filter: skip lines without "require" or "import"
+		// (the regex would discard them anyway, but avoiding the
+		// regex on hot lines speeds the walk).
+		if !strings.Contains(line, "require") && !strings.Contains(line, "import") {
+			continue
+		}
+		if jsDynamicImport.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldSkipJSDir reports whether a directory should be pruned during
+// the dynamic-import walk. Includes node_modules and common build
+// outputs so third-party code cannot mask a project's true signal.
+func shouldSkipJSDir(name string) bool {
+	switch name {
+	case "node_modules",
+		"dist", "build", "out", "coverage", ".next", ".nuxt", ".cache",
+		".git", ".hg", ".svn",
+		".idea", ".vscode":
+		return true
+	}
+	return false
+}
+
+func isJSSource(name string) bool {
+	lower := strings.ToLower(name)
+	switch filepath.Ext(lower) {
+	case ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx":
+		return true
+	}
+	return false
+}

--- a/internal/analyzers/jsreach/runner.go
+++ b/internal/analyzers/jsreach/runner.go
@@ -61,6 +61,13 @@ type RunnerResult struct {
 	// SourceFiles is the count of project source files the runner
 	// visited (for telemetry).
 	SourceFiles int
+	// DynamicImportsDetected is true when the runner observed
+	// dynamic-import constructs in app source it cannot follow
+	// statically (e.g. `require(variable)`, `import(variable)`,
+	// `await import(name)`). When true, the analyzer's "unreachable"
+	// verdicts are necessarily incomplete and the per-vuln
+	// Reachability.DynamicImportsDetected flag is set.
+	DynamicImportsDetected bool
 }
 
 // hasResult reports whether the runner produced anything actionable.

--- a/internal/analyzers/jsreach/runner_library.go
+++ b/internal/analyzers/jsreach/runner_library.go
@@ -139,16 +139,19 @@ func (r libraryRunner) Run(ctx context.Context, projectDir string) (RunnerResult
 	if err != nil {
 		return RunnerResult{}, err
 	}
+	dynamic := detectDynamicImports(projectDir)
 	r.logger.Debug("jsreach: in-process runner completed",
 		zap.String("project_dir", projectDir),
 		zap.Int("entry_points", len(entries)),
 		zap.Int("source_files", sourceFiles),
-		zap.Int("imported_packages", len(imports)))
+		zap.Int("imported_packages", len(imports)),
+		zap.Bool("dynamic_imports_detected", dynamic))
 
 	return RunnerResult{
-		ImportedPackages: imports,
-		EntryPoints:      entries,
-		SourceFiles:      sourceFiles,
+		ImportedPackages:       imports,
+		EntryPoints:            entries,
+		SourceFiles:            sourceFiles,
+		DynamicImportsDetected: dynamic,
 	}, nil
 }
 

--- a/internal/analyzers/jvmreach/analyzer.go
+++ b/internal/analyzers/jvmreach/analyzer.go
@@ -218,7 +218,8 @@ type applyOutcome struct{ reachable, unreachable, unknown int }
 func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, now time.Time) applyOutcome {
 	var outcome applyOutcome
 	timestamp := now.UTC().Format(time.RFC3339)
-	reachableIDs := computeReachablePackageIDs(g, runRes.ImportedArtifacts)
+	hopsByID := computeReachablePackageHops(g, runRes.ImportedArtifacts)
+	dynamicImports := runRes.DynamicImportsDetected
 	for _, pkg := range g.Packages() {
 		if pkg == nil || !isJVMPackage(pkg) {
 			continue
@@ -232,12 +233,16 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 				continue
 			}
 			r := &model.Reachability{
-				Analyzer:   Name,
-				AnalyzedAt: timestamp,
-				Tier:       model.TierPackage,
+				Analyzer:               Name,
+				AnalyzedAt:             timestamp,
+				Tier:                   model.TierPackage,
+				DynamicImportsDetected: dynamicImports,
 			}
-			if _, ok := reachableIDs[pkg.ID]; ok {
+			if hops, ok := hopsByID[pkg.ID]; ok {
 				r.Status = model.ReachabilityReachable
+				h := hops
+				r.Hops = &h
+				r.Confidence = model.DeriveConfidence(&h, dynamicImports)
 				outcome.reachable++
 			} else {
 				r.Status = model.ReachabilityUnreachable
@@ -250,14 +255,14 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 	return outcome
 }
 
-// computeReachablePackageIDs returns the set of graph package IDs
-// reachable from the imported-artifact set, expanded transitively
-// through Graph.Dependencies. The seed is every JVM package whose
-// `Org:Name` (groupId:artifactId) matches a coordinate in imports.
-func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map[string]struct{} {
-	reachable := make(map[string]struct{})
+// computeReachablePackageHops returns a map from graph package ID to
+// the shortest dep-graph distance from a directly-imported artifact.
+// Hop 0 packages are directly imported by app source; hop N packages
+// are reachable only via N transitive edges.
+func computeReachablePackageHops(g *model.Graph, imports map[string]struct{}) map[string]int {
+	hops := make(map[string]int)
 	if g == nil || len(imports) == 0 {
-		return reachable
+		return hops
 	}
 	queue := make([]string, 0)
 	for _, pkg := range g.Packages() {
@@ -267,15 +272,16 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 		if !isPackageImported(pkg, imports) {
 			continue
 		}
-		if _, ok := reachable[pkg.ID]; ok {
+		if _, ok := hops[pkg.ID]; ok {
 			continue
 		}
-		reachable[pkg.ID] = struct{}{}
+		hops[pkg.ID] = 0
 		queue = append(queue, pkg.ID)
 	}
 	for len(queue) > 0 {
 		id := queue[0]
 		queue = queue[1:]
+		current := hops[id]
 		deps, err := g.Dependencies(id)
 		if err != nil {
 			continue
@@ -284,14 +290,14 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 			if dep == nil {
 				continue
 			}
-			if _, ok := reachable[dep.ID]; ok {
+			if _, ok := hops[dep.ID]; ok {
 				continue
 			}
-			reachable[dep.ID] = struct{}{}
+			hops[dep.ID] = current + 1
 			queue = append(queue, dep.ID)
 		}
 	}
-	return reachable
+	return hops
 }
 
 // isPackageImported reports whether pkg's Maven coordinate (built

--- a/internal/analyzers/jvmreach/analyzer_test.go
+++ b/internal/analyzers/jvmreach/analyzer_test.go
@@ -201,7 +201,7 @@ func TestAnalyzerMarksTransitiveDepReachable(t *testing.T) {
 	}
 }
 
-func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
+func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
 	a := model.NewPackage(model.Package{Name: "a", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
 	b := model.NewPackage(model.Package{Name: "b", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
@@ -217,12 +217,12 @@ func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
 	if err := g.AddDependency(b.ID, a.ID); err != nil {
 		t.Fatal(err)
 	}
-	got := computeReachablePackageIDs(g, map[string]struct{}{"g:a": {}})
-	if _, ok := got[a.ID]; !ok {
-		t.Errorf("a missing from reachable set")
+	got := computeReachablePackageHops(g, map[string]struct{}{"g:a": {}})
+	if h, ok := got[a.ID]; !ok || h != 0 {
+		t.Errorf("expected a at hop 0: got=%v ok=%v", h, ok)
 	}
-	if _, ok := got[b.ID]; !ok {
-		t.Errorf("b missing from reachable set")
+	if h, ok := got[b.ID]; !ok || h != 1 {
+		t.Errorf("expected b at hop 1 (transitive of a): got=%v ok=%v", h, ok)
 	}
 }
 

--- a/internal/analyzers/jvmreach/cache.go
+++ b/internal/analyzers/jvmreach/cache.go
@@ -12,7 +12,7 @@ import (
 	cachepkg "github.com/bomly-dev/bomly-cli/internal/matchers/cache"
 )
 
-const cacheSchemaVersion = "v1"
+const cacheSchemaVersion = "v2"
 const defaultCacheTTL = 24 * time.Hour
 
 type resultCache struct {
@@ -20,9 +20,10 @@ type resultCache struct {
 }
 
 type cachedRunnerResult struct {
-	ImportedArtifacts []string `json:"imported_artifacts,omitempty"`
-	SourceFiles       int      `json:"source_files,omitempty"`
-	SkippedDirs       []string `json:"skipped_dirs,omitempty"`
+	ImportedArtifacts      []string `json:"imported_artifacts,omitempty"`
+	SourceFiles            int      `json:"source_files,omitempty"`
+	SkippedDirs            []string `json:"skipped_dirs,omitempty"`
+	DynamicImportsDetected bool     `json:"dynamic_imports_detected,omitempty"`
 }
 
 func newResultCache(dir string, ttl time.Duration) *resultCache {
@@ -108,9 +109,10 @@ func (c *resultCache) get(projectDir, runnerName, runnerVersion string) (RunnerR
 		artifacts[a] = struct{}{}
 	}
 	return RunnerResult{
-		ImportedArtifacts: artifacts,
-		SourceFiles:       cached.SourceFiles,
-		SkippedDirs:       append([]string(nil), cached.SkippedDirs...),
+		ImportedArtifacts:      artifacts,
+		SourceFiles:            cached.SourceFiles,
+		SkippedDirs:            append([]string(nil), cached.SkippedDirs...),
+		DynamicImportsDetected: cached.DynamicImportsDetected,
 	}, true
 }
 
@@ -127,9 +129,10 @@ func (c *resultCache) set(projectDir, runnerName, runnerVersion string, result R
 		artifacts = append(artifacts, a)
 	}
 	cached := cachedRunnerResult{
-		ImportedArtifacts: artifacts,
-		SourceFiles:       result.SourceFiles,
-		SkippedDirs:       append([]string(nil), result.SkippedDirs...),
+		ImportedArtifacts:      artifacts,
+		SourceFiles:            result.SourceFiles,
+		SkippedDirs:            append([]string(nil), result.SkippedDirs...),
+		DynamicImportsDetected: result.DynamicImportsDetected,
 	}
 	return cachepkg.Set(c.store, key, cached)
 }

--- a/internal/analyzers/jvmreach/dynamicimports.go
+++ b/internal/analyzers/jvmreach/dynamicimports.go
@@ -1,0 +1,103 @@
+package jvmreach
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// jvmDynamicImport matches JVM reflection-based class-loading
+// constructs that the static scanner cannot follow:
+//
+//	Class.forName(name)            # non-literal arg
+//	ClassLoader.loadClass(name)    # non-literal arg
+//	cl.loadClass(name)             # any loadClass call on a variable
+//	ServiceLoader.load(...)        # plugin discovery
+//	ResourceBundle.getBundle(name) # non-literal arg
+//
+// Matches when the call's first argument is not a string literal.
+// Literal-arg calls are not flagged because the import is already
+// statically resolvable.
+var jvmDynamicImport = regexp.MustCompile(
+	`(?:\bClass\.forName\s*\(\s*(?:[^"\s)])|` +
+		`\.loadClass\s*\(\s*(?:[^"\s)])|` +
+		`\bServiceLoader\.load\s*\(|` +
+		`\bResourceBundle\.getBundle\s*\(\s*(?:[^"\s)]))`,
+)
+
+// detectDynamicImports walks Java / Kotlin / Scala / Groovy source
+// under projectDir and returns true on the first match of a
+// reflection-based class load.
+func detectDynamicImports(projectDir string) bool {
+	found := false
+	_ = filepath.WalkDir(projectDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if path == projectDir {
+				return nil
+			}
+			if shouldSkipJVMDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isJVMSource(d.Name()) {
+			return nil
+		}
+		if fileContainsDynamicImport(path) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+func fileContainsDynamicImport(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "forName") &&
+			!strings.Contains(line, "loadClass") &&
+			!strings.Contains(line, "ServiceLoader") &&
+			!strings.Contains(line, "getBundle") {
+			continue
+		}
+		if jvmDynamicImport.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSkipJVMDir(name string) bool {
+	switch name {
+	case "target", "build", "out", ".gradle", ".idea", ".vscode",
+		".git", ".hg", ".svn",
+		"bin", "node_modules":
+		return true
+	}
+	return false
+}
+
+func isJVMSource(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".java", ".kt", ".kts", ".scala", ".groovy":
+		return true
+	}
+	return false
+}

--- a/internal/analyzers/jvmreach/runner.go
+++ b/internal/analyzers/jvmreach/runner.go
@@ -60,6 +60,13 @@ type RunnerResult struct {
 	// SkippedDirs lists directory names skipped during the walk
 	// (target/, build/, .gradle/, etc.) for debug logging.
 	SkippedDirs []string
+	// DynamicImportsDetected is true when the runner observed
+	// reflection-based class loading the static scanner cannot
+	// follow: Class.forName(name) on a variable, ClassLoader.loadClass,
+	// ServiceLoader.load, ResourceBundle.getBundle on a variable. When
+	// true, an "unreachable" verdict is necessarily incomplete and the
+	// per-vuln Reachability.DynamicImportsDetected flag is set.
+	DynamicImportsDetected bool
 }
 
 func (r RunnerResult) hasResult() bool { return r.SourceFiles > 0 }

--- a/internal/analyzers/jvmreach/runner_library.go
+++ b/internal/analyzers/jvmreach/runner_library.go
@@ -68,15 +68,18 @@ func (r libraryRunner) Run(ctx context.Context, projectDir string) (RunnerResult
 		return RunnerResult{}, walkErr
 	}
 
+	dynamic := detectDynamicImports(projectDir)
 	r.logger.Debug("jvmreach: in-process runner completed",
 		zap.String("project_dir", projectDir),
 		zap.Int("source_files", sourceFiles),
 		zap.Int("imported_artifacts", len(artifacts)),
-		zap.Strings("skipped_dirs", skipped))
+		zap.Strings("skipped_dirs", skipped),
+		zap.Bool("dynamic_imports_detected", dynamic))
 
 	return RunnerResult{
-		ImportedArtifacts: artifacts,
-		SourceFiles:       sourceFiles,
-		SkippedDirs:       skipped,
+		ImportedArtifacts:      artifacts,
+		SourceFiles:            sourceFiles,
+		SkippedDirs:            skipped,
+		DynamicImportsDetected: dynamic,
 	}, nil
 }

--- a/internal/analyzers/pyreach/analyzer.go
+++ b/internal/analyzers/pyreach/analyzer.go
@@ -253,7 +253,8 @@ type applyOutcome struct {
 func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, now time.Time) applyOutcome {
 	var outcome applyOutcome
 	timestamp := now.UTC().Format(time.RFC3339)
-	reachableIDs := computeReachablePackageIDs(g, runRes.ImportedDistributions)
+	hopsByID := computeReachablePackageHops(g, runRes.ImportedDistributions)
+	dynamicImports := runRes.DynamicImportsDetected
 	for _, pkg := range g.Packages() {
 		if pkg == nil || !isPythonPackage(pkg) {
 			continue
@@ -267,12 +268,16 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 				continue
 			}
 			r := &model.Reachability{
-				Analyzer:   Name,
-				AnalyzedAt: timestamp,
-				Tier:       model.TierPackage,
+				Analyzer:               Name,
+				AnalyzedAt:             timestamp,
+				Tier:                   model.TierPackage,
+				DynamicImportsDetected: dynamicImports,
 			}
-			if _, ok := reachableIDs[pkg.ID]; ok {
+			if hops, ok := hopsByID[pkg.ID]; ok {
 				r.Status = model.ReachabilityReachable
+				h := hops
+				r.Hops = &h
+				r.Confidence = model.DeriveConfidence(&h, dynamicImports)
 				outcome.reachable++
 			} else {
 				r.Status = model.ReachabilityUnreachable
@@ -285,15 +290,16 @@ func applyRunnerResult(g *model.Graph, projectRoot string, runRes RunnerResult, 
 	return outcome
 }
 
-// computeReachablePackageIDs returns the set of graph package IDs
-// reachable from the imported-distribution set, expanded transitively
-// through the dep graph. Working in IDs (rather than names) keeps the
-// attribution honest when multiple versions of the same distribution
-// coexist in the resolved lockfile.
-func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map[string]struct{} {
-	reachable := make(map[string]struct{})
+// computeReachablePackageHops returns a map from graph package ID to
+// the shortest dep-graph distance from a directly-imported
+// distribution. Hop 0 packages are directly imported; hop N packages
+// are reachable only via N transitive edges. Working in IDs (rather
+// than names) keeps the attribution honest when multiple versions of
+// the same distribution coexist in the resolved lockfile.
+func computeReachablePackageHops(g *model.Graph, imports map[string]struct{}) map[string]int {
+	hops := make(map[string]int)
 	if g == nil || len(imports) == 0 {
-		return reachable
+		return hops
 	}
 	queue := make([]string, 0)
 	for _, pkg := range g.Packages() {
@@ -303,15 +309,16 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 		if !isPackageImported(pkg, imports) {
 			continue
 		}
-		if _, ok := reachable[pkg.ID]; ok {
+		if _, ok := hops[pkg.ID]; ok {
 			continue
 		}
-		reachable[pkg.ID] = struct{}{}
+		hops[pkg.ID] = 0
 		queue = append(queue, pkg.ID)
 	}
 	for len(queue) > 0 {
 		id := queue[0]
 		queue = queue[1:]
+		current := hops[id]
 		deps, err := g.Dependencies(id)
 		if err != nil {
 			continue
@@ -320,14 +327,14 @@ func computeReachablePackageIDs(g *model.Graph, imports map[string]struct{}) map
 			if dep == nil {
 				continue
 			}
-			if _, ok := reachable[dep.ID]; ok {
+			if _, ok := hops[dep.ID]; ok {
 				continue
 			}
-			reachable[dep.ID] = struct{}{}
+			hops[dep.ID] = current + 1
 			queue = append(queue, dep.ID)
 		}
 	}
-	return reachable
+	return hops
 }
 
 // isPackageImported reports whether pkg's distribution name (in any

--- a/internal/analyzers/pyreach/analyzer_test.go
+++ b/internal/analyzers/pyreach/analyzer_test.go
@@ -337,9 +337,10 @@ func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
 	}
 }
 
-// TestComputeReachablePackageIDsHandlesCycles guards against the
-// classic BFS pitfall: a → b → a should not loop.
-func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
+// TestComputeReachablePackageHopsHandlesCycles guards against the
+// classic BFS pitfall: a → b → a should not loop, and the hop count
+// for a transitive dep should be the shortest distance.
+func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
 	a := model.NewPackage(model.Package{Name: "a", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
 	b := model.NewPackage(model.Package{Name: "b", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
@@ -356,12 +357,12 @@ func TestComputeReachablePackageIDsHandlesCycles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := computeReachablePackageIDs(g, map[string]struct{}{"a": {}})
-	if _, ok := got[a.ID]; !ok {
-		t.Errorf("expected a in reachable set: %v", got)
+	got := computeReachablePackageHops(g, map[string]struct{}{"a": {}})
+	if h, ok := got[a.ID]; !ok || h != 0 {
+		t.Errorf("expected a at hop 0: got=%v ok=%v", h, ok)
 	}
-	if _, ok := got[b.ID]; !ok {
-		t.Errorf("expected b (transitive of a) in reachable set: %v", got)
+	if h, ok := got[b.ID]; !ok || h != 1 {
+		t.Errorf("expected b at hop 1 (transitive of a): got=%v ok=%v", h, ok)
 	}
 }
 

--- a/internal/analyzers/pyreach/cache.go
+++ b/internal/analyzers/pyreach/cache.go
@@ -15,7 +15,7 @@ import (
 // cacheSchemaVersion bumps whenever the on-disk cache layout changes
 // in a way that would silently produce wrong results. Bumping
 // invalidates every previously cached entry.
-const cacheSchemaVersion = "v1"
+const cacheSchemaVersion = "v2"
 
 // defaultCacheTTL matches the OSV / EOL / govulncheck / jsreach
 // matchers. pyreach output changes whenever the project's lockfile
@@ -33,9 +33,10 @@ type resultCache struct {
 
 // cachedRunnerResult is the JSON-serializable form of RunnerResult.
 type cachedRunnerResult struct {
-	ImportedDistributions []string `json:"imported_distributions,omitempty"`
-	SourceFiles           int      `json:"source_files,omitempty"`
-	SkippedDirs           []string `json:"skipped_dirs,omitempty"`
+	ImportedDistributions  []string `json:"imported_distributions,omitempty"`
+	SourceFiles            int      `json:"source_files,omitempty"`
+	SkippedDirs            []string `json:"skipped_dirs,omitempty"`
+	DynamicImportsDetected bool     `json:"dynamic_imports_detected,omitempty"`
 }
 
 // newResultCache constructs a result cache rooted at dir. If dir is
@@ -141,9 +142,10 @@ func (c *resultCache) get(projectDir, runnerName, runnerVersion string) (RunnerR
 		imports[m] = struct{}{}
 	}
 	return RunnerResult{
-		ImportedDistributions: imports,
-		SourceFiles:           cached.SourceFiles,
-		SkippedDirs:           append([]string(nil), cached.SkippedDirs...),
+		ImportedDistributions:  imports,
+		SourceFiles:            cached.SourceFiles,
+		SkippedDirs:            append([]string(nil), cached.SkippedDirs...),
+		DynamicImportsDetected: cached.DynamicImportsDetected,
 	}, true
 }
 
@@ -162,9 +164,10 @@ func (c *resultCache) set(projectDir, runnerName, runnerVersion string, result R
 		imports = append(imports, m)
 	}
 	cached := cachedRunnerResult{
-		ImportedDistributions: imports,
-		SourceFiles:           result.SourceFiles,
-		SkippedDirs:           append([]string(nil), result.SkippedDirs...),
+		ImportedDistributions:  imports,
+		SourceFiles:            result.SourceFiles,
+		SkippedDirs:            append([]string(nil), result.SkippedDirs...),
+		DynamicImportsDetected: result.DynamicImportsDetected,
 	}
 	return cachepkg.Set(c.store, key, cached)
 }

--- a/internal/analyzers/pyreach/dynamicimports.go
+++ b/internal/analyzers/pyreach/dynamicimports.go
@@ -1,0 +1,90 @@
+package pyreach
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// pyDynamicImport matches dynamic-import constructs in Python that
+// the static scanner cannot follow:
+//
+//	importlib.import_module(name)         # non-literal arg
+//	__import__(name)                       # non-literal arg
+//	importlib.util.find_spec(name)         # non-literal arg
+//	pkgutil.iter_modules(...)              # any call (signals dynamic discovery)
+//	pkg_resources.iter_entry_points(...)   # plugin discovery
+//
+// The pattern fires when the import-related call is invoked but does
+// not statically take a string-literal argument. Bare string-literal
+// calls like importlib.import_module("yaml") are excluded because the
+// scanner can already see them.
+var pyDynamicImport = regexp.MustCompile(
+	`(?:\bimportlib\.import_module\s*\(\s*(?:[^"'\s)])|` +
+		`\b__import__\s*\(\s*(?:[^"'\s)])|` +
+		`\bimportlib\.util\.find_spec\s*\(\s*(?:[^"'\s)])|` +
+		`\bpkgutil\.iter_modules\s*\(|` +
+		`\bpkg_resources\.iter_entry_points\s*\()`,
+)
+
+// detectDynamicImports walks .py files under projectDir and returns
+// true on the first match of a dynamic-import construct. Skips venv,
+// site-packages, __pycache__, and other directories the regular
+// source walker also prunes.
+func detectDynamicImports(projectDir string) bool {
+	found := false
+	_ = filepath.WalkDir(projectDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if path == projectDir {
+				return nil
+			}
+			if shouldSkipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".py") {
+			return nil
+		}
+		if fileContainsDynamicImport(path) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+func fileContainsDynamicImport(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Pre-filter: skip lines without one of the trigger tokens.
+		if !strings.Contains(line, "import_module") &&
+			!strings.Contains(line, "__import__") &&
+			!strings.Contains(line, "find_spec") &&
+			!strings.Contains(line, "iter_modules") &&
+			!strings.Contains(line, "iter_entry_points") {
+			continue
+		}
+		if pyDynamicImport.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/analyzers/pyreach/runner.go
+++ b/internal/analyzers/pyreach/runner.go
@@ -68,6 +68,14 @@ type RunnerResult struct {
 	// SkippedDirs lists the directory names skipped during the walk
 	// (venv/, __pycache__/, etc.) for debug logging.
 	SkippedDirs []string
+	// DynamicImportsDetected is true when the runner observed Python
+	// dynamic-import constructs the static scanner cannot follow:
+	// importlib.import_module(name), __import__(name) on a variable,
+	// pkgutil.iter_modules / pkg_resources iterators. When true, an
+	// "unreachable" verdict from this analyzer is necessarily
+	// incomplete and the per-vuln Reachability.DynamicImportsDetected
+	// flag is set.
+	DynamicImportsDetected bool
 }
 
 // hasResult reports whether the runner produced anything actionable.

--- a/internal/analyzers/pyreach/runner_library.go
+++ b/internal/analyzers/pyreach/runner_library.go
@@ -85,15 +85,18 @@ func (r libraryRunner) Run(ctx context.Context, projectDir string) (RunnerResult
 		return RunnerResult{}, walkErr
 	}
 
+	dynamic := detectDynamicImports(projectDir)
 	r.logger.Debug("pyreach: in-process runner completed",
 		zap.String("project_dir", projectDir),
 		zap.Int("source_files", sourceFiles),
 		zap.Int("imported_distributions", len(imports)),
-		zap.Strings("skipped_dirs", skipped))
+		zap.Strings("skipped_dirs", skipped),
+		zap.Bool("dynamic_imports_detected", dynamic))
 
 	return RunnerResult{
-		ImportedDistributions: imports,
-		SourceFiles:           sourceFiles,
-		SkippedDirs:           skipped,
+		ImportedDistributions:  imports,
+		SourceFiles:            sourceFiles,
+		SkippedDirs:            skipped,
+		DynamicImportsDetected: dynamic,
 	}, nil
 }

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -100,12 +100,17 @@ type sarifThreadFlowLocation struct {
 }
 
 // sarifProperties exposes Bomly-specific finding metadata SARIF consumers
-// can surface (reachability status, tier, analyzer name).
+// can surface. SARIF 2.1.0 allows arbitrary `properties` per result;
+// these fields give consumers everything needed to triage a finding
+// without parsing the parallel JSON output.
 type sarifProperties struct {
-	Reachability       string `json:"reachability,omitempty"`
-	ReachabilityTier   string `json:"reachability_tier,omitempty"`
-	ReachabilityReason string `json:"reachability_reason,omitempty"`
-	Analyzer           string `json:"analyzer,omitempty"`
+	Reachability           string `json:"reachability,omitempty"`
+	ReachabilityTier       string `json:"reachability_tier,omitempty"`
+	ReachabilityReason     string `json:"reachability_reason,omitempty"`
+	Analyzer               string `json:"analyzer,omitempty"`
+	ReachabilityConfidence string `json:"reachability_confidence,omitempty"`
+	ReachabilityHops       *int   `json:"reachability_hops,omitempty"`
+	DynamicImportsDetected bool   `json:"reachability_dynamic_imports_detected,omitempty"`
 }
 
 // WriteSARIF writes findings as a SARIF 2.1.0 document to w.
@@ -161,12 +166,19 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion strin
 			},
 		}
 		if f.Reachability != nil {
-			result.Properties = &sarifProperties{
-				Reachability:       string(f.Reachability.Status),
-				ReachabilityTier:   string(f.Reachability.Tier),
-				ReachabilityReason: f.Reachability.Reason,
-				Analyzer:           f.Reachability.Analyzer,
+			props := &sarifProperties{
+				Reachability:           string(f.Reachability.Status),
+				ReachabilityTier:       string(f.Reachability.Tier),
+				ReachabilityReason:     f.Reachability.Reason,
+				Analyzer:               f.Reachability.Analyzer,
+				ReachabilityConfidence: string(f.Reachability.Confidence),
+				DynamicImportsDetected: f.Reachability.DynamicImportsDetected,
 			}
+			if f.Reachability.Hops != nil {
+				h := *f.Reachability.Hops
+				props.ReachabilityHops = &h
+			}
+			result.Properties = props
 			if flows := buildSARIFCodeFlows(f.Reachability.CallPaths); len(flows) > 0 {
 				result.CodeFlows = flows
 			}

--- a/sdk/reachability_test.go
+++ b/sdk/reachability_test.go
@@ -1,0 +1,63 @@
+package sdk
+
+import "testing"
+
+func TestDeriveConfidence(t *testing.T) {
+	cases := []struct {
+		name           string
+		hops           *int
+		dynamicImports bool
+		want           ReachabilityConfidence
+	}{
+		{"nil hops -> unknown", nil, false, ConfidenceUnknown},
+		{"nil hops with dynamic still unknown", nil, true, ConfidenceUnknown},
+		{"hops=0 -> high", intPtr(0), false, ConfidenceHigh},
+		{"hops=1 -> medium", intPtr(1), false, ConfidenceMedium},
+		{"hops=3 -> medium", intPtr(3), false, ConfidenceMedium},
+		{"hops=4 -> low", intPtr(4), false, ConfidenceLow},
+		{"hops=10 -> low", intPtr(10), false, ConfidenceLow},
+		{"dynamic forces low for direct", intPtr(0), true, ConfidenceLow},
+		{"dynamic forces low for medium chain", intPtr(2), true, ConfidenceLow},
+		{"dynamic forces low for long chain", intPtr(8), true, ConfidenceLow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DeriveConfidence(tc.hops, tc.dynamicImports); got != tc.want {
+				t.Errorf("DeriveConfidence(hops=%v, dyn=%v) = %q, want %q", tc.hops, tc.dynamicImports, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReachabilityCloneDeepCopiesHops(t *testing.T) {
+	five := 5
+	src := &Reachability{
+		Status:                 ReachabilityReachable,
+		Hops:                   &five,
+		Confidence:             ConfidenceMedium,
+		DynamicImportsDetected: true,
+	}
+	clone := src.Clone()
+	if clone == nil {
+		t.Fatal("clone is nil")
+	}
+	if clone.Hops == src.Hops {
+		t.Error("Hops pointer not deep-copied")
+	}
+	if clone.Hops == nil || *clone.Hops != 5 {
+		t.Errorf("Hops value = %v, want 5", clone.Hops)
+	}
+	// Mutating the original must not affect the clone.
+	*src.Hops = 99
+	if *clone.Hops != 5 {
+		t.Errorf("mutation to src.Hops leaked into clone: %v", *clone.Hops)
+	}
+	if clone.Confidence != ConfidenceMedium {
+		t.Errorf("Confidence not preserved: %v", clone.Confidence)
+	}
+	if !clone.DynamicImportsDetected {
+		t.Error("DynamicImportsDetected not preserved")
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -158,6 +158,34 @@ const (
 	TierNone ReachabilityTier = "none"
 )
 
+// ReachabilityConfidence is a coarse triage signal derived from Hops
+// and DynamicImportsDetected. Tier-3 analyzers compute it so consumers
+// can prioritize findings without parsing the underlying inputs.
+type ReachabilityConfidence string
+
+const (
+	// ConfidenceUnknown means the analyzer did not derive a confidence
+	// signal (e.g. status was unknown, or the analyzer is symbol-tier
+	// and confidence is not meaningful).
+	ConfidenceUnknown ReachabilityConfidence = ""
+	// ConfidenceHigh is set when the affected package is directly
+	// imported from app source and no dynamic imports were detected.
+	// Direct imports are very likely to actually exercise the
+	// vulnerable code path.
+	ConfidenceHigh ReachabilityConfidence = "high"
+	// ConfidenceMedium is set when the affected package is reachable
+	// only through 1–3 dep-graph hops from a directly-imported
+	// neighbour, and no dynamic imports were detected. Transitive
+	// chains of moderate length are likely but not guaranteed to be
+	// exercised.
+	ConfidenceMedium ReachabilityConfidence = "medium"
+	// ConfidenceLow is set when the affected package is reachable
+	// only through 4+ dep-graph hops, or when the project contains
+	// dynamic imports the analyzer cannot follow. Long chains often
+	// represent passive transitive deps that may never be exercised.
+	ConfidenceLow ReachabilityConfidence = "low"
+)
+
 // Reachability is the analyzer-supplied reachability annotation for one
 // vulnerability. Stored on PackageVulnerability and copied to Finding.
 type Reachability struct {
@@ -178,9 +206,46 @@ type Reachability struct {
 	// CallPaths are the entry → sink chains the analyzer found, with
 	// exact line numbers in app source where available.
 	CallPaths []CallPath `json:"call_paths,omitempty"`
+	// Hops is the dep-graph distance from a directly-imported package
+	// to this one. 0 means the package itself is directly imported.
+	// Tier-3 analyzers populate this during BFS closure; symbol-tier
+	// analyzers leave it nil. nil = not measured.
+	Hops *int `json:"hops,omitempty"`
+	// Confidence is a coarse triage label derived from Hops and
+	// DynamicImportsDetected. Set by Tier-3 analyzers; unset by
+	// symbol-tier analyzers and for unknown / not_applicable statuses.
+	Confidence ReachabilityConfidence `json:"confidence,omitempty"`
+	// DynamicImportsDetected is true when the analyzer found
+	// dynamic-import constructs in the project that it cannot follow
+	// statically (e.g. require(variable), importlib.import_module(name),
+	// Class.forName(string)). When true, an "unreachable" verdict is
+	// necessarily incomplete; consumers should treat it as
+	// lower-confidence.
+	DynamicImportsDetected bool `json:"dynamic_imports_detected,omitempty"`
 	// AnalyzedAt is the RFC3339 timestamp when the analyzer ran. Empty
 	// when the analyzer did not record one.
 	AnalyzedAt string `json:"analyzed_at,omitempty"`
+}
+
+// DeriveConfidence computes a confidence label from a hop count and a
+// dynamic-imports flag. Returns ConfidenceUnknown when hops is nil.
+// Tier-3 analyzers call this after BFS closure to populate
+// Reachability.Confidence consistently across ecosystems.
+func DeriveConfidence(hops *int, dynamicImports bool) ReachabilityConfidence {
+	if hops == nil {
+		return ConfidenceUnknown
+	}
+	if dynamicImports {
+		return ConfidenceLow
+	}
+	switch {
+	case *hops == 0:
+		return ConfidenceHigh
+	case *hops <= 3:
+		return ConfidenceMedium
+	default:
+		return ConfidenceLow
+	}
 }
 
 // Clone returns a deep copy of the reachability annotation.
@@ -200,6 +265,10 @@ func (r *Reachability) Clone() *Reachability {
 		for _, path := range r.CallPaths {
 			clone.CallPaths = append(clone.CallPaths, path.Clone())
 		}
+	}
+	if r.Hops != nil {
+		hops := *r.Hops
+		clone.Hops = &hops
 	}
 	return &clone
 }


### PR DESCRIPTION
## Summary

Implements the Tier-3 improvements from the [OSV-audit notes](../blob/feat/reachability/notes/reachability-tier-promotion-audit.md) plus the deferred govulncheck refinements (C.5). All changes are additive; nothing existing breaks.

## SDK additions

\`sdk.Reachability\` gains three optional fields:

| Field | Type | Meaning |
| --- | --- | --- |
| \`Hops\` | \`*int\` | Shortest dep-graph distance from a directly-imported package. \`0\` = direct, higher = transitive. Tier-3 only; symbol-tier leaves it nil. |
| \`Confidence\` | \`ReachabilityConfidence\` | \`high\` (direct, no dynamic imports), \`medium\` (1–3 hops, no dynamic imports), or \`low\` (4+ hops, OR dynamic imports detected). Triage signal. |
| \`DynamicImportsDetected\` | \`bool\` | Per-vuln flag set when the analyzer observed dynamic-import constructs in app source it cannot follow statically. When \`true\`, an "unreachable" verdict is necessarily incomplete. |

New \`sdk.DeriveConfidence(hops, dynamicImports)\` consolidates the derivation logic so every Tier-3 analyzer produces consistent labels.

\`Reachability.Clone\` deep-copies the new \`Hops\` pointer.

## Tier-3 analyzers (jsreach, pyreach, jvmreach)

Each one now:

1. **Computes a hops map during BFS closure** — renamed \`computeReachablePackageIDs\` → \`computeReachablePackageHops\`. Hop 0 is the seeded import set; transitive deps inherit hop+1 via shortest-path BFS, so cycles never inflate the count.
2. **Scans app source for dynamic-import constructs** and reports the result via \`Runner.RunnerResult.DynamicImportsDetected\`:
   - **jsreach** — \`require(variable)\`, \`import(variable)\`, \`System.import(...)\`
   - **pyreach** — \`importlib.import_module(name)\`, \`__import__(name)\`, \`importlib.util.find_spec(name)\`, \`pkgutil.iter_modules\`, \`pkg_resources.iter_entry_points\`
   - **jvmreach** — \`Class.forName(name)\`, \`.loadClass(name)\`, \`ServiceLoader.load\`, \`ResourceBundle.getBundle(name)\`
3. **Populates** \`Reachability.Hops\` + \`Confidence\` + \`DynamicImportsDetected\` when annotating each reachable vulnerability.
4. **Bumps cacheSchemaVersion** (\`v1\` → \`v2\`) so old entries are invalidated automatically.

## govulncheck refinements (C.5)

\`failureReason()\` now distinguishes **seven** reason codes instead of four. Consumers can branch on the exact failure mode in SARIF / JSON without parsing prose:

- \`missing-toolchain\` — \`go\` not on PATH, govulncheck unavailable
- \`no-go-packages\` — no \`.go\` files, build constraints exclude all
- \`module-resolution-failed\` — \`go.mod\` missing, missing \`go.sum\` entry, cannot find module
- \`invalid-go-mod\` — \`go.mod\` syntax errors
- \`build-failed\` — generic compile-stage failure
- \`cancelled\` — \`context.Canceled\` / \`DeadlineExceeded\`
- \`runner-error\` — fallback

## Output

- **JSON**: \`PackageVulnerability.Reachability\` already round-trips through \`*sdk.Reachability\`, so the new fields flow through automatically.
- **SARIF**: \`sarifProperties\` grows three keys — \`reachability_confidence\`, \`reachability_hops\` (\`*int\`, \`omitempty\`), \`reachability_dynamic_imports_detected\`.

## Tests

- [x] \`sdk/reachability_test.go\` — \`DeriveConfidence\` table-driven across the hops × dynamic-imports matrix; \`Clone\` deep-copy of \`Hops\`.
- [x] jsreach: \`TestComputeReachablePackageHopsHandlesCycles\` (renamed), \`TestAnalyzerPopulatesHopsAndConfidence\` (5-hop chain crosses high/medium/low boundary), \`TestAnalyzerHonorsRunnerDynamicImportFlag\` (dynamic flag forces \`low\` even for hop=0).
- [x] pyreach + jvmreach: analogous renamed cycle tests.
- [x] \`go test ./...\` green; \`make generate\` clean.

## Docs

- \`docs/REACHABILITY.md\` "Output shape" section documents the three new JSON / SARIF fields with the confidence table.
- govulncheck section enumerates the seven \`reason\` codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)