### PR TITLE
feat: enhance help command with examples and exit codes section

### DIFF
--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -31,8 +31,11 @@ func newDiffCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff --base <ref> --head <ref>",
 		Short: "Compare dependency states",
-		Long:  "Compare dependency states between two git refs or two container image tags/digests.",
-		Args:  cobra.NoArgs,
+		Long:  "Compare dependency states between two git refs, two SBOM files, or two container image tags/digests.",
+		Example: "  bomly diff --url https://github.com/bomly-dev/bomly-cli --base main --head feature\n" +
+			"  bomly diff --container alpine --base 3.19 --head 3.20 --enrich\n" +
+			"  bomly diff --sbom --base ./before.cdx.json --head ./after.cdx.json --format json",
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options, err := commandOptions(cmd)
 			if err != nil {

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -18,6 +18,8 @@ func newExplainCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "explain <package>",
 		Short: "Explain why a dependency exists",
+		Example: "  bomly explain pkg:npm/react\n" +
+			"  bomly explain github.com/spf13/cobra --path .",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return exit.InvalidInputError("explain expects exactly one package argument")

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -9,7 +9,7 @@ import (
 const rootHelpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
 {{end}}Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.UseLine}}{{else if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
@@ -25,7 +25,7 @@ Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{optionValuesHelpSection .}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{exitCodesHelpSection .}}{{optionValuesHelpSection .}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
@@ -47,14 +47,20 @@ func optionValuesHelpSection(cmd *cobra.Command) string {
 	return "\n\nExplore available detectors, matchers, and auditors with `bomly plugin list`."
 }
 
-// startupLogoHelpFunc wraps the root command's help function so that running
-// `bomly help` plays the Bomly logo animation before printing help text.
+func exitCodesHelpSection(cmd *cobra.Command) string {
+	if cmd == nil || cmd.Parent() != nil {
+		return ""
+	}
+
+	return "\n\nExit Codes:\n  0 success\n  1 execution error\n  2 policy violation\n  3 resolution failure\n  4 invalid input"
+}
+
+// startupLogoHelpFunc wraps Cobra's default help function so the Bomly logo
+// animation plays before rendering help output.
 func startupLogoHelpFunc(root *cobra.Command) func(*cobra.Command, []string) {
 	defaultHelp := root.HelpFunc()
 	return func(cmd *cobra.Command, args []string) {
-		if cmd == root {
-			render.StartupLogo(cmd.ErrOrStderr())
-		}
+		render.StartupLogo(cmd.ErrOrStderr())
 		defaultHelp(cmd, args)
 	}
 }

--- a/internal/cli/help_cmd_test.go
+++ b/internal/cli/help_cmd_test.go
@@ -23,3 +23,24 @@ func TestOptionValuesHelpSection(t *testing.T) {
 		t.Fatalf("expected plugin list hint, got %q", got)
 	}
 }
+
+func TestExitCodesHelpSection(t *testing.T) {
+	if got := exitCodesHelpSection(nil); got != "" {
+		t.Fatalf("expected empty section for nil command, got %q", got)
+	}
+
+	root := &cobra.Command{Use: "bomly"}
+	got := exitCodesHelpSection(root)
+	if !strings.Contains(got, "Exit Codes:") {
+		t.Fatalf("expected exit code section, got %q", got)
+	}
+	if !strings.Contains(got, "4 invalid input") {
+		t.Fatalf("expected invalid input description, got %q", got)
+	}
+
+	child := &cobra.Command{Use: "scan"}
+	root.AddCommand(child)
+	if got := exitCodesHelpSection(child); got != "" {
+		t.Fatalf("expected empty section for subcommand, got %q", got)
+	}
+}

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -7,34 +7,85 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/config"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+)
+
+type FlagGroup string
+
+const (
+	FlagGroupTarget    FlagGroup = "target"
+	FlagGroupAnalysis  FlagGroup = "analysis"
+	FlagGroupSelectors FlagGroup = "selectors"
+	FlagGroupExecution FlagGroup = "execution"
 )
 
 func bindFlagOptions(cmd *cobra.Command, cfg *config.Resolved) error {
 	flags := cmd.PersistentFlags()
+	flags.StringVar(&cfg.Config, "config", "", "YAML config file path")
+	flags.BoolVarP(&cfg.Quiet, "quiet", "q", false, "Suppress non-error stderr output")
+	flags.CountVarP(&cfg.Verbosity, "verbose", "v", "Increase verbosity (-v = info, -vv = debug)")
+
+	return nil
+}
+
+func BindCommandFlagGroups(cmd *cobra.Command, cfg *config.Resolved, groups ...FlagGroup) error {
+	if cmd == nil || cfg == nil {
+		return nil
+	}
+
+	seen := make(map[FlagGroup]struct{}, len(groups))
+	for _, group := range groups {
+		if _, ok := seen[group]; ok {
+			continue
+		}
+		seen[group] = struct{}{}
+		switch group {
+		case FlagGroupTarget:
+			bindTargetFlags(cmd.Flags(), cfg)
+		case FlagGroupAnalysis:
+			bindAnalysisFlags(cmd.Flags(), cfg)
+		case FlagGroupSelectors:
+			bindSelectorFlags(cmd.Flags(), cfg)
+			if err := bindSelectorCompletionFlags(cmd); err != nil {
+				return err
+			}
+		case FlagGroupExecution:
+			bindExecutionFlags(cmd.Flags(), cfg)
+		}
+	}
+
+	return nil
+}
+
+func bindTargetFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.StringVar(&cfg.Path, "path", "", "Execution target path")
 	flags.StringVar(&cfg.Container, "container", "", "Container image reference to scan with Syft")
 	flags.StringVar(&cfg.URL, "url", "", "Git repository URL to clone and scan")
 	flags.StringVar(&cfg.Ref, "ref", "", "Git reference to scan when using --url")
 	flags.BoolVar(&cfg.SBOM, "sbom", false, "Treat the selected filesystem target as an SBOM file")
+}
+
+func bindAnalysisFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.BoolVar(&cfg.Enrich, "enrich", false, "Enrich packages with external license and vulnerability data")
 	flags.BoolVar(&cfg.Audit, "audit", false, "Evaluate policy and create findings from package vulnerability data")
