### PR TITLE
Refine interactive filters and target labels

### DIFF
--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -190,6 +190,7 @@ Complete reference for the `bomly diff` JSON output.
 |-------|------|-------------|
 | `name` | `string` | |
 | `path` | `string` | |
+| `target_type` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -191,6 +191,7 @@ Complete reference for the `bomly diff` JSON output.
 | `name` | `string` | |
 | `path` | `string` | |
 | `target_type` | `string` | |
+| `target_ref` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -1733,6 +1733,9 @@
         "path": {
           "type": "string"
         },
+        "target_ref": {
+          "type": "string"
+        },
         "target_type": {
           "type": "string"
         }

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -1732,6 +1732,9 @@
         },
         "path": {
           "type": "string"
+        },
+        "target_type": {
+          "type": "string"
         }
       },
       "required": [

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -158,6 +158,7 @@ Complete reference for the `bomly explain` JSON output.
 |-------|------|-------------|
 | `name` | `string` | |
 | `path` | `string` | |
+| `target_type` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -159,6 +159,7 @@ Complete reference for the `bomly explain` JSON output.
 | `name` | `string` | |
 | `path` | `string` | |
 | `target_type` | `string` | |
+| `target_ref` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -1368,6 +1368,9 @@
         },
         "path": {
           "type": "string"
+        },
+        "target_type": {
+          "type": "string"
         }
       },
       "required": [
@@ -2721,6 +2724,9 @@
                 "type": "string"
               },
               "path": {
+                "type": "string"
+              },
+              "target_type": {
                 "type": "string"
               }
             },

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -1369,6 +1369,9 @@
         "path": {
           "type": "string"
         },
+        "target_ref": {
+          "type": "string"
+        },
         "target_type": {
           "type": "string"
         }
@@ -2724,6 +2727,9 @@
                 "type": "string"
               },
               "path": {
+                "type": "string"
+              },
+              "target_ref": {
                 "type": "string"
               },
               "target_type": {

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -129,6 +129,7 @@ Complete reference for the `bomly scan` JSON output.
 | `name` | `string` | |
 | `path` | `string` | |
 | `target_type` | `string` | |
+| `target_ref` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -128,6 +128,7 @@ Complete reference for the `bomly scan` JSON output.
 |-------|------|-------------|
 | `name` | `string` | |
 | `path` | `string` | |
+| `target_type` | `string` | |
 | `ecosystem` | `string` | |
 | `package_manager` | `string` | |
 

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -1024,6 +1024,9 @@
         },
         "path": {
           "type": "string"
+        },
+        "target_type": {
+          "type": "string"
         }
       },
       "required": [

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -1025,6 +1025,9 @@
         "path": {
           "type": "string"
         },
+        "target_ref": {
+          "type": "string"
+        },
         "target_type": {
           "type": "string"
         }

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -91,7 +91,7 @@ func newExplainCmd() *cobra.Command {
 			}
 			if context.ResolvedConfig.Interactive {
 				progress.Stop()
-				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewScanNavigator("Bomly Interactive Explain", payload.Project, explainResult.FocusedConsolidated, explainResult.FocusedGraph, explainResult.Findings)))
+				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewExplain(payload.Project, args[0], explainResult.FocusedConsolidated, explainResult.FocusedGraph, explainResult.Findings)))
 			}
 
 			writer, closeWriter, err := context.Writer(streams.reportWriter())

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -349,6 +349,7 @@ func (o *Options) ProjectDescriptor() output.ProjectDescriptor {
 		Name:           displayTargetName(o.executionTarget),
 		Path:           location,
 		TargetType:     displayTargetType(o.executionTarget),
+		TargetRef:      o.executionTarget.Ref,
 		Ecosystem:      ecosystem,
 		PackageManager: packageManager,
 	}
@@ -366,6 +367,7 @@ func (o *Options) ProjectDescriptorForSubproject(subproject sdk.Subproject) outp
 		Name:           name,
 		Path:           displayTargetLocation(subproject.ExecutionTarget),
 		TargetType:     displayTargetType(subproject.ExecutionTarget),
+		TargetRef:      subproject.ExecutionTarget.Ref,
 		Ecosystem:      string(subproject.Ecosystem),
 		PackageManager: subproject.PrimaryPackageManager().Name(),
 	}

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -344,9 +344,11 @@ func (o *Options) ProjectDescriptor() output.ProjectDescriptor {
 		ecosystem = string(o.subprojects[0].Ecosystem)
 		packageManager = o.subprojects[0].PrimaryPackageManager().Name()
 	}
+	location := displayTargetLocation(o.executionTarget)
 	return output.ProjectDescriptor{
-		Name:           filepath.Base(o.executionTarget.Location),
-		Path:           o.executionTarget.Location,
+		Name:           displayTargetName(o.executionTarget),
+		Path:           location,
+		TargetType:     displayTargetType(o.executionTarget),
 		Ecosystem:      ecosystem,
 		PackageManager: packageManager,
 	}
