### PR TITLE
redesign diff output and auditing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ Stage summary:
 5. Consolidation merges subproject graphs into a unified view.
 6. Matchers enrich packages with additional metadata such as licenses, EOL status, and vulnerability records.
 7. Analyzers run when `--reachability` is set. They consume the matched graph and annotate `PackageVulnerability.Reachability` with status (reachable/unreachable/unknown), tier (symbol/module/package/none), and call paths. Failures degrade to `Status=unknown` rather than aborting the pipeline. See `docs/REACHABILITY.md` for ecosystem coverage and tier semantics.
-8. Auditors evaluate policy against whatever vulnerability data is already present on packages and create findings when `--audit` is enabled. The `severity-policy` auditor accepts a repeatable `--fail-on` constraint set composing severity and reachability conditions.
+8. Auditors evaluate policy against the enriched package graph and create findings when `--audit` is enabled. The built-in `vulnerability`, `license`, and `package` auditors cover advisory thresholds, SPDX policy, and denied or suspicious packages respectively.
 9. Users combine `--enrich --audit` when they want external matcher data to feed policy evaluation in the same run.
 10. Output rendering emits text, JSON, SARIF, or SBOM documents.
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -26,6 +26,17 @@ Bomly resolves configuration in the following order, with later sources overridi
 | `audit` | `BOMLY_AUDIT` | `bool` | - | Evaluate policy and create findings from package vulnerability data |
 | `reachability` | `BOMLY_REACHABILITY` | `bool` | - | Run code analysis to confirm whether vulnerabilities are reachable from application code |
 | `fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable |
+| `fail_on_scopes` | `BOMLY_FAIL_ON_SCOPES` | `[]string` | - | Dependency scopes that may produce failing findings: runtime, development, unknown |
+| `allow_vulnerability_ids` | `BOMLY_ALLOW_VULNERABILITY_IDS` | `[]string` | - | Vulnerability IDs to ignore during policy evaluation |
+| `allow_licenses` | `BOMLY_ALLOW_LICENSES` | `[]string` | - | Allowed SPDX license identifiers or expressions |
+| `deny_licenses` | `BOMLY_DENY_LICENSES` | `[]string` | - | Denied SPDX license identifiers or expressions |
+| `license_exempt_packages` | `BOMLY_LICENSE_EXEMPT_PACKAGES` | `[]string` | - | Package URLs exempt from license policy checks |
+| `deny_packages` | `BOMLY_DENY_PACKAGES` | `[]string` | - | Package URLs to deny |
+| `deny_groups` | `BOMLY_DENY_GROUPS` | `[]string` | - | Package URL namespaces to deny |
+| `protected_packages` | `BOMLY_PROTECTED_PACKAGES` | `[]string` | - | Canonical package names to protect from typosquatting |
+| `typosquat_threshold` | `BOMLY_TYPOSQUAT_THRESHOLD` | `string` | 0.90 | Similarity threshold for typosquatting detection |
+| `typosquat_mode` | `BOMLY_TYPOSQUAT_MODE` | `string` | warn | Typosquatting policy mode: warn or fail |
+| `warn_only` | `BOMLY_WARN_ONLY` | `bool` | - | Downgrade failing findings to warnings |
 | `analyzers` | `BOMLY_ANALYZERS` | `string` | - | Reachability analyzer selectors; supports +name and -name modifiers |
 | `format` | `BOMLY_FORMAT` | `string` | - | Primary report format: text, json, or sarif |
 | `interactive` | `BOMLY_INTERACTIVE` | `bool` | - | Enable interactive TUI mode |
@@ -86,6 +97,28 @@ Bomly resolves configuration in the following order, with later sources overridi
 # reachability: false
 # Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable
 # fail_on: []
+# Dependency scopes that may produce failing findings: runtime, development, unknown
+# fail_on_scopes: []
+# Vulnerability IDs to ignore during policy evaluation
+# allow_vulnerability_ids: []
+# Allowed SPDX license identifiers or expressions
+# allow_licenses: []
+# Denied SPDX license identifiers or expressions
+# deny_licenses: []
+# Package URLs exempt from license policy checks
+# license_exempt_packages: []
+# Package URLs to deny
+# deny_packages: []
+# Package URL namespaces to deny
+# deny_groups: []
+# Canonical package names to protect from typosquatting
+# protected_packages: []
+# Similarity threshold for typosquatting detection
+# typosquat_threshold: 0.90
+# Typosquatting policy mode: warn or fail
+# typosquat_mode: warn
+# Downgrade failing findings to warnings
+# warn_only: false
 # Reachability analyzer selectors; supports +name and -name modifiers
 # analyzers: ""
 # Primary report format: text, json, or sarif

--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -38,6 +38,9 @@ Complete reference for the `bomly diff` JSON output.
 | `title` | `string` | |
 | `reasons` | Array<`string`> | |
 | `source` | `string` | |
+| `auditor` | `string` | |
+| `disposition` | `string` | |
+| `fixed_in` | `string` | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`
@@ -99,6 +102,37 @@ Complete reference for the `bomly diff` JSON output.
 | `base` | `string` | |
 | `head` | `string` | |
 