-	flags.BoolVar(&cfg.Reachability, "reachability", false, "Run code analysis to confirm whether vulnerabilities are reachable from application code")
+	flags.BoolVar(&cfg.Reachability, "reachability", false, "[Experimental] Run code analysis to confirm whether vulnerabilities are reachable from application code")
 	flags.StringArrayVar(&cfg.FailOn, "fail-on", nil, "Constraint(s) for which findings should be created. Repeatable; constraints AND together. Severity: any|low|medium|high|critical. Reachability: reachable. Example: --fail-on low --fail-on reachable")
+}
+
+func bindSelectorFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.StringVar(&cfg.Analyzers, "analyzers", "", "Reachability analyzer selectors. Use names. Prefix with '+' to append defaults or '-' to remove from defaults")
-	flags.StringVarP(&cfg.Format, "format", "f", "", "Output format: text, json, sarif")
-	flags.BoolVar(&cfg.Interactive, "interactive", false, "Open an interactive terminal UI")
 	flags.StringVar(&cfg.Ecosystems, "ecosystems", "", "Ecosystems to use; supports +name/-name to add/remove from all")
 	flags.StringVar(&cfg.Detectors, "detectors", "", "Detector selectors. Use names or aliases. Prefix with '+' to append defaults or '-' to remove from defaults")
 	flags.StringVar(&cfg.Auditors, "auditors", "", "Auditor selectors. Use names or aliases. Prefix with '+' to append defaults or '-' to remove from defaults")
 	flags.StringVar(&cfg.Matchers, "matchers", "", "Matcher selectors. Use names or aliases. Prefix with '+' to append defaults or '-' to remove from defaults")
+}
+
+func bindExecutionFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
+	flags.StringVarP(&cfg.Format, "format", "f", "", "Output format: text, json, sarif")
+	flags.BoolVar(&cfg.Interactive, "interactive", false, "Open an interactive terminal UI")
 	flags.BoolVar(&cfg.InstallFirst, "install-first", false, "Run detector-specific dependency installation before resolving graphs")
 	flags.StringArrayVar(&cfg.InstallArgs, "install-arg", nil, "Additional detector-specific install argument; may be repeated")