@@ -358,13 +360,49 @@ func (o *Options) ProjectDescriptor() output.ProjectDescriptor {
 func (o *Options) ProjectDescriptorForSubproject(subproject sdk.Subproject) output.ProjectDescriptor {
 	name := filepath.Base(subproject.ExecutionTarget.Location)
 	if subproject.RelativePath == "." {
-		name = filepath.Base(o.executionTarget.Location)
+		name = displayTargetName(o.executionTarget)
 	}
 	return output.ProjectDescriptor{
 		Name:           name,
-		Path:           subproject.ExecutionTarget.Location,
+		Path:           displayTargetLocation(subproject.ExecutionTarget),
+		TargetType:     displayTargetType(subproject.ExecutionTarget),
 		Ecosystem:      string(subproject.Ecosystem),
 		PackageManager: subproject.PrimaryPackageManager().Name(),
+	}
+}
+
+func displayTargetLocation(target sdk.ExecutionTarget) string {
+	if target.Kind == sdk.ExecutionTargetGitRepository && strings.TrimSpace(target.RepositoryURL) != "" {
+		return strings.TrimSpace(target.RepositoryURL)
+	}
+	return target.Location
+}
+
+func displayTargetName(target sdk.ExecutionTarget) string {
+	location := displayTargetLocation(target)
+	if strings.TrimSpace(location) == "" {
+		return ""
+	}
+	if target.Kind == sdk.ExecutionTargetContainerImage || target.Kind == sdk.ExecutionTargetGitRepository {
+		return location
+	}
+	trimmed := strings.TrimSuffix(strings.TrimRight(location, `/\`), ".git")
+	if idx := strings.LastIndexAny(trimmed, `/\`); idx >= 0 && idx < len(trimmed)-1 {
+		return trimmed[idx+1:]
+	}
+	return filepath.Base(trimmed)
+}
+
+func displayTargetType(target sdk.ExecutionTarget) string {
+	switch target.Kind {
+	case sdk.ExecutionTargetGitRepository:
+		return "git repository"
+	case sdk.ExecutionTargetContainerImage:
+		return "container image"
+	case sdk.ExecutionTargetFilesystem:
+		return "filesystem"
+	default:
+		return string(target.Kind)
 	}
 }
 

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -45,6 +45,20 @@ func TestCommandContextResolveExecutionTarget_Container(t *testing.T) {
 	}
 }
 
+func TestProjectDescriptor_UsesUserFacingTargetLabels(t *testing.T) {
+	containerOptions := Options{executionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetContainerImage, Location: "example/demo:1.0"}}
+	containerProject := containerOptions.ProjectDescriptor()
+	if containerProject.Name != "example/demo:1.0" || containerProject.Path != "example/demo:1.0" || containerProject.TargetType != "container image" {
+		t.Fatalf("unexpected container project descriptor: %#v", containerProject)
+	}
+
+	urlOptions := Options{executionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetGitRepository, Location: `C:\Temp\bomly-clone`, RepositoryURL: "https://github.com/acme/demo.git"}}
+	urlProject := urlOptions.ProjectDescriptor()
+	if urlProject.Name != "https://github.com/acme/demo.git" || urlProject.Path != "https://github.com/acme/demo.git" || urlProject.TargetType != "git repository" {
+		t.Fatalf("unexpected url project descriptor: %#v", urlProject)
+	}
+}
+
 func TestCommandContextResolveExecutionTarget_RejectsMultipleTargets(t *testing.T) {
 	options := Options{ResolvedConfig: config.Resolved{Path: ".", Container: "alpine:3.20"}}
 

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -52,9 +52,9 @@ func TestProjectDescriptor_UsesUserFacingTargetLabels(t *testing.T) {
 		t.Fatalf("unexpected container project descriptor: %#v", containerProject)
 	}
 
-	urlOptions := Options{executionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetGitRepository, Location: `C:\Temp\bomly-clone`, RepositoryURL: "https://github.com/acme/demo.git"}}
+	urlOptions := Options{executionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetGitRepository, Location: `C:\Temp\bomly-clone`, RepositoryURL: "https://github.com/acme/demo.git", Ref: "main"}}
 	urlProject := urlOptions.ProjectDescriptor()
-	if urlProject.Name != "https://github.com/acme/demo.git" || urlProject.Path != "https://github.com/acme/demo.git" || urlProject.TargetType != "git repository" {
+	if urlProject.Name != "https://github.com/acme/demo.git" || urlProject.Path != "https://github.com/acme/demo.git" || urlProject.TargetType != "git repository" || urlProject.TargetRef != "main" {
 		t.Fatalf("unexpected url project descriptor: %#v", urlProject)
 	}
 }

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -21,6 +21,7 @@ type Metadata struct {
 type ProjectDescriptor struct {
 	Name           string `json:"name,omitempty"`
 	Path           string `json:"path"`
+	TargetType     string `json:"target_type,omitempty"`
 	Ecosystem      string `json:"ecosystem"`
 	PackageManager string `json:"package_manager,omitempty"`
 }

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -22,6 +22,7 @@ type ProjectDescriptor struct {
 	Name           string `json:"name,omitempty"`
 	Path           string `json:"path"`
 	TargetType     string `json:"target_type,omitempty"`
+	TargetRef      string `json:"target_ref,omitempty"`
 	Ecosystem      string `json:"ecosystem"`
 	PackageManager string `json:"package_manager,omitempty"`
 }

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -261,6 +261,7 @@ func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, h
 		Project: ProjectDescriptor{
 			Name:           filepathBase(projectPath),
 			Path:           projectPath,
+			TargetType:     "dependency diff",
 			Ecosystem:      "multiple",
 			PackageManager: "multiple",
 		},

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -9,16 +9,132 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/output"
 )
 
+type diffTab string
+
+const (
+	diffTabOverview diffTab = "overview"
+	diffTabAdded    diffTab = "added"
+	diffTabRemoved  diffTab = "removed"
+	diffTabChanged  diffTab = "changed"
+)
+
 type diffModel struct {
 	*listModel
 	payload output.DiffResponse
+	active  diffTab
 }
 
 func NewDiff(payload output.DiffResponse) *diffModel {
-	manifests := append([]output.DiffManifestResult(nil), payload.Results.Manifests...)
-	sort.Slice(manifests, func(i, j int) bool {
-		left := manifests[i]
-		right := manifests[j]
+	model := &diffModel{payload: payload, active: diffTabOverview}
+	model.listModel = model.buildList()
+	return model
+}
+
+func (m *diffModel) CycleView() {
+	tabs := diffTabs()
+	for idx, tab := range tabs {
+		if tab == m.active {
+			m.active = tabs[(idx+1)%len(tabs)]
+			m.listModel = m.buildList()
+			return
+		}
+	}
+	m.active = diffTabOverview
+	m.listModel = m.buildList()
+}
+
+func (m *diffModel) SelectView(index int) {
+	tabs := diffTabs()
+	if index < 1 || index > len(tabs) {
+		return
+	}
+	m.active = tabs[index-1]
+	m.listModel = m.buildList()
+}
+
+func diffTabs() []diffTab {
+	return []diffTab{diffTabOverview, diffTabAdded, diffTabRemoved, diffTabChanged}
+}
+
+func (m *diffModel) buildList() *listModel {
+	switch m.active {
+	case diffTabAdded:
+		return m.buildPackageTab(diffTabAdded)
+	case diffTabRemoved:
+		return m.buildPackageTab(diffTabRemoved)
+	case diffTabChanged:
+		return m.buildPackageTab(diffTabChanged)
+	default:
+		return m.buildOverviewTab()
+	}
+}
+
+func (m *diffModel) buildOverviewTab() *listModel {
+	manifests := sortedDiffManifests(m.payload.Results.Manifests)
+	items := make([]listItem, 0, len(manifests))
+	for _, manifest := range manifests {
+		items = append(items, listItem{
+			title:    render.DiffManifestDisplayLabel(manifest),
+			subtitle: manifest.Status,
+			details:  diffManifestDetails(manifest),
+		})
+	}
+	return &listModel{
+		title:          "",
+		summary:        m.diffSummaryLines(),
+		listTitle:      fmt.Sprintf("Manifests (%d)", len(items)),
+		detailTitle:    "Manifest Details",
+		topPanels:      m.diffTopPanels(),
+		navigationHelp: interactiveCommonNavigationHelp,
+		filterHelp:     "Use / to search; Tab or 1-4 switches tabs; Enter keeps current result; Esc clears search",
+		emptyState:     "No manifest changes were found.",
+		items:          items,
+	}
+}
+
+func (m *diffModel) buildPackageTab(tab diffTab) *listModel {
+	items := make([]listItem, 0)
+	for _, manifest := range sortedDiffManifests(m.payload.Results.Manifests) {
+		switch tab {
+		case diffTabAdded:
+			for _, change := range manifest.Added {
+				label := render.DiffPackageDisplayName(change.Package)
+				items = append(items, listItem{title: label, subtitle: string(tab), details: diffPackageDetails("Added package", manifest, label, "", "")})
+			}
+		case diffTabRemoved:
+			for _, change := range manifest.Removed {
+				label := render.DiffPackageDisplayName(change.Package)
+				items = append(items, listItem{title: label, subtitle: string(tab), details: diffPackageDetails("Removed package", manifest, label, "", "")})
+			}
+		case diffTabChanged:
+			for _, change := range manifest.Changed {
+				before := render.DiffPackageDisplayName(change.Before)
+				after := render.DiffPackageDisplayName(change.After)
+				title := after
+				if title == "" {
+					title = before
+				}
+				items = append(items, listItem{title: title, subtitle: string(tab), details: diffPackageDetails("Changed package", manifest, title, before, after)})
+			}
+		}
+	}
+	return &listModel{
+		title:          "",
+		summary:        m.diffSummaryLines(),
+		listTitle:      fmt.Sprintf("%s Packages (%d)", titleCase(string(tab)), len(items)),
+		detailTitle:    "Package Details",
+		navigationHelp: interactiveCommonNavigationHelp,
+		filterHelp:     "Use / to search; Tab or 1-4 switches tabs; Enter keeps current result; Esc clears search",
+		emptyState:     fmt.Sprintf("No %s packages were found.", string(tab)),
+		items:          items,
+	}
+}
+
+func sortedDiffManifests(manifests []output.DiffManifestResult) []output.DiffManifestResult {
+	sorted := append([]output.DiffManifestResult(nil), manifests...)
+	sort.Slice(sorted, func(i, j int) bool {
+		left := sorted[i]
+		right := sorted[j]
 		if left.Status != right.Status {
 			return render.DiffManifestStatusOrder(left.Status) < render.DiffManifestStatusOrder(right.Status)
 		}
@@ -30,49 +146,90 @@ func NewDiff(payload output.DiffResponse) *diffModel {
 		}
 		return left.Subproject < right.Subproject
 	})
+	return sorted
+}
 
-	items := make([]listItem, 0, len(manifests))
-	for _, manifest := range manifests {
-		items = append(items, listItem{
-			title:    render.DiffManifestDisplayLabel(manifest),
-			subtitle: manifest.Status,
-			details:  diffManifestDetails(manifest),
-		})
+func (m *diffModel) diffSummaryLines() []string {
+	return []string{
+		diffTopBar(m.payload),
+		"",
+		m.diffTabLine(),
+		"",
 	}
+}
 
-	list := &listModel{
-		title: "",
-		summary: []string{
-			diffTopBar(payload),
-			"",
-			render.Style("[1] Diff", render.Yellow, render.Bold),
-			"",
-			summaryLine("Manifest changes", []string{
-				render.Style(fmt.Sprintf("added %d", payload.Summary.AddedManifestCount), render.Green, render.Bold),
-				render.Style(fmt.Sprintf("changed %d", payload.Summary.ChangedManifestCount), render.Yellow, render.Bold),
-				render.Style(fmt.Sprintf("unchanged %d", payload.Summary.UnchangedManifestCount), render.Cyan, render.Bold),
-				render.Style(fmt.Sprintf("removed %d", payload.Summary.RemovedManifestCount), render.Red, render.Bold),
-			}),
-			summaryLine("Package changes", []string{
-				render.Style(fmt.Sprintf("added %d", payload.Summary.AddedPackageCount), render.Green, render.Bold),
-				render.Style(fmt.Sprintf("updated %d", payload.Summary.ChangedPackageCount), render.Yellow, render.Bold),
-				render.Style(fmt.Sprintf("removed %d", payload.Summary.RemovedPackageCount), render.Red, render.Bold),
-			}),
-		},
-		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter keeps current result; Esc clears search",
-		emptyState:     "No manifest changes were found.",
-		items:          items,
+func (m *diffModel) diffTabLine() string {
+	labels := []struct {
+		tab   diffTab
+		label string
+	}{
+		{diffTabOverview, "Overview"},
+		{diffTabAdded, "Added"},
+		{diffTabRemoved, "Removed"},
+		{diffTabChanged, "Changed"},
 	}
-	return &diffModel{listModel: list, payload: payload}
+	parts := make([]string, 0, len(labels))
+	for idx, item := range labels {
+		text := fmt.Sprintf("[%d] %s", idx+1, item.label)
+		if item.tab == m.active {
+			parts = append(parts, render.Style(text, render.Yellow, render.Bold))
+		} else {
+			parts = append(parts, render.Style(text, render.Dim))
+		}
+	}
+	return strings.Join(parts, render.Style(" | ", render.Dim))
+}
+
+func (m *diffModel) diffTopPanels() []listPanel {
+	return []listPanel{
+		{title: "Manifest Changes", lines: []string{
+			render.Style(fmt.Sprintf("%d Added", m.payload.Summary.AddedManifestCount), render.Green, render.Bold),
+			render.Style(fmt.Sprintf("%d Changed", m.payload.Summary.ChangedManifestCount), render.Yellow, render.Bold),
+			render.Style(fmt.Sprintf("%d Removed", m.payload.Summary.RemovedManifestCount), render.Red, render.Bold),
+			render.Style(fmt.Sprintf("%d Unchanged", m.payload.Summary.UnchangedManifestCount), render.Cyan, render.Bold),
+		}, color: render.Cyan, weight: 1},
+		{title: "Package Changes", lines: []string{
+			render.Style(fmt.Sprintf("%d Added", m.payload.Summary.AddedPackageCount), render.Green, render.Bold),
+			render.Style(fmt.Sprintf("%d Changed", m.payload.Summary.ChangedPackageCount), render.Yellow, render.Bold),
+			render.Style(fmt.Sprintf("%d Removed", m.payload.Summary.RemovedPackageCount), render.Red, render.Bold),
+		}, color: render.Magenta, weight: 1},
+	}
 }
 
 func diffTopBar(payload output.DiffResponse) string {
+	targetParts := []string{
+		render.Style(valueOrDash(payload.Project.Name), render.White, render.Bold),
+		render.Style(targetKindLabel(payload.Project), render.Dim),
+	}
+	if payload.Project.TargetRef != "" {
+		targetParts = append(targetParts, render.Style("ref: "+payload.Project.TargetRef, render.Cyan, render.Bold))
+	}
+	targetParts = append(targetParts, render.Style(payload.Comparison.Base+" -> "+payload.Comparison.Head, render.Cyan, render.Bold))
 	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
 		render.Style("DIFF", render.BgBlue, render.White, render.Bold) + " " +
-		render.Style(valueOrDash(payload.Project.Name), render.White, render.Bold) + " " +
-		render.Style(targetKindLabel(payload.Project), render.Dim) + " " +
-		render.Style(payload.Comparison.Base+" -> "+payload.Comparison.Head, render.Cyan, render.Bold)
+		strings.Join(targetParts, render.Style(" | ", render.Dim))
+}
+
+func diffPackageDetails(title string, manifest output.DiffManifestResult, label, before, after string) []string {
+	lines := []string{
+		render.Style(title, render.Bold, render.Cyan),
+		"",
+		render.Style("  Package: ", render.Dim) + valueOrDash(label),
+		render.Style("  Manifest: ", render.Dim) + render.DiffManifestDisplayLabel(manifest),
+		render.Style("  Status: ", render.Dim) + statusText(manifest.Status),
+		render.Style("  Ecosystem: ", render.Dim) + valueOrDash(manifest.Ecosystem),
+		render.Style("  Package manager: ", render.Dim) + valueOrDash(manifest.PackageManager),
+	}
+	if before != "" || after != "" {
+		lines = append(lines,
+			"",
+			render.Style("Version Change", render.Bold, render.Magenta),
+			"",
+			render.Style("  Before: ", render.Dim)+valueOrDash(before),
+			render.Style("  After: ", render.Dim)+valueOrDash(after),
+		)
+	}
+	return lines
 }
 
 func summaryLine(label string, values []string) string {
@@ -86,6 +243,7 @@ func diffManifestDetails(manifest output.DiffManifestResult) []string {
 		render.Style("  Path: ", render.Dim) + valueOrDash(manifest.Path),
 		render.Style("  Kind: ", render.Dim) + valueOrDash(manifest.Kind),
 		render.Style("  Subproject: ", render.Dim) + valueOrDash(manifest.Subproject),
+		render.Style("  Ecosystem: ", render.Dim) + valueOrDash(manifest.Ecosystem),
 		render.Style("  Package manager: ", render.Dim) + valueOrDash(manifest.PackageManager),
 		"",
 	}

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -9,7 +9,12 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/output"
 )
 
-func NewDiff(payload output.DiffResponse) *listModel {
+type diffModel struct {
+	*listModel
+	payload output.DiffResponse
+}
+
+func NewDiff(payload output.DiffResponse) *diffModel {
 	manifests := append([]output.DiffManifestResult(nil), payload.Results.Manifests...)
 	sort.Slice(manifests, func(i, j int) bool {
 		left := manifests[i]
@@ -35,9 +40,13 @@ func NewDiff(payload output.DiffResponse) *listModel {
 		})
 	}
 
-	return &listModel{
-		title: fmt.Sprintf("Bomly Interactive Diff: %s -> %s", payload.Comparison.Base, payload.Comparison.Head),
+	list := &listModel{
+		title: "",
 		summary: []string{
+			diffTopBar(payload),
+			"",
+			render.Style("[1] Diff", render.Yellow, render.Bold),
+			"",
 			summaryLine("Manifest changes", []string{
 				render.Style(fmt.Sprintf("added %d", payload.Summary.AddedManifestCount), render.Green, render.Bold),
 				render.Style(fmt.Sprintf("changed %d", payload.Summary.ChangedManifestCount), render.Yellow, render.Bold),
@@ -55,6 +64,15 @@ func NewDiff(payload output.DiffResponse) *listModel {
 		emptyState:     "No manifest changes were found.",
 		items:          items,
 	}
+	return &diffModel{listModel: list, payload: payload}
+}
+
+func diffTopBar(payload output.DiffResponse) string {
+	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
+		render.Style("DIFF", render.BgBlue, render.White, render.Bold) + " " +
+		render.Style(valueOrDash(payload.Project.Name), render.White, render.Bold) + " " +
+		render.Style(targetKindLabel(payload.Project), render.Dim) + " " +
+		render.Style(payload.Comparison.Base+" -> "+payload.Comparison.Head, render.Cyan, render.Bold)
 }
 
 func summaryLine(label string, values []string) string {

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -16,6 +16,14 @@ func NewScan(project output.ProjectDescriptor, consolidated sdk.ConsolidatedGrap
 }
 
 func NewScanNavigator(titlePrefix string, project output.ProjectDescriptor, consolidated sdk.ConsolidatedGraph, graphValue *sdk.Graph, findings []sdk.Finding) *scanModel {
+	return newScanNavigator(titlePrefix, project, consolidated, graphValue, findings, "")
+}
+
+func NewExplain(project output.ProjectDescriptor, query string, consolidated sdk.ConsolidatedGraph, graphValue *sdk.Graph, findings []sdk.Finding) *scanModel {
+	return newScanNavigator("Bomly Interactive Explain", project, consolidated, graphValue, findings, query)
+}
+
+func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, consolidated sdk.ConsolidatedGraph, graphValue *sdk.Graph, findings []sdk.Finding, explainQuery string) *scanModel {
 	manifests := manifestRows(consolidated)
 	manifestByID := make(map[string]listPackageRow, len(manifests))
 	for _, manifest := range manifests {
@@ -33,6 +41,7 @@ func NewScanNavigator(titlePrefix string, project output.ProjectDescriptor, cons
 		allowManifestExit:     len(manifests) > 1,
 		findings:              findings,
 		activeView:            interactiveScanViewOverview,
+		explainQuery:          strings.TrimSpace(explainQuery),
 		sourceExpanded:        map[string]bool{"root": true},
 		componentExpanded:     map[string]bool{},
 		vulnerabilityGroup:    "component",
@@ -306,7 +315,7 @@ func (m *scanModel) CycleGroup() {
 	case interactiveScanViewLicenses:
 		m.licenseGroup = nextFilterValue(m.licenseGroup, []string{"license", "category", "recognition"})
 	case interactiveScanViewFindings:
-		m.findingGroup = nextFilterValue(m.findingGroup, []string{"type", "severity", "component"})
+		m.findingGroup = nextFilterValue(m.findingGroup, []string{"type", "severity", "component", "ecosystem"})
 	default:
 		return
 	}
@@ -342,6 +351,33 @@ func (m *scanModel) CycleSeverityFilter() {
 	}
 	m.severityFilter = nextSeverityFilter(m.severityFilter)
 	m.rebuildListPreserveSelection()
+}
+
+func (m *scanModel) CycleEcosystemFilter() {
+	if m == nil || m.activeView != interactiveScanViewPackages {
+		return
+	}
+	m.ecosystemFilter = nextFilterValue(m.ecosystemFilter, append([]string{""}, m.componentEcosystemValues()...))
+	m.rebuildListPreserveSelection()
+}
+
+func (m *scanModel) componentEcosystemValues() []string {
+	if m == nil || m.graphValue == nil {
+		return nil
+	}
+	values := make(map[string]struct{})
+	for _, pkg := range m.graphValue.Packages() {
+		if pkg == nil {
+			continue
+		}
+		values[valueOrDefault(pkg.Ecosystem, "unknown")] = struct{}{}
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (m *scanModel) OpenSelected() {
@@ -427,14 +463,32 @@ func scanViews() []scanView {
 }
 
 func (m *scanModel) scanSummaryLines(active scanView) []string {
+	targetParts := []string{
+		render.Style(valueOrDash(m.project.Name), render.White, render.Bold),
+		render.Style(targetKindLabel(m.project), render.Dim),
+	}
+	if m.explainMode && m.explainQuery != "" {
+		targetParts = append(targetParts, render.Style("package: "+m.explainQuery, render.Cyan, render.Bold))
+	}
 	return []string{
 		render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
-			render.Style("SCAN", render.BgBlue, render.White, render.Bold) + " " +
-			render.Style(valueOrDash(m.project.Name), render.White, render.Bold) + " " +
-			render.Style(targetKindLabel(m.project), render.Dim),
+			render.Style(m.commandLabel(), render.BgBlue, render.White, render.Bold) + " " +
+			strings.Join(targetParts, render.Style(" | ", render.Dim)),
 		"",
 		m.tabLine(active),
 		"",
+	}
+}
+
+func (m *scanModel) commandLabel() string {
+	lower := strings.ToLower(m.titlePrefix)
+	switch {
+	case strings.Contains(lower, "explain"):
+		return "EXPLAIN"
+	case strings.Contains(lower, "diff"):
+		return "DIFF"
+	default:
+		return "SCAN"
 	}
 }
 
@@ -506,14 +560,15 @@ func (m *scanModel) withScanFooter(list *listModel) *listModel {
 }
 
 func (m *scanModel) componentControlsLine() string {
-	return keyHint("/", "search") + " " + keyHint("r", "relationship") + " " + keyHint("s", "scope") + " " + keyHint("v", "severity") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all")
+	return keyHint("/", "search") + " " + keyHint("r", "relationship") + " " + keyHint("s", "scope") + " " + keyHint("v", "severity") + " " + keyHint("e", "ecosystem") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all")
 }
 
 func (m *scanModel) componentStateLine(extra string) string {
 	state := render.Style("Group: ", render.Dim) + render.Style("Dependency", render.BgYellow, render.Bold) +
 		render.Style(" | Relationship: ", render.Dim) + render.Style(valueOrDefault(m.relationshipFilter, "All"), render.BgYellow, render.Bold) +
 		render.Style(" | Scope: ", render.Dim) + render.Style(valueOrDefault(m.scopeFilter, "All"), render.BgYellow, render.Bold) +
-		render.Style(" | Severity: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold)
+		render.Style(" | Severity: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold) +
+		render.Style(" | Ecosystem: ", render.Dim) + render.Style(valueOrDefault(m.ecosystemFilter, "All"), render.BgYellow, render.Bold)
 	if strings.TrimSpace(extra) != "" {
 		state += render.Style(" | ", render.Dim) + extra
 	}
@@ -606,16 +661,7 @@ func (m *scanModel) buildComponentsTreeListModel() *listModel {
 				continue
 			}
 			rows := m.componentTreeRows(manifest.rootID)
-			rows = filterPackageRows(rows, m.relationshipFilter, m.scopeFilter)
-			if m.severityFilter != "" {
-				kept := rows[:0]
-				for _, row := range rows {
-					if strings.EqualFold(maxSevByID[row.id], m.severityFilter) {
-						kept = append(kept, row)
-					}
-				}
-				rows = kept
-			}
+			rows = m.filterComponentRows(rows, maxSevByID)
 			for _, row := range rows {
 				badges := packageBadges(row)
 				if sev := maxSevByID[row.id]; sev != "" {
@@ -721,7 +767,20 @@ func (m *scanModel) filteredManifestComponentRows(rootID string, maxSevByID map[
 		return nil
 	}
 	rows := componentCountRows(m.graphValue, rootID)
+	return m.filterComponentRows(rows, maxSevByID)
+}
+
+func (m *scanModel) filterComponentRows(rows []listPackageRow, maxSevByID map[string]string) []listPackageRow {
 	rows = filterPackageRows(rows, m.relationshipFilter, m.scopeFilter)
+	if m.ecosystemFilter != "" {
+		kept := rows[:0]
+		for _, row := range rows {
+			if strings.EqualFold(valueOrDefault(row.ecosystem, "unknown"), m.ecosystemFilter) {
+				kept = append(kept, row)
+			}
+		}
+		rows = kept
+	}
 	if m.severityFilter == "" {
 		return rows
 	}
@@ -884,7 +943,6 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 	leftWidth := width / 2
 	rightWidth := width - leftWidth - 1
 	topVuln := topVulnerableComponentStats(m.graphValue, m.findings, 8)
-	topDeps := topDependedOnComponentStats(m.graphValue, m.findings, 8)
 	leftA := remaining / 3
 	if leftA < 7 && remaining >= 14 {
 		leftA = 7
@@ -899,14 +957,19 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 		boxView("Ecosystem Distribution", coloredDistributionLines(stats.ecosystems, stats.components, 8, leftWidth-2), leftWidth, leftB, render.Cyan),
 		boxView("License Distribution", coloredDistributionLines(groupedLicenseCounts(m.graphValue, 10), stats.components, 10, leftWidth-2), leftWidth, leftC, render.Yellow),
 	)
-	rightA := remaining / 2
-	rightB := remaining - rightA - 1
-	if rightB < 4 {
-		rightB = 4
+	rightA := remaining / 3
+	if rightA < 6 && remaining >= 18 {
+		rightA = 6
+	}
+	rightB := (remaining - rightA - 2) / 2
+	rightC := remaining - rightA - rightB - 2
+	if rightC < 4 {
+		rightC = 4
 	}
 	rightContent := stackBoxes(
 		boxView(fmt.Sprintf("Top Vulnerable Components (%d)", vulnerableComponentTotal(m.graphValue, m.findings)), topVulnerableTableLines(topVuln, rightWidth-2), rightWidth, rightA, render.Red),
-		boxView(fmt.Sprintf("Top Depended-On Components (%d)", dependedOnComponentTotal(m.graphValue)), topDependedOnTableLines(topDeps, rightWidth-2), rightWidth, rightB, render.Green),
+		boxView("Components by Relationship", componentsByRelationshipLines(m.manifests, m.graphValue, rightWidth-2), rightWidth, rightB, render.Cyan),
+		boxView("Components by Scope", componentsByScopeLines(m.manifests, m.graphValue, rightWidth-2), rightWidth, rightC, render.Green),
 	)
 	lines = append(lines, joinColumns(leftContent, rightContent, leftWidth, rightWidth)...)
 	lines = append(lines, footerLines...)
@@ -1343,6 +1406,11 @@ func findingGroupKey(finding sdk.Finding, group string) string {
 		return titleCase(valueOrDefault(finding.Severity, "unknown"))
 	case "component":
 		return valueOrDefault(findingPackageName(finding), "unknown component")
+	case "ecosystem":
+		if finding.Package != nil {
+			return valueOrDefault(finding.Package.Ecosystem, "unknown")
+		}
+		return "unknown"
 	default:
 		return titleCase(string(finding.Kind))
 	}
@@ -1716,21 +1784,9 @@ func (m *scanModel) buildComponentListModel(manifest listPackageRow) *listModel 
 	rootPkg, _ := m.graphValue.Package(manifest.rootID)
 
 	rows := m.componentTreeRows(manifest.rootID)
-	rows = filterPackageRows(rows, m.relationshipFilter, m.scopeFilter)
-
 	// Compute highest severity per package for badge display, filtering, and sorting.
 	maxSevByID := maxSeverityByPkgID(m.findings)
-
-	// Apply severity filter.
-	if m.severityFilter != "" {
-		kept := rows[:0]
-		for _, row := range rows {
-			if strings.EqualFold(maxSevByID[row.id], m.severityFilter) {
-				kept = append(kept, row)
-			}
-		}
-		rows = kept
-	}
+	rows = m.filterComponentRows(rows, maxSevByID)
 
 	// Sort: highest severity first, then relationship, then ID.
 	sort.Slice(rows, func(i, j int) bool {
@@ -1804,17 +1860,8 @@ func (m *scanModel) buildExplainComponentListModel(manifest listPackageRow) *lis
 			rows = append(rows, row)
 		}
 	}
-	rows = filterPackageRows(rows, m.relationshipFilter, m.scopeFilter)
 	maxSevByID := maxSeverityByPkgID(m.findings)
-	if m.severityFilter != "" {
-		kept := rows[:0]
-		for _, row := range rows {
-			if strings.EqualFold(maxSevByID[row.id], m.severityFilter) {
-				kept = append(kept, row)
-			}
-		}
-		rows = kept
-	}
+	rows = m.filterComponentRows(rows, maxSevByID)
 	sort.Slice(rows, func(i, j int) bool {
 		si := severityRank(maxSevByID[rows[i].id])
 		sj := severityRank(maxSevByID[rows[j].id])
@@ -1890,11 +1937,20 @@ func manifestRows(consolidated sdk.ConsolidatedGraph) []listPackageRow {
 		}
 
 		rows = append(rows, listPackageRow{
-			id:           manifestID,
-			rootID:       rootID,
-			targetID:     manifestTargetID(manifest.Entry.Graph),
-			displayName:  manifestName,
-			relationship: "manifest",
+			id:               manifestID,
+			rootID:           rootID,
+			targetID:         manifestTargetID(manifest.Entry.Graph),
+			displayName:      manifestName,
+			ecosystem:        string(manifest.Subproject.Ecosystem),
+			relationship:     "manifest",
+			detectorName:     valueOrDefault(manifest.DetectorName, manifest.Subproject.PrimaryDetector),
+			origin:           string(manifest.Origin),
+			technique:        string(manifest.Technique),
+			packageManagers:  packageManagersLabel(manifest.Subproject.DetectedPackageManagers),
+			plannedDetectors: strings.Join(manifest.Subproject.PlannedDetectors, ", "),
+			relativePath:     manifest.Subproject.RelativePath,
+			targetKind:       string(manifest.Subproject.ExecutionTarget.Kind),
+			targetLocation:   manifest.Subproject.ExecutionTarget.Location,
 		})
 	}
 
@@ -1911,8 +1967,19 @@ func manifestDetails(graphValue *sdk.Graph, row listPackageRow) []string {
 		render.Style("  ID: ", render.Dim) + valueOrDash(row.id),
 		render.Style("  Kind: ", render.Dim) + valueOrDash(filepath.Base(row.id)),
 		render.Style("  Type: ", render.Dim) + statusText(row.relationship),
+		render.Style("  Ecosystem: ", render.Dim) + valueOrDash(row.ecosystem),
+		render.Style("  Package managers: ", render.Dim) + valueOrDash(row.packageManagers),
+		render.Style("  Relative path: ", render.Dim) + valueOrDash(row.relativePath),
+		render.Style("  Target: ", render.Dim) + valueOrDash(row.targetLocation),
 		"",
-		render.Style("Dependencies", render.Bold, render.Magenta),
+		render.Style("Detector", render.Bold, render.Magenta),
+		render.Style("  Name: ", render.Dim) + valueOrDash(row.detectorName),
+		render.Style("  Origin: ", render.Dim) + valueOrDash(row.origin),
+		render.Style("  Technique: ", render.Dim) + valueOrDash(row.technique),
+		render.Style("  Planned chain: ", render.Dim) + valueOrDash(row.plannedDetectors),
+		render.Style("  Target type: ", render.Dim) + valueOrDash(row.targetKind),
+		"",
+		render.Style("Dependencies", render.Bold, render.Cyan),
 		render.Style("  Root (project package): ", render.Dim) + packageDisplayName(rootPkg),
 		render.Style("  Direct dependencies: ", render.Dim) + fmt.Sprintf("%d", len(groups.direct)),
 		render.Style("  Transitive dependencies: ", render.Dim) + fmt.Sprintf("%d", len(groups.transitive)),
@@ -1921,6 +1988,17 @@ func manifestDetails(graphValue *sdk.Graph, row listPackageRow) []string {
 		"",
 	}
 	return lines
+}
+
+func packageManagersLabel(managers []sdk.PackageManager) string {
+	if len(managers) == 0 {
+		return ""
+	}
+	labels := make([]string, 0, len(managers))
+	for _, manager := range managers {
+		labels = append(labels, manager.Name())
+	}
+	return strings.Join(labels, ", ")
 }
 
 func manifestTargetID(graphValue *sdk.Graph) string {
@@ -1959,6 +2037,7 @@ func packageRowFromGraph(pkg *sdk.Package, relationship string) listPackageRow {
 		displayName:  displayName,
 		version:      pkg.Version,
 		scope:        pkg.Scope,
+		ecosystem:    pkg.Ecosystem,
 		relationship: relationship,
 		purl:         pkg.PURL,
 	}
@@ -2555,6 +2634,58 @@ func topDependedOnTableLines(stats []componentStat, width int) []string {
 	return lines
 }
 
+func componentsByRelationshipLines(manifests []listPackageRow, graphValue *sdk.Graph, width int) []string {
+	if len(manifests) == 0 {
+		return []string{render.Style("(none)", render.Dim)}
+	}
+	nameWidth := width - 36
+	if nameWidth < 16 {
+		nameWidth = 16
+	}
+	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Direct", 8)+padRight("Transitive", 12)+"Root", render.Dim)}
+	for _, manifest := range manifests {
+		counts := map[string]int{"root": 0, "direct": 0, "transitive": 0}
+		for _, row := range componentCountRows(graphValue, manifest.rootID) {
+			counts[valueOrDefault(row.relationship, "transitive")]++
+		}
+		lines = append(lines,
+			padRight(truncateToWidth(manifest.displayName, nameWidth), nameWidth)+
+				padRight(fmt.Sprintf("%d", counts["direct"]), 8)+
+				padRight(fmt.Sprintf("%d", counts["transitive"]), 12)+
+				fmt.Sprintf("%d", counts["root"]),
+		)
+	}
+	return lines
+}
+
+func componentsByScopeLines(manifests []listPackageRow, graphValue *sdk.Graph, width int) []string {
+	if len(manifests) == 0 {
+		return []string{render.Style("(none)", render.Dim)}
+	}
+	nameWidth := width - 42
+	if nameWidth < 16 {
+		nameWidth = 16
+	}
+	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Runtime", 9)+padRight("Development", 13)+"Unset", render.Dim)}
+	for _, manifest := range manifests {
+		counts := map[string]int{"runtime": 0, "development": 0, "unset": 0}
+		for _, row := range componentCountRows(graphValue, manifest.rootID) {
+			scope := valueOrDefault(row.scope, "unset")
+			if _, ok := counts[scope]; !ok {
+				scope = "unset"
+			}
+			counts[scope]++
+		}
+		lines = append(lines,
+			padRight(truncateToWidth(manifest.displayName, nameWidth), nameWidth)+
+				padRight(fmt.Sprintf("%d", counts["runtime"]), 9)+
+				padRight(fmt.Sprintf("%d", counts["development"]), 13)+
+				fmt.Sprintf("%d", counts["unset"]),
+		)
+	}
+	return lines
+}
+
 func vulnerableComponentTotal(graphValue *sdk.Graph, findings []sdk.Finding) int {
 	counts, _ := packageVulnerabilityStats(graphValue, findings)
 	return len(counts)
@@ -2818,6 +2949,8 @@ func indentLines(values []string) []string {
 
 func targetKindLabel(project output.ProjectDescriptor) string {
 	switch {
+	case strings.TrimSpace(project.TargetType) != "":
+		return project.TargetType
 	case project.PackageManager != "":
 		return project.PackageManager
 	case project.Ecosystem != "":

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -470,6 +470,9 @@ func (m *scanModel) scanSummaryLines(active scanView) []string {
 	if m.explainMode && m.explainQuery != "" {
 		targetParts = append(targetParts, render.Style("package: "+m.explainQuery, render.Cyan, render.Bold))
 	}
+	if strings.TrimSpace(m.project.TargetRef) != "" {
+		targetParts = append(targetParts, render.Style("ref: "+m.project.TargetRef, render.Cyan, render.Bold))
+	}
 	return []string{
 		render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
 			render.Style(m.commandLabel(), render.BgBlue, render.White, render.Bold) + " " +
@@ -669,6 +672,10 @@ func (m *scanModel) buildComponentsTreeListModel() *listModel {
 				}
 				deps, _ := m.graphValue.Dependencies(row.id)
 				expanded := expandedValue(m.componentExpanded, row.id, row.relationship == "root")
+				if row.repeated {
+					deps = nil
+					expanded = false
+				}
 				items = append(items, listItem{
 					title:    row.displayName,
 					subtitle: row.relationship,
@@ -928,6 +935,7 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 		boxView("Target", []string{
 			render.Style("Name: ", render.Dim) + valueOrDash(m.project.Name),
 			render.Style("Type: ", render.Dim) + targetKindLabel(m.project),
+			render.Style("Ref: ", render.Dim) + valueOrDash(m.project.TargetRef),
 			render.Style("Path: ", render.Dim) + valueOrDash(m.project.Path),
 			render.Style("Ecosystem: ", render.Dim) + valueOrDash(m.project.Ecosystem),
 			render.Style("Package manager: ", render.Dim) + valueOrDash(m.project.PackageManager),
@@ -953,9 +961,9 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 		leftC = 4
 	}
 	leftContent := stackBoxes(
-		boxView("Vulnerability Severity", severityDistributionLines(m.findings, leftWidth-2), leftWidth, leftA, render.Red),
-		boxView("Ecosystem Distribution", coloredDistributionLines(stats.ecosystems, stats.components, 8, leftWidth-2), leftWidth, leftB, render.Cyan),
-		boxView("License Distribution", coloredDistributionLines(groupedLicenseCounts(m.graphValue, 10), stats.components, 10, leftWidth-2), leftWidth, leftC, render.Yellow),
+		boxView("Ecosystem Distribution", coloredDistributionLines(stats.ecosystems, stats.components, 8, leftWidth-2), leftWidth, leftA, render.Cyan),
+		boxView("Relationship Distribution", componentsByRelationshipLines(m.manifests, m.graphValue, leftWidth-2), leftWidth, leftB, render.Cyan),
+		boxView("Scope Distribution", componentsByScopeLines(m.manifests, m.graphValue, leftWidth-2), leftWidth, leftC, render.Green),
 	)
 	rightA := remaining / 3
 	if rightA < 6 && remaining >= 18 {
@@ -967,9 +975,9 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 		rightC = 4
 	}
 	rightContent := stackBoxes(
-		boxView(fmt.Sprintf("Top Vulnerable Components (%d)", vulnerableComponentTotal(m.graphValue, m.findings)), topVulnerableTableLines(topVuln, rightWidth-2), rightWidth, rightA, render.Red),
-		boxView("Components by Relationship", componentsByRelationshipLines(m.manifests, m.graphValue, rightWidth-2), rightWidth, rightB, render.Cyan),
-		boxView("Components by Scope", componentsByScopeLines(m.manifests, m.graphValue, rightWidth-2), rightWidth, rightC, render.Green),
+		boxView("License Distribution", coloredDistributionLines(groupedLicenseCounts(m.graphValue, 10), stats.components, 10, rightWidth-2), rightWidth, rightA, render.Yellow),
+		boxView("Vulnerability Severity", severityDistributionLines(m.findings, rightWidth-2), rightWidth, rightB, render.Red),
+		boxView(fmt.Sprintf("Top Vulnerable Components (%d)", vulnerableComponentTotal(m.graphValue, m.findings)), topVulnerableTableLines(topVuln, rightWidth-2), rightWidth, rightC, render.Red),
 	)
 	lines = append(lines, joinColumns(leftContent, rightContent, leftWidth, rightWidth)...)
 	lines = append(lines, footerLines...)
@@ -1816,6 +1824,10 @@ func (m *scanModel) buildComponentListModel(manifest listPackageRow) *listModel 
 				expanded = m.componentExpanded[row.id]
 			}
 		}
+		if row.repeated {
+			deps = nil
+			expanded = false
+		}
 		items = append(items, listItem{
 			title:    row.displayName,
 			subtitle: row.relationship,
@@ -2052,6 +2064,7 @@ func (m *scanModel) componentTreeRows(rootID string) []listPackageRow {
 		return nil
 	}
 	rows := make([]listPackageRow, 0)
+	renderedSubtrees := make(map[string]struct{})
 	var walk func(pkg *sdk.Package, depth int, ancestors []bool, last bool, visited map[string]struct{})
 	walk = func(pkg *sdk.Package, depth int, ancestors []bool, last bool, visited map[string]struct{}) {
 		if pkg == nil {
@@ -2067,6 +2080,13 @@ func (m *scanModel) componentTreeRows(rootID string) []listPackageRow {
 		row := packageRowFromGraph(pkg, relationship)
 		row.depth = depth
 		row.tree = treePrefix(ancestors, last, depth)
+		if depth > 0 {
+			if _, repeated := renderedSubtrees[pkg.ID]; repeated {
+				row.repeated = true
+				rows = append(rows, row)
+				return
+			}
+		}
 		rows = append(rows, row)
 
 		expanded := m.componentExpanded[pkg.ID]
@@ -2083,6 +2103,7 @@ func (m *scanModel) componentTreeRows(rootID string) []listPackageRow {
 		if err != nil || len(deps) == 0 {
 			return
 		}
+		renderedSubtrees[pkg.ID] = struct{}{}
 		sort.Slice(deps, func(i, j int) bool {
 			return packageSortKey(deps[i]) < packageSortKey(deps[j])
 		})
@@ -2193,6 +2214,14 @@ func componentDetails(graphValue *sdk.Graph, row listPackageRow, manifest listPa
 		appendPackages("Dependencies", deps)
 		dependents, _ := graphValue.Dependents(row.id)
 		appendPackages("Dependents", dependents)
+	}
+	if row.repeated {
+		lines = append(lines,
+			render.Style("Repeated branch", render.Bold, render.Yellow),
+			"",
+			render.Style("  This component already appears earlier in the tree; its dependency branch is not repeated here.", render.Dim),
+			"",
+		)
 	}
 
 	// Vulnerabilities section
@@ -2643,7 +2672,8 @@ func componentsByRelationshipLines(manifests []listPackageRow, graphValue *sdk.G
 		nameWidth = 16
 	}
 	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Direct", 8)+padRight("Transitive", 12)+"Root", render.Dim)}
-	for _, manifest := range manifests {
+	displayed, remaining := displayManifestsWithRemainder(manifests, 10)
+	for _, manifest := range displayed {
 		counts := map[string]int{"root": 0, "direct": 0, "transitive": 0}
 		for _, row := range componentCountRows(graphValue, manifest.rootID) {
 			counts[valueOrDefault(row.relationship, "transitive")]++
@@ -2654,6 +2684,9 @@ func componentsByRelationshipLines(manifests []listPackageRow, graphValue *sdk.G
 				padRight(fmt.Sprintf("%d", counts["transitive"]), 12)+
 				fmt.Sprintf("%d", counts["root"]),
 		)
+	}
+	if remaining > 0 {
+		lines = append(lines, render.Style(fmt.Sprintf("+ %d more manifests", remaining), render.Dim))
 	}
 	return lines
 }
@@ -2667,7 +2700,8 @@ func componentsByScopeLines(manifests []listPackageRow, graphValue *sdk.Graph, w
 		nameWidth = 16
 	}
 	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Runtime", 9)+padRight("Development", 13)+"Unset", render.Dim)}
-	for _, manifest := range manifests {
+	displayed, remaining := displayManifestsWithRemainder(manifests, 10)
+	for _, manifest := range displayed {
 		counts := map[string]int{"runtime": 0, "development": 0, "unset": 0}
 		for _, row := range componentCountRows(graphValue, manifest.rootID) {
 			scope := valueOrDefault(row.scope, "unset")
@@ -2683,7 +2717,17 @@ func componentsByScopeLines(manifests []listPackageRow, graphValue *sdk.Graph, w
 				fmt.Sprintf("%d", counts["unset"]),
 		)
 	}
+	if remaining > 0 {
+		lines = append(lines, render.Style(fmt.Sprintf("+ %d more manifests", remaining), render.Dim))
+	}
 	return lines
+}
+
+func displayManifestsWithRemainder(manifests []listPackageRow, limit int) ([]listPackageRow, int) {
+	if limit <= 0 || len(manifests) <= limit {
+		return manifests, 0
+	}
+	return manifests[:limit], len(manifests) - limit
 }
 
 func vulnerableComponentTotal(graphValue *sdk.Graph, findings []sdk.Finding) int {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -31,6 +31,7 @@ type filterModel interface {
 	CycleRelationshipFilter()
 	CycleScopeFilter()
 	CycleSeverityFilter()
+	CycleEcosystemFilter()
 }
 
 type tabbedModel interface {
@@ -126,16 +127,25 @@ type listPanel struct {
 const interactiveCommonNavigationHelp = "Up/Down or j/k move; PgUp/PgDn or Ctrl+u/Ctrl+d scroll details; Home/End or g/G jump; q quits"
 
 type listPackageRow struct {
-	id           string
-	rootID       string
-	targetID     string
-	displayName  string
-	version      string
-	scope        string
-	relationship string
-	purl         string
-	depth        int
-	tree         string
+	id               string
+	rootID           string
+	targetID         string
+	displayName      string
+	version          string
+	scope            string
+	ecosystem        string
+	relationship     string
+	purl             string
+	detectorName     string
+	origin           string
+	technique        string
+	packageManagers  string
+	plannedDetectors string
+	relativePath     string
+	targetKind       string
+	targetLocation   string
+	depth            int
+	tree             string
 }
 
 type rootDependencyGroup struct {
@@ -176,6 +186,8 @@ type scanModel struct {
 	relationshipFilter    string
 	scopeFilter           string
 	severityFilter        string
+	ecosystemFilter       string
+	explainQuery          string
 	sourceExpanded        map[string]bool
 	componentExpanded     map[string]bool
 	vulnerabilityGroup    string
@@ -283,6 +295,10 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "v":
 			if filterModel, ok := m.inner.(filterModel); ok {
 				filterModel.CycleSeverityFilter()
+			}
+		case "e":
+			if filterModel, ok := m.inner.(filterModel); ok {
+				filterModel.CycleEcosystemFilter()
 			}
 		case "enter":
 			if m.confirmQuit {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -136,6 +136,7 @@ type listPackageRow struct {
 	ecosystem        string
 	relationship     string
 	purl             string
+	repeated         bool
 	detectorName     string
 	origin           string
 	technique        string

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -142,13 +142,12 @@ func TestNewDiffInteractiveModel_ViewIncludesManifestChanges(t *testing.T) {
 	for _, want := range []string{
 		"DIFF",
 		"base -> head",
-		"[1] Diff",
+		"[1] Overview",
+		"[2] Added",
 		"package.json (npm)",
-		"Manifest changes",
-		"Package changes",
+		"Manifest Changes",
+		"Package Changes",
 		"Added packages",
-		"zod@3.23.0",
-		"react@19.0.0 (18.2.0 -> 19.0.0)",
 	} {
 		if !strings.Contains(render.StripANSI(view), want) {
 			t.Fatalf("expected view to contain %q, got:\n%s", want, view)
@@ -1113,5 +1112,36 @@ func TestNewDiffInteractiveModel_OrdersRemovedAddedChanged(t *testing.T) {
 	}
 	if got, want := model.items[2].subtitle, "changed"; got != want {
 		t.Fatalf("expected third item status %q, got %q", want, got)
+	}
+}
+
+func TestNewDiffInteractiveModel_UsesPackageTabs(t *testing.T) {
+	model := NewDiff(output.DiffResponse{
+		Comparison: output.DiffComparison{Base: "base", Head: "head"},
+		Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
+			Status:         "changed",
+			Path:           "package.json",
+			PackageManager: "npm",
+			Added:          []output.DiffPackageChange{{Package: output.PackageRef{Name: "zod", Version: "3.23.0"}}},
+			Removed:        []output.DiffPackageChange{{Package: output.PackageRef{Name: "left-pad", Version: "1.3.0"}}},
+			Changed:        []output.DiffChangedPackage{{Before: output.PackageRef{Name: "react", Version: "18.2.0"}, After: output.PackageRef{Name: "react", Version: "19.0.0"}}},
+		}}},
+		Summary: output.DiffSummary{AddedPackageCount: 1, RemovedPackageCount: 1, ChangedPackageCount: 1},
+	})
+
+	model.SelectView(2)
+	plain := render.StripANSI(model.View(100, 26))
+	if !strings.Contains(plain, "[2] Added") || !strings.Contains(plain, "zod@3.23.0") || strings.Contains(plain, "left-pad@1.3.0") {
+		t.Fatalf("expected added package tab, got:\n%s", plain)
+	}
+	model.SelectView(3)
+	plain = render.StripANSI(model.View(100, 26))
+	if !strings.Contains(plain, "[3] Removed") || !strings.Contains(plain, "left-pad@1.3.0") || strings.Contains(plain, "zod@3.23.0") {
+		t.Fatalf("expected removed package tab, got:\n%s", plain)
+	}
+	model.SelectView(4)
+	plain = render.StripANSI(model.View(100, 26))
+	if !strings.Contains(plain, "[4] Changed") || !strings.Contains(plain, "react@19.0.0") || !strings.Contains(plain, "react@18.2.0") {
+		t.Fatalf("expected changed package tab, got:\n%s", plain)
 	}
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -140,7 +140,9 @@ func TestNewDiffInteractiveModel_ViewIncludesManifestChanges(t *testing.T) {
 
 	view := model.View(100, 26)
 	for _, want := range []string{
-		"Bomly Interactive Diff: base -> head",
+		"DIFF",
+		"base -> head",
+		"[1] Diff",
 		"package.json (npm)",
 		"Manifest changes",
 		"Package changes",
@@ -681,6 +683,112 @@ func TestScanInteractiveModel_FiltersAndScopeBadges(t *testing.T) {
 	plain = render.StripANSI(model.View(100, 30))
 	if strings.Contains(plain, "demo-app@1.0.0  ROOT") || !strings.Contains(plain, "react@18.2.0") {
 		t.Fatalf("expected direct relationship filter to hide root row, got:\n%s", plain)
+	}
+}
+
+func TestScanInteractiveModel_EcosystemFilterUpdatesComponents(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewPackage(sdk.Package{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	npmDep := sdk.NewPackage(sdk.Package{Name: "react", Version: "18.2.0", Ecosystem: "npm"})
+	goDep := sdk.NewPackage(sdk.Package{Name: "cobra", Version: "1.8.0", Ecosystem: "go"})
+	for _, pkg := range []*sdk.Package{root, npmDep, goDep} {
+		if err := g.AddPackage(pkg); err != nil {
+			t.Fatalf("add package: %v", err)
+		}
+	}
+	for _, dep := range []*sdk.Package{npmDep, goDep} {
+		if err := g.AddDependency(root.ID, dep.ID); err != nil {
+			t.Fatalf("add dependency: %v", err)
+		}
+	}
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo-app"},
+			RelativePath:            ".",
+			PrimaryDetector:         "npm-detector",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Technique:    sdk.LockfileTechnique,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
+	model.SelectView(2)
+	model.ecosystemFilter = "npm"
+	model.rebuildListPreserveSelection()
+
+	plain := render.StripANSI(model.View(110, 32))
+	if !strings.Contains(plain, "Ecosystem: npm") || !strings.Contains(plain, "Components (2)") {
+		t.Fatalf("expected npm ecosystem filter state and count, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "react@18.2.0") || strings.Contains(plain, "cobra@1.8.0") {
+		t.Fatalf("expected ecosystem filter to keep npm rows only, got:\n%s", plain)
+	}
+}
+
+func TestScanInteractiveModel_ManifestDetailsIncludeDetectorMetadata(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewPackage(sdk.Package{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	if err := g.AddPackage(root); err != nil {
+		t.Fatalf("add package: %v", err)
+	}
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo-app"},
+			RelativePath:            ".",
+			PrimaryDetector:         "npm-detector",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			PlannedDetectors:        []string{"npm-detector", "syft-detector"},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Technique:    sdk.LockfileTechnique,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
+	model.SelectView(2)
+	model.Move(1)
+
+	plain := render.StripANSI(model.View(110, 32))
+	for _, want := range []string{"Detector", "Name: npm-detector", "Package managers: npm", "Planned chain: npm-detector, syft-detector"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected manifest details to contain %q, got:\n%s", want, plain)
+		}
+	}
+}
+
+func TestScanInteractiveModel_FindingsCanGroupByEcosystem(t *testing.T) {
+	pkg := sdk.NewPackage(sdk.Package{Name: "react", Version: "18.2.0", Ecosystem: "npm"})
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, sdk.ConsolidatedGraph{}, sdk.New(), []sdk.Finding{
+		{ID: "F-1", Kind: sdk.FindingKindPolicy, Severity: "high", Package: pkg},
+	})
+	model.SelectView(5)
+	for range 3 {
+		model.CycleGroup()
+	}
+
+	plain := render.StripANSI(model.View(100, 26))
+	if !strings.Contains(plain, "Group: ecosystem") || !strings.Contains(plain, "npm (1)") {
+		t.Fatalf("expected findings grouped by ecosystem, got:\n%s", plain)
+	}
+}
+
+func TestScanInteractiveModel_ExplainTopBarUsesQuery(t *testing.T) {
+	model := NewExplain(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, "react", sdk.ConsolidatedGraph{}, sdk.New(), nil)
+	plain := render.StripANSI(model.View(100, 26))
+	if !strings.Contains(plain, "EXPLAIN") || !strings.Contains(plain, "package: react") || strings.Contains(plain, "SCAN") {
+		t.Fatalf("expected explain top bar to include command and query, got:\n%s", plain)
 	}
 }
 

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -151,6 +151,8 @@ func badgeView(badge badge) string {
 		return render.Style(label, render.BgYellow, render.Bold)
 	case "severity-low":
 		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
+	case "repeated":
+		return render.Style(label, render.BgBlue, render.White)
 	default:
 		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
 	}
@@ -342,6 +344,9 @@ func packageBadges(row listPackageRow) []badge {
 		badges = append(badges, badge{label: row.scope, kind: "scope-runtime"})
 	case "development":
 		badges = append(badges, badge{label: row.scope, kind: "scope-development"})
+	}
+	if row.repeated {
+		badges = append(badges, badge{label: "repeated", kind: "repeated"})
 	}
 	return badges
 }


### PR DESCRIPTION
## Summary
- add ecosystem filtering to Components and ecosystem grouping to Findings
- add detector metadata to manifest details and replace the overview depended-on pane with relationship/scope summaries
- bring Diff into the newer interactive shell, fix Explain top-bar labeling/query display, and show user-facing URL/container target labels
- add `target_type` to project output schemas and regenerate schema docs

## Tests
- `go test ./internal/tui ./internal/cli/opts ./internal/output ./internal/cli/render ./internal/cli`
- `make generate`
- `make test`
- `go run ./internal/tools/gofmtcheck`
- `C:\Users\ahmed\go\bin\golangci-lint.exe run`