### PR TITLE
Improve dependency ID resolution for hoisted packages

### DIFF
--- a/internal/detectors/node/lockfile_integration_test.go
+++ b/internal/detectors/node/lockfile_integration_test.go
@@ -191,6 +191,20 @@ func TestNPMLockfileV3_Metadata(t *testing.T) {
 	}
 }
 
+func TestNPMLockfileV3_SingleApplicationRoot(t *testing.T) {
+	g, err := resolveLockfileGraph(t, npm.LockfileDetector{}, fixture("npm-v3"))
+	if err != nil {
+		t.Fatalf("depGraphFromNPMLockfile(npm-v3): %v", err)
+	}
+	roots := g.Roots()
+	if len(roots) != 1 {
+		t.Fatalf("expected exactly one root package, got %d: %v", len(roots), graphPackageIDs(g))
+	}
+	if roots[0].ID != stableID("demo-app", "3.0.0") {
+		t.Fatalf("expected npm root %q, got %q", stableID("demo-app", "3.0.0"), roots[0].ID)
+	}
+}
+
 // ---- pnpm v5 (old format, no importers) ------------------------------------
 
 func TestPNPMLockfileV5_OldFormat(t *testing.T) {
@@ -307,6 +321,20 @@ func TestYarnLockfileV1_Metadata(t *testing.T) {
 	}
 	requireResolvedURL(t, g, "react", "18.2.0")
 	requireDigest(t, g, "react", "18.2.0", "sha512")
+}
+
+func TestYarnLockfileV1_SingleApplicationRoot(t *testing.T) {
+	g, err := resolveLockfileGraph(t, yarn.LockfileDetector{}, fixture("yarn-v1"))
+	if err != nil {
+		t.Fatalf("depGraphFromYarnLockfile(yarn-v1): %v", err)
+	}
+	roots := g.Roots()
+	if len(roots) != 1 {
+		t.Fatalf("expected exactly one root package, got %d: %v", len(roots), graphPackageIDs(g))
+	}
+	if roots[0].ID != stableID("demo-app", "1.0.0") {
+		t.Fatalf("expected yarn root %q, got %q", stableID("demo-app", "1.0.0"), roots[0].ID)
+	}
 }
 
 // ---- yarn Berry (v2+) ------------------------------------------------------

