### PR TITLE
Refactor workflows for improved artifact handling and permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -34,12 +35,17 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
-  licenses:
+  publish:
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -52,86 +58,51 @@ jobs:
       - name: Generate third-party license notices
         run: make licenses
 
-      - name: Upload license notices
-        uses: actions/upload-artifact@v4
-        with:
-          name: licenses
-          path: licenses/
-          retention-days: 1
-
-  package:
-    needs: [validate, licenses]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-          - goos: windows
-            goarch: arm64
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: |
-            go.sum
-
-      - name: Download license notices
-        uses: actions/download-artifact@v5
-        with:
-          name: licenses
-          path: licenses/
-
       - name: Build release archives
         shell: bash
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
           repo_root="${PWD}"
           binary_version="${VERSION#v}"
-          ext=""
-          archive_ext="tar.gz"
-          if [[ "${GOOS}" == "windows" ]]; then
-            ext=".exe"
-            archive_ext="zip"
-          fi
-
           mkdir -p dist
+
+          targets=(
+            "linux amd64"
+            "linux arm64"
+            "darwin amd64"
+            "darwin arm64"
+            "windows amd64"
+            "windows arm64"
+          )
 
           build_archive() {
             local archive_base="$1"
             local binary_name="$2"
             local build_tags="$3"
+            local target_goos="$4"
+            local target_goarch="$5"
             local stage_dir
             stage_dir="$(mktemp -d)"
 
+            local ext=""
+            local archive_ext="tar.gz"
+            if [[ "${target_goos}" == "windows" ]]; then
+              ext=".exe"
+              archive_ext="zip"
+            fi
+
             if [[ -n "${build_tags}" ]]; then
-              GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED=0 go build \
+              GOOS="${target_goos}" GOARCH="${target_goarch}" CGO_ENABLED=0 go build \
                 -trimpath \
                 -tags "${build_tags}" \
                 -ldflags "-s -w -X main.version=${binary_version}" \
                 -o "${stage_dir}/${binary_name}${ext}" \
                 ./cmd/bomly
             else
-              GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED=0 go build \
+              GOOS="${target_goos}" GOARCH="${target_goarch}" CGO_ENABLED=0 go build \
                 -trimpath \
                 -ldflags "-s -w -X main.version=${binary_version}" \
                 -o "${stage_dir}/${binary_name}${ext}" \
@@ -142,7 +113,7 @@ jobs:
             cp "${repo_root}/LICENSE" "${stage_dir}/LICENSE"
             cp "${repo_root}/NOTICE" "${stage_dir}/NOTICE"
 
-            local archive_path="dist/${archive_base}_${VERSION}_${GOOS}_${GOARCH}.${archive_ext}"
+            local archive_path="dist/${archive_base}_${VERSION}_${target_goos}_${target_goarch}.${archive_ext}"
             if [[ "${archive_ext}" == "zip" ]]; then
               (
                 cd "${stage_dir}"
@@ -155,33 +126,11 @@ jobs:
             rm -rf "${stage_dir}"
           }
 
-          build_archive "bomly" "bomly" ""
-          build_archive "bomly-lite" "bomly-lite" "bomly_external_syft,bomly_external_grype"
-
-      - name: Upload packaged artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/*
-          retention-days: 1
-
-  publish:
-    needs: package
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Download packaged artifacts
-        uses: actions/download-artifact@v5
-        with:
-          path: dist
-          pattern: release-*
-          merge-multiple: true
+          for target in "${targets[@]}"; do
+            read -r target_goos target_goarch <<< "${target}"
+            build_archive "bomly" "bomly" "" "${target_goos}" "${target_goarch}"
+            build_archive "bomly-lite" "bomly-lite" "bomly_external_syft,bomly_external_grype" "${target_goos}" "${target_goarch}"
+          done
 
       - name: Generate checksums
         shell: bash

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -124,28 +124,9 @@ jobs:
         continue-on-error: true
         run: make smoke ARGS="-run '${{ matrix.slice.run }}'"
 
-      - name: Regenerate candidate golden files
-        if: steps.smoke_tests.outcome == 'failure'
-        shell: bash
-        run: |
-          set -euo pipefail
-          make smoke ARGS="-run '${{ matrix.slice.run }}' -update"
-          mkdir -p smoke-artifacts
-          git diff -- test/smoke/testdata/golden > smoke-artifacts/golden.diff || true
-          cp -R test/smoke/testdata/golden smoke-artifacts/updated-golden
-
-      - name: Upload candidate golden files
-        if: steps.smoke_tests.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoke-updated-goldens-${{ matrix.slice.name }}
-          path: |
-            smoke-artifacts
-          if-no-files-found: ignore
-          retention-days: 3
-
       - name: Fail job if smoke tests failed
         if: steps.smoke_tests.outcome == 'failure'
         run: |
-          echo "Smoke tests failed. Candidate updated golden files were uploaded as an artifact for review."
+          echo "Smoke tests failed. Check the logs above for details."
+          echo "Use Update Smoke Goldens workflow to update golden files if the failures are due to expected changes."
           exit 1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for release and smoke testing to simplify the release process, improve maintainability, and clarify test failure messaging. The most significant changes involve consolidating and streamlining the release workflow, removing intermediate artifact steps, and updating smoke test handling.

**Release workflow simplification and improvements:**

* Merged the `licenses`, `package`, and `publish` jobs into a single `publish` job, eliminating the need for intermediate artifact uploads and downloads. The build process now loops over all target OS/architecture combinations directly within the job, simplifying the workflow and reducing complexity. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R48) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-R105) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L158-R133)
* Added timeouts to both the `validate` and `publish` jobs to prevent long-running or stuck jobs (`validate`: 30 minutes, `publish`: 45 minutes). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R19) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R48)
* Adjusted permissions for the workflow and jobs: the top-level workflow now defaults to `contents: read`, while `publish` is explicitly granted `contents: write` as needed. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L10-R10) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R48)

**Build process improvements:**

* Refactored the build script to loop over a list of target OS/architecture pairs, rather than using a matrix strategy, making the build logic more explicit and easier to maintain. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-R105) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L158-R133)
* Fixed archive naming to use the correct target OS/arch variables, ensuring generated artifacts are properly named.

**Smoke test workflow updates:**

* Removed the automatic regeneration and upload of candidate golden files on smoke test failure. Instead, the workflow now instructs users to use a dedicated "Update Smoke Goldens" workflow if golden files need updating, making the process more intentional and reducing unnecessary artifact uploads.