+### `DiffDependencyResults`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `added` | Array<[`DiffPackageChange`](#diffpackagechange)> | |
+| `removed` | Array<[`DiffPackageChange`](#diffpackagechange)> | |
+| `changed` | Array<[`DiffChangedPackage`](#diffchangedpackage)> | |
+
+### `DiffLicenseChange`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `package` | [`PackageRef`](#packageref) | |
+| `licenses` | Array<[`LicenseRef`](#licenseref)> | |
+
+### `DiffLicenseDelta`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `package` | [`PackageRef`](#packageref) | |
+| `before` | Array<[`LicenseRef`](#licenseref)> | |
+| `after` | Array<[`LicenseRef`](#licenseref)> | |
+
+### `DiffLicenseResults`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `added` | Array<[`DiffLicenseChange`](#difflicensechange)> | |
+| `removed` | Array<[`DiffLicenseChange`](#difflicensechange)> | |
+| `changed` | Array<[`DiffLicenseDelta`](#difflicensedelta)> | |
+
 ### `DiffManifestResult`
 
 | Field | Type | Description |
@@ -123,6 +157,9 @@ Complete reference for the `bomly diff` JSON output.
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `dependencies` | [`DiffDependencyResults`](#diffdependencyresults) | |
+| `licenses` | [`DiffLicenseResults`](#difflicenseresults) | |
+| `vulnerabilities` | [`DiffVulnerabilityResults`](#diffvulnerabilityresults) | |
 | `manifests` | Array<[`DiffManifestResult`](#diffmanifestresult)> | |
 
 ### `DiffSummary`
@@ -136,6 +173,23 @@ Complete reference for the `bomly diff` JSON output.
 | `added_package_count` | `integer` | |
 | `changed_package_count` | `integer` | |
 | `removed_package_count` | `integer` | |
+| `exact_match_count` | `integer` | |
+| `fuzzy_match_count` | `integer` | |
+| `unmatched_package_count` | `integer` | |
+
+### `DiffVulnerabilityChange`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `package` | [`PackageRef`](#packageref) | |
+| `vulnerability` | [`VulnerabilityRef`](#vulnerabilityref) | |
+
+### `DiffVulnerabilityResults`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `added` | Array<[`DiffVulnerabilityChange`](#diffvulnerabilitychange)> | |
+| `removed` | Array<[`DiffVulnerabilityChange`](#diffvulnerabilitychange)> | |
 
 ### `LicenseRef`
 

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -38,6 +38,15 @@
         "introduced": {
           "items": {
             "properties": {
+              "auditor": {
+                "type": "string"
+              },
+              "disposition": {
+                "type": "string"
+              },
+              "fixed_in": {
+                "type": "string"
+              },
               "id": {
                 "type": "string"
               },
@@ -580,6 +589,15 @@
         "persisted": {
           "items": {
             "properties": {
+              "auditor": {
+                "type": "string"
+              },
+              "disposition": {
+                "type": "string"
+              },
+              "fixed_in": {
+                "type": "string"
+              },
               "id": {
                 "type": "string"
               },
@@ -1122,6 +1140,15 @@
         "resolved": {
           "items": {
             "properties": {
+              "auditor": {
+                "type": "string"
+              },
+              "disposition": {
+                "type": "string"
+              },
+              "fixed_in": {
+                "type": "string"
+              },
               "id": {
                 "type": "string"
               },
@@ -1748,6 +1775,2654 @@
     },
     "results": {
       "properties": {
+        "dependencies": {
+          "properties": {
+            "added": {
+              "items": {
+                "properties": {
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "changed": {
+              "items": {
+                "properties": {
+                  "after": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  },
+                  "before": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "after",
+                  "before"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "removed": {
+              "items": {
+                "properties": {
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "licenses": {
+          "properties": {
+            "added": {
+              "items": {
+                "properties": {
+                  "licenses": {
+                    "items": {
+                      "properties": {
+                        "spdxExpression": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package",
+                  "licenses"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "changed": {
+              "items": {
+                "properties": {
+                  "after": {
+                    "items": {
+                      "properties": {
+                        "spdxExpression": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "before": {
+                    "items": {
+                      "properties": {
+                        "spdxExpression": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package",
+                  "before",
+                  "after"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "removed": {
+              "items": {
+                "properties": {
+                  "licenses": {
+                    "items": {
+                      "properties": {
+                        "spdxExpression": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package",
+                  "licenses"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
         "manifests": {
           "items": {
             "properties": {
@@ -3238,9 +5913,1309 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "vulnerabilities": {
+          "properties": {
+            "added": {
+              "items": {
+                "properties": {
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  },
+                  "vulnerability": {
+                    "properties": {
+                      "affected_symbols": {
+                        "items": {
+                          "properties": {
+                            "definition": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "module": {
+                              "type": "string"
+                            },
+                            "package": {
+                              "type": "string"
+                            },
+                            "symbol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "affected_version_range": {
+                        "type": "string"
+                      },
+                      "aliases": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "cvss": {
+                        "items": {
+                          "properties": {
+                            "Score": {
+                              "type": "number"
+                            },
+                            "Source": {
+                              "type": "string"
+                            },
+                            "Vector": {
+                              "type": "string"
+                            },
+                            "Version": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "Vector",
+                            "Score",
+                            "Version",
+                            "Source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "fixed_in": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "kev_exploited": {
+                        "type": "boolean"
+                      },
+                      "reachability": {
+                        "properties": {
+                          "analyzed_at": {
+                            "type": "string"
+                          },
+                          "analyzer": {
+                            "type": "string"
+                          },
+                          "call_paths": {
+                            "items": {
+                              "properties": {
+                                "frames": {
+                                  "items": {
+                                    "properties": {
+                                      "function": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "position": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "receiver": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "sink": {
+                                  "properties": {
+                                    "definition": {
+                                      "properties": {
+                                        "column": {
+                                          "type": "integer"
+                                        },
+                                        "end_line": {
+                                          "type": "integer"
+                                        },
+                                        "file": {
+                                          "type": "string"
+                                        },
+                                        "line": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "module": {
+                                      "type": "string"
+                                    },
+                                    "package": {
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "sink"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "confidence": {
+                            "type": "string"
+                          },
+                          "dynamic_imports_detected": {
+                            "type": "boolean"
+                          },
+                          "hops": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "symbols": {
+                            "items": {
+                              "properties": {
+                                "definition": {
+                                  "properties": {
+                                    "column": {
+                                      "type": "integer"
+                                    },
+                                    "end_line": {
+                                      "type": "integer"
+                                    },
+                                    "file": {
+                                      "type": "string"
+                                    },
+                                    "line": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "module": {
+                                  "type": "string"
+                                },
+                                "package": {
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "tier": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "type": "object"
+                      },
+                      "reasons": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "references": {
+                        "items": {
+                          "properties": {
+                            "Type": {
+                              "type": "string"
+                            },
+                            "URL": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "URL",
+                            "Type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "severity": {
+                        "type": "string"
+                      },
+                      "severity_source": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "source"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package",
+                  "vulnerability"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "removed": {
+              "items": {
+                "properties": {
+                  "package": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "licenses": {
+                        "items": {
+                          "properties": {
+                            "spdxExpression": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "locations": {
+                        "items": {
+                          "properties": {
+                            "access_path": {
+                              "type": "string"
+                            },
+                            "position": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "real_path": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "purl": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "vulnerabilities": {
+                        "items": {
+                          "properties": {
+                            "affected_symbols": {
+                              "items": {
+                                "properties": {
+                                  "definition": {
+                                    "properties": {
+                                      "column": {
+                                        "type": "integer"
+                                      },
+                                      "end_line": {
+                                        "type": "integer"
+                                      },
+                                      "file": {
+                                        "type": "string"
+                                      },
+                                      "line": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "affected_version_range": {
+                              "type": "string"
+                            },
+                            "aliases": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "cvss": {
+                              "items": {
+                                "properties": {
+                                  "Score": {
+                                    "type": "number"
+                                  },
+                                  "Source": {
+                                    "type": "string"
+                                  },
+                                  "Vector": {
+                                    "type": "string"
+                                  },
+                                  "Version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "Vector",
+                                  "Score",
+                                  "Version",
+                                  "Source"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fixed_in": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "kev_exploited": {
+                              "type": "boolean"
+                            },
+                            "reachability": {
+                              "properties": {
+                                "analyzed_at": {
+                                  "type": "string"
+                                },
+                                "analyzer": {
+                                  "type": "string"
+                                },
+                                "call_paths": {
+                                  "items": {
+                                    "properties": {
+                                      "frames": {
+                                        "items": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "position": {
+                                              "properties": {
+                                                "column": {
+                                                  "type": "integer"
+                                                },
+                                                "end_line": {
+                                                  "type": "integer"
+                                                },
+                                                "file": {
+                                                  "type": "string"
+                                                },
+                                                "line": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "receiver": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "sink": {
+                                        "properties": {
+                                          "definition": {
+                                            "properties": {
+                                              "column": {
+                                                "type": "integer"
+                                              },
+                                              "end_line": {
+                                                "type": "integer"
+                                              },
+                                              "file": {
+                                                "type": "string"
+                                              },
+                                              "line": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "module": {
+                                            "type": "string"
+                                          },
+                                          "package": {
+                                            "type": "string"
+                                          },
+                                          "symbol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "sink"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "confidence": {
+                                  "type": "string"
+                                },
+                                "dynamic_imports_detected": {
+                                  "type": "boolean"
+                                },
+                                "hops": {
+                                  "type": "integer"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "symbols": {
+                                  "items": {
+                                    "properties": {
+                                      "definition": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "module": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "symbol": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "tier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status"
+                              ],
+                              "type": "object"
+                            },
+                            "reasons": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "references": {
+                              "items": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "string"
+                                  },
+                                  "URL": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "URL",
+                                  "Type"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "severity": {
+                              "type": "string"
+                            },
+                            "severity_source": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "licenses",
+                      "vulnerabilities"
+                    ],
+                    "type": "object"
+                  },
+                  "vulnerability": {
+                    "properties": {
+                      "affected_symbols": {
+                        "items": {
+                          "properties": {
+                            "definition": {
+                              "properties": {
+                                "column": {
+                                  "type": "integer"
+                                },
+                                "end_line": {
+                                  "type": "integer"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "line": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "module": {
+                              "type": "string"
+                            },
+                            "package": {
+                              "type": "string"
+                            },
+                            "symbol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "affected_version_range": {
+                        "type": "string"
+                      },
+                      "aliases": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "cvss": {
+                        "items": {
+                          "properties": {
+                            "Score": {
+                              "type": "number"
+                            },
+                            "Source": {
+                              "type": "string"
+                            },
+                            "Vector": {
+                              "type": "string"
+                            },
+                            "Version": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "Vector",
+                            "Score",
+                            "Version",
+                            "Source"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "fixed_in": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "kev_exploited": {
+                        "type": "boolean"
+                      },
+                      "reachability": {
+                        "properties": {
+                          "analyzed_at": {
+                            "type": "string"
+                          },
+                          "analyzer": {
+                            "type": "string"
+                          },
+                          "call_paths": {
+                            "items": {
+                              "properties": {
+                                "frames": {
+                                  "items": {
+                                    "properties": {
+                                      "function": {
+                                        "type": "string"
+                                      },
+                                      "package": {
+                                        "type": "string"
+                                      },
+                                      "position": {
+                                        "properties": {
+                                          "column": {
+                                            "type": "integer"
+                                          },
+                                          "end_line": {
+                                            "type": "integer"
+                                          },
+                                          "file": {
+                                            "type": "string"
+                                          },
+                                          "line": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "receiver": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "sink": {
+                                  "properties": {
+                                    "definition": {
+                                      "properties": {
+                                        "column": {
+                                          "type": "integer"
+                                        },
+                                        "end_line": {
+                                          "type": "integer"
+                                        },
+                                        "file": {
+                                          "type": "string"
+                                        },
+                                        "line": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "module": {
+                                      "type": "string"
+                                    },
+                                    "package": {
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "sink"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "confidence": {
+                            "type": "string"
+                          },
+                          "dynamic_imports_detected": {
+                            "type": "boolean"
+                          },
+                          "hops": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "symbols": {
+                            "items": {
+                              "properties": {
+                                "definition": {
+                                  "properties": {
+                                    "column": {
+                                      "type": "integer"
+                                    },
+                                    "end_line": {
+                                      "type": "integer"
+                                    },
+                                    "file": {
+                                      "type": "string"
+                                    },
+                                    "line": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "module": {
+                                  "type": "string"
+                                },
+                                "package": {
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "tier": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "type": "object"
+                      },
+                      "reasons": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "references": {
+                        "items": {
+                          "properties": {
+                            "Type": {
+                              "type": "string"
+                            },
+                            "URL": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "URL",
+                            "Type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "severity": {
+                        "type": "string"
+                      },
+                      "severity_source": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "source"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "package",
+                  "vulnerability"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
         }
       },
       "required": [
+        "dependencies",
+        "licenses",
+        "vulnerabilities",
         "manifests"
       ],
       "type": "object"
@@ -3262,6 +7237,12 @@
         "changed_package_count": {
           "type": "integer"
         },
+        "exact_match_count": {
+          "type": "integer"
+        },
+        "fuzzy_match_count": {
+          "type": "integer"
+        },
         "removed_manifest_count": {
           "type": "integer"
         },
@@ -3269,6 +7250,9 @@
           "type": "integer"
         },
         "unchanged_manifest_count": {
+          "type": "integer"
+        },
+        "unmatched_package_count": {
           "type": "integer"
         }
       },
@@ -3279,7 +7263,10 @@
         "unchanged_manifest_count",
         "added_package_count",
         "changed_package_count",
-        "removed_package_count"
+        "removed_package_count",
+        "exact_match_count",
+        "fuzzy_match_count",
+        "unmatched_package_count"
       ],
       "type": "object"
     }

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -40,6 +40,9 @@ Complete reference for the `bomly explain` JSON output.
 | `title` | `string` | |
 | `reasons` | Array<`string`> | |
 | `source` | `string` | |
+| `auditor` | `string` | |
+| `disposition` | `string` | |
+| `fixed_in` | `string` | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -396,6 +396,15 @@
     "findings": {
       "items": {
         "properties": {
+          "auditor": {
+            "type": "string"
+          },
+          "disposition": {
+            "type": "string"
+          },
+          "fixed_in": {
+            "type": "string"
+          },
           "id": {
             "type": "string"
           },
@@ -1793,6 +1802,15 @@
           "findings": {
             "items": {
               "properties": {
+                "auditor": {
+                  "type": "string"
+                },
+                "disposition": {
+                  "type": "string"
+                },
+                "fixed_in": {
+                  "type": "string"
+                },
                 "id": {
                   "type": "string"
                 },

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -37,6 +37,9 @@ Complete reference for the `bomly scan` JSON output.
 | `title` | `string` | |
 | `reasons` | Array<`string`> | |
 | `source` | `string` | |
+| `auditor` | `string` | |
+| `disposition` | `string` | |
+| `fixed_in` | `string` | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -39,6 +39,15 @@
     "findings": {
       "items": {
         "properties": {
+          "auditor": {
+            "type": "string"
+          },
+          "disposition": {
+            "type": "string"
+          },
+          "fixed_in": {
+            "type": "string"
+          },
           "id": {
             "type": "string"
           },

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/evanw/esbuild v0.28.0
+	github.com/github/go-spdx/v2 v2.4.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
@@ -25,7 +26,6 @@ require (
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/zap v1.28.0
 	golang.org/x/term v0.43.0
-	golang.org/x/text v0.37.0
 	golang.org/x/vuln v1.3.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
@@ -146,7 +146,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/github/go-spdx/v2 v2.4.0 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
@@ -308,6 +307,7 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260421165255-392afab6f40e // indirect
+	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -1,0 +1,147 @@
+package license
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+	"github.com/github/go-spdx/v2/spdxexp"
+)
+
+const auditorName = "license"
+
+// Auditor evaluates package licenses against allow/deny SPDX policy.
+type Auditor struct {
+	AllowLicenses  []string
+	DenyLicenses   []string
+	ExemptPackages []string
+	FailOnScopes   []sdk.Scope
+}
+
+func (a Auditor) Descriptor() sdk.AuditorDescriptor {
+	return sdk.AuditorDescriptor{
+		Name:           auditorName,
+		Enabled:        true,
+		Origin:         sdk.CoreOrigin,
+		SupportedModes: []sdk.TargetMode{sdk.TargetModeFullGraph, sdk.TargetModeComponent},
+	}
+}
+
+func (a Auditor) Ready() bool {
+	return true
+}
+
+func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {
+	if req.AuditorFilter.Excludes(auditorName) {
+		return false, nil
+	}
+	if len(req.AuditorFilter.Include) > 0 && !req.AuditorFilter.Includes(auditorName) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
+	if req.Graph == nil {
+		return sdk.AuditResult{}, nil
+	}
+	packages := req.Graph.Packages()
+	if req.Mode == sdk.TargetModeComponent && req.Target != nil {
+		packages = []*sdk.Package{req.Target}
+	}
+
+	findings := make([]sdk.Finding, 0)
+	for _, pkg := range packages {
+		if pkg == nil || !scopeAllowed(pkg, a.FailOnScopes) || packageExempt(pkg, a.ExemptPackages) {
+			continue
+		}
+		licenses := pkg.LicenseValues()
+		if len(licenses) == 0 {
+			findings = append(findings, finding(pkg, "unknown-license", "Package license is unknown", sdk.FindingDispositionWarn))
+			continue
+		}
+		valid, invalid := spdxexp.ValidateLicenses(licenses)
+		if !valid {
+			findings = append(findings, finding(pkg, "invalid-license", "Package has invalid SPDX license: "+strings.Join(invalid, ", "), sdk.FindingDispositionFail))
+			continue
+		}
+		if len(a.AllowLicenses) > 0 {
+			allowed := false
+			for _, expr := range licenses {
+				ok, err := spdxexp.Satisfies(expr, a.AllowLicenses)
+				if err == nil && ok {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				findings = append(findings, finding(pkg, "denied-license", "Package license is not allowlisted", sdk.FindingDispositionFail))
+			}
+			continue
+		}
+		if len(a.DenyLicenses) > 0 {
+			for _, expr := range licenses {
+				used, err := spdxexp.ExtractLicenses(expr)
+				if err != nil {
+					continue
+				}
+				if intersectsLicenseList(used, a.DenyLicenses) {
+					findings = append(findings, finding(pkg, "denied-license", "Package license is denylisted", sdk.FindingDispositionFail))
+					break
+				}
+			}
+		}
+	}
+	return sdk.AuditResult{Graph: req.Graph, Target: req.Target, Findings: findings}, nil
+}
+
+func finding(pkg *sdk.Package, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
+	return sdk.Finding{
+		ID:          fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
+		Kind:        sdk.FindingKindPolicy,
+		Package:     pkg,
+		Title:       title,
+		Severity:    "unknown",
+		Source:      auditorName,
+		Auditor:     auditorName,
+		Disposition: disposition,
+	}
+}
+
+func packageExempt(pkg *sdk.Package, exemptions []string) bool {
+	base := sdk.PackageURLBase(sdk.CanonicalPackageURLFromPackage(pkg))
+	if base == "" {
+		return false
+	}
+	for _, exemption := range exemptions {
+		if base == sdk.PackageURLBase(exemption) {
+			return true
+		}
+	}
+	return false
+}
+
+func intersectsLicenseList(values, denied []string) bool {
+	for _, value := range values {
+		for _, candidate := range denied {
+			if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(candidate)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func scopeAllowed(pkg *sdk.Package, allowed []sdk.Scope) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	scope := sdk.Scope(pkg.Scope)
+	for _, candidate := range allowed {
+		if candidate == scope {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -1,0 +1,263 @@
+package packageauditor
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const auditorName = "package"
+
+// Auditor protects against denied packages and suspiciously similar package names.
+type Auditor struct {
+	DenyPackages       []string
+	DenyGroups         []string
+	ProtectedPackages  []string
+	TyposquatThreshold float64
+	TyposquatMode      string
+	FailOnScopes       []sdk.Scope
+}
+
+func (a Auditor) Descriptor() sdk.AuditorDescriptor {
+	return sdk.AuditorDescriptor{
+		Name:           auditorName,
+		Enabled:        true,
+		Origin:         sdk.CoreOrigin,
+		SupportedModes: []sdk.TargetMode{sdk.TargetModeFullGraph},
+	}
+}
+
+func (a Auditor) Ready() bool {
+	return true
+}
+
+func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {
+	if req.AuditorFilter.Excludes(auditorName) {
+		return false, nil
+	}
+	if len(req.AuditorFilter.Include) > 0 && !req.AuditorFilter.Includes(auditorName) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
+	if req.Graph == nil {
+		return sdk.AuditResult{}, nil
+	}
+	packages := req.Graph.Packages()
+	findings := make([]sdk.Finding, 0)
+	baseNames := protectedNames(req.BaselineGraph, a.ProtectedPackages)
+	baseIDs := packageIDs(req.BaselineGraph)
+	threshold := a.TyposquatThreshold
+	if threshold <= 0 {
+		threshold = 0.90
+	}
+
+	for _, pkg := range packages {
+		if pkg == nil || !scopeAllowed(pkg, a.FailOnScopes) {
+			continue
+		}
+		if deniedPackage(pkg, a.DenyPackages) {
+			findings = append(findings, finding(pkg, "denied-package", "Package is denylisted", sdk.FindingDispositionFail))
+			continue
+		}
+		if deniedGroup(pkg, a.DenyGroups) {
+			findings = append(findings, finding(pkg, "denied-group", "Package group is denylisted", sdk.FindingDispositionFail))
+			continue
+		}
+		if _, existed := baseIDs[pkg.ID]; existed || req.BaselineGraph == nil {
+			continue
+		}
+		if protected, score, ok := closestProtectedName(pkg.DisplayName(), baseNames, threshold); ok {
+			disposition := sdk.FindingDispositionWarn
+			if strings.EqualFold(strings.TrimSpace(a.TyposquatMode), "fail") {
+				disposition = sdk.FindingDispositionFail
+			}
+			f := finding(pkg, "suspicious-package", fmt.Sprintf("Package name is %.2f similar to protected package %s", score, protected), disposition)
+			f.Reasons = []string{"possible-typosquat"}
+			findings = append(findings, f)
+		}
+	}
+	return sdk.AuditResult{Graph: req.Graph, Target: req.Target, Findings: findings}, nil
+}
+
+func finding(pkg *sdk.Package, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
+	return sdk.Finding{
+		ID:          fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
+		Kind:        sdk.FindingKindPolicy,
+		Package:     pkg,
+		Title:       title,
+		Severity:    "unknown",
+		Source:      auditorName,
+		Auditor:     auditorName,
+		Disposition: disposition,
+	}
+}
+
+func packageIDs(graph *sdk.Graph) map[string]struct{} {
+	ids := make(map[string]struct{})
+	if graph == nil {
+		return ids
+	}
+	for _, pkg := range graph.Packages() {
+		if pkg != nil {
+			ids[pkg.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+func protectedNames(graph *sdk.Graph, configured []string) []string {
+	names := append([]string(nil), configured...)
+	if graph == nil {
+		return names
+	}
+	for _, pkg := range graph.Packages() {
+		if pkg == nil {
+			continue
+		}
+		names = append(names, pkg.DisplayName())
+	}
+	return names
+}
+
+func deniedPackage(pkg *sdk.Package, denied []string) bool {
+	canonical := sdk.CanonicalPackageURLFromPackage(pkg)
+	base := sdk.PackageURLBase(canonical)
+	if canonical == "" || base == "" {
+		return false
+	}
+	for _, candidate := range denied {
+		canonicalCandidate := sdk.CanonicalizePackageURL(candidate)
+		if canonicalCandidate == "" {
+			continue
+		}
+		parsed := sdk.ParsePackageURL(canonicalCandidate)
+		hasVersion := parsed != nil && strings.TrimSpace(parsed.Version) != ""
+		if hasVersion && canonical == canonicalCandidate {
+			return true
+		}
+		if !hasVersion && base == sdk.PackageURLBase(canonicalCandidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func deniedGroup(pkg *sdk.Package, denied []string) bool {
+	base := sdk.PackageURLBase(sdk.CanonicalPackageURLFromPackage(pkg))
+	if base == "" {
+		return false
+	}
+	for _, candidate := range denied {
+		group := strings.TrimSuffix(sdk.PackageURLBase(candidate), "/")
+		if group != "" && strings.HasPrefix(base, group+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func closestProtectedName(name string, protected []string, threshold float64) (string, float64, bool) {
+	bestName := ""
+	bestScore := 0.0
+	for _, candidate := range protected {
+		score := normalizedSimilarity(name, candidate)
+		if score >= threshold && score < 1 && score > bestScore {
+			bestName = candidate
+			bestScore = score
+		}
+	}
+	return bestName, bestScore, bestName != ""
+}
+
+func normalizedSimilarity(left, right string) float64 {
+	left = strings.ToLower(strings.TrimSpace(left))
+	right = strings.ToLower(strings.TrimSpace(right))
+	if left == "" || right == "" {
+		return 0
+	}
+	if left == right {
+		return 1
+	}
+	if collapseComparableName(left) == collapseComparableName(right) {
+		return 0.96
+	}
+	distance := levenshteinDistance(left, right)
+	maxLen := maxInt(len(left), len(right))
+	if maxLen == 0 {
+		return 0
+	}
+	return math.Max(0, 1-float64(distance)/float64(maxLen))
+}
+
+func collapseComparableName(value string) string {
+	replacer := strings.NewReplacer("-", "", "_", "", ".", "", " ", "")
+	return replacer.Replace(strings.ToLower(strings.TrimSpace(value)))
+}
+
+func levenshteinDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			curr[j] = minInt(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	best := values[0]
+	for _, value := range values[1:] {
+		if value < best {
+			best = value
+		}
+	}
+	return best
+}
+
+func maxInt(values ...int) int {
+	best := values[0]
+	for _, value := range values[1:] {
+		if value > best {
+			best = value
+		}
+	}
+	return best
+}
+
+func scopeAllowed(pkg *sdk.Package, allowed []sdk.Scope) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	scope := sdk.Scope(pkg.Scope)
+	for _, candidate := range allowed {
+		if candidate == scope {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auditors/vulnerability/auditor.go
+++ b/internal/auditors/vulnerability/auditor.go
@@ -1,4 +1,4 @@
-package policy
+package vulnerability
 
 import (
 	"context"
@@ -7,24 +7,21 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const auditorName = "severity-policy"
+const auditorName = "vulnerability"
 
-// Auditor evaluates enriched vulnerability data against a list of
-// fail-on constraints. Constraints AND together; an empty list emits a
-// finding for every vulnerability (the historical default behaviour
-// when --audit was set without --fail-on).
+// Auditor evaluates enriched vulnerability data against the configured policy.
 type Auditor struct {
-	FailOn []sdk.FailOnConstraint
+	FailOn                []sdk.FailOnConstraint
+	FailOnScopes          []sdk.Scope
+	AllowVulnerabilityIDs []string
 }
 
-// Descriptor returns the registration metadata for the policy auditor.
 func (a Auditor) Descriptor() sdk.AuditorDescriptor {
 	return sdk.AuditorDescriptor{
-		Name:                auditorName,
-		Enabled:             true,
-		Origin:              sdk.CoreOrigin,
-		SupportedEcosystems: nil,
-		SupportedModes:      []sdk.TargetMode{sdk.TargetModeFullGraph, sdk.TargetModeComponent},
+		Name:           auditorName,
+		Enabled:        true,
+		Origin:         sdk.CoreOrigin,
+		SupportedModes: []sdk.TargetMode{sdk.TargetModeFullGraph, sdk.TargetModeComponent},
 	}
 }
 
@@ -33,7 +30,7 @@ func (a Auditor) Ready() bool {
 }
 
 func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {
-	if len(req.AuditorFilter.Exclude) > 0 && req.AuditorFilter.Excludes(auditorName) {
+	if req.AuditorFilter.Excludes(auditorName) {
 		return false, nil
 	}
 	if len(req.AuditorFilter.Include) > 0 && !req.AuditorFilter.Includes(auditorName) {
@@ -42,10 +39,6 @@ func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, erro
 	return true, nil
 }
 
-// Audit evaluates enriched vulnerabilities and emits findings for entries
-// satisfying every configured constraint. Reachability data is propagated
-// onto each Finding regardless of constraint configuration so consumers
-// can render or filter on it.
 func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
 	if req.Graph == nil {
 		return sdk.AuditResult{}, nil
@@ -58,11 +51,11 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 
 	findings := make([]sdk.Finding, 0)
 	for _, pkg := range packages {
-		if pkg == nil {
+		if pkg == nil || !scopeAllowed(pkg, a.FailOnScopes) {
 			continue
 		}
 		for _, vulnerability := range collapsePreferredVulnerabilities(pkg.Vulnerabilities) {
-			if !vulnerability.MatchesConstraints(a.FailOn) {
+			if vulnerabilityAllowed(vulnerability, a.AllowVulnerabilityIDs) || !vulnerability.MatchesConstraints(a.FailOn) {
 				continue
 			}
 			title := strings.TrimSpace(vulnerability.Title)
@@ -77,6 +70,8 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 				Severity:             strings.ToLower(strings.TrimSpace(vulnerability.Severity)),
 				Reasons:              append([]string(nil), vulnerability.Reasons...),
 				Source:               vulnerability.Source,
+				Auditor:              auditorName,
+				Disposition:          sdk.FindingDispositionFail,
 				Aliases:              append([]string(nil), vulnerability.Aliases...),
 				Description:          vulnerability.Description,
 				SeveritySource:       vulnerability.SeveritySource,
@@ -90,18 +85,35 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 		}
 	}
 
-	return sdk.AuditResult{
-		Graph:    req.Graph,
-		Target:   req.Target,
-		Findings: findings,
-	}, nil
+	return sdk.AuditResult{Graph: req.Graph, Target: req.Target, Findings: findings}, nil
 }
 
-// collapsePreferredVulnerabilities collapses multiple vulnerabilities with the same ID into a single entry.
-func collapsePreferredVulnerabilities(vulnerabilities []sdk.PackageVulnerability) []sdk.PackageVulnerability {
-	type key struct {
-		id string
+func scopeAllowed(pkg *sdk.Package, allowed []sdk.Scope) bool {
+	if len(allowed) == 0 {
+		return true
 	}
+	scope := sdk.Scope(pkg.Scope)
+	for _, candidate := range allowed {
+		if candidate == scope {
+			return true
+		}
+	}
+	return false
+}
+
+func vulnerabilityAllowed(vulnerability sdk.PackageVulnerability, allow []string) bool {
+	for _, id := range append([]string{vulnerability.ID}, vulnerability.Aliases...) {
+		for _, allowed := range allow {
+			if strings.EqualFold(strings.TrimSpace(id), strings.TrimSpace(allowed)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func collapsePreferredVulnerabilities(vulnerabilities []sdk.PackageVulnerability) []sdk.PackageVulnerability {
+	type key struct{ id string }
 	type choice struct {
 		entry sdk.PackageVulnerability
 		rank  int
@@ -129,8 +141,6 @@ func collapsePreferredVulnerabilities(vulnerabilities []sdk.PackageVulnerability
 	return out
 }
 
-// sourceRank returns a value that can be used to sort vulnerabilities by source.
-// The lower the value, the higher the priority.
 func sourceRank(source string) int {
 	switch strings.ToLower(strings.TrimSpace(source)) {
 	case "grype":

--- a/internal/cli/cmd_progress.go
+++ b/internal/cli/cmd_progress.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/opts"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
+	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
+	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/internal/progress"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
@@ -43,7 +45,7 @@ func subprojectProgressChildren(results []sdk.DetectionResult) []progress.Child 
 	for _, r := range results {
 		label := r.SubprojectInfo.RelativePath
 		if label == "" || label == "." {
-			label = filepath.Base(r.SubprojectInfo.ExecutionTarget.Location)
+			label = progressTargetLabel(r.SubprojectInfo.ExecutionTarget)
 			if label == "" || label == "." {
 				label = "root"
 			}
@@ -55,6 +57,40 @@ func subprojectProgressChildren(results []sdk.DetectionResult) []progress.Child 
 		children = append(children, progress.Child{Label: label})
 	}
 	return children
+}
+
+func progressTargetLabel(target sdk.ExecutionTarget) string {
+	if label := gitProgressTargetLabel(target); label != "" {
+		return label
+	}
+	switch target.Kind {
+	case sdk.ExecutionTargetContainerImage:
+		return strings.TrimSpace(target.Location)
+	case sdk.ExecutionTargetFilesystem:
+		location := strings.TrimSpace(target.Location)
+		if location != "" {
+			return filepath.Base(location)
+		}
+	}
+	return filepath.Base(target.Location)
+}
+
+func gitProgressTargetLabel(target sdk.ExecutionTarget) string {
+	ref := strings.TrimSpace(target.Ref)
+	repo := strings.TrimSpace(target.RepositoryURL)
+	if target.Kind != sdk.ExecutionTargetGitRepository && repo == "" && ref == "" {
+		return ""
+	}
+	switch {
+	case repo != "" && ref != "":
+		return repo + " @ " + ref
+	case ref != "":
+		return ref
+	case repo != "":
+		return repo
+	default:
+		return ""
+	}
 }
 
 // detectorProgressChildren groups results by detector name, sums the total
@@ -106,6 +142,35 @@ func auditProgressChildren(auditorRuns []string, auditorFindings map[string]int,
 	}
 	children = append(children, warningProgressChildren(warnings)...)
 	return children
+}
+
+// diffPolicyOutcomeProgressChild summarizes introduced diff findings using
+// the same introduced-only failure semantics as `bomly diff --audit`.
+func diffPolicyOutcomeProgressChild(audit *diffengine.Audit) progress.Child {
+	if audit == nil {
+		return progress.Child{
+			Icon:   progress.CheckMark,
+			Label:  "Policy Outcome",
+			Detail: "[no audit delta]",
+		}
+	}
+	failing := output.FailingFindingCount(audit.Introduced)
+	warnings := len(audit.Introduced) - failing
+	child := progress.Child{
+		Icon:  progress.CheckMark,
+		Label: "Policy Outcome",
+	}
+	switch {
+	case failing > 0:
+		child.Icon = progress.CrossMark
+		child.Detail = fmt.Sprintf("[%d introduced failing, %d warnings]", failing, warnings)
+	case warnings > 0:
+		child.Icon = progress.WarningMark
+		child.Detail = fmt.Sprintf("[passed, %d introduced warnings]", warnings)
+	default:
+		child.Detail = "[passed, no introduced findings]"
+	}
+	return child
 }
 
 // matchProgressChildren returns ✔ children for each successful matcher run
@@ -209,8 +274,12 @@ func humanizeDetectorName(name string) string {
 // humanizeAuditorSource converts an auditor source name to a display name.
 func humanizeAuditorSource(source string) string {
 	switch strings.ToLower(source) {
-	case "severity-policy":
-		return "Severity Policy Auditor"
+	case "vulnerability":
+		return "Vulnerability Auditor"
+	case "license":
+		return "License Auditor"
+	case "package":
+		return "Package Auditor"
 	case "grype":
 		return "Grype Auditor"
 	case "osv":

--- a/internal/cli/cmd_progress_test.go
+++ b/internal/cli/cmd_progress_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/opts"
+	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
+	"github.com/bomly-dev/bomly-cli/internal/progress"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -66,18 +68,55 @@ func TestMatchProgressChildren_ReportsMatcherCounts(t *testing.T) {
 
 func TestAuditProgressChildren_UsesAuditorRunsNotFindingSources(t *testing.T) {
 	children := auditProgressChildren(
-		[]string{opts.SeverityPolicyAuditorName},
-		map[string]int{opts.SeverityPolicyAuditorName: 3},
+		[]string{opts.VulnerabilityAuditorName},
+		map[string]int{opts.VulnerabilityAuditorName: 3},
 		nil,
 	)
 
 	if len(children) != 1 {
 		t.Fatalf("expected 1 child, got %#v", children)
 	}
-	if children[0].Label != "Severity Policy Auditor" {
+	if children[0].Label != "Vulnerability Auditor" {
 		t.Fatalf("unexpected auditor label: %#v", children[0])
 	}
 	if children[0].Detail != "[3 findings]" {
 		t.Fatalf("unexpected auditor detail: %#v", children[0])
+	}
+}
+
+func TestSubprojectProgressChildren_UsesGitIdentityWhenConcreteTargetIsFilesystem(t *testing.T) {
+	children := subprojectProgressChildren([]sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget: sdk.ExecutionTarget{
+				Kind:          sdk.ExecutionTargetFilesystem,
+				Location:      `C:\Temp\bomly-git-ref-123`,
+				RepositoryURL: "https://github.com/bomly-dev/bomly-cli",
+				Ref:           "main",
+			},
+			RelativePath: ".",
+			Ecosystem:    sdk.EcosystemNPM,
+		},
+	}})
+
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %#v", children)
+	}
+	if children[0].Label != "https://github.com/bomly-dev/bomly-cli @ main (npm)" {
+		t.Fatalf("unexpected target label: %#v", children[0])
+	}
+}
+
+func TestDiffPolicyOutcomeProgressChild_ReportsIntroducedOutcome(t *testing.T) {
+	child := diffPolicyOutcomeProgressChild(&diffengine.Audit{
+		Introduced: []sdk.Finding{
+			{Disposition: sdk.FindingDispositionFail},
+			{Disposition: sdk.FindingDispositionWarn},
+		},
+	})
+	if child.Icon != progress.CrossMark {
+		t.Fatalf("expected failing outcome icon, got %#v", child)
+	}
+	if child.Detail != "[1 introduced failing, 1 warnings]" {
+		t.Fatalf("unexpected policy outcome detail: %#v", child)
 	}
 }

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -136,7 +136,8 @@ func newDiffCmd() *cobra.Command {
 			if current.Audit {
 				runs, findings := combineAuditProgress(diffResult.Base, diffResult.Head)
 				warnings := append(append([]engine.PipelineWarning{}, diffResult.Base.AuditWarnings...), diffResult.Head.AuditWarnings...)
-				progress.CompleteStep("Evaluated policy", auditProgressChildren(runs, findings, warnings))
+				children := append(auditProgressChildren(runs, findings, warnings), diffPolicyOutcomeProgressChild(diffResult.Audit))
+				progress.CompleteStep("Evaluated policy", children)
 			}
 
 			payload := output.BuildDiffResponse(projectIdentifier, compBase, compHead, diffResult.Base.Consolidated, diffResult.Head.Consolidated, auditPayload, started)
@@ -158,8 +159,10 @@ func newDiffCmd() *cobra.Command {
 					return render.Diff(w, payload)
 				},
 			})
-			if err == nil && current.Audit && auditPayload != nil && auditPayload.AuditSummary != nil && auditPayload.AuditSummary.Total > 0 {
-				return exit.PolicyViolationFindings(auditPayload.AuditSummary.Total)
+			if err == nil && current.Audit && diffResult.Audit != nil {
+				if failing := output.FailingFindingCount(diffResult.Audit.Introduced); failing > 0 {
+					return exit.PolicyViolationFindings(failing)
+				}
 			}
 			return err
 		},

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -30,7 +30,7 @@ func TestRenderDiffTextIncludesAuditOutcomeWithoutChanges(t *testing.T) {
 	report := out.String()
 	for _, want := range []string{
 		"Dependency diff main -> feature",
-		"Policy Outcome",
+		"Policy Evaluation",
 		"Current findings: 1 total (1 high).",
 		"Change summary: 0 introduced, 0 persisted, and 0 resolved findings.",
 		"No policy differences were identified between the base and head dependency sets.",
@@ -69,7 +69,7 @@ func TestRenderDiffTextIncludesAuditSections(t *testing.T) {
 				Package:  output.PackageRef{Name: "minimist", Version: "1.2.5"},
 				Source:   "osv",
 			}},
-			AuditSummary: &output.AuditSummary{High: 1, Medium: 1, Low: 1, Total: 3},
+			AuditSummary: &output.AuditSummary{High: 1, Medium: 1, Total: 2},
 		},
 	}
 
@@ -80,18 +80,22 @@ func TestRenderDiffTextIncludesAuditSections(t *testing.T) {
 
 	report := out.String()
 	for _, want := range []string{
-		"Policy Outcome",
-		"Current findings: 3 total (1 high, 1 medium, 1 low).",
+		"Policy Evaluation",
+		"Current findings: 2 total (1 high, 1 medium).",
 		"Change summary: 1 introduced, 1 persisted, and 1 resolved findings.",
 		"Introduced Findings",
-		"Persisted Findings",
 		"Resolved Findings",
-		"OSV-123 react@18.2.0 (osv): Prototype pollution in react",
-		"OSV-234 lodash@4.17.20 (osv)",
-		"OSV-345 minimist@1.2.5 (osv)",
+		"OSV-123 react@18.2.0: Prototype pollution in react",
+		"OSV-345 minimist@1.2.5",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("expected diff report to contain %q, got:\n%s", want, report)
 		}
+	}
+	if strings.Contains(report, "Persisted Findings") {
+		t.Fatalf("did not expect persisted findings subsection, got:\n%s", report)
+	}
+	if !strings.Contains(report, "Prototype pollution in react\x1b[0m\n\nResolved Findings") {
+		t.Fatalf("expected a blank line after introduced findings, got:\n%s", report)
 	}
 }

--- a/internal/cli/diff_resolve.go
+++ b/internal/cli/diff_resolve.go
@@ -75,9 +75,10 @@ func resolveDiffResultsForRef(ctx context.Context, options *opts.Options, logger
 		return os.RemoveAll(materializedPath)
 	}
 	executionTarget := sdk.ExecutionTarget{
-		Kind:     sdk.ExecutionTargetGitRepository,
-		Location: materializedPath,
-		Ref:      ref,
+		Kind:          sdk.ExecutionTargetGitRepository,
+		Location:      materializedPath,
+		RepositoryURL: strings.TrimSpace(options.GetConfig().URL),
+		Ref:           ref,
 	}
 	commandCtx, err := options.PrepareForExecutionTarget(ctx, logger, executionTarget, cleanup)
 	if err != nil {

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -121,8 +121,10 @@ func newExplainCmd() *cobra.Command {
 					return nil
 				},
 			})
-			if err == nil && context.ResolvedConfig.Audit && len(explainResult.Findings) > 0 {
-				return exit.PolicyViolationFindings(len(explainResult.Findings))
+			if err == nil && context.ResolvedConfig.Audit {
+				if failing := output.FailingFindingCount(explainResult.Findings); failing > 0 {
+					return exit.PolicyViolationFindings(failing)
+				}
 			}
 			return err
 		},

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -71,15 +71,26 @@ type mcpOptionsAdapter struct {
 // addition here plus a one-line apply in cloneWithOverrides — no signature
 // churn at every callsite.
 type mcpOverrides struct {
-	Path         string
-	Container    string
-	URL          string
-	Ref          string
-	Enrich       bool
-	Audit        bool
-	Reachability bool
-	FailOn       string
-	Ecosystems   string
+	Path                  string
+	Container             string
+	URL                   string
+	Ref                   string
+	Enrich                bool
+	Audit                 bool
+	Reachability          bool
+	FailOn                string
+	FailOnScopes          string
+	AllowVulnerabilityIDs string
+	AllowLicenses         string
+	DenyLicenses          string
+	LicenseExemptPackages string
+	DenyPackages          string
+	DenyGroups            string
+	ProtectedPackages     string
+	TyposquatThreshold    string
+	TyposquatMode         string
+	WarnOnly              bool
+	Ecosystems            string
 }
 
 // cloneWithOverrides returns a copy of CommandContext with per-call values layered on top.
@@ -93,6 +104,16 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 	applyStringOverride(&clone.ResolvedConfig.URL, o.URL)
 	applyStringOverride(&clone.ResolvedConfig.Ref, o.Ref)
 	applyFailOnOverride(&clone.ResolvedConfig.FailOn, o.FailOn)
+	applyCSVOverride(&clone.ResolvedConfig.FailOnScopes, o.FailOnScopes)
+	applyCSVOverride(&clone.ResolvedConfig.AllowVulnerabilityIDs, o.AllowVulnerabilityIDs)
+	applyCSVOverride(&clone.ResolvedConfig.AllowLicenses, o.AllowLicenses)
+	applyCSVOverride(&clone.ResolvedConfig.DenyLicenses, o.DenyLicenses)
+	applyCSVOverride(&clone.ResolvedConfig.LicenseExemptPackages, o.LicenseExemptPackages)
+	applyCSVOverride(&clone.ResolvedConfig.DenyPackages, o.DenyPackages)
+	applyCSVOverride(&clone.ResolvedConfig.DenyGroups, o.DenyGroups)
+	applyCSVOverride(&clone.ResolvedConfig.ProtectedPackages, o.ProtectedPackages)
+	applyStringOverride(&clone.ResolvedConfig.TyposquatThreshold, o.TyposquatThreshold)
+	applyStringOverride(&clone.ResolvedConfig.TyposquatMode, o.TyposquatMode)
 	applyStringOverride(&clone.ResolvedConfig.Ecosystems, o.Ecosystems)
 	if o.Enrich {
 		clone.ResolvedConfig.Enrich = true
@@ -103,6 +124,9 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 	if o.Reachability {
 		clone.ResolvedConfig.Reachability = true
 	}
+	if o.WarnOnly {
+		clone.ResolvedConfig.WarnOnly = true
+	}
 	clone.ResolvedConfig.Interactive = false
 
 	applyStringOverride(&resolved.Path, o.Path)
@@ -110,6 +134,16 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 	applyStringOverride(&resolved.URL, o.URL)
 	applyStringOverride(&resolved.Ref, o.Ref)
 	applyFailOnOverride(&resolved.FailOn, o.FailOn)
+	applyCSVOverride(&resolved.FailOnScopes, o.FailOnScopes)
+	applyCSVOverride(&resolved.AllowVulnerabilityIDs, o.AllowVulnerabilityIDs)
+	applyCSVOverride(&resolved.AllowLicenses, o.AllowLicenses)
+	applyCSVOverride(&resolved.DenyLicenses, o.DenyLicenses)
+	applyCSVOverride(&resolved.LicenseExemptPackages, o.LicenseExemptPackages)
+	applyCSVOverride(&resolved.DenyPackages, o.DenyPackages)
+	applyCSVOverride(&resolved.DenyGroups, o.DenyGroups)
+	applyCSVOverride(&resolved.ProtectedPackages, o.ProtectedPackages)
+	applyStringOverride(&resolved.TyposquatThreshold, o.TyposquatThreshold)
+	applyStringOverride(&resolved.TyposquatMode, o.TyposquatMode)
 	applyStringOverride(&resolved.Ecosystems, o.Ecosystems)
 	if o.Enrich {
 		resolved.Enrich = true
@@ -119,6 +153,9 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 	}
 	if o.Reachability {
 		resolved.Reachability = true
+	}
+	if o.WarnOnly {
+		resolved.WarnOnly = true
 	}
 	resolved.Interactive = false
 	clone.SetConfig(resolved)
@@ -139,6 +176,20 @@ func applyFailOnOverride(target *[]string, value string) {
 	if strings.TrimSpace(value) != "" {
 		*target = []string{value}
 	}
+}
+
+func applyCSVOverride(target *[]string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	*target = out
 }
 
 func (a *mcpOptionsAdapter) RunScan(ctx context.Context, req mcp.ScanRequest) (output.ScanResponse, error) {
@@ -212,11 +263,23 @@ func (a *mcpOptionsAdapter) RunExplain(ctx context.Context, req mcp.ExplainReque
 func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (output.DiffResponse, error) {
 	started := time.Now()
 	o := a.cloneWithOverrides(mcpOverrides{
-		Path:         req.Path,
-		Container:    req.Container,
-		Enrich:       req.Enrich,
-		Audit:        req.Audit,
-		Reachability: req.Reachability,
+		Path:                  req.Path,
+		Container:             req.Container,
+		Enrich:                req.Enrich,
+		Audit:                 req.Audit,
+		Reachability:          req.Reachability,
+		FailOn:                req.FailOn,
+		FailOnScopes:          req.FailOnScopes,
+		AllowVulnerabilityIDs: req.AllowVulnerabilityIDs,
+		AllowLicenses:         req.AllowLicenses,
+		DenyLicenses:          req.DenyLicenses,
+		LicenseExemptPackages: req.LicenseExemptPackages,
+		DenyPackages:          req.DenyPackages,
+		DenyGroups:            req.DenyGroups,
+		ProtectedPackages:     req.ProtectedPackages,
+		TyposquatThreshold:    req.TyposquatThreshold,
+		TyposquatMode:         req.TyposquatMode,
+		WarnOnly:              req.WarnOnly,
 	})
 	logger := a.logger
 

--- a/internal/cli/opts/filters.go
+++ b/internal/cli/opts/filters.go
@@ -22,7 +22,7 @@ type detectorOptionRow struct {
 const (
 	OSVMatcherName             = "osv"
 	GrypeMatcherName           = "grype"
-	SeverityPolicyAuditorName  = "severity-policy"
+	VulnerabilityAuditorName   = "vulnerability"
 	ClearlyDefinedCheckerName  = "clearlydefined-license-checker"
 	clearlyDefinedCheckerAlias = "clearlydefined"
 	DepsdevCheckerName         = "depsdev-license-checker"

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -71,6 +71,17 @@ func bindAnalysisFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.BoolVar(&cfg.Audit, "audit", false, "Evaluate policy and create findings from package vulnerability data")
 	flags.BoolVar(&cfg.Reachability, "reachability", false, "[Experimental] Run code analysis to confirm whether vulnerabilities are reachable from application code")
 	flags.StringArrayVar(&cfg.FailOn, "fail-on", nil, "Constraint(s) for which findings should be created. Repeatable; constraints AND together. Severity: any|low|medium|high|critical. Reachability: reachable. Example: --fail-on low --fail-on reachable")
+	flags.StringArrayVar(&cfg.FailOnScopes, "fail-on-scope", nil, "Dependency scope that may produce failing findings: runtime, development, or unknown. Repeatable")
+	flags.StringArrayVar(&cfg.AllowVulnerabilityIDs, "allow-vulnerability-id", nil, "Vulnerability ID to ignore during policy evaluation. Repeatable")
+	flags.StringArrayVar(&cfg.AllowLicenses, "allow-license", nil, "Allowed SPDX license identifier or expression. Repeatable")
+	flags.StringArrayVar(&cfg.DenyLicenses, "deny-license", nil, "Denied SPDX license identifier or expression. Repeatable")
+	flags.StringArrayVar(&cfg.LicenseExemptPackages, "license-exempt-package", nil, "Package URL exempt from license policy checks. Repeatable")
+	flags.StringArrayVar(&cfg.DenyPackages, "deny-package", nil, "Package URL to deny. Repeatable")
+	flags.StringArrayVar(&cfg.DenyGroups, "deny-group", nil, "Package URL namespace to deny. Repeatable")
+	flags.StringArrayVar(&cfg.ProtectedPackages, "protected-package", nil, "Canonical package name to protect from typosquatting. Repeatable")
+	flags.StringVar(&cfg.TyposquatThreshold, "typosquat-threshold", "", "Similarity threshold for typosquatting detection")
+	flags.StringVar(&cfg.TyposquatMode, "typosquat-mode", "", "Typosquatting policy mode: warn or fail")
+	flags.BoolVar(&cfg.WarnOnly, "warn-only", false, "Downgrade failing findings to warnings")
 }
 
 func bindSelectorFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
@@ -119,6 +130,39 @@ func applyFlagOverrides(dst *config.Resolved, flags config.Resolved, cmd *cobra.
 	}
 	if flagChanged(cmd, "fail-on") {
 		dst.FailOn = append([]string(nil), flags.FailOn...)
+	}
+	if flagChanged(cmd, "fail-on-scope") {
+		dst.FailOnScopes = append([]string(nil), flags.FailOnScopes...)
+	}
+	if flagChanged(cmd, "allow-vulnerability-id") {
+		dst.AllowVulnerabilityIDs = append([]string(nil), flags.AllowVulnerabilityIDs...)
+	}
+	if flagChanged(cmd, "allow-license") {
+		dst.AllowLicenses = append([]string(nil), flags.AllowLicenses...)
+	}
+	if flagChanged(cmd, "deny-license") {
+		dst.DenyLicenses = append([]string(nil), flags.DenyLicenses...)
+	}
+	if flagChanged(cmd, "license-exempt-package") {
+		dst.LicenseExemptPackages = append([]string(nil), flags.LicenseExemptPackages...)
+	}
+	if flagChanged(cmd, "deny-package") {
+		dst.DenyPackages = append([]string(nil), flags.DenyPackages...)
+	}
+	if flagChanged(cmd, "deny-group") {
+		dst.DenyGroups = append([]string(nil), flags.DenyGroups...)
+	}
+	if flagChanged(cmd, "protected-package") {
+		dst.ProtectedPackages = append([]string(nil), flags.ProtectedPackages...)
+	}
+	if flagChanged(cmd, "typosquat-threshold") {
+		dst.TyposquatThreshold = flags.TyposquatThreshold
+	}
+	if flagChanged(cmd, "typosquat-mode") {
+		dst.TyposquatMode = flags.TyposquatMode
+	}
+	if flagChanged(cmd, "warn-only") {
+		dst.WarnOnly = flags.WarnOnly
 	}
 	if flagChanged(cmd, "analyzers") {
 		dst.Analyzers = flags.Analyzers

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/exit"
@@ -112,6 +113,15 @@ func (o Options) AnalyzerFilter() sdk.AnalyzerFilter {
 // PipelineRequest builds the scan pipeline request for this prepared command context.
 func (o Options) PipelineRequest(scope sdk.Scope, stderr io.Writer) engine.PipelineRequest {
 	failOn, _ := sdk.ParseFailOnList(o.ResolvedConfig.FailOn)
+	failOnScopes := make([]sdk.Scope, 0, len(o.ResolvedConfig.FailOnScopes))
+	for _, rawScope := range o.ResolvedConfig.FailOnScopes {
+		parsed, err := sdk.ParseScope(rawScope)
+		if err != nil {
+			continue
+		}
+		failOnScopes = append(failOnScopes, parsed)
+	}
+	typosquatThreshold, _ := strconv.ParseFloat(strings.TrimSpace(o.ResolvedConfig.TyposquatThreshold), 64)
 	return engine.PipelineRequest{
 		ProjectPath:                o.executionTarget.Location,
 		ExecutionTarget:            o.executionTarget,
@@ -125,6 +135,17 @@ func (o Options) PipelineRequest(scope sdk.Scope, stderr io.Writer) engine.Pipel
 		AnalyzerFilter:             o.analyzerFilter,
 		DetectorFilter:             o.detectorFilter,
 		FailOn:                     failOn,
+		FailOnScopes:               failOnScopes,
+		AllowVulnerabilityIDs:      append([]string(nil), o.ResolvedConfig.AllowVulnerabilityIDs...),
+		AllowLicenses:              append([]string(nil), o.ResolvedConfig.AllowLicenses...),
+		DenyLicenses:               append([]string(nil), o.ResolvedConfig.DenyLicenses...),
+		LicenseExemptPackages:      append([]string(nil), o.ResolvedConfig.LicenseExemptPackages...),
+		DenyPackages:               append([]string(nil), o.ResolvedConfig.DenyPackages...),
+		DenyGroups:                 append([]string(nil), o.ResolvedConfig.DenyGroups...),
+		ProtectedPackages:          append([]string(nil), o.ResolvedConfig.ProtectedPackages...),
+		TyposquatThreshold:         typosquatThreshold,
+		TyposquatMode:              strings.TrimSpace(o.ResolvedConfig.TyposquatMode),
+		WarnOnly:                   o.ResolvedConfig.WarnOnly,
 		InstallFirst:               o.ResolvedConfig.InstallFirst,
 		InstallArgs:                append([]string(nil), o.ResolvedConfig.InstallArgs...),
 		Stderr:                     stderr,

--- a/internal/cli/opts/registry.go
+++ b/internal/cli/opts/registry.go
@@ -12,15 +12,33 @@ import (
 // callers (tests, plugin adapters) stay functional.
 func RegistryConfigsFromResolved(cfg config.Resolved) engine.RegistryConfigs {
 	failOn, _ := sdk.ParseFailOnList(cfg.FailOn)
+	failOnScopes := make([]sdk.Scope, 0, len(cfg.FailOnScopes))
+	for _, rawScope := range cfg.FailOnScopes {
+		scope, err := sdk.ParseScope(rawScope)
+		if err != nil {
+			continue
+		}
+		failOnScopes = append(failOnScopes, scope)
+	}
 	return engine.RegistryConfigs{
-		FailOn:      failOn,
-		OsvAPIBase:  cfg.OsvAPIBase,
-		OsvCacheDir: cfg.OsvCacheDir,
-		OsvCacheTTL: cfg.OsvCacheTTL,
-		KEVCacheDir: cfg.KEVCacheDir,
-		KEVCacheTTL: cfg.KEVCacheTTL,
-		EOLAPIBase:  cfg.EOLAPIBase,
-		EOLCacheDir: cfg.EOLCacheDir,
-		EOLCacheTTL: cfg.EOLCacheTTL,
+		FailOn:                failOn,
+		FailOnScopes:          failOnScopes,
+		AllowVulnerabilityIDs: append([]string(nil), cfg.AllowVulnerabilityIDs...),
+		AllowLicenses:         append([]string(nil), cfg.AllowLicenses...),
+		DenyLicenses:          append([]string(nil), cfg.DenyLicenses...),
+		LicenseExemptPackages: append([]string(nil), cfg.LicenseExemptPackages...),
+		DenyPackages:          append([]string(nil), cfg.DenyPackages...),
+		DenyGroups:            append([]string(nil), cfg.DenyGroups...),
+		ProtectedPackages:     append([]string(nil), cfg.ProtectedPackages...),
+		TyposquatThreshold:    cfg.TyposquatThreshold,
+		TyposquatMode:         cfg.TyposquatMode,
+		OsvAPIBase:            cfg.OsvAPIBase,
+		OsvCacheDir:           cfg.OsvCacheDir,
+		OsvCacheTTL:           cfg.OsvCacheTTL,
+		KEVCacheDir:           cfg.KEVCacheDir,
+		KEVCacheTTL:           cfg.KEVCacheTTL,
+		EOLAPIBase:            cfg.EOLAPIBase,
+		EOLCacheDir:           cfg.EOLCacheDir,
+		EOLCacheTTL:           cfg.EOLCacheTTL,
 	}
 }

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -7,12 +7,9 @@ import (
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/output"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
-// DiffManifestStatusOrder returns the sort rank for a diff manifest status
-// (removed, added, changed, unchanged). Lower wins; unknown sorts last.
+// DiffManifestStatusOrder returns the sort rank for a diff manifest status.
 func DiffManifestStatusOrder(status string) int {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "removed":
@@ -30,36 +27,23 @@ func DiffManifestStatusOrder(status string) int {
 
 // Diff writes the human-readable diff report for the diff command.
 func Diff(w io.Writer, payload output.DiffResponse) error {
-	if _, err := fmt.Fprintf(w, "Dependency diff %s -> %s\n", payload.Comparison.Base, payload.Comparison.Head); err != nil {
-		return err
+	lines := []string{
+		fmt.Sprintf("Dependency diff %s -> %s", payload.Comparison.Base, payload.Comparison.Head),
+		fmt.Sprintf(
+			"Matches: %d exact, %d fuzzy, %d unmatched",
+			payload.Summary.ExactMatchCount,
+			payload.Summary.FuzzyMatchCount,
+			payload.Summary.UnmatchedPackageCount,
+		),
+		"",
 	}
-	if _, err := fmt.Fprintf(
-		w,
-		"Manifest changes: %d added, %d changed, %d unchanged, and %d removed\n",
-		payload.Summary.AddedManifestCount,
-		payload.Summary.ChangedManifestCount,
-		payload.Summary.UnchangedManifestCount,
-		payload.Summary.RemovedManifestCount,
-	); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(
-		w,
-		"Package changes: %d added, %d updated, and %d removed\n",
-		payload.Summary.AddedPackageCount,
-		payload.Summary.ChangedPackageCount,
-		payload.Summary.RemovedPackageCount,
-	); err != nil {
-		return err
-	}
+	lines = append(lines, dependencyTextSections(payload.Results.Dependencies)...)
+	lines = append(lines, licenseTextSections(payload.Results.Licenses)...)
+	lines = append(lines, vulnerabilityTextSections(payload.Results.Vulnerabilities)...)
 	if payload.Audit != nil {
-		for _, line := range diffAuditTextSections(*payload.Audit) {
-			if _, err := fmt.Fprintln(w, line); err != nil {
-				return err
-			}
-		}
+		lines = append(lines, policyTextSections(*payload.Audit)...)
 	}
-	for _, line := range diffTextSections(payload.Results.Manifests) {
+	for _, line := range lines {
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err
 		}
@@ -67,53 +51,187 @@ func Diff(w io.Writer, payload output.DiffResponse) error {
 	return nil
 }
 
-func diffAuditTextSections(audit output.DiffAudit) []string {
+func dependencyTextSections(results output.DiffDependencyResults) []string {
+	lines := []string{"Dependencies"}
+	nameWidth := dependencyNameWidth(results)
+	appendAdded := func() {
+		if len(results.Added) == 0 {
+			return
+		}
+		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
+		for _, change := range results.Added {
+			pkg := change.Package
+			line := fmt.Sprintf("  + %-*s  %-8s %s", nameWidth, DiffPackageDisplayName(pkg), primaryLicense(pkg), displayScope(pkg.Scope))
+			lines = append(lines, Wrap(strings.TrimRight(line, " "), Green))
+		}
+	}
+	appendRemoved := func() {
+		if len(results.Removed) == 0 {
+			return
+		}
+		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
+		for _, change := range results.Removed {
+			line := fmt.Sprintf("  - %s", DiffPackageDisplayName(change.Package))
+			lines = append(lines, Wrap(line, Red))
+		}
+	}
+	appendChanged := func() {
+		if len(results.Changed) == 0 {
+			return
+		}
+		lines = append(lines, fmt.Sprintf("Changed (%d)", len(results.Changed)))
+		for _, change := range results.Changed {
+			name := change.After.Name
+			if strings.TrimSpace(name) == "" {
+				name = change.After.ID
+			}
+			line := fmt.Sprintf("  ~ %-*s  %s -> %s", changedNameWidth(results), name, change.Before.Version, change.After.Version)
+			lines = append(lines, Wrap(line, Yellow))
+		}
+	}
+	appendAdded()
+	appendRemoved()
+	appendChanged()
+	if len(lines) == 1 {
+		lines = append(lines, "  No dependency changes.")
+	}
+	lines = append(lines, "")
+	return lines
+}
+
+func licenseTextSections(results output.DiffLicenseResults) []string {
+	lines := []string{"Licenses"}
+	if len(results.Added) == 0 && len(results.Removed) == 0 && len(results.Changed) == 0 {
+		return append(lines, "  No license changes.", "")
+	}
+	if len(results.Added) > 0 {
+		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
+		for _, change := range results.Added {
+			lines = append(lines, Wrap(fmt.Sprintf("  + %s  %s", DiffPackageDisplayName(change.Package), licenseList(change.Licenses)), Green))
+		}
+	}
+	if len(results.Removed) > 0 {
+		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
+		for _, change := range results.Removed {
+			lines = append(lines, Wrap(fmt.Sprintf("  - %s  %s", DiffPackageDisplayName(change.Package), licenseList(change.Licenses)), Red))
+		}
+	}
+	if len(results.Changed) > 0 {
+		lines = append(lines, fmt.Sprintf("Changed (%d)", len(results.Changed)))
+		for _, change := range results.Changed {
+			lines = append(lines, Wrap(fmt.Sprintf("  ~ %s  %s -> %s", DiffPackageDisplayName(change.Package), licenseList(change.Before), licenseList(change.After)), Yellow))
+		}
+	}
+	return append(lines, "")
+}
+
+func vulnerabilityTextSections(results output.DiffVulnerabilityResults) []string {
+	lines := []string{"Vulnerabilities"}
+	if len(results.Added) == 0 && len(results.Removed) == 0 {
+		return append(lines, "  No vulnerability changes.", "")
+	}
+	if len(results.Added) > 0 {
+		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
+		for _, change := range results.Added {
+			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package)), Red))
+		}
+	}
+	if len(results.Removed) > 0 {
+		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
+		for _, change := range results.Removed {
+			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package)), Green))
+		}
+	}
+	return append(lines, "")
+}
+
+func policyTextSections(audit output.DiffAudit) []string {
 	lines := []string{
-		"",
-		"Policy Outcome",
+		"Policy Evaluation",
 		fmt.Sprintf("  Current findings: %s.", diffAuditFindingsSummary(audit.AuditSummary)),
-		fmt.Sprintf(
-			"  Change summary: %d introduced, %d persisted, and %d resolved findings.",
-			len(audit.Introduced),
-			len(audit.Persisted),
-			len(audit.Resolved),
-		),
+		fmt.Sprintf("  Change summary: %d introduced, %d persisted, and %d resolved findings.", len(audit.Introduced), len(audit.Persisted), len(audit.Resolved)),
 	}
-
-	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
-		return append(lines, "  No policy differences were identified between the base and head dependency sets.")
-	}
-
 	appendSection := func(title string, findings []output.AuditFinding, color string) {
 		if len(findings) == 0 {
 			return
 		}
-		lines = append(lines, "")
 		lines = append(lines, title)
 		for _, finding := range sortDiffAuditFindings(findings) {
-			line := fmt.Sprintf("  - [%s] %s", strings.ToUpper(ValueOrDash(finding.Severity)), ValueOrDash(finding.ID))
-			pkgLabel := DiffPackageDisplayName(finding.Package)
-			if pkgLabel != "" {
+			disposition := strings.ToUpper(ValueOrDash(finding.Disposition))
+			line := fmt.Sprintf("  - [%s/%s] %s", strings.ToUpper(ValueOrDash(finding.Severity)), disposition, ValueOrDash(finding.ID))
+			if pkgLabel := DiffPackageDisplayName(finding.Package); pkgLabel != "" {
 				line += " " + pkgLabel
 			}
-			if strings.TrimSpace(finding.Source) != "" {
-				line += fmt.Sprintf(" (%s)", finding.Source)
-			}
 			if strings.TrimSpace(finding.Title) != "" && finding.Title != finding.ID {
-				line += fmt.Sprintf(": %s", finding.Title)
+				line += ": " + finding.Title
 			}
 			if color != "" {
 				line = Wrap(line, color)
 			}
 			lines = append(lines, line)
 		}
+		lines = append(lines, "")
 	}
-
 	appendSection("Introduced Findings", audit.Introduced, Red)
-	appendSection("Persisted Findings", audit.Persisted, "")
 	appendSection("Resolved Findings", audit.Resolved, Green)
-
+	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
+		lines = append(lines, "  No policy differences were identified between the base and head dependency sets.")
+	}
 	return lines
+}
+
+func dependencyNameWidth(results output.DiffDependencyResults) int {
+	width := 0
+	for _, change := range results.Added {
+		width = max(width, len(DiffPackageDisplayName(change.Package)))
+	}
+	return width
+}
+
+func changedNameWidth(results output.DiffDependencyResults) int {
+	width := 0
+	for _, change := range results.Changed {
+		name := change.After.Name
+		if name == "" {
+			name = change.After.ID
+		}
+		width = max(width, len(name))
+	}
+	return width
+}
+
+func primaryLicense(pkg output.PackageRef) string {
+	if len(pkg.Licenses) == 0 {
+		return "-"
+	}
+	if value := pkg.Licenses[0].Identifier(); value != "" {
+		return value
+	}
+	return "-"
+}
+
+func displayScope(scope string) string {
+	if strings.TrimSpace(scope) == "" {
+		return "unknown"
+	}
+	return scope
+}
+
+func licenseList(values []output.LicenseRef) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	licenses := make([]string, 0, len(values))
+	for _, value := range values {
+		if id := value.Identifier(); id != "" {
+			licenses = append(licenses, id)
+		}
+	}
+	if len(licenses) == 0 {
+		return "-"
+	}
+	sort.Strings(licenses)
+	return strings.Join(licenses, ", ")
 }
 
 func diffAuditFindingsSummary(summary *output.AuditSummary) string {
@@ -124,8 +242,7 @@ func diffAuditFindingsSummary(summary *output.AuditSummary) string {
 }
 
 func sortDiffAuditFindings(findings []output.AuditFinding) []output.AuditFinding {
-	sorted := make([]output.AuditFinding, len(findings))
-	copy(sorted, findings)
+	sorted := append([]output.AuditFinding(nil), findings...)
 	sort.Slice(sorted, func(i, j int) bool {
 		si := severityRankTable(sorted[i].Severity)
 		sj := severityRankTable(sorted[j].Severity)
@@ -145,52 +262,7 @@ func sortDiffAuditFindings(findings []output.AuditFinding) []output.AuditFinding
 	return sorted
 }
 
-func diffTextSections(manifests []output.DiffManifestResult) []string {
-	lines := make([]string, 0, len(manifests)*8)
-	titleCaser := cases.Title(language.English)
-	appendSection := func(title string, values []string, indent string) {
-		if len(values) == 0 {
-			return
-		}
-		lines = append(lines, indent+title)
-		for _, value := range values {
-			lines = append(lines, indent+"- "+value)
-		}
-	}
-
-	for _, manifest := range manifests {
-		lines = append(lines, "")
-		statusLine := fmt.Sprintf("%s manifest %s", titleCaser.String(manifest.Status), DiffManifestDisplayLabel(manifest))
-		switch manifest.Status {
-		case "added":
-			statusLine = Wrap(statusLine, Green)
-		case "removed":
-			statusLine = Wrap(statusLine, Red)
-		}
-		lines = append(lines, statusLine)
-
-		added := make([]string, 0, len(manifest.Added))
-		for _, change := range manifest.Added {
-			added = append(added, Wrap(DiffPackageDisplayName(change.Package), Green))
-		}
-		changed := make([]string, 0, len(manifest.Changed))
-		for _, change := range manifest.Changed {
-			changed = append(changed, fmt.Sprintf("%s (%s -> %s)", DiffPackageDisplayName(change.After), change.Before.Version, change.After.Version))
-		}
-		removed := make([]string, 0, len(manifest.Removed))
-		for _, change := range manifest.Removed {
-			removed = append(removed, Wrap(DiffPackageDisplayName(change.Package), Red))
-		}
-
-		appendSection("Added", added, "  ")
-		appendSection("Changed", changed, "  ")
-		appendSection("Removed", removed, "  ")
-	}
-	return lines
-}
-
-// DiffPackageDisplayName returns a human-readable label for a package
-// referenced by the diff API: "name@version", "name", "id", or "".
+// DiffPackageDisplayName returns a human-readable label for a package.
 func DiffPackageDisplayName(pkg output.PackageRef) string {
 	switch {
 	case pkg.Name != "" && pkg.Version != "":
@@ -204,8 +276,7 @@ func DiffPackageDisplayName(pkg output.PackageRef) string {
 	}
 }
 
-// DiffManifestDisplayLabel returns a human-readable label for a manifest in
-// diff output, optionally suffixed with the package manager name.
+// DiffManifestDisplayLabel returns a human-readable label for a manifest in diff output.
 func DiffManifestDisplayLabel(manifest output.DiffManifestResult) string {
 	label := manifest.Path
 	if strings.TrimSpace(label) == "" {

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -608,7 +608,7 @@ func TestRoot_DiffCommand_AuditUsesResolvedGitRefs(t *testing.T) {
 		"--enrich",
 		"--audit",
 		"--matchers", "grype,osv",
-		"--auditors", "severity-policy",
+		"--auditors", "vulnerability",
 		"--format", "json",
 	})
 

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -150,8 +150,10 @@ func newScanCmd() *cobra.Command {
 					return err
 				},
 			})
-			if err == nil && commandCtx.ResolvedConfig.Audit && len(findings) > 0 {
-				return exit.PolicyViolationFindings(len(findings))
+			if err == nil && commandCtx.ResolvedConfig.Audit {
+				if failing := output.FailingFindingCount(findings); failing > 0 {
+					return exit.PolicyViolationFindings(failing)
+				}
 			}
 			return err
 		},

--- a/internal/cli/scan_output.go
+++ b/internal/cli/scan_output.go
@@ -11,7 +11,6 @@ func diffAuditOutput(audit *diffengine.Audit) *output.DiffAudit {
 		return nil
 	}
 	combined := append(append([]sdk.Finding{}, audit.Introduced...), audit.Persisted...)
-	combined = append(combined, audit.Resolved...)
 	return &output.DiffAudit{
 		Introduced:   output.FindingsFromScan(audit.Introduced),
 		Resolved:     output.FindingsFromScan(audit.Resolved),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,28 +19,39 @@ package config
 // Resolved holds the fully-merged CLI configuration: defaults overridden by
 // the YAML config file, then env vars, then explicit flags.
 type Resolved struct {
-	Path         string   `doc:"Filesystem path to scan" env:"BOMLY_PATH"`
-	Container    string   `doc:"Container image to scan (e.g. alpine:latest)" env:"BOMLY_CONTAINER"`
-	URL          string   `doc:"Remote Git URL to clone and scan" env:"BOMLY_URL"`
-	Ref          string   `doc:"Git ref to checkout when scanning a URL" env:"BOMLY_REF"`
-	SBOM         bool     `doc:"Treat the selected filesystem target as an SBOM file" env:"BOMLY_SBOM"`
-	Enrich       bool     `doc:"Enrich packages with external license and vulnerability data" env:"BOMLY_ENRICH"`
-	Audit        bool     `doc:"Evaluate policy and create findings from package vulnerability data" env:"BOMLY_AUDIT"`
-	Reachability bool     `doc:"Run code analysis to confirm whether vulnerabilities are reachable from application code" env:"BOMLY_REACHABILITY"`
-	FailOn       []string `doc:"Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable" env:"BOMLY_FAIL_ON"`
-	Analyzers    string   `doc:"Reachability analyzer selectors; supports +name and -name modifiers" env:"BOMLY_ANALYZERS"`
-	Format       string   `doc:"Primary report format: text, json, or sarif" env:"BOMLY_FORMAT"`
-	Interactive  bool     `doc:"Enable interactive TUI mode" env:"BOMLY_INTERACTIVE"`
-	Ecosystems   string   `doc:"Ecosystem selectors; supports +name and -name modifiers" env:"BOMLY_ECOSYSTEMS"`
-	Detectors    string   `doc:"Detector selectors; supports +name and -name modifiers" env:"BOMLY_DETECTORS"`
-	Auditors     string   `doc:"Auditor selectors; supports +name and -name modifiers" env:"BOMLY_AUDITORS"`
-	Matchers     string   `doc:"Matcher selectors; supports +name and -name modifiers" env:"BOMLY_MATCHERS"`
-	InstallFirst bool     `doc:"Run detector-specific dependency installation before resolving graphs" env:"BOMLY_INSTALL_FIRST"`
-	InstallArgs  []string `doc:"Additional detector-specific install arguments" env:"BOMLY_INSTALL_ARGS"`
-	Config       string   `doc:"Explicit YAML config file path" env:"BOMLY_CONFIG"`
-	Quiet        bool     `doc:"Suppress all non-error output" env:"BOMLY_QUIET"`
-	Verbosity    int      `doc:"Verbosity level (0=normal, 1=verbose, 2+=debug)" env:"BOMLY_VERBOSE"`
-	LoadedFiles  []string
+	Path                  string   `doc:"Filesystem path to scan" env:"BOMLY_PATH"`
+	Container             string   `doc:"Container image to scan (e.g. alpine:latest)" env:"BOMLY_CONTAINER"`
+	URL                   string   `doc:"Remote Git URL to clone and scan" env:"BOMLY_URL"`
+	Ref                   string   `doc:"Git ref to checkout when scanning a URL" env:"BOMLY_REF"`
+	SBOM                  bool     `doc:"Treat the selected filesystem target as an SBOM file" env:"BOMLY_SBOM"`
+	Enrich                bool     `doc:"Enrich packages with external license and vulnerability data" env:"BOMLY_ENRICH"`
+	Audit                 bool     `doc:"Evaluate policy and create findings from package vulnerability data" env:"BOMLY_AUDIT"`
+	Reachability          bool     `doc:"Run code analysis to confirm whether vulnerabilities are reachable from application code" env:"BOMLY_REACHABILITY"`
+	FailOn                []string `doc:"Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable" env:"BOMLY_FAIL_ON"`
+	FailOnScopes          []string `doc:"Dependency scopes that may produce failing findings: runtime, development, unknown" env:"BOMLY_FAIL_ON_SCOPES"`
+	AllowVulnerabilityIDs []string `doc:"Vulnerability IDs to ignore during policy evaluation" env:"BOMLY_ALLOW_VULNERABILITY_IDS"`
+	AllowLicenses         []string `doc:"Allowed SPDX license identifiers or expressions" env:"BOMLY_ALLOW_LICENSES"`
+	DenyLicenses          []string `doc:"Denied SPDX license identifiers or expressions" env:"BOMLY_DENY_LICENSES"`
+	LicenseExemptPackages []string `doc:"Package URLs exempt from license policy checks" env:"BOMLY_LICENSE_EXEMPT_PACKAGES"`
+	DenyPackages          []string `doc:"Package URLs to deny" env:"BOMLY_DENY_PACKAGES"`
+	DenyGroups            []string `doc:"Package URL namespaces to deny" env:"BOMLY_DENY_GROUPS"`
+	ProtectedPackages     []string `doc:"Canonical package names to protect from typosquatting" env:"BOMLY_PROTECTED_PACKAGES"`
+	TyposquatThreshold    string   `doc:"Similarity threshold for typosquatting detection" env:"BOMLY_TYPOSQUAT_THRESHOLD" default:"0.90"`
+	TyposquatMode         string   `doc:"Typosquatting policy mode: warn or fail" env:"BOMLY_TYPOSQUAT_MODE" default:"warn"`
+	WarnOnly              bool     `doc:"Downgrade failing findings to warnings" env:"BOMLY_WARN_ONLY"`
+	Analyzers             string   `doc:"Reachability analyzer selectors; supports +name and -name modifiers" env:"BOMLY_ANALYZERS"`
+	Format                string   `doc:"Primary report format: text, json, or sarif" env:"BOMLY_FORMAT"`
+	Interactive           bool     `doc:"Enable interactive TUI mode" env:"BOMLY_INTERACTIVE"`
+	Ecosystems            string   `doc:"Ecosystem selectors; supports +name and -name modifiers" env:"BOMLY_ECOSYSTEMS"`
+	Detectors             string   `doc:"Detector selectors; supports +name and -name modifiers" env:"BOMLY_DETECTORS"`
+	Auditors              string   `doc:"Auditor selectors; supports +name and -name modifiers" env:"BOMLY_AUDITORS"`
+	Matchers              string   `doc:"Matcher selectors; supports +name and -name modifiers" env:"BOMLY_MATCHERS"`
+	InstallFirst          bool     `doc:"Run detector-specific dependency installation before resolving graphs" env:"BOMLY_INSTALL_FIRST"`
+	InstallArgs           []string `doc:"Additional detector-specific install arguments" env:"BOMLY_INSTALL_ARGS"`
+	Config                string   `doc:"Explicit YAML config file path" env:"BOMLY_CONFIG"`
+	Quiet                 bool     `doc:"Suppress all non-error output" env:"BOMLY_QUIET"`
+	Verbosity             int      `doc:"Verbosity level (0=normal, 1=verbose, 2+=debug)" env:"BOMLY_VERBOSE"`
+	LoadedFiles           []string
 
 	// OSV matcher settings
 	OsvAPIBase  string `doc:"Base URL for the OSV vulnerability API" env:"BOMLY_OSV_API_BASE" default:"https://api.osv.dev"`
@@ -63,28 +74,39 @@ type Resolved struct {
 // configref generator parses this struct's yaml tags to map each Resolved
 // field to its corresponding YAML key in the reference docs.
 type File struct {
-	Path         *string    `yaml:"path,omitempty"`
-	Container    *string    `yaml:"container,omitempty"`
-	URL          *string    `yaml:"url,omitempty"`
-	Ref          *string    `yaml:"ref,omitempty"`
-	SBOM         *bool      `yaml:"sbom,omitempty"`
-	Enrich       *bool      `yaml:"enrich,omitempty"`
-	Audit        *bool      `yaml:"audit,omitempty"`
-	Reachability *bool      `yaml:"reachability,omitempty"`
-	FailOn       FailOnList `yaml:"fail_on,omitempty"`
-	Analyzers    *string    `yaml:"analyzers,omitempty"`
-	Format       *string    `yaml:"format,omitempty"`
-	Interactive  *bool      `yaml:"interactive,omitempty"`
-	Ecosystems   *string    `yaml:"ecosystems,omitempty"`
-	Detectors    *string    `yaml:"detectors,omitempty"`
-	Auditors     *string    `yaml:"auditors,omitempty"`
-	Matchers     *string    `yaml:"matchers,omitempty"`
-	InstallFirst *bool      `yaml:"install_first,omitempty"`
-	InstallArgs  []string   `yaml:"install_args,omitempty"`
-	Config       *string    `yaml:"config,omitempty"`
-	Quiet        *bool      `yaml:"quiet,omitempty"`
-	Verbosity    *int       `yaml:"verbosity,omitempty"`
-	Verbose      *bool      `yaml:"verbose,omitempty"`
+	Path                  *string    `yaml:"path,omitempty"`
+	Container             *string    `yaml:"container,omitempty"`
+	URL                   *string    `yaml:"url,omitempty"`
+	Ref                   *string    `yaml:"ref,omitempty"`
+	SBOM                  *bool      `yaml:"sbom,omitempty"`
+	Enrich                *bool      `yaml:"enrich,omitempty"`
+	Audit                 *bool      `yaml:"audit,omitempty"`
+	Reachability          *bool      `yaml:"reachability,omitempty"`
+	FailOn                FailOnList `yaml:"fail_on,omitempty"`
+	FailOnScopes          []string   `yaml:"fail_on_scopes,omitempty"`
+	AllowVulnerabilityIDs []string   `yaml:"allow_vulnerability_ids,omitempty"`
+	AllowLicenses         []string   `yaml:"allow_licenses,omitempty"`
+	DenyLicenses          []string   `yaml:"deny_licenses,omitempty"`
+	LicenseExemptPackages []string   `yaml:"license_exempt_packages,omitempty"`
+	DenyPackages          []string   `yaml:"deny_packages,omitempty"`
+	DenyGroups            []string   `yaml:"deny_groups,omitempty"`
+	ProtectedPackages     []string   `yaml:"protected_packages,omitempty"`
+	TyposquatThreshold    *string    `yaml:"typosquat_threshold,omitempty"`
+	TyposquatMode         *string    `yaml:"typosquat_mode,omitempty"`
+	WarnOnly              *bool      `yaml:"warn_only,omitempty"`
+	Analyzers             *string    `yaml:"analyzers,omitempty"`
+	Format                *string    `yaml:"format,omitempty"`
+	Interactive           *bool      `yaml:"interactive,omitempty"`
+	Ecosystems            *string    `yaml:"ecosystems,omitempty"`
+	Detectors             *string    `yaml:"detectors,omitempty"`
+	Auditors              *string    `yaml:"auditors,omitempty"`
+	Matchers              *string    `yaml:"matchers,omitempty"`
+	InstallFirst          *bool      `yaml:"install_first,omitempty"`
+	InstallArgs           []string   `yaml:"install_args,omitempty"`
+	Config                *string    `yaml:"config,omitempty"`
+	Quiet                 *bool      `yaml:"quiet,omitempty"`
+	Verbosity             *int       `yaml:"verbosity,omitempty"`
+	Verbose               *bool      `yaml:"verbose,omitempty"`
 
 	// OSV matcher settings
 	OsvAPIBase  *string `yaml:"osv_api_base,omitempty"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -83,6 +84,30 @@ func ApplyFileConfig(dst *Resolved, src File) {
 	// FailOn is a custom-unmarshaled slice (FailOnList) — replace when set.
 	if len(src.FailOn) > 0 {
 		dst.FailOn = append([]string(nil), src.FailOn...)
+	}
+	if len(src.FailOnScopes) > 0 {
+		dst.FailOnScopes = append([]string(nil), src.FailOnScopes...)
+	}
+	if len(src.AllowVulnerabilityIDs) > 0 {
+		dst.AllowVulnerabilityIDs = append([]string(nil), src.AllowVulnerabilityIDs...)
+	}
+	if len(src.AllowLicenses) > 0 {
+		dst.AllowLicenses = append([]string(nil), src.AllowLicenses...)
+	}
+	if len(src.DenyLicenses) > 0 {
+		dst.DenyLicenses = append([]string(nil), src.DenyLicenses...)
+	}
+	if len(src.LicenseExemptPackages) > 0 {
+		dst.LicenseExemptPackages = append([]string(nil), src.LicenseExemptPackages...)
+	}
+	if len(src.DenyPackages) > 0 {
+		dst.DenyPackages = append([]string(nil), src.DenyPackages...)
+	}
+	if len(src.DenyGroups) > 0 {
+		dst.DenyGroups = append([]string(nil), src.DenyGroups...)
+	}
+	if len(src.ProtectedPackages) > 0 {
+		dst.ProtectedPackages = append([]string(nil), src.ProtectedPackages...)
 	}
 	// Verbose is a legacy shorthand; map it to Verbosity=1 if not already set.
 	if src.Verbose != nil && *src.Verbose && dst.Verbosity == 0 {
@@ -171,6 +196,26 @@ func Validate(cfg Resolved) error {
 	if cfg.Reachability && !cfg.Enrich {
 		return fmt.Errorf("--reachability requires --enrich")
 	}
+	if len(cfg.AllowLicenses) > 0 && len(cfg.DenyLicenses) > 0 {
+		return fmt.Errorf("--allow-license cannot be combined with --deny-license")
+	}
+	for _, scope := range cfg.FailOnScopes {
+		switch strings.ToLower(strings.TrimSpace(scope)) {
+		case "", "runtime", "development", "unknown":
+		default:
+			return fmt.Errorf("unsupported --fail-on-scope value %q (accepted: runtime, development, unknown)", scope)
+		}
+	}
+	if threshold := strings.TrimSpace(cfg.TyposquatThreshold); threshold != "" {
+		if _, err := strconv.ParseFloat(threshold, 64); err != nil {
+			return fmt.Errorf("invalid --typosquat-threshold %q", cfg.TyposquatThreshold)
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.TyposquatMode)) {
+	case "", "warn", "fail":
+	default:
+		return fmt.Errorf("unsupported --typosquat-mode value %q (accepted: warn, fail)", cfg.TyposquatMode)
+	}
 	return nil
 }
 
@@ -207,15 +252,16 @@ func parseCSV(value string) []string {
 	items := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 	for _, part := range parts {
-		normalized := strings.ToLower(strings.TrimSpace(part))
-		if normalized == "" {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
 			continue
 		}
-		if _, ok := seen[normalized]; ok {
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[normalized] = struct{}{}
-		items = append(items, normalized)
+		seen[key] = struct{}{}
+		items = append(items, trimmed)
 	}
 	return items
 }

--- a/internal/engine/diff/diff.go
+++ b/internal/engine/diff/diff.go
@@ -52,6 +52,7 @@ func Run(ctx context.Context, req Request) (Result, error) {
 		return result, fmt.Errorf("base pipeline: %w", err)
 	}
 
+	req.Head.Request.BaselineGraph = base.Graph
 	head, err := req.Head.Pipeline.Run(ctx, req.Head.Request)
 	result.Head = head
 	if err != nil {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -227,12 +227,19 @@ func (p *Pipeline) runAudit(ctx context.Context, result *PipelineResult, req Pip
 	}
 	if !GraphHasVulnerabilityData(result.Graph) {
 		result.AuditWarnings = append(result.AuditWarnings, PipelineWarning{
-			Source:  "severity-policy",
+			Source:  "vulnerability",
 			Message: "no vulnerability enrichment input was available; policy evaluation may produce no findings",
 		})
 	}
 	auditResult, auditWarnings := p.audit(ctx, result.Graph, req)
 	result.Findings = DeduplicateFindings(auditResult.Findings)
+	if req.WarnOnly {
+		for idx := range result.Findings {
+			if result.Findings[idx].Disposition == "" || result.Findings[idx].Disposition == sdk.FindingDispositionFail {
+				result.Findings[idx].Disposition = sdk.FindingDispositionWarn
+			}
+		}
+	}
 	result.RiskScores = auditResult.RiskScores
 	result.AuditorRuns = auditResult.AuditorRuns
 	result.AuditorFindings = auditResult.AuditorFindings
@@ -296,6 +303,7 @@ func (p *Pipeline) audit(ctx context.Context, g *sdk.Graph, req PipelineRequest)
 		ExecutionTarget: req.ExecutionTarget,
 		Mode:            sdk.TargetModeFullGraph,
 		Graph:           g,
+		BaselineGraph:   req.BaselineGraph,
 		AuditorFilter:   req.AuditorFilter,
 		Stderr:          req.Stderr,
 	}

--- a/internal/engine/pipeline_explain.go
+++ b/internal/engine/pipeline_explain.go
@@ -108,7 +108,7 @@ func (p *Pipeline) RunExplain(ctx context.Context, req ExplainRequest) (ExplainR
 
 	if auditEnabled && !GraphHasVulnerabilityData(base.Graph) {
 		result.AuditWarnings = append(result.AuditWarnings, PipelineWarning{
-			Source:  "severity-policy",
+			Source:  "vulnerability",
 			Message: "no vulnerability enrichment input was available; policy evaluation may produce no findings",
 		})
 	}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -33,6 +33,18 @@ type PipelineRequest struct {
 	AnalyzerFilter             sdk.AnalyzerFilter
 	DetectorFilter             sdk.DetectorFilter
 	FailOn                     []sdk.FailOnConstraint
+	FailOnScopes               []sdk.Scope
+	AllowVulnerabilityIDs      []string
+	AllowLicenses              []string
+	DenyLicenses               []string
+	LicenseExemptPackages      []string
+	DenyPackages               []string
+	DenyGroups                 []string
+	ProtectedPackages          []string
+	TyposquatThreshold         float64
+	TyposquatMode              string
+	WarnOnly                   bool
+	BaselineGraph              *sdk.Graph
 	InstallFirst               bool
 	InstallArgs                []string
 	CoreVersion                string

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,13 +35,25 @@ type ExplainRequest struct {
 
 // DiffRequest holds per-call overrides for the bomly_diff tool.
 type DiffRequest struct {
-	Base         string `json:"base"`
-	Head         string `json:"head"`
-	Path         string `json:"path"`
-	Container    string `json:"container"`
-	Enrich       bool   `json:"enrich"`
-	Audit        bool   `json:"audit"`
-	Reachability bool   `json:"reachability"`
+	Base                  string `json:"base"`
+	Head                  string `json:"head"`
+	Path                  string `json:"path"`
+	Container             string `json:"container"`
+	Enrich                bool   `json:"enrich"`
+	Audit                 bool   `json:"audit"`
+	Reachability          bool   `json:"reachability"`
+	FailOn                string `json:"fail_on"`
+	FailOnScopes          string `json:"fail_on_scopes"`
+	AllowVulnerabilityIDs string `json:"allow_vulnerability_ids"`
+	AllowLicenses         string `json:"allow_licenses"`
+	DenyLicenses          string `json:"deny_licenses"`
+	LicenseExemptPackages string `json:"license_exempt_packages"`
+	DenyPackages          string `json:"deny_packages"`
+	DenyGroups            string `json:"deny_groups"`
+	ProtectedPackages     string `json:"protected_packages"`
+	TyposquatThreshold    string `json:"typosquat_threshold"`
+	TyposquatMode         string `json:"typosquat_mode"`
+	WarnOnly              bool   `json:"warn_only"`
 }
 
 // VulnFixRequest holds per-call overrides for the bomly_vuln_fix_context tool.

--- a/internal/mcp/tool_diff.go
+++ b/internal/mcp/tool_diff.go
@@ -22,6 +22,18 @@ func registerDiffTool(s *server.MCPServer, mcpCtx MCPContext) {
 		mcplib.WithBoolean("enrich", mcplib.Description("Enrich packages with vulnerability and license data")),
 		mcplib.WithBoolean("audit", mcplib.Description("Include audit delta (introduced, resolved, and persisted findings) (requires enrich)")),
 		mcplib.WithBoolean("reachability", mcplib.Description("Run code analysis on each side and include reachability annotations on the audit delta (requires enrich)")),
+		mcplib.WithString("fail_on", mcplib.Description("Vulnerability threshold constraint, such as high or reachable")),
+		mcplib.WithString("fail_on_scopes", mcplib.Description("Comma-separated dependency scopes that may produce failing findings")),
+		mcplib.WithString("allow_vulnerability_ids", mcplib.Description("Comma-separated vulnerability IDs to ignore")),
+		mcplib.WithString("allow_licenses", mcplib.Description("Comma-separated SPDX licenses to allow")),
+		mcplib.WithString("deny_licenses", mcplib.Description("Comma-separated SPDX licenses to deny")),
+		mcplib.WithString("license_exempt_packages", mcplib.Description("Comma-separated package URLs exempt from license checks")),
+		mcplib.WithString("deny_packages", mcplib.Description("Comma-separated package URLs to deny")),
+		mcplib.WithString("deny_groups", mcplib.Description("Comma-separated package URL namespaces to deny")),
+		mcplib.WithString("protected_packages", mcplib.Description("Comma-separated package names to protect from typosquatting")),
+		mcplib.WithString("typosquat_threshold", mcplib.Description("Typosquatting similarity threshold")),
+		mcplib.WithString("typosquat_mode", mcplib.Description("Typosquatting mode: warn or fail")),
+		mcplib.WithBoolean("warn_only", mcplib.Description("Downgrade failing findings to warnings")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		base, err := req.RequireString("base")
@@ -33,12 +45,24 @@ func registerDiffTool(s *server.MCPServer, mcpCtx MCPContext) {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 		diffReq := DiffRequest{
-			Base:         base,
-			Head:         head,
-			Path:         req.GetString("path", ""),
-			Enrich:       req.GetBool("enrich", false),
-			Audit:        req.GetBool("audit", false),
-			Reachability: req.GetBool("reachability", false),
+			Base:                  base,
+			Head:                  head,
+			Path:                  req.GetString("path", ""),
+			Enrich:                req.GetBool("enrich", false),
+			Audit:                 req.GetBool("audit", false),
+			Reachability:          req.GetBool("reachability", false),
+			FailOn:                req.GetString("fail_on", ""),
+			FailOnScopes:          req.GetString("fail_on_scopes", ""),
+			AllowVulnerabilityIDs: req.GetString("allow_vulnerability_ids", ""),
+			AllowLicenses:         req.GetString("allow_licenses", ""),
+			DenyLicenses:          req.GetString("deny_licenses", ""),
+			LicenseExemptPackages: req.GetString("license_exempt_packages", ""),
+			DenyPackages:          req.GetString("deny_packages", ""),
+			DenyGroups:            req.GetString("deny_groups", ""),
+			ProtectedPackages:     req.GetString("protected_packages", ""),
+			TyposquatThreshold:    req.GetString("typosquat_threshold", ""),
+			TyposquatMode:         req.GetString("typosquat_mode", ""),
+			WarnOnly:              req.GetBool("warn_only", false),
 		}
 		result, err := mcpCtx.Adapter.RunDiff(ctx, diffReq)
 		if err != nil {

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -226,6 +226,9 @@ type AuditFinding struct {
 	Title        string            `json:"title"`
 	Reasons      []string          `json:"reasons,omitempty"`
 	Source       string            `json:"source"`
+	Auditor      string            `json:"auditor,omitempty"`
+	Disposition  string            `json:"disposition,omitempty"`
+	FixedIn      string            `json:"fixed_in,omitempty"`
 	Reachability *sdk.Reachability `json:"reachability,omitempty"`
 }
 
@@ -251,10 +254,24 @@ func FindingsFromScan(findings []sdk.Finding) []AuditFinding {
 			Title:        f.Title,
 			Reasons:      f.Reasons,
 			Source:       f.Source,
+			Auditor:      f.Auditor,
+			Disposition:  string(f.Disposition),
+			FixedIn:      f.FixedIn,
 			Reachability: f.Reachability.Clone(),
 		})
 	}
 	return result
+}
+
+// FailingFindingCount reports how many findings should fail policy evaluation.
+func FailingFindingCount(findings []sdk.Finding) int {
+	total := 0
+	for _, finding := range findings {
+		if finding.Disposition == "" || finding.Disposition == sdk.FindingDispositionFail {
+			total++
+		}
+	}
+	return total
 }
 
 // SummaryFromFindings aggregates finding counts by severity band.

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -488,7 +488,10 @@ func diffManifestKey(manifest diffManifestRef, idx int) string {
 	if subproject == "" {
 		subproject = "."
 	}
-	return strings.Join([]string{subproject, manifest.PackageManager, manifest.Kind, pathValue}, "::")
+	if strings.TrimSpace(manifest.Path) == "" {
+		return strings.Join([]string{subproject, manifest.PackageManager, manifest.Kind, pathValue}, "::")
+	}
+	return strings.Join([]string{subproject, manifest.PackageManager, pathValue}, "::")
 }
 
 func diffManifestKeyForConsolidated(manifest sdk.ConsolidatedManifest, ref diffManifestRef, idx int) string {

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -61,7 +61,49 @@ type DiffComparison struct {
 
 // DiffResults groups per-manifest diff results.
 type DiffResults struct {
-	Manifests []DiffManifestResult `json:"manifests"`
+	Dependencies    DiffDependencyResults    `json:"dependencies"`
+	Licenses        DiffLicenseResults       `json:"licenses"`
+	Vulnerabilities DiffVulnerabilityResults `json:"vulnerabilities"`
+	Manifests       []DiffManifestResult     `json:"manifests"`
+}
+
+// DiffDependencyResults aggregates package changes across all manifests.
+type DiffDependencyResults struct {
+	Added   []DiffPackageChange  `json:"added,omitempty"`
+	Removed []DiffPackageChange  `json:"removed,omitempty"`
+	Changed []DiffChangedPackage `json:"changed,omitempty"`
+}
+
+// DiffLicenseResults aggregates license changes across all manifests.
+type DiffLicenseResults struct {
+	Added   []DiffLicenseChange `json:"added,omitempty"`
+	Removed []DiffLicenseChange `json:"removed,omitempty"`
+	Changed []DiffLicenseDelta  `json:"changed,omitempty"`
+}
+
+// DiffLicenseChange is a package whose license set was introduced or removed.
+type DiffLicenseChange struct {
+	Package  PackageRef   `json:"package"`
+	Licenses []LicenseRef `json:"licenses"`
+}
+
+// DiffLicenseDelta is a package whose license set changed.
+type DiffLicenseDelta struct {
+	Package PackageRef   `json:"package"`
+	Before  []LicenseRef `json:"before"`
+	After   []LicenseRef `json:"after"`
+}
+
+// DiffVulnerabilityResults aggregates vulnerability changes across all manifests.
+type DiffVulnerabilityResults struct {
+	Added   []DiffVulnerabilityChange `json:"added,omitempty"`
+	Removed []DiffVulnerabilityChange `json:"removed,omitempty"`
+}
+
+// DiffVulnerabilityChange is one vulnerability introduced or removed for a package.
+type DiffVulnerabilityChange struct {
+	Package       PackageRef       `json:"package"`
+	Vulnerability VulnerabilityRef `json:"vulnerability"`
 }
 
 // DiffPackageChange is one added or removed package.
@@ -97,6 +139,9 @@ type DiffSummary struct {
 	AddedPackageCount      int `json:"added_package_count"`
 	ChangedPackageCount    int `json:"changed_package_count"`
 	RemovedPackageCount    int `json:"removed_package_count"`
+	ExactMatchCount        int `json:"exact_match_count"`
+	FuzzyMatchCount        int `json:"fuzzy_match_count"`
+	UnmatchedPackageCount  int `json:"unmatched_package_count"`
 }
 
 // ExplainResponse is the structured payload for the explain command.
@@ -328,6 +373,7 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 			results.Manifests = append(results.Manifests, result)
 			summary.AddedManifestCount++
 			summary.AddedPackageCount += len(result.Added)
+			summary.UnmatchedPackageCount += len(result.Added)
 		case hasBase && !hasHead:
 			result := DiffManifestResult{
 				Status:         "removed",
@@ -341,12 +387,17 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 			results.Manifests = append(results.Manifests, result)
 			summary.RemovedManifestCount++
 			summary.RemovedPackageCount += len(result.Removed)
+			summary.UnmatchedPackageCount += len(result.Removed)
 		case hasBase && hasHead:
 			manifestDiff := sdk.Compare(baseManifest.Graph, headManifest.Graph)
 			if isSBOMDiffManifest(baseManifest, headManifest) {
 				filterSBOMPseudoPackageDiff(&manifestDiff, baseManifest.Graph, headManifest.Graph)
 			}
+			exactMatches := len(manifestDiff.Updated)
 			reconcileDiffWithFuzzyMatches(&manifestDiff)
+			summary.ExactMatchCount += exactMatches
+			summary.FuzzyMatchCount += len(manifestDiff.Updated) - exactMatches
+			summary.UnmatchedPackageCount += len(manifestDiff.Added) + len(manifestDiff.Removed)
 			result := DiffManifestResult{
 				Status:         "unchanged",
 				Path:           headManifest.Manifest.Path,
@@ -384,8 +435,139 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 		}
 		return left.Subproject < right.Subproject
 	})
+	results.Dependencies = aggregateDependencyChanges(results.Manifests)
+	results.Licenses = aggregateLicenseChanges(results.Dependencies)
+	results.Vulnerabilities = aggregateVulnerabilityChanges(results.Dependencies)
 
 	return results, summary
+}
+
+func aggregateDependencyChanges(manifests []DiffManifestResult) DiffDependencyResults {
+	added := make(map[string]DiffPackageChange)
+	removed := make(map[string]DiffPackageChange)
+	changed := make(map[string]DiffChangedPackage)
+	for _, manifest := range manifests {
+		for _, change := range manifest.Added {
+			added[change.Package.ID] = change
+		}
+		for _, change := range manifest.Removed {
+			removed[change.Package.ID] = change
+		}
+		for _, change := range manifest.Changed {
+			key := change.Before.ID + "->" + change.After.ID
+			changed[key] = change
+		}
+	}
+	out := DiffDependencyResults{}
+	for _, change := range added {
+		out.Added = append(out.Added, change)
+	}
+	for _, change := range removed {
+		out.Removed = append(out.Removed, change)
+	}
+	for _, change := range changed {
+		out.Changed = append(out.Changed, change)
+	}
+	sort.Slice(out.Added, func(i, j int) bool { return out.Added[i].Package.ID < out.Added[j].Package.ID })
+	sort.Slice(out.Removed, func(i, j int) bool { return out.Removed[i].Package.ID < out.Removed[j].Package.ID })
+	sort.Slice(out.Changed, func(i, j int) bool { return out.Changed[i].After.ID < out.Changed[j].After.ID })
+	return out
+}
+
+func aggregateLicenseChanges(dependencies DiffDependencyResults) DiffLicenseResults {
+	out := DiffLicenseResults{}
+	for _, change := range dependencies.Added {
+		if len(change.Package.Licenses) > 0 {
+			out.Added = append(out.Added, DiffLicenseChange{Package: change.Package, Licenses: change.Package.Licenses})
+		}
+	}
+	for _, change := range dependencies.Removed {
+		if len(change.Package.Licenses) > 0 {
+			out.Removed = append(out.Removed, DiffLicenseChange{Package: change.Package, Licenses: change.Package.Licenses})
+		}
+	}
+	for _, change := range dependencies.Changed {
+		if licenseRefsEqual(change.Before.Licenses, change.After.Licenses) {
+			continue
+		}
+		out.Changed = append(out.Changed, DiffLicenseDelta{
+			Package: change.After,
+			Before:  change.Before.Licenses,
+			After:   change.After.Licenses,
+		})
+	}
+	return out
+}
+
+func aggregateVulnerabilityChanges(dependencies DiffDependencyResults) DiffVulnerabilityResults {
+	out := DiffVulnerabilityResults{}
+	for _, change := range dependencies.Added {
+		for _, vulnerability := range change.Package.Vulnerabilities {
+			out.Added = append(out.Added, DiffVulnerabilityChange{Package: change.Package, Vulnerability: vulnerability})
+		}
+	}
+	for _, change := range dependencies.Removed {
+		for _, vulnerability := range change.Package.Vulnerabilities {
+			out.Removed = append(out.Removed, DiffVulnerabilityChange{Package: change.Package, Vulnerability: vulnerability})
+		}
+	}
+	for _, change := range dependencies.Changed {
+		before := indexVulnerabilities(change.Before.Vulnerabilities)
+		after := indexVulnerabilities(change.After.Vulnerabilities)
+		for id, vulnerability := range after {
+			if _, ok := before[id]; !ok {
+				out.Added = append(out.Added, DiffVulnerabilityChange{Package: change.After, Vulnerability: vulnerability})
+			}
+		}
+		for id, vulnerability := range before {
+			if _, ok := after[id]; !ok {
+				out.Removed = append(out.Removed, DiffVulnerabilityChange{Package: change.Before, Vulnerability: vulnerability})
+			}
+		}
+	}
+	sort.Slice(out.Added, func(i, j int) bool {
+		if out.Added[i].Package.ID != out.Added[j].Package.ID {
+			return out.Added[i].Package.ID < out.Added[j].Package.ID
+		}
+		return out.Added[i].Vulnerability.ID < out.Added[j].Vulnerability.ID
+	})
+	sort.Slice(out.Removed, func(i, j int) bool {
+		if out.Removed[i].Package.ID != out.Removed[j].Package.ID {
+			return out.Removed[i].Package.ID < out.Removed[j].Package.ID
+		}
+		return out.Removed[i].Vulnerability.ID < out.Removed[j].Vulnerability.ID
+	})
+	return out
+}
+
+func licenseRefsEqual(left, right []LicenseRef) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftIDs := make([]string, 0, len(left))
+	rightIDs := make([]string, 0, len(right))
+	for _, ref := range left {
+		leftIDs = append(leftIDs, ref.Identifier())
+	}
+	for _, ref := range right {
+		rightIDs = append(rightIDs, ref.Identifier())
+	}
+	sort.Strings(leftIDs)
+	sort.Strings(rightIDs)
+	for idx := range leftIDs {
+		if leftIDs[idx] != rightIDs[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func indexVulnerabilities(values []VulnerabilityRef) map[string]VulnerabilityRef {
+	indexed := make(map[string]VulnerabilityRef, len(values))
+	for _, value := range values {
+		indexed[value.ID] = value
+	}
+	return indexed
 }
 
 func diffManifestStatusOrder(status string) int {

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -246,6 +246,12 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 	if response.Summary.ChangedManifestCount != 1 || response.Summary.AddedPackageCount != 1 {
 		t.Fatalf("unexpected diff summary: %#v", response.Summary)
 	}
+	if response.Summary.UnmatchedPackageCount != 1 {
+		t.Fatalf("expected one unmatched package, got %#v", response.Summary)
+	}
+	if len(response.Results.Dependencies.Added) != 1 || response.Results.Dependencies.Added[0].Package.Name != "newpkg" {
+		t.Fatalf("expected global dependency aggregate, got %#v", response.Results.Dependencies)
+	}
 	if len(response.Results.Manifests) != 1 || response.Results.Manifests[0].Status != "changed" {
 		t.Fatalf("unexpected manifest results: %#v", response.Results.Manifests)
 	}
@@ -641,6 +647,9 @@ func TestBuildDiffResponseFuzzyReconcilesRenamedPackage(t *testing.T) {
 	}
 	if response.Summary.AddedPackageCount != 0 || response.Summary.RemovedPackageCount != 0 {
 		t.Fatalf("expected no residual add/remove after fuzzy reconciliation, got %#v", response.Summary)
+	}
+	if response.Summary.FuzzyMatchCount != 1 || response.Summary.UnmatchedPackageCount != 0 {
+		t.Fatalf("expected fuzzy match diagnostics, got %#v", response.Summary)
 	}
 	if len(response.Results.Manifests) != 1 || len(response.Results.Manifests[0].Changed) != 1 {
 		t.Fatalf("expected one changed package in manifest, got %#v", response.Results.Manifests)

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -251,6 +251,52 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 	}
 }
 
+func TestBuildDiffResponseMatchesSameManifestWhenKindDiffers(t *testing.T) {
+	baseGraph := newViewTestGraph(t)
+	headGraph := newViewTestGraph(t)
+	if err := headGraph.AddPackage(sdk.NewPackageRef("newpkg", "1.0.0")); err != nil {
+		t.Fatalf("add package: %v", err)
+	}
+	if err := headGraph.AddDependency("app@1.0.0", "newpkg@1.0.0"); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	baseResults := []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{RelativePath: ".", PrimaryDetector: "go-detector", DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerGoMod}, Ecosystem: sdk.EcosystemGo},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    baseGraph,
+			Manifest: sdk.ManifestMetadata{Path: "go.mod", Kind: "go-module"},
+		}}},
+	}}
+	headResults := []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{RelativePath: ".", PrimaryDetector: "go-detector", DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerGoMod}, Ecosystem: sdk.EcosystemGo},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    headGraph,
+			Manifest: sdk.ManifestMetadata{Path: "go.mod", Kind: "go.mod"},
+		}}},
+	}}
+
+	baseConsolidated, err := consolidation.ConsolidateGraphs(baseResults)
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(base) error = %v", err)
+	}
+	headConsolidated, err := consolidation.ConsolidateGraphs(headResults)
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(head) error = %v", err)
+	}
+
+	response := output.BuildDiffResponse("/tmp/demo", "base", "head", baseConsolidated, headConsolidated, nil, time.Now().Add(-time.Second))
+	if response.Summary.ChangedManifestCount != 1 {
+		t.Fatalf("expected one changed manifest, got %#v", response.Summary)
+	}
+	if response.Summary.AddedManifestCount != 0 || response.Summary.RemovedManifestCount != 0 {
+		t.Fatalf("expected same manifest path to match despite kind drift, got %#v", response.Summary)
+	}
+	if len(response.Results.Manifests) != 1 || response.Results.Manifests[0].Kind != "go.mod" {
+		t.Fatalf("expected head manifest metadata on the matched result, got %#v", response.Results.Manifests)
+	}
+}
+
 func TestBuildDiffResponseTreatsSBOMFilesAsSameManifestWhenOnlyEvidencePathDiffers(t *testing.T) {
 	baseGraph := newViewTestGraph(t)
 	headGraph := newViewTestGraph(t)

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -2,9 +2,13 @@ package registry
 
 import (
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/bomly-dev/bomly-cli/internal/auditors/policy"
+	"github.com/bomly-dev/bomly-cli/internal/auditors/license"
+	packageauditor "github.com/bomly-dev/bomly-cli/internal/auditors/package"
+	"github.com/bomly-dev/bomly-cli/internal/auditors/vulnerability"
 	"github.com/bomly-dev/bomly-cli/internal/detectors"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cargo"
 	"github.com/bomly-dev/bomly-cli/internal/detectors/cocoapods"
@@ -40,15 +44,25 @@ type RegistryConfigs struct {
 	// FailOn is the parsed list of --fail-on constraints. The policy
 	// auditor evaluates findings against this AND-set; an empty slice
 	// preserves the historical behaviour of emitting every finding.
-	FailOn      []sdk.FailOnConstraint
-	OsvAPIBase  string
-	OsvCacheDir string
-	OsvCacheTTL string
-	KEVCacheDir string
-	KEVCacheTTL string
-	EOLAPIBase  string
-	EOLCacheDir string
-	EOLCacheTTL string
+	FailOn                []sdk.FailOnConstraint
+	FailOnScopes          []sdk.Scope
+	AllowVulnerabilityIDs []string
+	AllowLicenses         []string
+	DenyLicenses          []string
+	LicenseExemptPackages []string
+	DenyPackages          []string
+	DenyGroups            []string
+	ProtectedPackages     []string
+	TyposquatThreshold    string
+	TyposquatMode         string
+	OsvAPIBase            string
+	OsvCacheDir           string
+	OsvCacheTTL           string
+	KEVCacheDir           string
+	KEVCacheTTL           string
+	EOLAPIBase            string
+	EOLCacheDir           string
+	EOLCacheTTL           string
 }
 
 // RegistryFilter narrows a registry down to the runtime-relevant selections.
@@ -263,7 +277,31 @@ func (r *Registry) RegisterAnalyzer(analyzer sdk.Analyzer) {
 }
 
 func (r *Registry) registerAuditors() {
-	for _, auditor := range builtInAuditors([]sdk.Auditor{policy.Auditor{FailOn: append([]sdk.FailOnConstraint(nil), r.configs.FailOn...)}}) {
+	threshold, _ := strconv.ParseFloat(strings.TrimSpace(r.configs.TyposquatThreshold), 64)
+	if threshold == 0 {
+		threshold = 0.90
+	}
+	for _, auditor := range builtInAuditors([]sdk.Auditor{
+		vulnerability.Auditor{
+			FailOn:                append([]sdk.FailOnConstraint(nil), r.configs.FailOn...),
+			FailOnScopes:          append([]sdk.Scope(nil), r.configs.FailOnScopes...),
+			AllowVulnerabilityIDs: append([]string(nil), r.configs.AllowVulnerabilityIDs...),
+		},
+		license.Auditor{
+			AllowLicenses:  append([]string(nil), r.configs.AllowLicenses...),
+			DenyLicenses:   append([]string(nil), r.configs.DenyLicenses...),
+			ExemptPackages: append([]string(nil), r.configs.LicenseExemptPackages...),
+			FailOnScopes:   append([]sdk.Scope(nil), r.configs.FailOnScopes...),
+		},
+		packageauditor.Auditor{
+			DenyPackages:       append([]string(nil), r.configs.DenyPackages...),
+			DenyGroups:         append([]string(nil), r.configs.DenyGroups...),
+			ProtectedPackages:  append([]string(nil), r.configs.ProtectedPackages...),
+			TyposquatThreshold: threshold,
+			TyposquatMode:      r.configs.TyposquatMode,
+			FailOnScopes:       append([]sdk.Scope(nil), r.configs.FailOnScopes...),
+		},
+	}) {
 		r.RegisterAuditor(auditor)
 	}
 }

--- a/sdk/auditor.go
+++ b/sdk/auditor.go
@@ -31,6 +31,7 @@ type AuditRequest struct {
 	Mode            TargetMode      `json:"mode,omitempty"`
 	Query           PackageQuery    `json:"query"`
 	Graph           *Graph          `json:"graph,omitempty"`
+	BaselineGraph   *Graph          `json:"baselineGraph,omitempty"`
 	Target          *Package        `json:"target,omitempty"`
 	AuditorFilter   AuditorFilter   `json:"auditorFilter"`
 	Stderr          io.Writer       `json:"-"`

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -9,6 +9,15 @@ const (
 	FindingKindPolicy        FindingKind = "policy"
 )
 
+// FindingDisposition controls whether a finding should fail policy evaluation
+// or surface as a warning only.
+type FindingDisposition string
+
+const (
+	FindingDispositionFail FindingDisposition = "fail"
+	FindingDispositionWarn FindingDisposition = "warn"
+)
+
 // CVSSScore captures one CVSS vector and score.
 type CVSSScore struct {
 	Vector  string
@@ -326,13 +335,15 @@ func (v PackageVulnerability) Clone() PackageVulnerability {
 
 // Finding describes a normalized audit result.
 type Finding struct {
-	ID       string
-	Kind     FindingKind
-	Package  *Package
-	Title    string
-	Severity string
-	Reasons  []string
-	Source   string
+	ID          string
+	Kind        FindingKind
+	Package     *Package
+	Title       string
+	Severity    string
+	Reasons     []string
+	Source      string
+	Auditor     string
+	Disposition FindingDisposition
 	// VexStatus is set when a VEX statement applies to this finding.
 	// Values: "not_affected", "false_positive", "in_triage", "exploitable", or empty.
 	VexStatus string

--- a/test/smoke/audit_test.go
+++ b/test/smoke/audit_test.go
@@ -91,17 +91,17 @@ func TestAuditScan(t *testing.T) {
 		},
 		{
 			name:  "scan-go-audit",
-			args:  []string{"scan", "--url", "https://github.com/google/uuid", "--ref", "v1.6.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "severity-policy"},
+			args:  []string{"scan", "--url", "https://github.com/google/uuid", "--ref", "v1.6.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "vulnerability"},
 			tools: []string{"go"},
 		},
 		{
 			name:  "scan-go-audit-high",
-			args:  []string{"scan", "--url", "https://github.com/google/uuid", "--ref", "v1.6.0", "--format", "json", "--enrich", "--audit", "--fail-on", "high", "--matchers", "osv", "--auditors", "severity-policy"},
+			args:  []string{"scan", "--url", "https://github.com/google/uuid", "--ref", "v1.6.0", "--format", "json", "--enrich", "--audit", "--fail-on", "high", "--matchers", "osv", "--auditors", "vulnerability"},
 			tools: []string{"go"},
 		},
 		{
 			name:  "scan-npm-audit",
-			args:  []string{"scan", "--url", "https://github.com/ljharb/qs", "--ref", "v6.13.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "severity-policy"},
+			args:  []string{"scan", "--url", "https://github.com/ljharb/qs", "--ref", "v6.13.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "vulnerability"},
 			tools: []string{"npm"},
 		},
 	}
@@ -142,7 +142,7 @@ func TestContainerAuditScan(t *testing.T) {
 	}{
 		{
 			name: "container-scan-alpine-audit",
-			args: []string{"scan", "--container", alpineImage, "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "severity-policy"},
+			args: []string{"scan", "--container", alpineImage, "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "vulnerability"},
 		},
 	}
 
@@ -173,7 +173,7 @@ func TestAuditDiffAndExplain(t *testing.T) {
 	}{
 		{
 			name:  "diff-go-audit",
-			args:  []string{"diff", "--url", "https://github.com/google/uuid", "--base", "v1.5.0", "--head", "v1.6.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "severity-policy"},
+			args:  []string{"diff", "--url", "https://github.com/google/uuid", "--base", "v1.5.0", "--head", "v1.6.0", "--format", "json", "--enrich", "--audit", "--matchers", "osv", "--auditors", "vulnerability"},
 			tools: []string{"go"},
 		},
 		{


### PR DESCRIPTION
## Summary
- redesign `bomly diff` around a global-first dependency/license/vulnerability/policy report
- replace temp-path progress labels with user-facing target labels and surface diff policy outcomes in progress output
- split auditing into `vulnerability`, `license`, and `package` auditors with introduced-only diff failure semantics
- add structured diff aggregates, matching diagnostics, new policy configuration, MCP wiring, and refreshed generated schema/docs

## Why
The diff command was still organized around manifest-local output and a single vulnerability policy auditor, which made PR-oriented review harder to scan and left license/package policy outside the main diff workflow. This change makes the CLI output and machine-readable payloads better suited for dependency review and future action integration.

## Notes
- `severity-policy` is intentionally replaced by `vulnerability` without a compatibility alias.
- Persisted findings remain counted in policy summaries but are no longer printed as their own text subsection.
- This branch also includes the earlier manifest path matching fix already present on the branch before the larger diff work.

## Validation
- `go test ./...`
- commit hook: `gofmtcheck` and `golangci-lint`