--- a/internal/detectors/node/npm/npm_lockfile_parser.go
+++ b/internal/detectors/node/npm/npm_lockfile_parser.go
@@ -218,7 +218,7 @@ func recordDependencyScopes(target map[string]sdk.Scope, dependencies map[string
 }
 
 func resolveNPMLockDependencyID(parentPath string, dependencyName string, dependencyVersion string, lockfile npmPackageLock, pathToID map[string]string) (string, bool) {
-	searchBase := parentPath
+	searchBase := strings.TrimPrefix(strings.TrimSpace(strings.ReplaceAll(parentPath, "\\", "/")), "./")
 	for {
 		candidate := "node_modules/" + dependencyName
 		if searchBase != "" {
@@ -227,11 +227,18 @@ func resolveNPMLockDependencyID(parentPath string, dependencyName string, depend
 		if id, ok := pathToID[candidate]; ok {
 			return id, true
 		}
-		idx := strings.LastIndex(searchBase, "/node_modules/")
-		if idx < 0 {
+		if searchBase == "" {
 			break
 		}
-		searchBase = searchBase[:idx]
+		if idx := strings.LastIndex(searchBase, "/node_modules/"); idx >= 0 {
+			searchBase = searchBase[:idx]
+			continue
+		}
+		if strings.HasPrefix(searchBase, "node_modules/") {
+			searchBase = ""
+			continue
+		}
+		break
 	}
 
 	normalizedDepVersion := node.NormalizeVersionToken(dependencyVersion)

--- a/internal/detectors/node/npm/npm_lockfile_parser_test.go
+++ b/internal/detectors/node/npm/npm_lockfile_parser_test.go
@@ -76,3 +76,30 @@ func TestResolveNPMLockDependencyIDFallsBackDeterministically(t *testing.T) {
 		t.Fatalf("expected lexicographically first package path to win, got %q", got)
 	}
 }
+
+func TestResolveNPMLockDependencyIDResolvesHoistedFromTopLevelParent(t *testing.T) {
+	lockfile := npmPackageLock{
+		Packages: map[string]npmLockPackage{
+			"node_modules/cliui/node_modules/string-width": {
+				Name:    "string-width",
+				Version: "3.1.0",
+			},
+			"node_modules/string-width": {
+				Name:    "string-width",
+				Version: "2.1.1",
+			},
+		},
+	}
+	pathToID := map[string]string{
+		"node_modules/cliui/node_modules/string-width": "pkg:npm/string-width@3.1.0",
+		"node_modules/string-width":                    "pkg:npm/string-width@2.1.1",
+	}
+
+	got, ok := resolveNPMLockDependencyID("node_modules/wide-align", "string-width", "^1.0.2 || 2", lockfile, pathToID)
+	if !ok {
+		t.Fatal("expected hoisted dependency resolution to succeed")
+	}
+	if got != "pkg:npm/string-width@2.1.1" {
+		t.Fatalf("expected top-level hoisted package to be selected, got %q", got)
+	}
+}

--- a/internal/detectors/node/yarn/yarn_lockfile_parser.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser.go
@@ -48,6 +48,14 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 	entryNodeByIndex := make(map[int]string, len(entries))
 	entriesByName := make(map[string][]int)
 	for idx, entry := range entries {
+		entriesByName[entry.Name] = append(entriesByName[entry.Name], idx)
+	}
+
+	addEntryNode := func(idx int) (string, error) {
+		if id, ok := entryNodeByIndex[idx]; ok {
+			return id, nil
+		}
+		entry := entries[idx]
 		pkg := sdk.Package{
 			Ecosystem:   string(sdk.EcosystemNPM),
 			Name:        entry.Name,
@@ -57,10 +65,10 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 		}
 		pkgNode := sdk.NewPackage(pkg)
 		if err := node.AddNodeIfMissing(depsGraph, pkgNode); err != nil {
-			return nil, err
+			return "", err
 		}
 		entryNodeByIndex[idx] = pkgNode.ID
-		entriesByName[entry.Name] = append(entriesByName[entry.Name], idx)
+		return pkgNode.ID, nil
 	}
 
 	runtimeDeps := node.MergeStringMaps(manifest.Dependencies, node.MergeStringMaps(manifest.OptionalDependencies, manifest.PeerDependencies))
@@ -72,8 +80,12 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 		if !ok {
 			continue
 		}
-		if err := depsGraph.AddDependency(rootNode.ID, entryNodeByIndex[entryIdx]); err != nil {
-			return nil, fmt.Errorf("add yarn root dependency %q -> %q: %w", rootNode.ID, entryNodeByIndex[entryIdx], err)
+		entryID, err := addEntryNode(entryIdx)
+		if err != nil {
+			return nil, err
+		}
+		if err := depsGraph.AddDependency(rootNode.ID, entryID); err != nil {
+			return nil, fmt.Errorf("add yarn root dependency %q -> %q: %w", rootNode.ID, entryID, err)
 		}
 		queue = append(queue, entryIdx)
 	}
@@ -86,12 +98,19 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 		}
 		seen[current] = struct{}{}
 
-		parentID := entryNodeByIndex[current]
+		parentID, err := addEntryNode(current)
+		if err != nil {
+			return nil, err
+		}
 		for dependencyName, requested := range entries[current].Dependencies {
 			entryIdx, ok := selectYarnEntry(entries, entriesByName, dependencyName, requested)
 			if ok {
-				if err := depsGraph.AddDependency(parentID, entryNodeByIndex[entryIdx]); err != nil {
-					return nil, fmt.Errorf("add yarn dependency %q -> %q: %w", parentID, entryNodeByIndex[entryIdx], err)
+				entryID, err := addEntryNode(entryIdx)
+				if err != nil {
+					return nil, err
+				}
+				if err := depsGraph.AddDependency(parentID, entryID); err != nil {
+					return nil, fmt.Errorf("add yarn dependency %q -> %q: %w", parentID, entryID, err)
 				}
 				queue = append(queue, entryIdx)
 				continue

--- a/internal/detectors/node/yarn/yarn_lockfile_parser_test.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser_test.go
@@ -1,0 +1,52 @@
+package yarn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestYarnLockfileParserSkipsUnreachableEntries(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "left-pad": "^1.3.0"
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "yarn.lock"), []byte(`left-pad@^1.3.0:
+  version "1.3.0"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+
+tweetnacl@^0.14.0:
+  version "0.14.5"
+`), 0o644); err != nil {
+		t.Fatalf("write yarn.lock: %v", err)
+	}
+
+	graph, err := depGraphFromYarnLockfile(projectDir)
+	if err != nil {
+		t.Fatalf("depGraphFromYarnLockfile() error = %v", err)
+	}
+	if graph.Size() != 2 {
+		t.Fatalf("expected only root + reachable dependency packages, got %d", graph.Size())
+	}
+	if _, ok := graph.Package("bcrypt-pbkdf@1.0.2"); ok {
+		t.Fatal("expected unreachable bcrypt-pbkdf entry to be excluded")
+	}
+	if _, ok := graph.Package("tweetnacl@0.14.5"); ok {
+		t.Fatal("expected unreachable tweetnacl entry to be excluded")
+	}
+	roots := graph.Roots()
+	if len(roots) != 1 {
+		t.Fatalf("expected single root package, got %d", len(roots))
+	}
+	if roots[0] == nil || roots[0].ID != "demo-app@1.0.0" {
+		t.Fatalf("expected app root demo-app@1.0.0, got %#v", roots[0])
+	}
+}

--- a/internal/engine/consolidation/consolidation_test.go
+++ b/internal/engine/consolidation/consolidation_test.go
@@ -253,6 +253,62 @@ func TestConsolidateGraphs_SynthesizesManifestRootWhenEntryHasMultipleRoots(t *t
 	}
 }
 
+func TestConsolidateGraphs_PrefersApplicationRootWhenEntryHasMultipleRoots(t *testing.T) {
+	npmGraph := sdk.New()
+	app := sdk.NewPackage(sdk.Package{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0", Type: "application"})
+	react := sdk.NewPackage(sdk.Package{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
+	orphan := sdk.NewPackage(sdk.Package{Ecosystem: "npm", Name: "string-width", Version: "2.1.1"})
+	for _, pkg := range []*sdk.Package{app, react, orphan} {
+		if err := npmGraph.AddPackage(pkg); err != nil {
+			t.Fatalf("add %s: %v", pkg.ID, err)
+		}
+	}
+	if err := npmGraph.AddDependency(app.ID, react.ID); err != nil {
+		t.Fatalf("link app->react: %v", err)
+	}
+
+	consolidated, err := ConsolidateGraphs([]sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetWorkingDirectory, Location: "/repo"},
+			RelativePath:            ".",
+			PrimaryDetector:         "npm-detector",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Graphs: sdk.SingleGraphContainer(npmGraph, sdk.ManifestMetadata{
+			Path: "package-lock.json",
+			Kind: "package-lock.json",
+		}),
+	}})
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs() error = %v", err)
+	}
+
+	if len(consolidated.Manifests) != 1 {
+		t.Fatalf("expected 1 manifest, got %d", len(consolidated.Manifests))
+	}
+	if consolidated.Manifests[0].RootManifestID != "pkg:npm/demo-app@1.0.0" {
+		t.Fatalf("expected root manifest ID to be application package, got %q", consolidated.Manifests[0].RootManifestID)
+	}
+
+	mergedGraph, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	if _, ok := mergedGraph.Package("package-lock.json"); ok {
+		t.Fatal("did not expect synthesized manifest package for npm graph with application root")
+	}
+
+	deps, err := mergedGraph.Dependencies("pkg:npm/demo-app@1.0.0")
+	if err != nil {
+		t.Fatalf("Dependencies(app) error = %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("expected application root to depend on both original roots, got %d", len(deps))
+	}
+}
+
 type nodeFixture struct {
 	id      string
 	name    string

--- a/internal/engine/consolidation/manifest.go
+++ b/internal/engine/consolidation/manifest.go
@@ -150,6 +150,22 @@ func ensureEntryRoot(g *sdk.Graph, manifest sdk.ManifestMetadata, idx int) error
 		return nil
 	}
 
+	roots := g.Roots()
+	if preferred := selectApplicationRoot(roots); preferred != nil {
+		for _, target := range roots {
+			if target == nil || target.ID == preferred.ID {
+				continue
+			}
+			if err := g.AddDependency(preferred.ID, target.ID); err != nil {
+				if errors.Is(err, sdk.ErrSelfDependency) {
+					continue
+				}
+				return fmt.Errorf("attach application root %q -> %q: %w", preferred.ID, target.ID, err)
+			}
+		}
+		return nil
+	}
+
 	rootID := virtualManifestRootID(g, manifest, idx)
 	manifestLabel := strings.TrimSpace(manifest.Path)
 	if manifestLabel == "" {
@@ -187,6 +203,18 @@ func ensureEntryRoot(g *sdk.Graph, manifest sdk.ManifestMetadata, idx int) error
 		}
 	}
 
+	return nil
+}
+
+func selectApplicationRoot(roots []*sdk.Package) *sdk.Package {
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(root.Type), "application") {
+			return root
+		}
+	}
 	return nil
 }
 

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/engine/consolidation"
 	"github.com/bomly-dev/bomly-cli/internal/engine/hooks"
