### PR TITLE
docs: split installation into its own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,50 +53,20 @@ Walkthrough: [Getting Started](docs/GETTING_STARTED.md).
 
 ## Installation
 
-### `go install` for the full Bomly CLI
-
 ```bash
+# Go toolchain — Go 1.21 or later on PATH
 go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest
 ```
 
-`go install` now builds the default full Bomly binary, including builtin Syft and Grype support. The command package path is intentional: it follows Go conventions and installs an executable named `bomly`.
+Or grab a prebuilt archive from [GitHub Releases](https://github.com/bomly-dev/bomly-cli/releases). Each release publishes `bomly` (full binary with builtin Syft and Grype) and `bomly-lite` (smaller binary that shells out to external `syft` and `grype`) archives for Linux, macOS, and Windows.
 
-### GitHub Releases
-
-GitHub Releases are the canonical distribution point for packaged binaries. Each draft prerelease includes:
-
-- `bomly` archives for Linux, macOS, and Windows
-- `bomly-lite` archives for users who prefer external `syft` and `grype` binaries on `PATH`
-- `SHA256SUMS` for checksum verification
-
-Each archive also contains `LICENSE`, `NOTICE`, and a `licenses/` directory with the full license text for every bundled dependency.
-
-Archive naming follows this pattern:
-
-- `bomly_<version>_<os>_<arch>.tar.gz`
-- `bomly-lite_<version>_<os>_<arch>.tar.gz`
-- Windows archives use `.zip`
-
-### `bomly` vs `bomly-lite`
-
-| Artifact | Behavior |
-| --- | --- |
-| `bomly` | Full default binary with compiled-in Syft and Grype support |
-| `bomly-lite` | Alternate binary that shells out to external `syft` and `grype` binaries |
-
-### Verify release checksums
-
-On Linux and macOS:
+Verify:
 
 ```bash
-sha256sum --check SHA256SUMS
+bomly version
 ```
 
-On PowerShell:
-
-```powershell
-Get-FileHash .\bomly_v0.2.0_windows_amd64.zip -Algorithm SHA256
-```
+Full install matrix — `bomly` vs `bomly-lite`, checksum verification, PowerShell instructions, uninstall, CI install — lives in [docs/INSTALLATION.md](docs/INSTALLATION.md).
 
 ## What It Scans
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,23 +4,19 @@ This page walks you from installation to your first useful scan in five minutes.
 
 ## Install
 
-Pick one:
+If you have Go on `PATH`:
 
 ```bash
-# Go toolchain (builds the full binary with builtin Syft and Grype)
 go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest
-
-# Or download a release archive from GitHub
-# https://github.com/bomly-dev/bomly-cli/releases
 ```
 
-Verify:
+Otherwise download a prebuilt archive from [GitHub Releases](https://github.com/bomly-dev/bomly-cli/releases) and put `bomly` on your `PATH`. Verify:
 
 ```bash
 bomly version
 ```
 
-If you'd rather shell out to external `syft` and `grype` binaries, install the `bomly-lite` archive from the same release.
+For the full install matrix — `bomly` vs `bomly-lite`, checksum verification, PowerShell instructions, uninstall — see [Installation](INSTALLATION.md).
 
 ## Scan a project
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,154 @@
+# Installation
+
+Bomly ships as a single binary. Pick the install method that fits your environment.
+
+## Quick install
+
+```bash
+# Go toolchain — Go 1.21 or later on PATH
+go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest
+```
+
+Or grab a release archive from [GitHub Releases](https://github.com/bomly-dev/bomly-cli/releases). Verify:
+
+```bash
+bomly version
+```
+
+If you're ready to scan, jump to [Getting Started](GETTING_STARTED.md).
+
+## Install methods
+
+### `go install`
+
+The most common path for developers who already have Go on `PATH`.
+
+```bash
+go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest
+```
+
+`go install` builds the **full** Bomly binary with builtin Syft and Grype support — no extra binaries required. The command package path follows Go conventions; the installed executable is named `bomly`.
+
+**Requirements**: Go 1.21 or later. Bomly does not bundle a Go toolchain.
+
+### GitHub Releases
+
+The canonical distribution point for prebuilt packaged binaries. Each release publishes:
+
+- `bomly` archives for Linux, macOS, and Windows.
+- `bomly-lite` archives for users who prefer external `syft` and `grype` binaries on `PATH`.
+- `SHA256SUMS` for checksum verification.
+
+Each archive also contains `LICENSE`, `NOTICE`, and a `licenses/` directory with the full license text for every bundled dependency.
+
+Archive naming:
+
+- `bomly_<version>_<os>_<arch>.tar.gz`
+- `bomly-lite_<version>_<os>_<arch>.tar.gz`
+- Windows archives use `.zip`.
+
+#### Linux / macOS
+
+```bash
+# Replace VERSION, OS (linux|darwin), ARCH (amd64|arm64)
+curl -L -o bomly.tar.gz \
+  https://github.com/bomly-dev/bomly-cli/releases/download/VERSION/bomly_VERSION_OS_ARCH.tar.gz
+tar -xzf bomly.tar.gz
+sudo install -m 0755 bomly /usr/local/bin/
+```
+
+Or auto-detect host details:
+
+```bash
+curl -L -o bomly.tar.gz \
+  https://github.com/bomly-dev/bomly-cli/releases/latest/download/bomly_$(uname -s)_$(uname -m).tar.gz
+tar -xzf bomly.tar.gz
+sudo install -m 0755 bomly /usr/local/bin/
+```
+
+#### Windows (PowerShell)
+
+```powershell
+$archive = "bomly_v0.2.0_windows_amd64.zip"
+Invoke-WebRequest -Uri "https://github.com/bomly-dev/bomly-cli/releases/latest/download/$archive" -OutFile $archive
+Expand-Archive -Path $archive -DestinationPath .
+# Move bomly.exe somewhere on your PATH
+```
+
+## `bomly` vs `bomly-lite`
+
+| Artifact | Behavior |
+| --- | --- |
+| `bomly` | Full default binary with compiled-in Syft and Grype support. No extra runtime dependencies. |
+| `bomly-lite` | Alternate binary that shells out to external `syft` and `grype` binaries on `PATH`. Smaller download, requires Syft/Grype installed separately. |
+
+Most users want `bomly`. Pick `bomly-lite` only if you already manage `syft` and `grype` versions across your fleet and want Bomly to ride along on those.
+
+If you choose `bomly-lite`, install Syft and Grype with Anchore's official scripts:
+
+```bash
+curl -sSfL https://get.anchore.io/syft  | sh -s -- -b /usr/local/bin
+curl -sSfL https://get.anchore.io/grype | sh -s -- -b /usr/local/bin
+```
+
+## Verify release checksums
+
+Releases include a `SHA256SUMS` file alongside every archive.
+
+On Linux and macOS:
+
+```bash
+curl -L -O https://github.com/bomly-dev/bomly-cli/releases/latest/download/SHA256SUMS
+sha256sum --check SHA256SUMS --ignore-missing
+```
+
+On PowerShell:
+
+```powershell
+Get-FileHash .\bomly_v0.2.0_windows_amd64.zip -Algorithm SHA256
+# Compare the printed hash against the line for this archive in SHA256SUMS.
+```
+
+## CI installation
+
+For pinned, scripted installs in CI pipelines, see [CI integration](CI_INTEGRATION.md). The most common pattern is:
+
+```bash
+curl -sSfL https://github.com/bomly-dev/bomly-cli/releases/latest/download/bomly_linux_amd64.tar.gz \
+  | tar -xz -C /usr/local/bin bomly
+```
+
+Pin to a specific release tag rather than `latest` to make scans reproducible.
+
+## Upgrading
+
+`go install` users can re-run the install command to pull the latest tag:
+
+```bash
+go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest
+```
+
+GitHub Release users replace the binary on disk. Check the current version with `bomly version` before and after.
+
+## Uninstall
+
+`go install` writes to `$GOBIN` (defaults to `$GOPATH/bin`). Remove the binary directly:
+
+```bash
+rm "$(command -v bomly)"
+```
+
+For Release-archive installs, remove the binary from wherever you placed it (typically `/usr/local/bin/bomly`).
+
+Bomly does not write configuration or cache state during install. To also clear runtime state:
+
+```bash
+rm -rf ~/.bomly                               # Unix/macOS — config, plugins, cache
+Remove-Item -Recurse $env:USERPROFILE\.bomly  # PowerShell
+```
+
+## Next
+
+- [Getting Started](GETTING_STARTED.md) — run your first scan in five minutes.
+- [CI integration](CI_INTEGRATION.md) — drop-in recipes for GitHub Actions, GitLab, Jenkins, Azure DevOps, CircleCI.
+- [Plugins](PLUGINS.md) — install and enable external detectors, matchers, and auditors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ Start with [Getting Started](GETTING_STARTED.md) if you're new. Otherwise pick t
 
 Task-oriented walkthroughs.
 
-- [Getting Started](GETTING_STARTED.md) — install, first scan, enrich, audit, diff
+- [Installation](INSTALLATION.md) — install methods, `bomly` vs `bomly-lite`, checksum verification, uninstall
+- [Getting Started](GETTING_STARTED.md) — first scan, enrich, audit, diff
 - [Scan Targets](SCAN_TARGETS.md) — directories, Git repos, containers, SBOMs
 - [Output Formats](OUTPUT_FORMATS.md) — text, JSON, SARIF, SBOM
 - [SBOM Formats](SBOM.md) — SPDX vs. CycloneDX, write and ingest


### PR DESCRIPTION
## Summary

Pulls installation details out of \`README.md\` and \`docs/GETTING_STARTED.md\` into a dedicated \`docs/INSTALLATION.md\`. Getting Started can now be a tight first-scan walkthrough; the install matrix has its own page with room for the full set of options users actually need.

## What's in INSTALLATION.md

- Quick install + verify
- \`go install\` (Go 1.21 or later)
- GitHub Release archives for Linux / macOS / Windows, with auto-detected and explicit \`curl\` recipes
- PowerShell instructions
- \`bomly\` vs \`bomly-lite\` comparison and when to pick each
- SHA256SUMS verification on bash and PowerShell
- CI install one-liner with a link to \`docs/CI_INTEGRATION.md\`
- Upgrade and uninstall steps

## What shrunk

- \`README.md\` install section: 47 lines → 14 lines. Quick command, mention of both binaries, link to the full matrix.
- \`docs/GETTING_STARTED.md\` install section: same pattern, short pointer to INSTALLATION.md.
- \`docs/README.md\`: adds Installation to the Guides group.

## Verification

\`make generate\`, \`make test\`, \`make lint\` all clean. Total: +164 / -43 across 4 files.

## Test plan

- [ ] Browse \`docs/INSTALLATION.md\` end-to-end and confirm every command runs as documented.
- [ ] Confirm \`README.md\` and \`docs/GETTING_STARTED.md\` both link out cleanly.
- [ ] Open \`docs/README.md\` and confirm Installation appears in the Guides group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)