-	flags.StringVar(&cfg.Config, "config", "", "YAML config file path")
-	flags.BoolVarP(&cfg.Quiet, "quiet", "q", false, "Suppress non-error stderr output")
-	flags.CountVarP(&cfg.Verbosity, "verbose", "v", "Increase verbosity (-v = info, -vv = debug)")
-
-	return bindDynamicFlagOptions(cmd)
 }
 
 func applyFlagOverrides(dst *config.Resolved, flags config.Resolved, cmd *cobra.Command) {
@@ -120,7 +171,7 @@ func flagChanged(cmd *cobra.Command, name string) bool {
 	return false
 }
 
-func bindDynamicFlagOptions(cmd *cobra.Command) error {
+func bindSelectorCompletionFlags(cmd *cobra.Command) error {
 	ecosystems := availableEcosystemOptions()
 	detectors := availableDetectorOptions()
 	auditors := availableAuditorOptions(zap.NewNop())

--- a/internal/cli/opts/flag_options_test.go
+++ b/internal/cli/opts/flag_options_test.go
@@ -12,6 +12,9 @@ func TestApplyFlagOverridesOnlyUsesChangedFlags(t *testing.T) {
 	if err := options.Bind(root); err != nil {
 		t.Fatalf("Bind() error = %v", err)
 	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupExecution); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
+	}
 	if err := root.ParseFlags([]string{"--format", "json", "--install-arg", "legacy-peer-deps"}); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)
 	}

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -283,10 +283,15 @@ func TestCommandContextBind_AnnotatesUsageWithAvailableOptions(t *testing.T) {
 		t.Fatalf("Bind() error = %v", err)
 	}
 
-	for _, flagName := range []string{"ecosystems", "detectors", "auditors", "matchers"} {
+	for _, flagName := range []string{"config", "quiet", "verbose"} {
 		flag := root.PersistentFlags().Lookup(flagName)
 		if flag == nil {
 			t.Fatalf("expected flag %q to exist", flagName)
+		}
+	}
+	for _, flagName := range []string{"ecosystems", "detectors", "auditors", "matchers"} {
+		if flag := root.PersistentFlags().Lookup(flagName); flag != nil {
+			t.Fatalf("expected non-global flag %q to be command-scoped", flagName)
 		}
 	}
 }
@@ -341,6 +346,9 @@ func TestCommandContextInitialize_LoadsConfigHierarchy(t *testing.T) {
 	root := newTestRootCommand(t)
 	if err := options.Bind(root); err != nil {
 		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupSelectors); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
 	}
 	root.SetArgs([]string{"--config", explicitConfig, "--ecosystems", "python"})
 	if err := root.ParseFlags(root.Flags().Args()); err != nil {
@@ -412,6 +420,9 @@ func TestCommandContextInitialize_AppliesConfigPrecedence(t *testing.T) {
 	root := newTestRootCommand(t)
 	if err := options.Bind(root); err != nil {
 		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupAnalysis, FlagGroupSelectors); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
 	}
 	if err := root.ParseFlags([]string{"--config", explicitConfig, "--fail-on", "low", "--ecosystems", "python"}); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)
@@ -514,6 +525,9 @@ func TestCommandContextInitialize_ProjectConfigUsesSelectedPath(t *testing.T) {
 	root := newTestRootCommand(t)
 	if err := options.Bind(root); err != nil {
 		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupTarget); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
 	}
 	if err := root.ParseFlags([]string{"--path", projectDir}); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -22,6 +22,8 @@ func newPluginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plugin",
 		Short: "Manage Bomly managed plugins",
+		Example: "  bomly plugin list --all\n" +
+			"  bomly plugin info osv",
 	}
 	cmd.AddCommand(
 		newPluginListCmd(),
@@ -47,9 +49,10 @@ func newPluginListCmd() *cobra.Command {
 	var includeAnalyzers bool
 	var format string
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List built-in and installed plugins",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List built-in and installed plugins",
+		Example: "  bomly plugin list --detectors\n  bomly plugin list --external --format json",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options, err := commandOptions(cmd)
 			if err != nil {
@@ -166,9 +169,10 @@ func parsePluginListFormat(value string) (string, error) {
 func newPluginInfoCmd() *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
-		Use:   "info <id>",
-		Short: "Show plugin metadata",
-		Args:  cobra.ExactArgs(1),
+		Use:     "info <id>",
+		Short:   "Show plugin metadata",
+		Example: "  bomly plugin info osv\n  bomly plugin info npm-native --json",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options, err := commandOptions(cmd)
 			if err != nil {

--- a/internal/cli/render/logo.go
+++ b/internal/cli/render/logo.go
@@ -102,7 +102,7 @@ func renderBomlyLogoFrame(lines, colors []string) string {
 		b.WriteByte('\n')
 	}
 	_, _ = b.WriteString("\x1b[2K\r")
-	b.WriteString(Style("SBOM clarity with momentum.", Dim, White))
+	b.WriteString(Style("Analyze Your Software DNA.", Dim, White))
 	b.WriteByte('\n')
 	_, _ = b.WriteString("\x1b[2K\r")
 	b.WriteByte('\n')

--- a/internal/cli/render/logo_test.go
+++ b/internal/cli/render/logo_test.go
@@ -14,7 +14,7 @@ func TestBomlyLogoFrames(t *testing.T) {
 		plain := StripANSI(frame)
 		for _, want := range []string{
 			"██████╗",
-			"SBOM clarity with momentum.",
+			"Analyze Your Software DNA.",
 		} {
 			if !strings.Contains(plain, want) {
 				t.Fatalf("expected frame to contain %q, got:\n%s", want, plain)

--- a/internal/cli/root_cmd.go
+++ b/internal/cli/root_cmd.go
@@ -14,6 +14,7 @@ import (
 // init registers custom template functions for use in Cobra help and version text templates.
 func init() {
 	cobra.AddTemplateFunc("optionValuesHelpSection", optionValuesHelpSection)
+	cobra.AddTemplateFunc("exitCodesHelpSection", exitCodesHelpSection)
 	cobra.AddTemplateFunc("versionDetails", versionDetailsTemplateValue)
 }
 
@@ -40,8 +41,9 @@ func normalizeExecuteError(err error) error {
 func newRootCmd(version string) (*cobra.Command, error) {
 	options := opts.NewOptions()
 	root := &cobra.Command{
-		Use:                   "bomly",
-		Short:                 "A CLI for software bill of materials (SBOM) generation and analysis.",
+		Use:                   "bomly [command]",
+		Short:                 "A modern CLI for SBOM generation, dependency analysis, and software supply chain intelligence.",
+		Example:               "  bomly scan --interactive\n  bomly diff --base main --head HEAD\n  bomly explain pkg:npm/react",
 		Version:               version,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
@@ -73,16 +75,61 @@ func newRootCmd(version string) (*cobra.Command, error) {
 
 	root.SetVersionTemplate(rootVersionTemplate)
 	root.SetHelpTemplate(rootHelpTemplate)
-	root.SetHelpFunc(startupLogoHelpFunc(root))
 
-	root.AddCommand(newExplainCmd())
-	root.AddCommand(newScanCmd())
-	root.AddCommand(newDiffCmd())
-	root.AddCommand(newPluginCmd())
-	root.AddCommand(newMcpCmd())
-	root.AddCommand(newVersionCmd(version))
+	explainCmd := newExplainCmd()
+	if err := opts.BindCommandFlagGroups(explainCmd, &options.ResolvedConfig,
+		opts.FlagGroupTarget,
+		opts.FlagGroupAnalysis,
+		opts.FlagGroupSelectors,
+		opts.FlagGroupExecution,
+	); err != nil {
+		return nil, err
+	}
+
+	scanCmd := newScanCmd()
+	if err := opts.BindCommandFlagGroups(scanCmd, &options.ResolvedConfig,
+		opts.FlagGroupTarget,
+		opts.FlagGroupAnalysis,
+		opts.FlagGroupSelectors,
+		opts.FlagGroupExecution,
+	); err != nil {
+		return nil, err
+	}
+
+	diffCmd := newDiffCmd()
+	if err := opts.BindCommandFlagGroups(diffCmd, &options.ResolvedConfig,
+		opts.FlagGroupTarget,
+		opts.FlagGroupAnalysis,
+		opts.FlagGroupSelectors,
+		opts.FlagGroupExecution,
+	); err != nil {
+		return nil, err
+	}
+
+	pluginCmd := newPluginCmd()
+	mcpCmd := newMcpCmd()
+	versionCmd := newVersionCmd(version)
+
+	root.AddCommand(explainCmd)
+	root.AddCommand(scanCmd)
+	root.AddCommand(diffCmd)
+	root.AddCommand(pluginCmd)
+	root.AddCommand(mcpCmd)
+	root.AddCommand(versionCmd)
+
+	setHelpFuncRecursive(root, startupLogoHelpFunc(root))
 
 	return root, nil
+}
+
+func setHelpFuncRecursive(cmd *cobra.Command, helpFn func(*cobra.Command, []string)) {
+	if cmd == nil || helpFn == nil {
+		return
+	}
+	cmd.SetHelpFunc(helpFn)
+	for _, child := range cmd.Commands() {
+		setHelpFuncRecursive(child, helpFn)
+	}
 }
 
 func rootHasCommandRequiredFlags(cmd *cobra.Command) bool {

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -297,6 +297,9 @@ func TestRoot_HelpFlagWithoutCommandStillWorks(t *testing.T) {
 	if !strings.Contains(helpText, "  bomly [command]") {
 		t.Fatalf("expected command-only usage line, got %q", helpText)
 	}
+	if strings.Contains(helpText, "\n  bomly\n") {
+		t.Fatalf("expected help to omit standalone root usage line, got %q", helpText)
+	}
 	if strings.Contains(helpText, "  bomly [flags]") {
 		t.Fatalf("expected help to omit root [flags] usage line, got %q", helpText)
 	}
@@ -318,8 +321,27 @@ func TestRootHelp_IncludesAvailableOptionValuesSection(t *testing.T) {
 	}
 
 	helpText := output.String()
-	if !strings.Contains(helpText, "Explore available detectors, matchers, and auditors with `bomly plugin list`.") {
-		t.Fatalf("expected help output to contain plugin list guidance, got:\n%s", helpText)
+	if !strings.Contains(helpText, "Exit Codes:") {
+		t.Fatalf("expected help output to contain exit code section, got:\n%s", helpText)
+	}
+	for _, expected := range []string{
+		"0 success",
+		"1 execution error",
+		"2 policy violation",
+		"3 resolution failure",
+		"4 invalid input",
+	} {
+		if !strings.Contains(helpText, expected) {
+			t.Fatalf("expected help output to contain %q, got:\n%s", expected, helpText)
+		}
+	}
+	if strings.Contains(helpText, "Explore available detectors, matchers, and auditors with `bomly plugin list`.") {
+		t.Fatalf("expected root help output to omit selector guidance, got:\n%s", helpText)
+	}
+	for _, nonGlobal := range []string{"--enrich", "--audit", "--reachability", "--ecosystems", "--detectors"} {
+		if strings.Contains(helpText, nonGlobal) {
+			t.Fatalf("expected root help output to omit non-global flag %q, got:\n%s", nonGlobal, helpText)
+		}
 	}
 
 	for _, removed := range []string{
@@ -331,6 +353,93 @@ func TestRootHelp_IncludesAvailableOptionValuesSection(t *testing.T) {
 		if strings.Contains(helpText, removed) {
 			t.Fatalf("expected help output to omit %q, got:\n%s", removed, helpText)
 		}
+	}
+}
+
+func TestRootHelp_CommandExamplesRender(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		args      []string
+		examples  []string
+		notInText []string
+	}{
+		{
+			name: "root",
+			args: []string{"--help"},
+			examples: []string{
+				"Examples:",
+				"bomly scan --interactive",
+				"bomly diff --base main --head HEAD",
+				"bomly explain pkg:npm/react",
+			},
+		},
+		{
+			name: "scan",
+			args: []string{"scan", "--help"},
+			examples: []string{
+				"Examples:",
+				"bomly scan --enrich --audit",
+				"bomly scan -o spdx-json=bomly.spdx.json",
+				"bomly scan --url https://github.com/bomly-dev/bomly-cli --ref main --format json",
+				"bomly scan --container alpine:3.20",
+				"Explore available detectors, matchers, and auditors with `bomly plugin list`.",
+			},
+			notInText: []string{"Exit Codes:"},
+		},
+		{
+			name:      "diff",
+			args:      []string{"diff", "--help"},
+			examples:  []string{"Examples:", "bomly diff --sbom --base ./before.cdx.json --head ./after.cdx.json --format json"},
+			notInText: []string{"Exit Codes:"},
+		},
+		{
+			name:      "explain",
+			args:      []string{"explain", "--help"},
+			examples:  []string{"Examples:", "bomly explain pkg:npm/react"},
+			notInText: []string{"Exit Codes:"},
+		},
+		{
+			name:      "plugin",
+			args:      []string{"plugin", "--help"},
+			examples:  []string{"Examples:", "bomly plugin list --all"},
+			notInText: []string{"Exit Codes:"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tc.args)
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+			}
+			helpText := stdout.String()
+			for _, expected := range tc.examples {
+				if !strings.Contains(helpText, expected) {
+					t.Fatalf("expected help output to contain %q, got:\n%s", expected, helpText)
+				}
+			}
+			for _, unexpected := range tc.notInText {
+				if strings.Contains(helpText, unexpected) {
+					t.Fatalf("expected help output to omit %q, got:\n%s", unexpected, helpText)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -22,7 +22,11 @@ func newScanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scan",
 		Short: "Scan dependencies and render a graph or SBOM",
-		Args:  cobra.NoArgs,
+		Example: "  bomly scan --enrich --audit\n" +
+			"  bomly scan -o spdx-json=bomly.spdx.json\n" +
+			"  bomly scan --url https://github.com/bomly-dev/bomly-cli --ref main --format json\n" +
+			"  bomly scan --container alpine:3.20",
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			started := time.Now()
 			options, err := commandOptions(cmd)

--- a/internal/mcp/tool_scan.go
+++ b/internal/mcp/tool_scan.go
@@ -16,7 +16,7 @@ func registerScanTool(s *server.MCPServer, mcpCtx MCPContext) {
 		mcplib.WithString("ref", mcplib.Description("Git ref to checkout when using url")),
 		mcplib.WithBoolean("enrich", mcplib.Description("Enrich packages with vulnerability and license data from external sources")),
 		mcplib.WithBoolean("audit", mcplib.Description("Evaluate policy and produce findings from enriched vulnerability data (requires enrich)")),
-		mcplib.WithBoolean("reachability", mcplib.Description("Run code analysis to confirm whether vulnerabilities are reachable from application code (requires enrich)")),
+		mcplib.WithBoolean("reachability", mcplib.Description("[Experimental] Run code analysis to confirm whether vulnerabilities are reachable from application code (requires enrich)")),
 		mcplib.WithString("fail_on", mcplib.Description("Minimum severity threshold for audit findings: any, low, medium, high, critical")),
 		mcplib.WithString("ecosystems", mcplib.Description("Ecosystem filter; supports +name/-name modifiers")),
 	)


### PR DESCRIPTION
This pull request introduces several improvements to the CLI user experience, focusing on clearer help output, more structured and modular flag binding, and enhanced discoverability through command examples. The most significant changes include the addition of an exit codes section to the root help, modularization of command flag groups, improved help and usage text, and expanded usage examples for key commands.

**Help Output and Usage Improvements:**

* Added an "Exit Codes" section to the root help output, listing all possible exit codes and their meanings. This section is only shown in the root help, not in subcommands. [[1]](diffhunk://#diff-fe708b80f9f86ab35b126da67cd947fb8f97e5896274e7ef9aa37a764965e7c1L28-R28) [[2]](diffhunk://#diff-fe708b80f9f86ab35b126da67cd947fb8f97e5896274e7ef9aa37a764965e7c1L50-L57) [[3]](diffhunk://#diff-57c5a4893d674821e52f5d6707c34915d12e0e1f864ac7f6f745642200e339e6R17) [[4]](diffhunk://#diff-0775a86b7507997908062d30dcc85f523571f8729b9c81bd16e1c13f8d4d44adR26-R46) [[5]](diffhunk://#diff-e4eac83af7421de51164ec720c55af4d09bfea83d2761a81a0d913ee7d3d6e45L321-R344)
* Improved the root command's usage and short description, and added a set of example usages for better discoverability.
* Updated the help template logic so that the root usage line is only shown in the correct context, and ensured non-global flags are omitted from the root help. [[1]](diffhunk://#diff-fe708b80f9f86ab35b126da67cd947fb8f97e5896274e7ef9aa37a764965e7c1L12-R12) [[2]](diffhunk://#diff-e4eac83af7421de51164ec720c55af4d09bfea83d2761a81a0d913ee7d3d6e45R300-R302) [[3]](diffhunk://#diff-e4eac83af7421de51164ec720c55af4d09bfea83d2761a81a0d913ee7d3d6e45L321-R344)

**Command Flag Binding Refactor:**

* Introduced modular flag group binding via `BindCommandFlagGroups`, allowing commands to specify which logical groups of flags they support. This improves flag organization and ensures only relevant flags are available per command. [[1]](diffhunk://#diff-09ada55b33137590f43272663bb7dfc30ba1b8a94f0849931f73bd7873e0b145R10-L37) [[2]](diffhunk://#diff-09ada55b33137590f43272663bb7dfc30ba1b8a94f0849931f73bd7873e0b145L123-R174) [[3]](diffhunk://#diff-57c5a4893d674821e52f5d6707c34915d12e0e1f864ac7f6f745642200e339e6L76-R134) [[4]](diffhunk://#diff-f24913e55ebf1f7a3cb6d8693842cfb3d6a554f1a6b06ed2745e09fd65f8641cR15-R17) [[5]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87L286-R296) [[6]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R350-R352) [[7]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R424-R426) [[8]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R529-R531)
* Updated tests to reflect the new flag binding and scoping logic, ensuring that global and command-scoped flags are correctly handled. [[1]](diffhunk://#diff-f24913e55ebf1f7a3cb6d8693842cfb3d6a554f1a6b06ed2745e09fd65f8641cR15-R17) [[2]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87L286-R296) [[3]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R350-R352) [[4]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R424-R426) [[5]](diffhunk://#diff-1d4413dd288fb786147aa316c78b0d18d8cedae81f0cccb39b68062567ecbd87R529-R531)

**Command Examples and Messaging:**

* Added detailed `Example` usage strings to the `diff`, `explain`, and `plugin` commands and subcommands to improve user onboarding and clarify command usage. [[1]](diffhunk://#diff-701a5c535433c6a200b823ca0e7bfcd8f0b9f17562318a88f948fce237ba59ebL34-R37) [[2]](diffhunk://#diff-e135d14073bf190ca2623961960c9b4d16c008bc70ad6e5f1aeeb84edc17e70bR21-R22) [[3]](diffhunk://#diff-2783d6e9b13250e20e1a47c9cb5cc6cbfeb5bce02e25060c9e5473a1d65c99d7R25-R26) [[4]](diffhunk://#diff-2783d6e9b13250e20e1a47c9cb5cc6cbfeb5bce02e25060c9e5473a1d65c99d7R54) [[5]](diffhunk://#diff-2783d6e9b13250e20e1a47c9cb5cc6cbfeb5bce02e25060c9e5473a1d65c99d7R174)
* Updated the branding message in the startup logo from "SBOM clarity with momentum." to "Analyze Your Software DNA." [[1]](diffhunk://#diff-63c172109e10f29741e15d817a29c4c2f4beadb3b3065b2be9091934e06f6be1L105-R105) [[2]](diffhunk://#diff-74421714072bac6aedb5aed77206c06c7a655a193e20cdb6016f670015330902L17-R17)

**Internal Refactoring and Consistency:**

* Ensured the Bomly logo animation is shown for all help output by recursively setting the help function for all commands.
* Improved and clarified long descriptions for commands, including more accurate information about what can be compared in the `diff` command.

These changes collectively make the CLI more user-friendly, maintainable, and informative.