@@ -65,6 +66,7 @@ func (p *Pipeline) runPre(ctx context.Context, req PipelineRequest) error {
 func (p *Pipeline) runResolve(ctx context.Context, result *PipelineResult, req PipelineRequest) error {
 	resolveResults, resolveErr := p.resolveAll(ctx, req)
 	result.ResolveResults = resolveResults
+	p.logUnexpectedMultiRootResolveGraphs(resolveResults)
 	if resolveErr != nil && len(resolveResults) == 0 {
 		return fmt.Errorf("dependency resolution: %w", resolveErr)
 	}
@@ -106,7 +108,58 @@ func (p *Pipeline) runConsolidate(result *PipelineResult, req PipelineRequest) e
 		}
 	}
 	result.Graph = selectedGraph
+	p.logUnexpectedMultiRootGraph("consolidated", "", "", selectedGraph, sdk.ManifestMetadata{})
 	return nil
+}
+
+func (p *Pipeline) logUnexpectedMultiRootResolveGraphs(results []sdk.DetectionResult) {
+	for _, result := range results {
+		if result.Graphs == nil {
+			continue
+		}
+		for _, entry := range result.Graphs.Entries {
+			p.logUnexpectedMultiRootGraph(
+				"resolve",
+				result.DetectorName,
+				result.SubprojectInfo.RelativePath,
+				entry.Graph,
+				entry.Manifest,
+			)
+		}
+	}
+}
+
+func (p *Pipeline) logUnexpectedMultiRootGraph(stage, detector, subproject string, graph *sdk.Graph, manifest sdk.ManifestMetadata) {
+	if p == nil || p.Logger == nil || graph == nil {
+		return
+	}
+	roots := graph.Roots()
+	if len(roots) <= 1 {
+		return
+	}
+	hasApplicationRoot := false
+	rootIDs := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+		rootIDs = append(rootIDs, root.ID)
+		if strings.EqualFold(strings.TrimSpace(root.Type), "application") {
+			hasApplicationRoot = true
+		}
+	}
+	if !hasApplicationRoot {
+		return
+	}
+	p.Logger.Warn(
+		"pipeline: unexpected multi-root graph detected",
+		zap.String("stage", stage),
+		zap.String("detector", detector),
+		zap.String("subproject", subproject),
+		zap.String("manifest_path", strings.TrimSpace(manifest.Path)),
+		zap.Int("root_count", len(roots)),
+		zap.Strings("root_ids", rootIDs),
+	)
 }
 
 func (p *Pipeline) runMatch(ctx context.Context, result *PipelineResult, req PipelineRequest) {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes focused on handling dependency graphs for Node.js lockfiles (npm, yarn), particularly around multi-root graphs, root selection, and dependency resolution. The changes ensure that application roots are preferred when present, unreachable dependencies are excluded from the graph, and dependency resolution logic is more robust and deterministic. Additional logging is added to help diagnose unexpected multi-root scenarios.

**Dependency graph root handling and consolidation:**

* When a dependency graph has multiple roots, the code now prefers an "application" root if present, linking other roots to it, and only synthesizes a manifest root if no application root exists (`internal/engine/consolidation/manifest.go`, `internal/engine/consolidation/consolidation_test.go`). [[1]](diffhunk://#diff-19bac161052fda1cbc35f3880d0d48139699a4e5e91a60e64be75aa8449fa162R153-R168) [[2]](diffhunk://#diff-19bac161052fda1cbc35f3880d0d48139699a4e5e91a60e64be75aa8449fa162R209-R220) [[3]](diffhunk://#diff-3df237bfdf7735fd84094f568a40d96224a83aeda23b92fa6b494059302db87dR256-R311)
* Added logging to warn when a multi-root graph is detected during dependency resolution or consolidation, but only if an application root is present (`internal/engine/pipeline.go`). [[1]](diffhunk://#diff-0738eb0f2b6a65dd5a9a95899e519da96f9a162c7b0719830a00e7cedeca1e54R69) [[2]](diffhunk://#diff-0738eb0f2b6a65dd5a9a95899e519da96f9a162c7b0719830a00e7cedeca1e54R111-R164)

**Node lockfile parsing and dependency resolution:**

* Improved the npm lockfile dependency resolution logic to handle hoisted dependencies from the top-level parent more reliably, and added a test to verify this behavior (`internal/detectors/node/npm/npm_lockfile_parser.go`, `internal/detectors/node/npm/npm_lockfile_parser_test.go`). [[1]](diffhunk://#diff-2392419bc6d8baffea1f31c11e899ca81aa062ee17a48082e1861d436fea6dc9L221-R221) [[2]](diffhunk://#diff-2392419bc6d8baffea1f31c11e899ca81aa062ee17a48082e1861d436fea6dc9L230-R241) [[3]](diffhunk://#diff-8a516f6c056f1cb0e523ac347959f24bbe95a1af62327361c1f5decaf3bd153aR79-R105)

**Yarn lockfile graph construction:**

* Refactored the yarn lockfile parser to ensure that only reachable dependencies from the root are included in the graph, and added a test to confirm unreachable entries are excluded (`internal/detectors/node/yarn/yarn_lockfile_parser.go`, `internal/detectors/node/yarn/yarn_lockfile_parser_test.go`). [[1]](diffhunk://#diff-adf44716c21ac83950b334eb0bb807c3c8d38732cc3cf58e8c02a636494c30d0R51-R58) [[2]](diffhunk://#diff-adf44716c21ac83950b334eb0bb807c3c8d38732cc3cf58e8c02a636494c30d0L60-R71) [[3]](diffhunk://#diff-adf44716c21ac83950b334eb0bb807c3c8d38732cc3cf58e8c02a636494c30d0L75-R88) [[4]](diffhunk://#diff-adf44716c21ac83950b334eb0bb807c3c8d38732cc3cf58e8c02a636494c30d0L89-R113) [[5]](diffhunk://#diff-88c953ca152d6f58c5eb3f715f11bfee5af75179e2cee3f947ca89731ddef67dR1-R52)

**Test coverage improvements:**

* Added integration tests to verify that npm and yarn lockfile graphs have exactly one application root when expected (`internal/detectors/node/lockfile_integration_test.go`). [[1]](diffhunk://#diff-a224034bdc5d76ff2850c57101755087f4c078338dfd4e860549e73838f07e57R194-R207) [[2]](diffhunk://#diff-a224034bdc5d76ff2850c57101755087f4c078338dfd4e860549e73838f07e57R326-R339)

These changes improve the accuracy and maintainability of dependency graph construction and root handling, especially for complex Node.js projects with multiple roots or hoisted dependencies.