### PR TITLE
feat(diff): redesign interactive TUI with shared skeleton and richer tabs

### DIFF
--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -51,9 +51,28 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 		packages = []*sdk.Package{req.Target}
 	}
 
+	// Root packages are the project itself (e.g. github.com/your/repo) —
+	// they rarely declare a license in lockfile data and the license is
+	// typically expressed at the repository level. Flagging the root with
+	// "unknown-license" generates noise that is never actionable from
+	// within a dependency manifest. We treat roots as implicitly exempt
+	// for full-graph audits; component-mode audits (`req.Target != nil`)
+	// still evaluate whatever target was passed in.
+	rootIDs := map[string]struct{}{}
+	if req.Mode != sdk.TargetModeComponent {
+		for _, r := range req.Graph.Roots() {
+			if r != nil {
+				rootIDs[r.ID] = struct{}{}
+			}
+		}
+	}
+
 	findings := make([]sdk.Finding, 0)
 	for _, pkg := range packages {
 		if pkg == nil || !scopeAllowed(pkg, a.FailOnScopes) || packageExempt(pkg, a.ExemptPackages) {
+			continue
+		}
+		if _, isRoot := rootIDs[pkg.ID]; isRoot {
 			continue
 		}
 		licenses := pkg.LicenseValues()
@@ -99,7 +118,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 func finding(pkg *sdk.Package, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
 	return sdk.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
-		Kind:        sdk.FindingKindPolicy,
+		Kind:        sdk.FindingKindLicense,
 		Package:     pkg,
 		Title:       title,
 		Severity:    "unknown",

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -1,0 +1,75 @@
+package license
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// TestAuditor_SkipsRootPackage locks in the policy that the license
+// auditor must NOT emit "unknown-license" findings for the root package
+// of a project. The root is what the project IS, not a dependency, and
+// most projects (especially private ones) don't carry a license attached
+// to that node in lockfile data. Flagging it produces unactionable noise.
+func TestAuditor_SkipsRootPackage(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewPackageRef("github.com/example/private-app", "0.0.0")
+	dep := sdk.NewPackageRef("github.com/pkg/errors", "0.9.1")
+	for _, p := range []*sdk.Package{root, dep} {
+		if err := g.AddPackage(p); err != nil {
+			t.Fatalf("add %s: %v", p.ID, err)
+		}
+	}
+	if err := g.AddDependency(root.ID, dep.ID); err != nil {
+		t.Fatalf("add dep: %v", err)
+	}
+
+	result, err := Auditor{}.Audit(context.Background(), sdk.AuditRequest{Graph: g})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	for _, f := range result.Findings {
+		if f.Package != nil && f.Package.ID == root.ID {
+			t.Errorf("license auditor emitted finding for root package %q (id=%s): %#v",
+				root.DisplayName(), root.ID, f)
+		}
+	}
+	// The dependency should still be flagged — it has no license.
+	flaggedDep := false
+	for _, f := range result.Findings {
+		if f.Package != nil && f.Package.ID == dep.ID {
+			flaggedDep = true
+			break
+		}
+	}
+	if !flaggedDep {
+		t.Errorf("expected the dependency to be flagged for unknown-license; findings: %#v", result.Findings)
+	}
+}
+
+// TestAuditor_ComponentModeStillFlagsTarget verifies that the root-skip
+// only applies to full-graph audits. When a caller invokes the auditor
+// with `Mode=TargetModeComponent` against a specific target, that target
+// is exactly what the user asked about — never skip it.
+func TestAuditor_ComponentModeStillFlagsTarget(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewPackageRef("github.com/example/app", "0.0.0")
+	if err := g.AddPackage(root); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	result, err := Auditor{}.Audit(context.Background(), sdk.AuditRequest{
+		Graph: g, Target: root, Mode: sdk.TargetModeComponent,
+	})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding for explicit component target, got %d: %#v", len(result.Findings), result.Findings)
+	}
+	if !strings.Contains(result.Findings[0].ID, "unknown-license") {
+		t.Errorf("expected unknown-license finding, got ID=%q", result.Findings[0].ID)
+	}
+}

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -88,7 +88,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 func finding(pkg *sdk.Package, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
 	return sdk.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
-		Kind:        sdk.FindingKindPolicy,
+		Kind:        sdk.FindingKindPackage,
 		Package:     pkg,
 		Title:       title,
 		Severity:    "unknown",

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -147,7 +147,7 @@ func newDiffCmd() *cobra.Command {
 			}
 			if current.Interactive {
 				progress.Stop()
-				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewDiff(payload)))
+				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewDiff(payload, diffResult.Base.Consolidated, diffResult.Head.Consolidated).WithEnrichEnabled(current.Enrich)))
 			}
 
 			progress.Success("Resolved Graph")

--- a/internal/engine/findings_test.go
+++ b/internal/engine/findings_test.go
@@ -11,7 +11,7 @@ func TestDeduplicateFindingsKeepsHighestPrioritySource(t *testing.T) {
 	findings := []sdk.Finding{
 		{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Source: "osv", Package: pkg},
 		{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Source: "grype", Package: pkg},
-		{ID: "POLICY-1", Kind: sdk.FindingKindPolicy, Source: "policy", Package: pkg},
+		{ID: "POLICY-1", Kind: sdk.FindingKindLicense, Source: "license", Package: pkg},
 	}
 
 	got := DeduplicateFindings(findings)

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -7,127 +7,1789 @@ import (
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
 	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-type diffTab string
+type diffStatus string
 
 const (
-	diffTabOverview diffTab = "overview"
-	diffTabAdded    diffTab = "added"
-	diffTabRemoved  diffTab = "removed"
-	diffTabChanged  diffTab = "changed"
+	diffStatusAll     diffStatus = ""
+	diffStatusAdded   diffStatus = "added"
+	diffStatusRemoved diffStatus = "removed"
+	diffStatusChanged diffStatus = "changed"
 )
 
+// componentsGroup names the cycling-axis for the Components tab. "status"
+// groups Added/Changed/Removed; "manifest" groups by manifest (the old
+// nested tree); "ecosystem" groups by ecosystem.
+type componentsGroup string
+
+const (
+	componentsGroupStatus    componentsGroup = "status"
+	componentsGroupManifest  componentsGroup = "manifest"
+	componentsGroupEcosystem componentsGroup = "ecosystem"
+)
+
+type diffSourceSide string
+
+const (
+	diffSourceBase diffSourceSide = "base"
+	diffSourceHead diffSourceSide = "head"
+)
+
+// diffModel renders the interactive `bomly diff` TUI. Tab cycling, the tab
+// strip, and the top bar are owned by the embedded *shellModel; this struct
+// holds diff payload data and per-tab state (filters, expansion maps).
 type diffModel struct {
-	*listModel
-	payload output.DiffResponse
-	active  diffTab
+	*shellModel
+
+	payload   output.DiffResponse
+	baseGraph sdk.ConsolidatedGraph
+	headGraph sdk.ConsolidatedGraph
+
+	enrichEnabled bool
+
+	componentsGroup        componentsGroup
+	componentsRelationship string // "", "root", "direct", "transitive"
+	componentsScope        string // "", "runtime", "development", "unset"
+	componentsSeverity     string // "", "critical", "high", "medium", "low", "unknown"
+	componentsEcosystem    string // "" or one of the known ecosystem names
+	componentsExpanded     map[string]bool
+
+	vulnGroup    string
+	vulnExpanded map[string]bool
+
+	licenseGroup    string
+	licenseExpanded map[string]bool
+
+	findingGroup    string
+	findingExpanded map[string]bool
+
+	sourceSide         diffSourceSide
+	sourceBaseExpanded map[string]bool
+	sourceHeadExpanded map[string]bool
 }
 
-func NewDiff(payload output.DiffResponse) *diffModel {
-	model := &diffModel{payload: payload, active: diffTabOverview}
-	model.listModel = model.buildList()
-	return model
-}
-
-func (m *diffModel) CycleView() {
-	tabs := diffTabs()
-	for idx, tab := range tabs {
-		if tab == m.active {
-			m.active = tabs[(idx+1)%len(tabs)]
-			m.listModel = m.buildList()
-			return
-		}
+// NewDiff constructs the diff TUI model. baseGraph and headGraph are the
+// consolidated graphs from the two pipeline runs; they feed the Source tab.
+func NewDiff(payload output.DiffResponse, baseGraph, headGraph sdk.ConsolidatedGraph) *diffModel {
+	m := &diffModel{
+		payload:            payload,
+		baseGraph:          baseGraph,
+		headGraph:          headGraph,
+		componentsGroup:    componentsGroupStatus,
+		componentsExpanded: map[string]bool{},
+		vulnGroup:          "status",
+		vulnExpanded:       map[string]bool{},
+		licenseGroup:       "license",
+		licenseExpanded:    map[string]bool{},
+		findingGroup:       "status",
+		findingExpanded:    map[string]bool{},
+		sourceSide:         diffSourceBase,
+		sourceBaseExpanded: map[string]bool{"root": true, "manifests": true},
+		sourceHeadExpanded: map[string]bool{"root": true, "manifests": true},
 	}
-	m.active = diffTabOverview
-	m.listModel = m.buildList()
+	m.shellModel = newShell(ShellSpec{
+		TopBar: m.topBarLine,
+		Tabs: []TabSpec{
+			{ID: "overview", Label: "Overview", Build: m.buildOverviewTab},
+			{ID: "components", Label: "Components", Build: m.buildComponentsTab},
+			{ID: "vulnerabilities", Label: "Vulnerabilities", Build: m.buildVulnsTab},
+			{ID: "licenses", Label: "Licenses", Build: m.buildLicensesTab},
+			{ID: "findings", Label: "Findings", Build: m.buildFindingsTab},
+			{ID: "source", Label: "Source", Build: m.buildSourceTab},
+		},
+		Footer: func() (string, string) {
+			return m.diffFooterSummary(), m.diffLegend()
+		},
+	})
+	return m
 }
 
-func (m *diffModel) SelectView(index int) {
-	tabs := diffTabs()
-	if index < 1 || index > len(tabs) {
+// WithEnrichEnabled records whether enrichment ran, so empty Vuln/Findings
+// tabs can distinguish "not requested" from "no matches".
+func (m *diffModel) WithEnrichEnabled(enabled bool) *diffModel {
+	if m == nil {
+		return nil
+	}
+	m.enrichEnabled = enabled
+	m.Rebuild()
+	return m
+}
+
+// CycleGroup is the per-tab "g" key handler. Each tab interprets it
+// differently (grouping axis, source-side focus).
+func (m *diffModel) CycleGroup() {
+	switch m.ActiveTabID() {
+	case "components":
+		m.componentsGroup = nextComponentsGroup(m.componentsGroup)
+	case "vulnerabilities":
+		m.vulnGroup = nextVulnGroup(m.vulnGroup)
+	case "licenses":
+		m.licenseGroup = nextLicenseGroup(m.licenseGroup)
+	case "findings":
+		m.findingGroup = nextFindingGroup(m.findingGroup)
+	case "source":
+		if m.sourceSide == diffSourceBase {
+			m.sourceSide = diffSourceHead
+		} else {
+			m.sourceSide = diffSourceBase
+		}
+	default:
 		return
 	}
-	m.active = tabs[index-1]
-	m.listModel = m.buildList()
+	m.Rebuild()
 }
 
-func diffTabs() []diffTab {
-	return []diffTab{diffTabOverview, diffTabAdded, diffTabRemoved, diffTabChanged}
-}
-
-func (m *diffModel) buildList() *listModel {
-	switch m.active {
-	case diffTabAdded:
-		return m.buildPackageTab(diffTabAdded)
-	case diffTabRemoved:
-		return m.buildPackageTab(diffTabRemoved)
-	case diffTabChanged:
-		return m.buildPackageTab(diffTabChanged)
-	default:
-		return m.buildOverviewTab()
+// CycleRelationshipFilter advances the relationship filter on the Components
+// tab (None → root → direct → transitive → None).
+func (m *diffModel) CycleRelationshipFilter() {
+	if m.ActiveTabID() != "components" {
+		return
 	}
+	m.componentsRelationship = cycleString(m.componentsRelationship, []string{"", "root", "direct", "transitive"})
+	m.Rebuild()
+}
+
+// CycleScopeFilter advances the scope filter (None → runtime → development → unset → None).
+func (m *diffModel) CycleScopeFilter() {
+	if m.ActiveTabID() != "components" {
+		return
+	}
+	m.componentsScope = cycleString(m.componentsScope, []string{"", "runtime", "development", "unset"})
+	m.Rebuild()
+}
+
+// CycleSeverityFilter advances the severity filter on the Components tab
+// (driven by attached PackageRef.Vulnerabilities).
+func (m *diffModel) CycleSeverityFilter() {
+	if m.ActiveTabID() != "components" {
+		return
+	}
+	m.componentsSeverity = cycleString(m.componentsSeverity, []string{"", "critical", "high", "medium", "low", "unknown"})
+	m.Rebuild()
+}
+
+// CycleEcosystemFilter advances the ecosystem filter, drawn from the
+// distinct ecosystems present across changed manifests.
+func (m *diffModel) CycleEcosystemFilter() {
+	if m.ActiveTabID() != "components" {
+		return
+	}
+	ecos := map[string]struct{}{}
+	for _, mf := range m.payload.Results.Manifests {
+		if mf.Ecosystem != "" {
+			ecos[mf.Ecosystem] = struct{}{}
+		}
+	}
+	options := []string{""}
+	for e := range ecos {
+		options = append(options, e)
+	}
+	sort.Strings(options[1:])
+	m.componentsEcosystem = cycleString(m.componentsEcosystem, options)
+	m.Rebuild()
+}
+
+// nextComponentsGroup advances the Components-tab grouping axis through
+// status → manifest → ecosystem → status.
+func nextComponentsGroup(g componentsGroup) componentsGroup {
+	switch g {
+	case componentsGroupStatus:
+		return componentsGroupManifest
+	case componentsGroupManifest:
+		return componentsGroupEcosystem
+	default:
+		return componentsGroupStatus
+	}
+}
+
+func cycleString(current string, options []string) string {
+	for i, opt := range options {
+		if opt == current {
+			return options[(i+1)%len(options)]
+		}
+	}
+	return options[0]
+}
+
+// ToggleSelected toggles the expansion of the currently-focused tree node.
+func (m *diffModel) ToggleSelected() { m.setSelectedExpansion(toggleExpansion) }
+
+// ExpandSelected forces the focused node open.
+func (m *diffModel) ExpandSelected() { m.setSelectedExpansion(forceExpand) }
+
+// CollapseSelected forces the focused node closed.
+func (m *diffModel) CollapseSelected() { m.setSelectedExpansion(forceCollapse) }
+
+// ExpandAll opens every expandable node in the active tab.
+func (m *diffModel) ExpandAll() { m.setAllExpansion(true) }
+
+// CollapseAll closes every expandable node in the active tab.
+func (m *diffModel) CollapseAll() { m.setAllExpansion(false) }
+
+type expansionAction int
+
+const (
+	toggleExpansion expansionAction = iota
+	forceExpand
+	forceCollapse
+)
+
+func (m *diffModel) currentExpansionMap() map[string]bool {
+	switch m.ActiveTabID() {
+	case "components":
+		return m.componentsExpanded
+	case "vulnerabilities":
+		return m.vulnExpanded
+	case "licenses":
+		return m.licenseExpanded
+	case "findings":
+		return m.findingExpanded
+	case "source":
+		if m.sourceSide == diffSourceBase {
+			return m.sourceBaseExpanded
+		}
+		return m.sourceHeadExpanded
+	}
+	return nil
+}
+
+func (m *diffModel) setSelectedExpansion(action expansionAction) {
+	expansion := m.currentExpansionMap()
+	if expansion == nil {
+		return
+	}
+	list := m.List()
+	if list == nil {
+		return
+	}
+	visible := list.visibleItemIndices()
+	if len(visible) == 0 {
+		return
+	}
+	item := list.items[visible[list.selectedVisibleIndex(visible)]]
+	if !item.canOpen || item.key == "" {
+		return
+	}
+	switch action {
+	case toggleExpansion:
+		expansion[item.key] = !item.expanded
+	case forceExpand:
+		if item.expanded {
+			return
+		}
+		expansion[item.key] = true
+	case forceCollapse:
+		if !item.expanded {
+			return
+		}
+		expansion[item.key] = false
+	}
+	m.rebuildPreserveSelection()
+}
+
+func (m *diffModel) setAllExpansion(expanded bool) {
+	expansion := m.currentExpansionMap()
+	if expansion == nil {
+		return
+	}
+	list := m.List()
+	if list == nil {
+		return
+	}
+	for _, item := range list.items {
+		if !item.canOpen || item.key == "" {
+			continue
+		}
+		expansion[item.key] = expanded
+	}
+	m.rebuildPreserveSelection()
+}
+
+func (m *diffModel) rebuildPreserveSelection() {
+	list := m.List()
+	prevSelected := 0
+	if list != nil {
+		prevSelected = list.selected
+	}
+	m.Rebuild()
+	if list := m.List(); list != nil {
+		if prevSelected < len(list.items) {
+			list.selected = prevSelected
+		}
+	}
+}
+
+// diffFooterSummary is the single-line stats bar pinned to the bottom of
+// every diff tab. Each count is a *delta total* — items that changed
+// between base and head — so the numbers add up to "what this diff
+// represents." See diffAggregateCounts for the exact semantics.
+func (m *diffModel) diffFooterSummary() string {
+	c := m.diffAggregateCounts()
+	return fmt.Sprintf("Manifests: %d | Packages: %d | Vulns: %d | Licenses: %d | Findings: %d",
+		c.ManifestDeltas, c.PackageDeltas, c.VulnDeltas, c.LicenseUniqueDeltas, c.FindingDeltas)
+}
+
+// diffAggregateCounts holds the per-tab status-bar counts, broken out
+// so they're individually testable. Every field is a "delta" — i.e.
+// items affected by the diff — not a head-pipeline total.
+//
+// Semantics:
+//
+//	ManifestDeltas:       Added + Changed + Removed manifests.
+//	PackageDeltas:        Added + Changed + Removed packages across all manifests.
+//	VulnDeltas:           Introduced + Persisted + Resolved audit findings whose
+//	                      Kind classifies them as a vulnerability (matches
+//	                      isVulnerabilityFinding). Persisted is included because
+//	                      the head pipeline still carries the vuln; the user
+//	                      wants to see it in the per-diff vuln total.
+//	LicenseUniqueDeltas:  Count of distinct SPDX identifiers that were either
+//	                      introduced or retired. Same identifier introduced by
+//	                      five packages counts ONCE.
+//	FindingDeltas:        Introduced + Persisted + Resolved audit findings whose
+//	                      Kind is NOT a vulnerability (policy/risk/license).
+//	                      With the built-in policy auditor (which emits
+//	                      Kind=vulnerability for every match), this is typically
+//	                      zero — non-zero values come from external auditors or
+//	                      future kinds.
+type diffAggregateCounts struct {
+	ManifestDeltas      int
+	PackageDeltas       int
+	VulnDeltas          int
+	LicenseUniqueDeltas int
+	FindingDeltas       int
+}
+
+func (m *diffModel) diffAggregateCounts() diffAggregateCounts {
+	s := m.payload.Summary
+	out := diffAggregateCounts{
+		ManifestDeltas: s.AddedManifestCount + s.ChangedManifestCount + s.RemovedManifestCount,
+		PackageDeltas:  s.AddedPackageCount + s.ChangedPackageCount + s.RemovedPackageCount,
+	}
+	if m.payload.Audit != nil {
+		for _, bucket := range [][]output.AuditFinding{m.payload.Audit.Introduced, m.payload.Audit.Persisted, m.payload.Audit.Resolved} {
+			for _, f := range bucket {
+				if isVulnerabilityFinding(f) {
+					out.VulnDeltas++
+				} else {
+					out.FindingDeltas++
+				}
+			}
+		}
+	}
+	uniqueLicenses := make(map[string]struct{})
+	for _, d := range m.collectLicenseDeltas() {
+		uniqueLicenses[d.license] = struct{}{}
+	}
+	out.LicenseUniqueDeltas = len(uniqueLicenses)
+	return out
+}
+
+// diffLegend mirrors scan's legend so the keyboard help row reads identical
+// across commands.
+func (m *diffModel) diffLegend() string {
+	return strings.Join([]string{
+		keyHint("Tab", "switch"),
+		keyHint("Enter", "select"),
+		keyHint("→", "expand"),
+		keyHint("←", "collapse"),
+		keyHint("]", "expand all"),
+		keyHint("[", "collapse all"),
+		keyHint("↑/↓", "move"),
+		keyHint("q", "quit"),
+	}, " ")
+}
+
+func (m *diffModel) topBarLine() string {
+	parts := []string{
+		render.Style(valueOrDash(m.payload.Project.Name), render.White, render.Bold),
+		render.Style(targetKindLabel(m.payload.Project), render.Dim),
+	}
+	if m.payload.Project.TargetRef != "" {
+		parts = append(parts, render.Style("ref: "+m.payload.Project.TargetRef, render.Cyan, render.Bold))
+	}
+	parts = append(parts, render.Style(m.payload.Comparison.Base+" -> "+m.payload.Comparison.Head, render.Cyan, render.Bold))
+	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
+		render.Style("DIFF", render.BgBlue, render.White, render.Bold) + " " +
+		strings.Join(parts, render.Style(" | ", render.Dim))
+}
+
+// --- Overview tab ---------------------------------------------------------
+
+// View overrides the embedded shellModel.View so the Overview tab can
+// render its custom dashboard layout. All other tabs (including Source,
+// which uses listModel.bodyOverride for its two-pane body) fall through
+// to the shared shellModel renderer so the chrome stays identical.
+func (m *diffModel) View(width, height int) string {
+	if m == nil || m.shellModel == nil {
+		return ""
+	}
+	if m.ActiveTabID() == "overview" && !m.IsSearching() {
+		return m.overviewDashboardView(width, height)
+	}
+	return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
 }
 
 func (m *diffModel) buildOverviewTab() *listModel {
-	manifests := sortedDiffManifests(m.payload.Results.Manifests)
-	items := make([]listItem, 0, len(manifests))
-	for _, manifest := range manifests {
+	summary := m.payload.Summary
+	items := []listItem{
+		{
+			title:    "Comparison",
+			subtitle: "overview",
+			details: []string{
+				render.Style("Comparison", render.Bold, render.Cyan),
+				"",
+				render.Style("  Base: ", render.Dim) + valueOrDash(m.payload.Comparison.Base),
+				render.Style("  Head: ", render.Dim) + valueOrDash(m.payload.Comparison.Head),
+				render.Style("  Project: ", render.Dim) + valueOrDash(m.payload.Project.Name),
+				render.Style("  Target: ", render.Dim) + targetKindLabel(m.payload.Project),
+			},
+		},
+		{
+			title:    "Manifests",
+			subtitle: "summary",
+			details: []string{
+				render.Style("Manifest Changes", render.Bold, render.Cyan),
+				"",
+				render.Style("  Added: ", render.Dim) + fmt.Sprintf("%d", summary.AddedManifestCount),
+				render.Style("  Changed: ", render.Dim) + fmt.Sprintf("%d", summary.ChangedManifestCount),
+				render.Style("  Removed: ", render.Dim) + fmt.Sprintf("%d", summary.RemovedManifestCount),
+				render.Style("  Unchanged: ", render.Dim) + fmt.Sprintf("%d", summary.UnchangedManifestCount),
+			},
+		},
+		{
+			title:    "Packages",
+			subtitle: "summary",
+			details: []string{
+				render.Style("Package Changes", render.Bold, render.Cyan),
+				"",
+				render.Style("  Added: ", render.Dim) + fmt.Sprintf("%d", summary.AddedPackageCount),
+				render.Style("  Changed: ", render.Dim) + fmt.Sprintf("%d", summary.ChangedPackageCount),
+				render.Style("  Removed: ", render.Dim) + fmt.Sprintf("%d", summary.RemovedPackageCount),
+			},
+		},
+	}
+	if m.payload.Audit != nil {
 		items = append(items, listItem{
-			title:    render.DiffManifestDisplayLabel(manifest),
-			subtitle: manifest.Status,
-			details:  diffManifestDetails(manifest),
+			title:    "Vulnerabilities",
+			subtitle: "audit",
+			details:  m.overviewAuditDetails(),
+		})
+		items = append(items, listItem{
+			title:    "Audit Severity",
+			subtitle: "distribution",
+			details:  m.overviewAuditSummaryDetails(),
 		})
 	}
+	items = append(items, listItem{
+		title:    "Top Changed Manifests",
+		subtitle: "top",
+		details:  m.overviewTopChangedManifests(),
+	})
+
 	return &listModel{
-		title:          "",
-		summary:        m.diffSummaryLines(),
-		listTitle:      fmt.Sprintf("Manifests (%d)", len(items)),
-		detailTitle:    "Manifest Details",
-		topPanels:      m.diffTopPanels(),
+		topPanels:      m.overviewPanels(),
+		listTitle:      "Overview",
+		detailTitle:    "Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Tab or 1-4 switches tabs; Enter keeps current result; Esc clears search",
-		emptyState:     "No manifest changes were found.",
+		filterHelp:     "Use / to search; Tab or 1-6 switches tabs; Esc clears search",
+		emptyState:     "No diff overview is available.",
 		items:          items,
 	}
 }
 
-func (m *diffModel) buildPackageTab(tab diffTab) *listModel {
-	items := make([]listItem, 0)
-	for _, manifest := range sortedDiffManifests(m.payload.Results.Manifests) {
-		switch tab {
-		case diffTabAdded:
-			for _, change := range manifest.Added {
-				label := render.DiffPackageDisplayName(change.Package)
-				items = append(items, listItem{title: label, subtitle: string(tab), details: diffPackageDetails("Added package", manifest, label, "", "")})
+// diffOverviewStats aggregates everything the Overview dashboard needs.
+// Every field is documented because the Overview's headline + distribution
+// panes are easy to mis-aggregate. See computeOverviewStats for the
+// authoritative source-of-truth comments per field.
+type diffOverviewStats struct {
+	// ecosystems: ecosystem -> number of change events (Added+Changed+Removed)
+	// scoped to manifests in that ecosystem. Sum equals changedTotal.
+	ecosystems map[string]int
+
+	// scopes: composite key "<status> <scope>" (e.g. "added runtime") ->
+	// number of change events. The composite key keeps the bar-chart
+	// honest: a user can tell at a glance that direct-runtime additions
+	// are different from runtime removals.
+	scopes map[string]int
+
+	// relationships: composite key "<status> <relationship>" (e.g. "removed
+	// direct") -> number of change events. The relationship is looked up in
+	// whichever graph the package belongs to: added/changed packages use
+	// the HEAD graph; removed packages use the BASE graph (so removals
+	// don't degenerate to "unknown").
+	relationships map[string]int
+
+	// licenseDeltas: "introduced"/"retired" -> count of license-delta EVENTS
+	// (not unique IDs). Multiple packages contributing the same license each
+	// add 1.
+	licenseDeltas map[string]int
+
+	// licenseUniqueIDs: SPDX id -> number of delta events referencing it.
+	// `len(licenseUniqueIDs)` is the "unique licenses affected" count.
+	licenseUniqueIDs map[string]int
+
+	// findingsByKind: kind ("vulnerability", "license", "package") ->
+	// total count across all three audit-delta buckets. Reads
+	// AuditFinding.Kind directly. Powers the "Findings" summary card
+	// in the Overview's top row.
+	findingsByKind map[string]int
+
+	// vulnByStatus: row key (severity, e.g. "critical") -> column map
+	// (status -> count). Powers the "Vulnerability Findings" table.
+	// Rows include every severity tier even when the bucket is zero so
+	// the table layout stays stable across diffs.
+	vulnByStatus map[string]map[string]int
+
+	// licenseByStatus: rule key parsed from AuditFinding.ID for the license
+	// auditor ("unknown", "invalid", "denied") -> status -> count. Powers
+	// the "License Findings" table.
+	licenseByStatus map[string]map[string]int
+
+	// packageByStatus: rule key parsed from AuditFinding.ID for the package
+	// auditor ("denied-package", "denied-group", "suspicious") -> status ->
+	// count. Powers the "Package Findings" table.
+	packageByStatus map[string]map[string]int
+
+	// matchedExact: number of Changed entries that were NOT fuzzy-reconciled
+	// (i.e. name match with version change).
+	matchedExact int
+
+	// matchedFuzzy: number of Changed entries reconciled by the fuzzy
+	// matcher (PackageRef.Metadata["bomly.diff.fuzzy_reconciled"] == true).
+	matchedFuzzy int
+
+	// unmatchedAdded: total Added packages — entries that did NOT find a
+	// peer in the base, even after fuzzy reconciliation. (Fuzzy matches are
+	// moved out of Added/Removed into Changed at build time.)
+	unmatchedAdded int
+
+	// unmatchedRemoved: total Removed packages — see unmatchedAdded.
+	unmatchedRemoved int
+
+	// changedTotal: total package-level change events (Added+Changed+Removed).
+	changedTotal int
+
+	// auditSummaryTotal: the raw AuditSummary.Total field. Per
+	// `internal/cli/scan_output.go` this is currently Introduced+Persisted
+	// (Resolved is no longer added). Use it for "head state size" context;
+	// the exit-code gate lives in auditVerdict.FailingIntroduced, NOT here.
+	auditSummaryTotal int
+
+	// auditRan: true when --enrich --audit produced an AuditSummary.
+	auditRan bool
+}
+
+func (m *diffModel) computeOverviewStats() diffOverviewStats {
+	out := diffOverviewStats{
+		ecosystems:       make(map[string]int),
+		scopes:           make(map[string]int),
+		relationships:    make(map[string]int),
+		licenseDeltas:    make(map[string]int),
+		licenseUniqueIDs: make(map[string]int),
+		findingsByKind:   make(map[string]int),
+		vulnByStatus:     newRuleStatusTable(severityRowKeys()),
+		licenseByStatus:  newRuleStatusTable(licenseRuleRowKeys()),
+		packageByStatus:  newRuleStatusTable(packageRuleRowKeys()),
+	}
+
+	headRels := map[string]string{}
+	if g, _ := graphFromConsolidated(m.headGraph); g != nil {
+		headRels = classifyRelationships(g)
+	}
+	baseRels := map[string]string{}
+	if g, _ := graphFromConsolidated(m.baseGraph); g != nil {
+		baseRels = classifyRelationships(g)
+	}
+
+	// relForChange looks up a package's relationship in whichever graph it
+	// belongs to. Added/Changed packages live in HEAD; removed packages live
+	// in BASE; falling back across both keeps the bar-chart honest when
+	// one side is missing (e.g. fuzzy-changed packages whose ID differs).
+	relForChange := func(status, pkgID string) string {
+		if status == "removed" {
+			if r := baseRels[pkgID]; r != "" {
+				return r
 			}
-		case diffTabRemoved:
-			for _, change := range manifest.Removed {
-				label := render.DiffPackageDisplayName(change.Package)
-				items = append(items, listItem{title: label, subtitle: string(tab), details: diffPackageDetails("Removed package", manifest, label, "", "")})
+			if r := headRels[pkgID]; r != "" {
+				return r
 			}
-		case diffTabChanged:
-			for _, change := range manifest.Changed {
-				before := render.DiffPackageDisplayName(change.Before)
-				after := render.DiffPackageDisplayName(change.After)
-				title := after
-				if title == "" {
-					title = before
+		} else {
+			if r := headRels[pkgID]; r != "" {
+				return r
+			}
+			if r := baseRels[pkgID]; r != "" {
+				return r
+			}
+		}
+		return "unknown"
+	}
+
+	addScopeRel := func(status string, scope string, pkgID string) {
+		out.scopes[status+" "+scopeBucket(scope)]++
+		out.relationships[status+" "+relForChange(status, pkgID)]++
+	}
+
+	for _, mf := range m.payload.Results.Manifests {
+		eco := strings.TrimSpace(mf.Ecosystem)
+		if eco == "" {
+			eco = "unknown"
+		}
+		n := len(mf.Added) + len(mf.Changed) + len(mf.Removed)
+		if n > 0 {
+			out.ecosystems[eco] += n
+			out.changedTotal += n
+		}
+		for _, change := range mf.Added {
+			addScopeRel("added", change.Package.Scope, change.Package.ID)
+		}
+		for _, change := range mf.Removed {
+			addScopeRel("removed", change.Package.Scope, change.Package.ID)
+		}
+		for _, change := range mf.Changed {
+			addScopeRel("changed", change.After.Scope, change.After.ID)
+			if isFuzzyReconciled(change.After) {
+				out.matchedFuzzy++
+			} else {
+				out.matchedExact++
+			}
+		}
+		out.unmatchedAdded += len(mf.Added)
+		out.unmatchedRemoved += len(mf.Removed)
+	}
+
+	// License deltas (events + unique IDs).
+	for _, d := range m.collectLicenseDeltas() {
+		out.licenseDeltas[d.status]++
+		out.licenseUniqueIDs[d.license]++
+	}
+
+	// Audit aggregations — walk all three delta buckets and split by
+	// FindingKind. AuditFinding.Kind is the source of truth; the older
+	// auditor-name heuristic ('vulnerability'/'license'/'package' as
+	// strings) is no longer used.
+	if m.payload.Audit != nil {
+		out.auditRan = true
+		if m.payload.Audit.AuditSummary != nil {
+			out.auditSummaryTotal = m.payload.Audit.AuditSummary.Total
+		}
+		bucketStatus := []string{"introduced", "persisted", "resolved"}
+		buckets := [][]output.AuditFinding{m.payload.Audit.Introduced, m.payload.Audit.Persisted, m.payload.Audit.Resolved}
+		for bIdx, bucket := range buckets {
+			status := bucketStatus[bIdx]
+			for _, f := range bucket {
+				kind := findingKindOf(f)
+				out.findingsByKind[kind]++
+				switch kind {
+				case "vulnerability":
+					sev := strings.ToLower(strings.TrimSpace(f.Severity))
+					if _, ok := out.vulnByStatus[sev]; !ok {
+						sev = "unknown"
+					}
+					out.vulnByStatus[sev][status]++
+				case "license":
+					rule := findingRule(f, "unknown")
+					if _, ok := out.licenseByStatus[rule]; !ok {
+						// Bucket unrecognized rules under "other" so the
+						// pre-seeded table layout doesn't get extra rows
+						// for novel plugin findings; the user still sees
+						// the count.
+						rule = "other"
+						if _, ok := out.licenseByStatus[rule]; !ok {
+							out.licenseByStatus[rule] = map[string]int{}
+						}
+					}
+					out.licenseByStatus[rule][status]++
+				case "package":
+					rule := findingRule(f, "other")
+					if _, ok := out.packageByStatus[rule]; !ok {
+						rule = "other"
+						if _, ok := out.packageByStatus[rule]; !ok {
+							out.packageByStatus[rule] = map[string]int{}
+						}
+					}
+					out.packageByStatus[rule][status]++
 				}
-				items = append(items, listItem{title: title, subtitle: string(tab), details: diffPackageDetails("Changed package", manifest, title, before, after)})
 			}
 		}
 	}
+	return out
+}
+
+// auditStatusLabel maps the internal audit-delta status to its short
+// user-facing word. Internal data continues to use the long forms
+// ("introduced"/"persisted"/"resolved") so existing keys and sort
+// orders stay stable, but the UI shows the shorter "new"/"old"/"fixed".
+// License deltas use "introduced"/"retired" — only "introduced" overlaps
+// and gets the same translation; "retired" passes through unchanged.
+func auditStatusLabel(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "introduced":
+		return "new"
+	case "persisted":
+		return "old"
+	case "resolved":
+		return "fixed"
+	}
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+// auditStatusTitle is auditStatusLabel with the first letter capitalised
+// (for bucket headers and labels inside boxes).
+func auditStatusTitle(status string) string {
+	return titleCase(auditStatusLabel(status))
+}
+
+// findingKindOf returns the lowercased FindingKind for a finding, with a
+// last-resort heuristic for payloads that omit the Kind field entirely
+// (older diff outputs, external plugins). The fallback mirrors the
+// classification done by isVulnerabilityFinding so this function and that
+// predicate never disagree.
+func findingKindOf(f output.AuditFinding) string {
+	if k := strings.ToLower(strings.TrimSpace(f.Kind)); k != "" {
+		switch k {
+		case "vuln", "advisory", "cve":
+			return "vulnerability"
+		}
+		return k
+	}
+	if isVulnerabilityFinding(f) {
+		return "vulnerability"
+	}
+	switch strings.ToLower(strings.TrimSpace(f.Auditor)) {
+	case "license":
+		return "license"
+	case "package":
+		return "package"
+	}
+	return "other"
+}
+
+// findingRule pulls the rule keyword from an AuditFinding.ID. Built-in
+// auditors format IDs as "<auditor>:<rule>:<package-id>" (see
+// internal/auditors/{license,package}/auditor.go). The rule chunk is the
+// 2nd colon-separated field; we additionally strip a trailing "-license"
+// / "-package" so callers see consistent short keys ("unknown" instead
+// of "unknown-license", "denied" instead of "denied-license").
+func findingRule(f output.AuditFinding, fallback string) string {
+	id := strings.TrimSpace(f.ID)
+	if id == "" {
+		return fallback
+	}
+	parts := strings.SplitN(id, ":", 3)
+	if len(parts) < 2 {
+		return fallback
+	}
+	rule := parts[1]
+	rule = strings.TrimSuffix(rule, "-license")
+	rule = strings.TrimSuffix(rule, "-package")
+	if rule == "" {
+		return fallback
+	}
+	return rule
+}
+
+// severityRowKeys / licenseRuleRowKeys / packageRuleRowKeys define the
+// row layout (and visible order) for the corresponding Overview tables.
+// They live alongside the renderer so adding a new severity tier or
+// auditor rule is a single-spot change.
+func severityRowKeys() []string {
+	return []string{"critical", "high", "medium", "low", "unknown"}
+}
+
+func licenseRuleRowKeys() []string {
+	// Mirrors the rule IDs in internal/auditors/license/auditor.go:
+	//   unknown-license / invalid-license / denied-license
+	// Plus an "other" row so external license auditors land somewhere.
+	return []string{"unknown", "invalid", "denied", "other"}
+}
+
+func packageRuleRowKeys() []string {
+	// Mirrors the rule IDs in internal/auditors/package/auditor.go:
+	//   denied-package / denied-group / suspicious-package
+	// Plus an "other" row for external package auditors.
+	return []string{"denied", "denied-group", "suspicious", "other"}
+}
+
+// newRuleStatusTable pre-allocates an inner map for every known row so
+// the table always renders the full set, even if a particular diff has
+// zero findings on a row (the user sees "0 0 0" rather than the row
+// vanishing).
+func newRuleStatusTable(rows []string) map[string]map[string]int {
+	out := make(map[string]map[string]int, len(rows))
+	for _, r := range rows {
+		out[r] = map[string]int{}
+	}
+	return out
+}
+
+func scopeBucket(scope string) string {
+	s := strings.ToLower(strings.TrimSpace(scope))
+	if s == "" {
+		return "unset"
+	}
+	return s
+}
+
+func isFuzzyReconciled(pkg output.PackageRef) bool {
+	if pkg.Metadata == nil {
+		return false
+	}
+	v, ok := pkg.Metadata["bomly.diff.fuzzy_reconciled"]
+	if !ok {
+		return false
+	}
+	b, _ := v.(bool)
+	return b
+}
+
+// classifyRelationships labels every package in a graph as root, direct, or
+// transitive. Roots are packages with no incoming edges; direct dependencies
+// are immediate children of any root; everything else is transitive.
+func classifyRelationships(g *sdk.Graph) map[string]string {
+	out := make(map[string]string)
+	if g == nil {
+		return out
+	}
+	rootIDs := make(map[string]struct{})
+	for _, r := range g.Roots() {
+		if r == nil {
+			continue
+		}
+		rootIDs[r.ID] = struct{}{}
+		out[r.ID] = "root"
+	}
+	for rid := range rootIDs {
+		deps, _ := g.Dependencies(rid)
+		for _, d := range deps {
+			if d == nil {
+				continue
+			}
+			if _, isRoot := rootIDs[d.ID]; isRoot {
+				continue
+			}
+			if _, alreadyLabeled := out[d.ID]; alreadyLabeled {
+				continue
+			}
+			out[d.ID] = "direct"
+		}
+	}
+	for _, pkg := range g.Packages() {
+		if pkg == nil {
+			continue
+		}
+		if _, ok := out[pkg.ID]; !ok {
+			out[pkg.ID] = "transitive"
+		}
+	}
+	return out
+}
+
+// overviewHeadline renders the one-line headline above the panes. Each
+// chip reports a *delta-scoped* fact. The "audit verdict" chip mirrors
+// `internal/cli/diff_cmd.go:161-165`: FAIL iff at least one *introduced*
+// finding's Disposition gates the exit code (i.e. `output.FailingFindingCount`
+// returns > 0). Persisted and resolved findings never gate exit code on
+// their own.
+func (m *diffModel) overviewHeadline(width int) string {
+	stats := m.computeOverviewStats()
+	v := m.auditVerdict()
+	parts := make([]string, 0, 4)
+	if stats.changedTotal == 0 {
+		parts = append(parts, render.Style("✓ No changes detected", render.Green, render.Bold))
+	} else {
+		parts = append(parts, render.Style(fmt.Sprintf("Δ %d package changes", stats.changedTotal), render.Yellow, render.Bold))
+	}
+	vulnIntroduced := 0
+	if m.payload.Audit != nil {
+		for _, f := range m.payload.Audit.Introduced {
+			if isVulnerabilityFinding(f) {
+				vulnIntroduced++
+			}
+		}
+	}
+	if vulnIntroduced == 0 {
+		parts = append(parts, render.Style("✓ No new vulnerabilities", render.Green, render.Bold))
+	} else {
+		parts = append(parts, render.Style(fmt.Sprintf("✗ %d new vulnerabilities", vulnIntroduced), render.Red, render.Bold))
+	}
+	switch v.Verdict() {
+	case "NOT EVALUATED":
+		parts = append(parts, render.Style("◌ Audit not run", render.Dim, render.Bold))
+	case "FAIL":
+		parts = append(parts, render.Style(fmt.Sprintf("✗ Audit FAIL (%d new, exit 2)", v.FailingIntroduced), render.Red, render.Bold))
+	case "PASS":
+		if v.IntroducedTotal > 0 {
+			// All introduced findings are warn-only.
+			parts = append(parts, render.Style(fmt.Sprintf("⚠ Audit PASS (%d warn-only, exit 0)", v.IntroducedTotal), render.Yellow, render.Bold))
+		} else {
+			parts = append(parts, render.Style("✓ Audit PASS (exit 0)", render.Green, render.Bold))
+		}
+	}
+	if stats.matchedFuzzy > 0 {
+		parts = append(parts, render.Style(fmt.Sprintf("≈ %d fuzzy-reconciled", stats.matchedFuzzy), render.Cyan, render.Bold))
+	}
+	sep := render.Style("  •  ", render.Dim)
+	return truncateToWidth(strings.Join(parts, sep), width)
+}
+
+func (m *diffModel) overviewDashboardView(width, height int) string {
+	if width < 80 || height < 22 {
+		return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
+	}
+	var lines []string
+	for _, line := range m.shellSummaryLines() {
+		lines = append(lines, truncateToWidth(line, width))
+	}
+	// Headline row + spacer.
+	lines = append(lines, m.overviewHeadline(width), "")
+	footerLines := m.diffFooterLines(width)
+	bodyHeight := height - len(lines) - len(footerLines)
+	if bodyHeight < 14 {
+		return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
+	}
+
+	stats := m.computeOverviewStats()
+	s := m.payload.Summary
+	cardHeight := 9
+	gap := 1
+	cardWidth := (width - 4*gap) / 5
+	// Five equal cards on the top row: Manifests / Packages /
+	// Vulnerabilities / Licenses / Findings. The 5th "Findings" card
+	// summarizes audit findings broken out by FindingKind so the user
+	// has a single read of "what kinds of policy problems are in play"
+	// before drilling into the per-kind tables below.
+	findingsTotal := stats.findingsByKind["vulnerability"] +
+		stats.findingsByKind["license"] +
+		stats.findingsByKind["package"] +
+		stats.findingsByKind["other"]
+	cards := [][]string{
+		boxView("Manifests", summaryCountCardLines(s.AddedManifestCount+s.ChangedManifestCount+s.RemovedManifestCount, "Changed Manifests", cardWidth-2, render.Cyan,
+			render.Style(fmt.Sprintf("%d added", s.AddedManifestCount), render.Green),
+			render.Style(fmt.Sprintf("%d changed", s.ChangedManifestCount), render.Yellow),
+			render.Style(fmt.Sprintf("%d removed", s.RemovedManifestCount), render.Red),
+		), cardWidth, cardHeight, render.Cyan),
+		boxView("Packages", summaryCountCardLines(s.AddedPackageCount+s.ChangedPackageCount+s.RemovedPackageCount, "Package Changes", cardWidth-2, render.Magenta,
+			render.Style(fmt.Sprintf("%d added", s.AddedPackageCount), render.Green),
+			render.Style(fmt.Sprintf("%d changed", s.ChangedPackageCount), render.Yellow),
+			render.Style(fmt.Sprintf("%d removed", s.RemovedPackageCount), render.Red),
+		), cardWidth, cardHeight, render.Magenta),
+		boxView("Vulnerabilities", summaryCountCardLines(diffVulnTotal(m.payload), "Vuln Deltas", cardWidth-2, render.Red,
+			render.Style(fmt.Sprintf("%d new", diffVulnCount(m.payload, "introduced")), render.Red),
+			render.Style(fmt.Sprintf("%d old", diffVulnCount(m.payload, "persisted")), render.Yellow),
+			render.Style(fmt.Sprintf("%d fixed", diffVulnCount(m.payload, "resolved")), render.Green),
+		), cardWidth, cardHeight, render.Red),
+		boxView("Licenses", summaryCountCardLines(len(stats.licenseUniqueIDs), "Unique Licenses", cardWidth-2, render.Yellow,
+			render.Style(fmt.Sprintf("%d introduced events", stats.licenseDeltas["introduced"]), render.Green),
+			render.Style(fmt.Sprintf("%d retired events", stats.licenseDeltas["retired"]), render.Red),
+		), cardWidth, cardHeight, render.Yellow),
+		boxView("Findings", summaryCountCardLines(findingsTotal, "Findings by Kind", cardWidth-2, render.Magenta,
+			render.Style(fmt.Sprintf("%d vulnerability", stats.findingsByKind["vulnerability"]), render.Red),
+			render.Style(fmt.Sprintf("%d license", stats.findingsByKind["license"]), render.Yellow),
+			render.Style(fmt.Sprintf("%d package", stats.findingsByKind["package"]), render.Cyan),
+		), cardWidth, cardHeight, render.Magenta),
+	}
+	for idx := 0; idx < cardHeight; idx++ {
+		row := cards[0][idx]
+		for c := 1; c < len(cards); c++ {
+			row += " " + cards[c][idx]
+		}
+		lines = append(lines, row)
+	}
+	lines = append(lines, "")
+
+	remaining := bodyHeight - cardHeight - 1
+	leftWidth := width / 2
+	rightWidth := width - leftWidth - 1
+	leftA := remaining / 3
+	if leftA < 6 && remaining >= 18 {
+		leftA = 6
+	}
+	leftB := (remaining - leftA - 2) / 2
+	leftC := remaining - leftA - leftB - 2
+	if leftC < 4 {
+		leftC = 4
+	}
+	leftContent := stackBoxes(
+		boxView("Changes per Ecosystem", coloredDistributionLines(stats.ecosystems, stats.changedTotal, 8, leftWidth-2), leftWidth, leftA, render.Cyan),
+		boxView("Changes per Relationship", coloredDistributionLines(stats.relationships, sumCounts(stats.relationships), 6, leftWidth-2), leftWidth, leftB, render.Cyan),
+		boxView("Changes per Scope", coloredDistributionLines(stats.scopes, sumCounts(stats.scopes), 6, leftWidth-2), leftWidth, leftC, render.Green),
+	)
+	rightA := remaining / 3
+	if rightA < 6 && remaining >= 18 {
+		rightA = 6
+	}
+	rightB := (remaining - rightA - 2) / 2
+	rightC := remaining - rightA - rightB - 2
+	if rightC < 4 {
+		rightC = 4
+	}
+	rightContent := stackBoxes(
+		boxView("Vulnerability Findings", findingsTableLines("Severity", severityRowKeys(), stats.vulnByStatus, severityRowColor, rightWidth-2), rightWidth, rightA, render.Red),
+		boxView("License Findings", findingsTableLines("Rule", licenseRuleRowKeys(), stats.licenseByStatus, ruleRowColor, rightWidth-2), rightWidth, rightB, render.Yellow),
+		boxView("Package Findings", findingsTableLines("Rule", packageRuleRowKeys(), stats.packageByStatus, ruleRowColor, rightWidth-2), rightWidth, rightC, render.Cyan),
+	)
+	lines = append(lines, joinColumns(leftContent, rightContent, leftWidth, rightWidth)...)
+	lines = append(lines, footerLines...)
+	return strings.Join(lines, "\n")
+}
+
+// diffFooterLines mirrors scan's scanFooterLines for use by the dashboard.
+func (m *diffModel) diffFooterLines(width int) []string {
+	return []string{
+		statusBar(m.diffFooterSummary(), width),
+		centerLine(m.diffLegend(), width),
+	}
+}
+
+// sumCounts returns the total of all values in a map[string]int.
+func sumCounts(counts map[string]int) int {
+	n := 0
+	for _, v := range counts {
+		n += v
+	}
+	return n
+}
+
+// findingsTableLines renders a 4-column table (label / introduced /
+// persisted / resolved) for the per-kind finding panes on the Overview
+// tab. The first column header (label) is passed in by the caller so the
+// same renderer powers severity tables and rule tables.
+//
+// Rows always appear in `rows` order, even when every cell is zero — a
+// stable layout makes it easier to scan multiple diffs.
+func findingsTableLines(label string, rows []string, table map[string]map[string]int, rowColor func(row string) string, width int) []string {
+	const (
+		introCol = "introduced"
+		persCol  = "persisted"
+		resvCol  = "resolved"
+	)
+	// Column headers use the short audit-status labels (New/Old/Fixed)
+	// so the table reads consistently with everything else on the tab.
+	header := render.Style(
+		padRight(label, findingsTableLabelWidth(width))+
+			padRight("New", 6)+
+			padRight("Old", 6)+
+			padRight("Fixed", 7),
+		render.Dim,
+	)
+	out := []string{header}
+	totalIntro, totalPers, totalResv := 0, 0, 0
+	for _, row := range rows {
+		cells := table[row]
+		intro, pers, resv := cells[introCol], cells[persCol], cells[resvCol]
+		totalIntro += intro
+		totalPers += pers
+		totalResv += resv
+		color := render.Dim
+		if rowColor != nil {
+			color = rowColor(row)
+			if color == "" {
+				color = render.Dim
+			}
+		}
+		// Dim 0-rows entirely so the eye lands on populated rows; bold any
+		// nonzero figure so introduced/persisted/resolved differences pop.
+		if intro+pers+resv == 0 {
+			color = render.Dim
+		}
+		labelStyled := render.Style(padRight(titleCase(row), findingsTableLabelWidth(width)), color, render.Bold)
+		out = append(out, labelStyled+
+			styledCell(intro, 6, render.Red)+
+			styledCell(pers, 6, render.Yellow)+
+			styledCell(resv, 7, render.Green))
+	}
+	// Footer total row helps the reader gut-check against the per-kind
+	// total shown in the Findings card.
+	out = append(out, render.Style(
+		padRight("Total", findingsTableLabelWidth(width)),
+		render.White, render.Bold,
+	)+
+		styledCell(totalIntro, 6, render.White)+
+		styledCell(totalPers, 6, render.White)+
+		styledCell(totalResv, 7, render.White))
+	return out
+}
+
+// findingsTableLabelWidth picks a sensible label-column width given the
+// pane's available width. Reserves room for the New/Old/Fixed numeric
+// columns (6+6+7 = 19 cells); everything else goes to the label.
+func findingsTableLabelWidth(width int) int {
+	w := width - 19
+	if w < 8 {
+		return 8
+	}
+	if w > 22 {
+		return 22
+	}
+	return w
+}
+
+// styledCell renders a numeric cell of fixed width. Zero is dimmed so
+// the eye skips it; nonzero values get the supplied color.
+func styledCell(n, colWidth int, color string) string {
+	text := fmt.Sprintf("%d", n)
+	if n == 0 {
+		return render.Style(padRight(text, colWidth), render.Dim)
+	}
+	return render.Style(padRight(text, colWidth), color, render.Bold)
+}
+
+// severityRowColor maps a severity row name to its display color so the
+// table can lean on the existing severityColorCode helper.
+func severityRowColor(row string) string {
+	return severityColorCode(row)
+}
+
+// ruleRowColor returns a neutral color for license/package rule rows —
+// the rule name itself isn't intrinsically red or green. We use a single
+// Cyan for non-"other" rows and Dim for the "other" catch-all.
+func ruleRowColor(row string) string {
+	if row == "other" {
+		return render.Dim
+	}
+	return render.Cyan
+}
+
+// diffVulnTotal returns the total count of vuln-kind deltas across all
+// audit-status buckets (Introduced+Persisted+Resolved).
+func diffVulnTotal(p output.DiffResponse) int {
+	if p.Audit == nil {
+		return 0
+	}
+	n := 0
+	for _, group := range [][]output.AuditFinding{p.Audit.Introduced, p.Audit.Persisted, p.Audit.Resolved} {
+		for _, f := range group {
+			if isVulnerabilityFinding(f) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func diffVulnCount(p output.DiffResponse, status string) int {
+	if p.Audit == nil {
+		return 0
+	}
+	var bucket []output.AuditFinding
+	switch status {
+	case "introduced":
+		bucket = p.Audit.Introduced
+	case "persisted":
+		bucket = p.Audit.Persisted
+	case "resolved":
+		bucket = p.Audit.Resolved
+	}
+	n := 0
+	for _, f := range bucket {
+		if isVulnerabilityFinding(f) {
+			n++
+		}
+	}
+	return n
+}
+
+func (m *diffModel) overviewPanels() []listPanel {
+	summary := m.payload.Summary
+	panels := []listPanel{
+		{title: "Manifests", lines: []string{
+			render.Style(fmt.Sprintf("%d Added", summary.AddedManifestCount), render.Green, render.Bold),
+			render.Style(fmt.Sprintf("%d Changed", summary.ChangedManifestCount), render.Yellow, render.Bold),
+			render.Style(fmt.Sprintf("%d Removed", summary.RemovedManifestCount), render.Red, render.Bold),
+			render.Style(fmt.Sprintf("%d Unchanged", summary.UnchangedManifestCount), render.Cyan, render.Bold),
+		}, color: render.Cyan, weight: 1},
+		{title: "Packages", lines: []string{
+			render.Style(fmt.Sprintf("%d Added", summary.AddedPackageCount), render.Green, render.Bold),
+			render.Style(fmt.Sprintf("%d Changed", summary.ChangedPackageCount), render.Yellow, render.Bold),
+			render.Style(fmt.Sprintf("%d Removed", summary.RemovedPackageCount), render.Red, render.Bold),
+		}, color: render.Magenta, weight: 1},
+	}
+	if m.payload.Audit != nil {
+		panels = append(panels, listPanel{
+			title: "Vulnerabilities",
+			lines: []string{
+				render.Style(fmt.Sprintf("%d New", len(m.payload.Audit.Introduced)), render.Red, render.Bold),
+				render.Style(fmt.Sprintf("%d Old", len(m.payload.Audit.Persisted)), render.Yellow, render.Bold),
+				render.Style(fmt.Sprintf("%d Fixed", len(m.payload.Audit.Resolved)), render.Green, render.Bold),
+			},
+			color:  render.Red,
+			weight: 1,
+		})
+	}
+	return panels
+}
+
+func (m *diffModel) overviewAuditDetails() []string {
+	audit := m.payload.Audit
+	if audit == nil {
+		return []string{render.Style("Audit data not available. Run with --enrich --audit.", render.Dim)}
+	}
+	return []string{
+		render.Style("Vulnerability Deltas", render.Bold, render.Red),
+		"",
+		render.Style("  New: ", render.Dim) + render.Style(fmt.Sprintf("%d", len(audit.Introduced)), render.Red, render.Bold),
+		render.Style("  Old: ", render.Dim) + render.Style(fmt.Sprintf("%d", len(audit.Persisted)), render.Yellow, render.Bold),
+		render.Style("  Fixed: ", render.Dim) + render.Style(fmt.Sprintf("%d", len(audit.Resolved)), render.Green, render.Bold),
+	}
+}
+
+func (m *diffModel) overviewAuditSummaryDetails() []string {
+	audit := m.payload.Audit
+	if audit == nil || audit.AuditSummary == nil {
+		return []string{render.Style("Severity histogram not available.", render.Dim)}
+	}
+	s := audit.AuditSummary
+	return []string{
+		render.Style("Severity Histogram", render.Bold, render.Red),
+		"",
+		render.Style("  Critical: ", render.Dim) + fmt.Sprintf("%d", s.Critical),
+		render.Style("  High: ", render.Dim) + fmt.Sprintf("%d", s.High),
+		render.Style("  Medium: ", render.Dim) + fmt.Sprintf("%d", s.Medium),
+		render.Style("  Low: ", render.Dim) + fmt.Sprintf("%d", s.Low),
+		render.Style("  Unknown: ", render.Dim) + fmt.Sprintf("%d", s.Unknown),
+		render.Style("  Total: ", render.Dim) + render.Style(fmt.Sprintf("%d", s.Total), render.White, render.Bold),
+	}
+}
+
+func (m *diffModel) overviewTopChangedManifests() []string {
+	type ranked struct {
+		name  string
+		count int
+	}
+	rows := make([]ranked, 0, len(m.payload.Results.Manifests))
+	for _, mf := range m.payload.Results.Manifests {
+		rows = append(rows, ranked{
+			name:  render.DiffManifestDisplayLabel(mf),
+			count: len(mf.Added) + len(mf.Changed) + len(mf.Removed),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].count > rows[j].count })
+	lines := []string{render.Style("Top Changed Manifests", render.Bold, render.Cyan), ""}
+	limit := 10
+	if len(rows) < limit {
+		limit = len(rows)
+	}
+	for i := 0; i < limit; i++ {
+		if rows[i].count == 0 {
+			continue
+		}
+		lines = append(lines, render.Style("  "+rows[i].name+": ", render.Dim)+fmt.Sprintf("%d changes", rows[i].count))
+	}
+	if len(lines) == 2 {
+		lines = append(lines, render.Style("  (no changes)", render.Dim))
+	}
+	return lines
+}
+
+// --- Components tab -------------------------------------------------------
+
+// flatComponentChange is one Added/Changed/Removed package, lifted out of
+// its manifest into a flat list so the Components tab can group it freely
+// (by status, manifest, or ecosystem) and filter by scope/relationship/severity.
+type flatComponentChange struct {
+	manifest     output.DiffManifestResult
+	manifestKey  string
+	manifestName string
+	ecosystem    string
+	status       string // "added" / "changed" / "removed"
+	pkgName      string
+	pkgRef       output.PackageRef // After for changed, Package for added/removed
+	beforePkg    output.PackageRef // populated for changed entries
+	beforeVer    string
+	afterVer     string
+	maxSeverity  string // worst severity across pkgRef.Vulnerabilities
+	relationship string // root/direct/transitive — looked up in head/base graph
+}
+
+func (m *diffModel) collectComponentChanges() []flatComponentChange {
+	headRels := map[string]string{}
+	if g, _ := graphFromConsolidated(m.headGraph); g != nil {
+		headRels = classifyRelationships(g)
+	}
+	baseRels := map[string]string{}
+	if g, _ := graphFromConsolidated(m.baseGraph); g != nil {
+		baseRels = classifyRelationships(g)
+	}
+	// pickRel prefers the graph where the package actually exists. Removed
+	// packages live in BASE; added/changed live in HEAD. Fall through to
+	// the other graph if the primary lookup misses (e.g. fuzzy-changed
+	// packages whose ID differs between sides).
+	pickRel := func(status, pkgID string) string {
+		primary := headRels
+		fallback := baseRels
+		if status == "removed" {
+			primary, fallback = baseRels, headRels
+		}
+		if r := primary[pkgID]; r != "" {
+			return r
+		}
+		if r := fallback[pkgID]; r != "" {
+			return r
+		}
+		return ""
+	}
+	out := make([]flatComponentChange, 0)
+	for _, mf := range m.payload.Results.Manifests {
+		mfKey := diffManifestKey(mf)
+		mfName := render.DiffManifestDisplayLabel(mf)
+		eco := valueOrDefault(mf.Ecosystem, "unknown")
+		for _, change := range mf.Added {
+			out = append(out, flatComponentChange{
+				manifest: mf, manifestKey: mfKey, manifestName: mfName, ecosystem: eco,
+				status: "added", pkgName: render.DiffPackageDisplayName(change.Package),
+				pkgRef: change.Package, maxSeverity: maxSeverity(change.Package.Vulnerabilities),
+				relationship: pickRel("added", change.Package.ID),
+			})
+		}
+		for _, change := range mf.Changed {
+			out = append(out, flatComponentChange{
+				manifest: mf, manifestKey: mfKey, manifestName: mfName, ecosystem: eco,
+				status: "changed", pkgName: render.DiffPackageDisplayName(change.After),
+				pkgRef: change.After, beforePkg: change.Before,
+				beforeVer: change.Before.Version, afterVer: change.After.Version,
+				maxSeverity:  maxSeverity(change.After.Vulnerabilities),
+				relationship: pickRel("changed", change.After.ID),
+			})
+		}
+		for _, change := range mf.Removed {
+			out = append(out, flatComponentChange{
+				manifest: mf, manifestKey: mfKey, manifestName: mfName, ecosystem: eco,
+				status: "removed", pkgName: render.DiffPackageDisplayName(change.Package),
+				pkgRef: change.Package, maxSeverity: maxSeverity(change.Package.Vulnerabilities),
+				relationship: pickRel("removed", change.Package.ID),
+			})
+		}
+	}
+	return out
+}
+
+func relationshipFromMap(rels map[string]string, id string) string {
+	if r, ok := rels[id]; ok {
+		return r
+	}
+	return ""
+}
+
+func maxSeverity(vulns []output.VulnerabilityRef) string {
+	best := ""
+	bestRank := severityRank("zzz")
+	for _, v := range vulns {
+		sev := strings.ToLower(strings.TrimSpace(v.Severity))
+		if sev == "" {
+			sev = "unknown"
+		}
+		if r := severityRank(sev); r < bestRank {
+			bestRank = r
+			best = sev
+		}
+	}
+	return best
+}
+
+func (m *diffModel) buildComponentsTab() *listModel {
+	all := m.collectComponentChanges()
+
+	// Apply filters.
+	filtered := make([]flatComponentChange, 0, len(all))
+	for _, c := range all {
+		if m.componentsRelationship != "" && c.relationship != m.componentsRelationship {
+			continue
+		}
+		if m.componentsScope != "" {
+			scope := strings.ToLower(strings.TrimSpace(c.pkgRef.Scope))
+			if scope == "" {
+				scope = "unset"
+			}
+			if scope != m.componentsScope {
+				continue
+			}
+		}
+		if m.componentsSeverity != "" && !strings.EqualFold(c.maxSeverity, m.componentsSeverity) {
+			continue
+		}
+		if m.componentsEcosystem != "" && !strings.EqualFold(c.ecosystem, m.componentsEcosystem) {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+
+	group := m.componentsGroup
+	if group == "" {
+		group = componentsGroupStatus
+	}
+
+	// Bucket by current group key.
+	groups := make(map[string][]flatComponentChange)
+	for _, c := range filtered {
+		groups[componentsGroupKey(c, group)] = append(groups[componentsGroupKey(c, group)], c)
+	}
+	keys := sortedComponentsGroupKeys(groups, group)
+
+	items := make([]listItem, 0)
+	for _, key := range keys {
+		groupItems := groups[key]
+		gKey := string(group) + ":" + key
+		isExpanded := expandedValue(m.componentsExpanded, gKey, true)
+		items = append(items, listItem{
+			title:    fmt.Sprintf("%s (%d)", componentsGroupLabel(key, group), len(groupItems)),
+			subtitle: string(group),
+			details:  m.componentsGroupDetails(key, group, groupItems),
+			key:      gKey,
+			canOpen:  len(groupItems) > 0,
+			expanded: isExpanded,
+		})
+		if !isExpanded {
+			continue
+		}
+		for _, c := range groupItems {
+			items = append(items, listItem{
+				title:    componentChangeRowTitle(c),
+				subtitle: c.status,
+				badges:   componentChangeBadges(c),
+				details:  componentChangeDetails(c),
+				depth:    1,
+				tree:     "  ",
+			})
+		}
+	}
+
+	added, changed, removed := 0, 0, 0
+	for _, c := range filtered {
+		switch c.status {
+		case "added":
+			added++
+		case "changed":
+			changed++
+		case "removed":
+			removed++
+		}
+	}
+
+	controls := []string{
+		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("r", "relationship") + " " + keyHint("s", "scope") + " " + keyHint("v", "severity") + " " + keyHint("e", "ecosystem") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		render.Style("Group: ", render.Dim) + render.Style(componentsGroupName(group), render.BgYellow, render.Bold) +
+			render.Style(" | Relationship: ", render.Dim) + render.Style(valueOrDefault(m.componentsRelationship, "All"), render.BgYellow, render.Bold) +
+			render.Style(" | Scope: ", render.Dim) + render.Style(valueOrDefault(m.componentsScope, "All"), render.BgYellow, render.Bold) +
+			render.Style(" | Severity: ", render.Dim) + render.Style(valueOrDefault(m.componentsSeverity, "All"), render.BgYellow, render.Bold) +
+			render.Style(" | Ecosystem: ", render.Dim) + render.Style(valueOrDefault(m.componentsEcosystem, "All"), render.BgYellow, render.Bold) +
+			render.Style(" | Added: ", render.Dim) + render.Style(fmt.Sprintf("%d", added), render.Green, render.Bold) +
+			render.Style(" | Changed: ", render.Dim) + render.Style(fmt.Sprintf("%d", changed), render.Yellow, render.Bold) +
+			render.Style(" | Removed: ", render.Dim) + render.Style(fmt.Sprintf("%d", removed), render.Red, render.Bold),
+	}
+
 	return &listModel{
-		title:          "",
-		summary:        m.diffSummaryLines(),
-		listTitle:      fmt.Sprintf("%s Packages (%d)", titleCase(string(tab)), len(items)),
-		detailTitle:    "Package Details",
+		controls:       controls,
+		listTitle:      fmt.Sprintf("Components (%d)", len(filtered)),
+		detailTitle:    "Component Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Tab or 1-4 switches tabs; Enter keeps current result; Esc clears search",
-		emptyState:     fmt.Sprintf("No %s packages were found.", string(tab)),
+		filterHelp:     "Use / to search; g cycles group; r/s/v cycle relationship/scope/severity; Enter expands; 1-6 switch tabs",
+		emptyState:     "No package changes match the current filters.",
 		items:          items,
 	}
+}
+
+func componentsGroupKey(c flatComponentChange, group componentsGroup) string {
+	switch group {
+	case componentsGroupManifest:
+		if c.manifestName == "" {
+			return "(unknown manifest)"
+		}
+		return c.manifestName
+	case componentsGroupEcosystem:
+		return c.ecosystem
+	default:
+		return c.status
+	}
+}
+
+func componentsGroupLabel(key string, group componentsGroup) string {
+	switch group {
+	case componentsGroupStatus:
+		return titleCase(key)
+	default:
+		return key
+	}
+}
+
+func componentsGroupName(group componentsGroup) string {
+	switch group {
+	case componentsGroupManifest:
+		return "Manifest"
+	case componentsGroupEcosystem:
+		return "Ecosystem"
+	default:
+		return "Status"
+	}
+}
+
+func sortedComponentsGroupKeys(groups map[string][]flatComponentChange, group componentsGroup) []string {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if group == componentsGroupStatus {
+			order := map[string]int{"added": 0, "changed": 1, "removed": 2}
+			return order[keys[i]] < order[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func (m *diffModel) componentsGroupDetails(key string, group componentsGroup, items []flatComponentChange) []string {
+	lines := []string{
+		render.Style(componentsGroupLabel(key, group), render.Bold, render.Cyan),
+		"",
+		render.Style("  Group axis: ", render.Dim) + componentsGroupName(group),
+		render.Style("  Items: ", render.Dim) + fmt.Sprintf("%d", len(items)),
+	}
+	counts := map[string]int{"added": 0, "changed": 0, "removed": 0}
+	for _, c := range items {
+		counts[c.status]++
+	}
+	lines = append(lines,
+		render.Style("  Added: ", render.Dim)+fmt.Sprintf("%d", counts["added"]),
+		render.Style("  Changed: ", render.Dim)+fmt.Sprintf("%d", counts["changed"]),
+		render.Style("  Removed: ", render.Dim)+fmt.Sprintf("%d", counts["removed"]),
+	)
+	// When grouping by manifest, surface the manifest's full metadata
+	// (ecosystem, package manager, detector, subproject path) so the user
+	// knows exactly what this row represents.
+	if group == componentsGroupManifest && len(items) > 0 {
+		mf := items[0].manifest
+		lines = append(lines,
+			"",
+			render.Style("Manifest", render.Bold, render.Magenta),
+			render.Style("  Path: ", render.Dim)+valueOrDash(mf.Path),
+			render.Style("  Kind: ", render.Dim)+valueOrDash(mf.Kind),
+			render.Style("  Subproject: ", render.Dim)+valueOrDash(mf.Subproject),
+			render.Style("  Ecosystem: ", render.Dim)+valueOrDash(mf.Ecosystem),
+			render.Style("  Package manager: ", render.Dim)+valueOrDash(mf.PackageManager),
+			render.Style("  Detector: ", render.Dim)+valueOrDash(m.detectorForManifest(mf)),
+			render.Style("  Status: ", render.Dim)+statusText(mf.Status),
+		)
+	}
+	return lines
+}
+
+func componentChangeRowTitle(c flatComponentChange) string {
+	if c.status == "changed" {
+		return fmt.Sprintf("%s  (%s → %s)", c.pkgName, valueOrDash(c.beforeVer), valueOrDash(c.afterVer))
+	}
+	return c.pkgName
+}
+
+func componentChangeDetailTitle(c flatComponentChange) string {
+	switch c.status {
+	case "added":
+		return "Added package"
+	case "removed":
+		return "Removed package"
+	default:
+		return "Changed package"
+	}
+}
+
+func componentChangeBadges(c flatComponentChange) []badge {
+	// The row's subtitle already renders a colored status badge for
+	// added/changed/removed (see statusBadge). Adding the same word
+	// again as a badge here showed it twice, which the user flagged.
+	// Severity and relationship still get their own badges since they
+	// carry orthogonal information.
+	out := make([]badge, 0, 2)
+	if c.maxSeverity != "" {
+		out = append(out, badge{label: strings.ToUpper(c.maxSeverity), kind: "severity-" + c.maxSeverity})
+	}
+	if c.relationship != "" {
+		out = append(out, badge{label: strings.ToUpper(c.relationship), kind: "relationship-" + c.relationship})
+	}
+	return out
+}
+
+// componentChangeDetails renders the right-pane details for one Component
+// row. For changed packages it shows BEFORE/AFTER for version, scope,
+// licenses, and vulnerabilities so the user can see exactly what shifted.
+// For added/removed packages it shows the package's full inventory.
+func (m *diffModel) detectorForManifest(mf output.DiffManifestResult) string {
+	if det := lookupDetector(m.headGraph, mf); det != "" {
+		return det
+	}
+	if det := lookupDetector(m.baseGraph, mf); det != "" {
+		return det
+	}
+	return ""
+}
+
+func lookupDetector(consolidated sdk.ConsolidatedGraph, mf output.DiffManifestResult) string {
+	for _, cm := range consolidated.Manifests {
+		if cm.Entry.Manifest.Path == mf.Path && cm.Subproject.RelativePath == mf.Subproject {
+			return cm.DetectorName
+		}
+	}
+	// Fallback: match by path alone.
+	for _, cm := range consolidated.Manifests {
+		if cm.Entry.Manifest.Path == mf.Path {
+			return cm.DetectorName
+		}
+	}
+	return ""
+}
+
+func componentChangeDetails(c flatComponentChange) []string {
+	title := componentChangeDetailTitle(c)
+	lines := []string{
+		render.Style(title, render.Bold, render.Cyan),
+		render.Style("  "+c.pkgName, render.White, render.Bold),
+		"",
+		render.Style("Identity", render.Bold, render.Magenta),
+		render.Style("  ID: ", render.Dim) + valueOrDash(c.pkgRef.ID),
+		render.Style("  Purl: ", render.Dim) + valueOrDash(c.pkgRef.Purl),
+		render.Style("  Scope: ", render.Dim) + valueOrDash(c.pkgRef.Scope),
+		render.Style("  Relationship: ", render.Dim) + valueOrDash(c.relationship),
+		render.Style("  Ecosystem: ", render.Dim) + valueOrDash(c.ecosystem),
+		"",
+		render.Style("Manifest", render.Bold, render.Magenta),
+		render.Style("  Path: ", render.Dim) + valueOrDash(c.manifest.Path),
+		render.Style("  Kind: ", render.Dim) + valueOrDash(c.manifest.Kind),
+		render.Style("  Subproject: ", render.Dim) + valueOrDash(c.manifest.Subproject),
+		render.Style("  Package manager: ", render.Dim) + valueOrDash(c.manifest.PackageManager),
+		render.Style("  Manifest status: ", render.Dim) + statusText(c.manifest.Status),
+	}
+
+	if c.status == "changed" {
+		lines = append(lines,
+			"",
+			render.Style("Version", render.Bold, render.Yellow),
+			render.Style("  Before: ", render.Dim)+valueOrDash(c.beforeVer),
+			render.Style("  After:  ", render.Dim)+valueOrDash(c.afterVer),
+		)
+		if c.beforePkg.Scope != c.pkgRef.Scope {
+			lines = append(lines,
+				"",
+				render.Style("Scope changed", render.Bold, render.Yellow),
+				render.Style("  Before: ", render.Dim)+valueOrDash(c.beforePkg.Scope),
+				render.Style("  After:  ", render.Dim)+valueOrDash(c.pkgRef.Scope),
+			)
+		}
+		lines = append(lines, renderLicenseDelta(c.beforePkg.Licenses, c.pkgRef.Licenses)...)
+		lines = append(lines, renderVulnDelta(c.beforePkg.Vulnerabilities, c.pkgRef.Vulnerabilities)...)
+	} else {
+		lines = append(lines, renderLicenseList(c.pkgRef.Licenses)...)
+		lines = append(lines, renderVulnList(c.pkgRef.Vulnerabilities)...)
+	}
+	return lines
+}
+
+// renderLicenseList renders one package's license inventory.
+func renderLicenseList(licenses []output.LicenseRef) []string {
+	out := []string{"", render.Style("Licenses", render.Bold, render.Yellow)}
+	if len(licenses) == 0 {
+		out = append(out, render.Style("  (none)", render.Dim))
+		return out
+	}
+	for _, lic := range licenses {
+		id := lic.Identifier()
+		if id == "" {
+			id = "(empty)"
+		}
+		line := render.Style("  - ", render.Dim) + id
+		if lic.Type != "" {
+			line += render.Style("  ["+lic.Type+"]", render.Dim)
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// renderLicenseDelta shows before/after license sets for a changed package.
+func renderLicenseDelta(before, after []output.LicenseRef) []string {
+	beforeSet, afterSet := licenseIDSet(before), licenseIDSet(after)
+	if len(beforeSet) == 0 && len(afterSet) == 0 {
+		return nil
+	}
+	out := []string{"", render.Style("Licenses (before → after)", render.Bold, render.Yellow)}
+	for id := range afterSet {
+		switch {
+		case beforeSet[id]:
+			out = append(out, render.Style("  = ", render.Dim)+id+render.Style("  (unchanged)", render.Dim))
+		default:
+			out = append(out, render.Style("  + ", render.Green, render.Bold)+id+render.Style("  (new)", render.Dim))
+		}
+	}
+	for id := range beforeSet {
+		if !afterSet[id] {
+			out = append(out, render.Style("  - ", render.Red, render.Bold)+id+render.Style("  (retired)", render.Dim))
+		}
+	}
+	return out
+}
+
+func licenseIDSet(licenses []output.LicenseRef) map[string]bool {
+	out := make(map[string]bool, len(licenses))
+	for _, lic := range licenses {
+		if id := lic.Identifier(); id != "" {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+// renderVulnList renders one package's full vulnerability inventory.
+func renderVulnList(vulns []output.VulnerabilityRef) []string {
+	out := []string{"", render.Style("Vulnerabilities", render.Bold, render.Red)}
+	if len(vulns) == 0 {
+		out = append(out, render.Style("  (none)", render.Dim))
+		return out
+	}
+	for _, v := range vulns {
+		out = append(out, render.Style("  - ", render.Dim)+severityText(v.Severity)+" "+valueOrDash(v.ID))
+		if v.FixedIn != "" {
+			out = append(out, render.Style("      fixed in: ", render.Dim)+v.FixedIn)
+		}
+	}
+	return out
+}
+
+// renderVulnDelta shows before/after vulnerabilities for a changed package.
+func renderVulnDelta(before, after []output.VulnerabilityRef) []string {
+	beforeSet, afterSet := vulnIDSet(before), vulnIDSet(after)
+	if len(beforeSet) == 0 && len(afterSet) == 0 {
+		return nil
+	}
+	out := []string{"", render.Style("Vulnerabilities (before → after)", render.Bold, render.Red)}
+	for id, v := range afterSet {
+		switch {
+		case beforeSet[id] != nil:
+			out = append(out, render.Style("  = ", render.Dim)+severityText(v.Severity)+" "+id+render.Style("  (old)", render.Dim))
+		default:
+			out = append(out, render.Style("  + ", render.Red, render.Bold)+severityText(v.Severity)+" "+id+render.Style("  (new)", render.Dim))
+		}
+	}
+	for id, v := range beforeSet {
+		if afterSet[id] == nil {
+			out = append(out, render.Style("  - ", render.Green, render.Bold)+severityText(v.Severity)+" "+id+render.Style("  (fixed)", render.Dim))
+		}
+	}
+	return out
+}
+
+func vulnIDSet(vulns []output.VulnerabilityRef) map[string]*output.VulnerabilityRef {
+	out := make(map[string]*output.VulnerabilityRef, len(vulns))
+	for i := range vulns {
+		v := &vulns[i]
+		if v.ID == "" {
+			continue
+		}
+		out[v.ID] = v
+	}
+	return out
+}
+
+func diffManifestKey(mf output.DiffManifestResult) string {
+	return mf.Path + "|" + mf.Subproject + "|" + mf.PackageManager
 }
 
 func sortedDiffManifests(manifests []output.DiffManifestResult) []output.DiffManifestResult {
@@ -149,68 +1811,7 @@ func sortedDiffManifests(manifests []output.DiffManifestResult) []output.DiffMan
 	return sorted
 }
 
-func (m *diffModel) diffSummaryLines() []string {
-	return []string{
-		diffTopBar(m.payload),
-		"",
-		m.diffTabLine(),
-		"",
-	}
-}
-
-func (m *diffModel) diffTabLine() string {
-	labels := []struct {
-		tab   diffTab
-		label string
-	}{
-		{diffTabOverview, "Overview"},
-		{diffTabAdded, "Added"},
-		{diffTabRemoved, "Removed"},
-		{diffTabChanged, "Changed"},
-	}
-	parts := make([]string, 0, len(labels))
-	for idx, item := range labels {
-		text := fmt.Sprintf("[%d] %s", idx+1, item.label)
-		if item.tab == m.active {
-			parts = append(parts, render.Style(text, render.Yellow, render.Bold))
-		} else {
-			parts = append(parts, render.Style(text, render.Dim))
-		}
-	}
-	return strings.Join(parts, render.Style(" | ", render.Dim))
-}
-
-func (m *diffModel) diffTopPanels() []listPanel {
-	return []listPanel{
-		{title: "Manifest Changes", lines: []string{
-			render.Style(fmt.Sprintf("%d Added", m.payload.Summary.AddedManifestCount), render.Green, render.Bold),
-			render.Style(fmt.Sprintf("%d Changed", m.payload.Summary.ChangedManifestCount), render.Yellow, render.Bold),
-			render.Style(fmt.Sprintf("%d Removed", m.payload.Summary.RemovedManifestCount), render.Red, render.Bold),
-			render.Style(fmt.Sprintf("%d Unchanged", m.payload.Summary.UnchangedManifestCount), render.Cyan, render.Bold),
-		}, color: render.Cyan, weight: 1},
-		{title: "Package Changes", lines: []string{
-			render.Style(fmt.Sprintf("%d Added", m.payload.Summary.AddedPackageCount), render.Green, render.Bold),
-			render.Style(fmt.Sprintf("%d Changed", m.payload.Summary.ChangedPackageCount), render.Yellow, render.Bold),
-			render.Style(fmt.Sprintf("%d Removed", m.payload.Summary.RemovedPackageCount), render.Red, render.Bold),
-		}, color: render.Magenta, weight: 1},
-	}
-}
-
-func diffTopBar(payload output.DiffResponse) string {
-	targetParts := []string{
-		render.Style(valueOrDash(payload.Project.Name), render.White, render.Bold),
-		render.Style(targetKindLabel(payload.Project), render.Dim),
-	}
-	if payload.Project.TargetRef != "" {
-		targetParts = append(targetParts, render.Style("ref: "+payload.Project.TargetRef, render.Cyan, render.Bold))
-	}
-	targetParts = append(targetParts, render.Style(payload.Comparison.Base+" -> "+payload.Comparison.Head, render.Cyan, render.Bold))
-	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
-		render.Style("DIFF", render.BgBlue, render.White, render.Bold) + " " +
-		strings.Join(targetParts, render.Style(" | ", render.Dim))
-}
-
-func diffPackageDetails(title string, manifest output.DiffManifestResult, label, before, after string) []string {
+func diffPackageDetails(title string, manifest output.DiffManifestResult, label, before, after string, pkg output.PackageRef) []string {
 	lines := []string{
 		render.Style(title, render.Bold, render.Cyan),
 		"",
@@ -229,11 +1830,19 @@ func diffPackageDetails(title string, manifest output.DiffManifestResult, label,
 			render.Style("  After: ", render.Dim)+valueOrDash(after),
 		)
 	}
+	if len(pkg.Licenses) > 0 {
+		lines = append(lines, "", render.Style("Licenses", render.Bold, render.Yellow), "")
+		for _, lic := range pkg.Licenses {
+			lines = append(lines, render.Style("  - ", render.Dim)+valueOrDash(lic.Identifier()))
+		}
+	}
+	if len(pkg.Vulnerabilities) > 0 {
+		lines = append(lines, "", render.Style("Vulnerabilities", render.Bold, render.Red), "")
+		for _, v := range pkg.Vulnerabilities {
+			lines = append(lines, render.Style("  - ", render.Dim)+severityText(v.Severity)+" "+valueOrDash(v.ID))
+		}
+	}
 	return lines
-}
-
-func summaryLine(label string, values []string) string {
-	return render.Style(label+": ", render.Dim) + strings.Join(values, render.Style("  |  ", render.Dim))
 }
 
 func diffManifestDetails(manifest output.DiffManifestResult) []string {
@@ -247,20 +1856,17 @@ func diffManifestDetails(manifest output.DiffManifestResult) []string {
 		render.Style("  Package manager: ", render.Dim) + valueOrDash(manifest.PackageManager),
 		"",
 	}
-
 	appendSection := func(title string, values []string) {
 		lines = append(lines, render.Style(title, render.Bold, render.Magenta))
 		if len(values) == 0 {
-			lines = append(lines, render.Style("  (none)", render.Dim))
-			lines = append(lines, "")
+			lines = append(lines, render.Style("  (none)", render.Dim), "")
 			return
 		}
-		for _, value := range values {
-			lines = append(lines, render.Style("  - ", render.Dim)+value)
+		for _, v := range values {
+			lines = append(lines, render.Style("  - ", render.Dim)+v)
 		}
 		lines = append(lines, "")
 	}
-
 	added := make([]string, 0, len(manifest.Added))
 	for _, change := range manifest.Added {
 		added = append(added, render.DiffPackageDisplayName(change.Package))
@@ -273,9 +1879,1281 @@ func diffManifestDetails(manifest output.DiffManifestResult) []string {
 	for _, change := range manifest.Removed {
 		removed = append(removed, render.DiffPackageDisplayName(change.Package))
 	}
-
 	appendSection("Added packages", added)
 	appendSection("Changed packages", changed)
 	appendSection("Removed packages", removed)
 	return lines
+}
+
+// --- Vulnerabilities / Findings tab ---------------------------------------
+
+type auditDelta struct {
+	status   string // "introduced", "persisted", "resolved"
+	finding  output.AuditFinding
+	severity string
+}
+
+// auditDeltas walks the three diff buckets and returns the subset
+// matching `keep`. A nil predicate keeps every finding — used by the
+// Findings tab which spans every FindingKind. The Vulnerabilities tab
+// passes isVulnerabilityFinding.
+func (m *diffModel) auditDeltas(keep func(output.AuditFinding) bool) []auditDelta {
+	out := make([]auditDelta, 0)
+	if m.payload.Audit == nil {
+		return out
+	}
+	collect := func(status string, findings []output.AuditFinding) {
+		for _, f := range findings {
+			if keep != nil && !keep(f) {
+				continue
+			}
+			out = append(out, auditDelta{status: status, finding: f, severity: f.Severity})
+		}
+	}
+	collect("introduced", m.payload.Audit.Introduced)
+	collect("persisted", m.payload.Audit.Persisted)
+	collect("resolved", m.payload.Audit.Resolved)
+	return out
+}
+
+func isVulnerabilityFinding(f output.AuditFinding) bool {
+	// Prefer the explicit Auditor name when present — it's what the diff
+	// engine sets and is the most reliable signal.
+	switch strings.ToLower(strings.TrimSpace(f.Auditor)) {
+	case "vulnerability":
+		return true
+	case "license", "package":
+		return false
+	}
+	kind := strings.ToLower(strings.TrimSpace(f.Kind))
+	if kind == "" {
+		// Fallback: presence of a CVE/GHSA-shaped ID or a Source like
+		// "osv"/"grype" implies a vulnerability finding.
+		source := strings.ToLower(f.Source)
+		if strings.HasPrefix(strings.ToUpper(f.ID), "CVE-") || strings.HasPrefix(strings.ToUpper(f.ID), "GHSA-") {
+			return true
+		}
+		return source == "osv" || source == "grype" || strings.Contains(source, "vuln")
+	}
+	return kind == "vulnerability" || kind == "vuln" || kind == "advisory" || kind == "cve"
+}
+
+// nextVulnGroup cycles the grouping axis for the Vulnerabilities tab.
+// Severity makes sense here because every vuln finding carries one.
+func nextVulnGroup(group string) string {
+	switch group {
+	case "status":
+		return "severity"
+	case "severity":
+		return "package"
+	default:
+		return "status"
+	}
+}
+
+// nextFindingGroup cycles the grouping axis for the Findings tab.
+// Severity is intentionally absent — license and package auditors emit
+// `Severity = "unknown"` for everything, so grouping by it is degenerate.
+// "kind" (auditor name) replaces severity since it's the most useful
+// secondary axis for non-vuln findings.
+func nextFindingGroup(group string) string {
+	switch group {
+	case "status":
+		return "kind"
+	case "kind":
+		return "package"
+	default:
+		return "status"
+	}
+}
+
+func (m *diffModel) buildVulnsTab() *listModel {
+	list := m.buildAuditTab(auditTabConfig{
+		keep:       isVulnerabilityFinding,
+		group:      m.vulnGroup,
+		groupHints: "status/severity/package",
+		expanded:   m.vulnExpanded,
+		listLabel:  "Vulnerabilities",
+		itemNoun:   "vulnerability",
+	})
+	list.topPanels = append(m.vulnsOutcomePanels(), list.topPanels...)
+	return list
+}
+
+func (m *diffModel) buildFindingsTab() *listModel {
+	// The Findings tab spans EVERY FindingKind — no kind filter. The
+	// "kind" group axis below uses AuditFinding.Kind so users can split
+	// the list by vulnerability / license / package / (other).
+	list := m.buildAuditTab(auditTabConfig{
+		keep:       nil,
+		group:      m.findingGroup,
+		groupHints: "status/kind/package",
+		expanded:   m.findingExpanded,
+		listLabel:  "Findings",
+		itemNoun:   "finding",
+	})
+	list.topPanels = append(m.findingsOutcomePanels(), list.topPanels...)
+	return list
+}
+
+// auditTabConfig collects everything buildAuditTab needs.
+type auditTabConfig struct {
+	keep       func(output.AuditFinding) bool // nil keeps every finding
+	group      string
+	groupHints string // shown after "g cycles group "
+	expanded   map[string]bool
+	listLabel  string // e.g. "Vulnerabilities" / "Findings"
+	itemNoun   string // e.g. "vulnerability" / "finding"
+}
+
+// auditVerdict captures the diff command's audit outcome, mirroring
+// `internal/cli/diff_cmd.go:161-165`:
+//
+//	if audit didn't run                                                → NotEvaluated
+//	if audit ran AND no INTRODUCED finding has a failing Disposition   → Pass
+//	if audit ran AND at least one INTRODUCED finding fails policy      → Fail (exit 2)
+//
+// A finding "fails policy" when its Disposition is either empty (the
+// auditor didn't set one — historical default = fail) or "fail". See
+// internal/output/types.go::FailingFindingCount. Only the *Introduced*
+// bucket gates the exit code, so resolving or persisting findings does
+// NOT trip the FAIL exit on its own.
+type auditVerdict struct {
+	Ran                      bool
+	Total                    int // AuditSummary.Total (Introduced+Persisted with current scan_output.go)
+	FailingIntroduced        int // count of introduced findings with Disposition ∈ {"", "fail"} — gates run-level exit code
+	FailingIntroducedVuln    int // subset of FailingIntroduced whose finding is vuln-kind
+	FailingIntroducedNonVuln int // subset of FailingIntroduced whose finding is NOT vuln-kind (lives in Findings tab)
+	WarnIntroduced           int // count of introduced findings with Disposition == "warn"
+	IntroducedTotal          int
+	PersistedTotal           int
+	ResolvedTotal            int
+	IntroducedVuln           int
+	PersistedVuln            int
+	ResolvedVuln             int
+	IntroducedNonVuln        int
+	PersistedNonVuln         int
+	ResolvedNonVuln          int
+	HasNonVulnFindings       bool // true when at least one finding has Kind != vulnerability
+}
+
+// auditFindingFails mirrors output.FailingFindingCount's gate but operates
+// on the output.AuditFinding type that the TUI consumes. Keeping this
+// helper alongside the verdict struct makes the mapping explicit.
+func auditFindingFails(f output.AuditFinding) bool {
+	switch f.Disposition {
+	case "", string(sdk.FindingDispositionFail):
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *diffModel) auditVerdict() auditVerdict {
+	v := auditVerdict{}
+	if m.payload.Audit == nil {
+		return v
+	}
+	v.Ran = true
+	if m.payload.Audit.AuditSummary != nil {
+		v.Total = m.payload.Audit.AuditSummary.Total
+	}
+	classify := func(bucket []output.AuditFinding) (total, vuln, nonVuln int) {
+		for _, f := range bucket {
+			total++
+			if isVulnerabilityFinding(f) {
+				vuln++
+			} else {
+				nonVuln++
+				v.HasNonVulnFindings = true
+			}
+		}
+		return
+	}
+	v.IntroducedTotal, v.IntroducedVuln, v.IntroducedNonVuln = classify(m.payload.Audit.Introduced)
+	v.PersistedTotal, v.PersistedVuln, v.PersistedNonVuln = classify(m.payload.Audit.Persisted)
+	v.ResolvedTotal, v.ResolvedVuln, v.ResolvedNonVuln = classify(m.payload.Audit.Resolved)
+	// Disposition gate runs on Introduced ONLY — same as diff_cmd.go:161-165.
+	// We also split the failing count by vuln vs non-vuln so each tab
+	// (Vulnerabilities / Findings) can render an outcome panel that
+	// stays consistent with the rows it's actually showing.
+	for _, f := range m.payload.Audit.Introduced {
+		switch f.Disposition {
+		case "", string(sdk.FindingDispositionFail):
+			v.FailingIntroduced++
+			if isVulnerabilityFinding(f) {
+				v.FailingIntroducedVuln++
+			} else {
+				v.FailingIntroducedNonVuln++
+			}
+		case string(sdk.FindingDispositionWarn):
+			v.WarnIntroduced++
+		}
+	}
+	return v
+}
+
+// Verdict returns PASS / FAIL / NOT EVALUATED for the diff command's exit
+// code, matching diff_cmd.go:161-165.
+func (v auditVerdict) Verdict() string {
+	switch {
+	case !v.Ran:
+		return "NOT EVALUATED"
+	case v.FailingIntroduced > 0:
+		return "FAIL"
+	default:
+		return "PASS"
+	}
+}
+
+// findingsOutcomePanels renders the audit-outcome summary at the top of
+// the Findings tab.
+func (m *diffModel) findingsOutcomePanels() []listPanel {
+	v := m.auditVerdict()
+	if !v.Ran {
+		return []listPanel{{
+			title: "Audit Outcome",
+			lines: []string{
+				render.Style(" NOT EVALUATED ", render.BgYellow, render.Black, render.Bold),
+				"",
+				render.Style("Audit was not run.", render.Dim),
+				render.Style("Re-run with --enrich --audit", render.Dim),
+				render.Style("to evaluate policy.", render.Dim),
+			},
+			color:  render.Yellow,
+			weight: 2,
+		}}
+	}
+
+	// The Findings tab spans every FindingKind, so the outcome panel
+	// matches the run-level verdict exactly — no "(this tab)" qualifier
+	// is needed. The breakdown beneath it shows ALL findings, split by
+	// kind so the user can see which auditor produced what.
+	var verdictBadge, verdictExplain, verdictNote, verdictColor string
+	switch {
+	case v.FailingIntroduced > 0:
+		verdictBadge = render.Style(" FAIL ", render.BgRed, render.White, render.Bold)
+		verdictExplain = fmt.Sprintf("%d new finding(s) gate exit code", v.FailingIntroduced)
+		verdictNote = fmt.Sprintf("Exit code 2 (%d vuln + %d license/package)",
+			v.FailingIntroducedVuln, v.FailingIntroducedNonVuln)
+		verdictColor = render.Red
+	case v.IntroducedTotal > 0:
+		verdictBadge = render.Style(" PASS (warn-only) ", render.BgYellow, render.Black, render.Bold)
+		verdictExplain = fmt.Sprintf("%d new finding(s), all Disposition=warn", v.IntroducedTotal)
+		verdictNote = "warn-only findings do not gate the exit code"
+		verdictColor = render.Yellow
+	default:
+		verdictBadge = render.Style(" PASS ", render.BgGreen, render.Black, render.Bold)
+		verdictExplain = "No new findings"
+		verdictNote = "Exit code 0 (clean)"
+		verdictColor = render.Green
+	}
+	outcomeLines := []string{
+		verdictBadge,
+		"",
+		render.Style(verdictExplain, render.White, render.Bold),
+		render.Style(verdictNote, render.Dim),
+	}
+
+	// Findings Delta — all kinds, all buckets. Sum equals the count of
+	// rows shown in the list below.
+	bucketLines := []string{
+		render.Style(fmt.Sprintf("%d New", v.IntroducedTotal), verdictDeltaColor(v.IntroducedTotal, render.Red), render.Bold),
+		render.Style(fmt.Sprintf("%d Old", v.PersistedTotal), render.Yellow, render.Bold),
+		render.Style(fmt.Sprintf("%d Fixed", v.ResolvedTotal), verdictDeltaColor(v.ResolvedTotal, render.Green), render.Bold),
+	}
+
+	// By-Kind breakdown reads AuditFinding.Kind directly. This is what
+	// the user sees on the Overview's "Findings" card AND on the Findings
+	// tab's grouping axis when they press `g` to group by kind, so the
+	// numbers stay consistent across the entire UI.
+	byKind := map[string]int{}
+	for _, bucket := range [][]output.AuditFinding{m.payload.Audit.Introduced, m.payload.Audit.Persisted, m.payload.Audit.Resolved} {
+		for _, f := range bucket {
+			byKind[findingKindOf(f)]++
+		}
+	}
+	kindLines := []string{}
+	for _, k := range []string{"vulnerability", "license", "package", "other"} {
+		if n := byKind[k]; n > 0 {
+			kindLines = append(kindLines, render.Style(fmt.Sprintf("%d %s", n, k), kindColor(k), render.Bold))
+		}
+	}
+	if len(kindLines) == 0 {
+		kindLines = []string{render.Style("(no findings)", render.Dim)}
+	}
+
+	return []listPanel{
+		{title: "Audit Outcome", lines: outcomeLines, color: verdictColor, weight: 2},
+		{title: "Findings Delta", lines: bucketLines, color: render.Cyan, weight: 2},
+		{title: "By Kind", lines: kindLines, color: render.Magenta, weight: 2},
+	}
+}
+
+// kindColor maps a FindingKind to its display color. Used in any panel
+// that visualizes per-kind counts.
+func kindColor(kind string) string {
+	switch strings.ToLower(kind) {
+	case "vulnerability":
+		return render.Red
+	case "license":
+		return render.Yellow
+	case "package":
+		return render.Cyan
+	}
+	return render.Dim
+}
+
+// vulnsOutcomePanels is the analogue of findingsOutcomePanels but scoped
+// to vulnerability-kind findings — so the outcome on the Vulnerabilities
+// tab agrees with the rows shown below.
+func (m *diffModel) vulnsOutcomePanels() []listPanel {
+	v := m.auditVerdict()
+	if !v.Ran {
+		return []listPanel{{
+			title: "Audit Outcome (this tab)",
+			lines: []string{
+				render.Style(" NOT EVALUATED ", render.BgYellow, render.Black, render.Bold),
+				"",
+				render.Style("Audit was not run.", render.Dim),
+				render.Style("Re-run with --enrich --audit", render.Dim),
+				render.Style("to evaluate vulnerabilities.", render.Dim),
+			},
+			color:  render.Yellow,
+			weight: 2,
+		}}
+	}
+	var verdictBadge, verdictExplain, verdictNote, verdictColor string
+	switch {
+	case v.FailingIntroducedVuln > 0:
+		verdictBadge = render.Style(" FAIL ", render.BgRed, render.White, render.Bold)
+		verdictExplain = fmt.Sprintf("%d new vulnerability(ies) gate exit code", v.FailingIntroducedVuln)
+		verdictNote = "This tab's vulnerabilities would FAIL the audit"
+		verdictColor = render.Red
+	case v.IntroducedVuln > 0:
+		verdictBadge = render.Style(" PASS (warn-only) ", render.BgYellow, render.Black, render.Bold)
+		verdictExplain = fmt.Sprintf("%d new vuln(s), all Disposition=warn", v.IntroducedVuln)
+		verdictNote = "warn-only vulnerabilities do not gate the exit code"
+		verdictColor = render.Yellow
+	default:
+		verdictBadge = render.Style(" PASS ", render.BgGreen, render.Black, render.Bold)
+		verdictExplain = "No new vulnerabilities"
+		verdictNote = "Vulnerabilities tab is clean for this diff"
+		verdictColor = render.Green
+	}
+	runLevel := "Run exit code: 0 (PASS)"
+	switch {
+	case v.FailingIntroduced == 0 && v.IntroducedTotal > 0:
+		runLevel = "Run exit code: 0 (warn-only)"
+	case v.FailingIntroduced > 0:
+		runLevel = fmt.Sprintf("Run exit code: 2 (FAIL — %d failing: %d vuln + %d policy)",
+			v.FailingIntroduced, v.FailingIntroducedVuln, v.FailingIntroducedNonVuln)
+	}
+	outcomeLines := []string{
+		verdictBadge,
+		"",
+		render.Style(verdictExplain, render.White, render.Bold),
+		render.Style(verdictNote, render.Dim),
+		render.Style(runLevel, render.Dim),
+	}
+	bucketLines := []string{
+		render.Style(fmt.Sprintf("%d New", v.IntroducedVuln), verdictDeltaColor(v.IntroducedVuln, render.Red), render.Bold),
+		render.Style(fmt.Sprintf("%d Old", v.PersistedVuln), render.Yellow, render.Bold),
+		render.Style(fmt.Sprintf("%d Fixed", v.ResolvedVuln), verdictDeltaColor(v.ResolvedVuln, render.Green), render.Bold),
+	}
+	// By-severity scoped to vuln-kind across all three buckets — gives the
+	// reader a quick read of what kinds of severities the diff touched.
+	severity := map[string]int{}
+	for _, bucket := range [][]output.AuditFinding{m.payload.Audit.Introduced, m.payload.Audit.Persisted, m.payload.Audit.Resolved} {
+		for _, f := range bucket {
+			if !isVulnerabilityFinding(f) {
+				continue
+			}
+			sev := strings.ToLower(strings.TrimSpace(f.Severity))
+			if sev == "" {
+				sev = "unknown"
+			}
+			severity[sev]++
+		}
+	}
+	severityLines := []string{}
+	for _, sev := range []string{"critical", "high", "medium", "low", "unknown"} {
+		if n := severity[sev]; n > 0 {
+			severityLines = append(severityLines, render.Style(fmt.Sprintf("%d %s", n, titleCase(sev)), render.Red, render.Bold))
+		}
+	}
+	if len(severityLines) == 0 {
+		severityLines = []string{render.Style("(no vulnerabilities)", render.Dim)}
+	}
+	return []listPanel{
+		{title: "Audit Outcome (this tab)", lines: outcomeLines, color: verdictColor, weight: 2},
+		{title: "Vuln Deltas (this tab)", lines: bucketLines, color: render.Cyan, weight: 2},
+		{title: "By Severity (this tab)", lines: severityLines, color: render.Red, weight: 2},
+	}
+}
+
+// verdictDeltaColor dims a 0-valued count so PASS/empty diffs feel quiet.
+func verdictDeltaColor(n int, color string) string {
+	if n == 0 {
+		return render.Dim
+	}
+	return color
+}
+
+func (m *diffModel) buildAuditTab(cfg auditTabConfig) *listModel {
+	deltas := m.auditDeltas(cfg.keep)
+	emptyState := fmt.Sprintf("No %s deltas were found.", cfg.itemNoun)
+	if m.payload.Audit == nil {
+		if m.enrichEnabled {
+			emptyState = fmt.Sprintf("Enrichment ran but no %s deltas were produced.", cfg.itemNoun)
+		} else {
+			emptyState = fmt.Sprintf("No %s data. Run with --enrich --audit to populate.", cfg.itemNoun)
+		}
+	}
+
+	group := cfg.group
+	if group == "" {
+		group = "status"
+	}
+	groups := make(map[string][]auditDelta)
+	for _, d := range deltas {
+		groups[auditGroupKey(d, group)] = append(groups[auditGroupKey(d, group)], d)
+	}
+	keys := sortedAuditGroupKeys(groups, group)
+
+	items := make([]listItem, 0)
+	for _, key := range keys {
+		groupItems := groups[key]
+		groupKey := group + ":" + key
+		isExpanded := expandedValue(cfg.expanded, groupKey, true)
+		items = append(items, listItem{
+			title:    fmt.Sprintf("%s (%d)", auditGroupLabel(key, group), len(groupItems)),
+			subtitle: group,
+			details:  auditGroupDetails(key, group, groupItems, cfg.itemNoun),
+			key:      groupKey,
+			canOpen:  len(groupItems) > 0,
+			expanded: isExpanded,
+		})
+		if !isExpanded {
+			continue
+		}
+		for _, d := range groupItems {
+			items = append(items, listItem{
+				title:    auditDeltaTitle(d),
+				subtitle: d.status,
+				badges:   auditDeltaBadges(d),
+				details:  auditDeltaDetails(d),
+				depth:    1,
+				tree:     "  ",
+			})
+		}
+	}
+
+	groupHints := "g cycles group"
+	if cfg.groupHints != "" {
+		groupHints = "g cycles group (" + cfg.groupHints + ")"
+	}
+	controls := []string{
+		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "expand") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		render.Style("Group: ", render.Dim) + render.Style(groupLabel(group), render.BgYellow, render.Bold) +
+			render.Style(" | Count: ", render.Dim) + fmt.Sprintf("%d", len(deltas)),
+	}
+	if m.payload.Audit != nil {
+		controls[1] += render.Style(" | New: ", render.Dim) + render.Style(fmt.Sprintf("%d", auditCount(deltas, "introduced")), render.Red, render.Bold) +
+			render.Style(" | Old: ", render.Dim) + render.Style(fmt.Sprintf("%d", auditCount(deltas, "persisted")), render.Yellow, render.Bold) +
+			render.Style(" | Fixed: ", render.Dim) + render.Style(fmt.Sprintf("%d", auditCount(deltas, "resolved")), render.Green, render.Bold)
+	}
+	return &listModel{
+		controls:       controls,
+		listTitle:      fmt.Sprintf("%s (%d)", cfg.listLabel, len(deltas)),
+		detailTitle:    cfg.listLabel + " Details",
+		navigationHelp: interactiveCommonNavigationHelp,
+		filterHelp:     "Use / to search; " + groupHints + "; Enter expands; 1-6 switch tabs",
+		emptyState:     emptyState,
+		items:          items,
+	}
+}
+
+func groupLabel(group string) string {
+	switch group {
+	case "status":
+		return "Status"
+	case "severity":
+		return "Severity"
+	case "package":
+		return "Package"
+	case "license":
+		return "License"
+	case "manifest":
+		return "Manifest"
+	case "kind":
+		return "Kind (Auditor)"
+	case "category":
+		return "Category"
+	case "recognition":
+		return "Recognition"
+	}
+	if group == "" {
+		return "Status"
+	}
+	return titleCase(group)
+}
+
+func auditCount(deltas []auditDelta, status string) int {
+	n := 0
+	for _, d := range deltas {
+		if d.status == status {
+			n++
+		}
+	}
+	return n
+}
+
+func auditGroupKey(d auditDelta, group string) string {
+	switch group {
+	case "severity":
+		sev := strings.ToLower(strings.TrimSpace(d.severity))
+		if sev == "" {
+			sev = "unknown"
+		}
+		return sev
+	case "package":
+		name := render.DiffPackageDisplayName(d.finding.Package)
+		if name == "" {
+			return "unknown"
+		}
+		return name
+	case "kind":
+		// "kind" axis groups by AuditFinding.Kind — the actual finding
+		// kind (vulnerability / license / package / other), NOT the
+		// auditor name. This is the dimension users want when they ask
+		// "what kind of policy problems do I have on this diff?"
+		return findingKindOf(d.finding)
+	default:
+		return d.status
+	}
+}
+
+func auditGroupLabel(key, group string) string {
+	switch group {
+	case "status":
+		return titleCase(key)
+	case "severity":
+		return strings.ToUpper(key)
+	case "kind":
+		return titleCase(key) // "license" → "License", "package" → "Package", ...
+	case "package":
+		return key
+	default:
+		return key
+	}
+}
+
+func sortedAuditGroupKeys(groups map[string][]auditDelta, group string) []string {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		switch group {
+		case "status":
+			return auditStatusOrder(keys[i]) < auditStatusOrder(keys[j])
+		case "severity":
+			return severityRank(keys[i]) < severityRank(keys[j])
+		case "kind":
+			return findingKindOrder(keys[i]) < findingKindOrder(keys[j])
+		default:
+			return keys[i] < keys[j]
+		}
+	})
+	return keys
+}
+
+// findingKindOrder controls the row order when grouping the Findings tab
+// by kind. Vulnerabilities float to the top because they're the most
+// security-critical; everything else lands underneath alphabetically.
+func findingKindOrder(kind string) int {
+	switch strings.ToLower(kind) {
+	case "vulnerability":
+		return 0
+	case "license":
+		return 1
+	case "package":
+		return 2
+	}
+	return 3
+}
+
+func auditStatusOrder(s string) int {
+	switch strings.ToLower(s) {
+	case "introduced":
+		return 0
+	case "persisted":
+		return 1
+	case "resolved":
+		return 2
+	}
+	return 3
+}
+
+func auditDeltaTitle(d auditDelta) string {
+	id := strings.TrimSpace(d.finding.ID)
+	if id == "" {
+		id = "(no id)"
+	}
+	pkg := render.DiffPackageDisplayName(d.finding.Package)
+	if pkg == "" {
+		return id
+	}
+	return id + "  " + render.Style("— "+pkg, render.Dim)
+}
+
+func auditDeltaBadges(d auditDelta) []badge {
+	// Subtitle (rendered via statusBadge) already shows the New/Old/Fixed
+	// audit-delta-status badge for this row — adding a second copy here
+	// was the duplicate the user flagged on the Vulnerabilities and
+	// Findings tabs. Severity stays as its own badge.
+	out := make([]badge, 0, 1)
+	if sev := strings.TrimSpace(d.severity); sev != "" {
+		out = append(out, badge{label: strings.ToUpper(sev), kind: "severity-" + strings.ToLower(sev)})
+	}
+	return out
+}
+
+func auditDeltaDetails(d auditDelta) []string {
+	f := d.finding
+	lines := []string{
+		render.Style(valueOrDash(f.ID), render.Bold, render.Red),
+	}
+	if f.Title != "" && f.Title != f.ID {
+		lines = append(lines, render.Style("  "+f.Title, render.White, render.Bold))
+	}
+	lines = append(lines,
+		"",
+		render.Style("Status", render.Bold, render.Cyan),
+		render.Style("  Delta status: ", render.Dim)+statusText(auditStatusLabel(d.status)),
+		render.Style("  Disposition: ", render.Dim)+valueOrDash(string(f.Disposition)),
+		render.Style("  Severity: ", render.Dim)+severityText(f.Severity),
+		"",
+		render.Style("Classification", render.Bold, render.Magenta),
+		render.Style("  Kind: ", render.Dim)+valueOrDash(f.Kind),
+		render.Style("  Auditor: ", render.Dim)+valueOrDash(f.Auditor),
+		render.Style("  Source: ", render.Dim)+valueOrDash(f.Source),
+		"",
+		render.Style("Package", render.Bold, render.Magenta),
+		render.Style("  Display: ", render.Dim)+valueOrDash(render.DiffPackageDisplayName(f.Package)),
+		render.Style("  Purl: ", render.Dim)+valueOrDash(f.Package.Purl),
+		render.Style("  Scope: ", render.Dim)+valueOrDash(f.Package.Scope),
+	)
+	if len(f.Reasons) > 0 {
+		lines = append(lines, "", render.Style("Reasons", render.Bold, render.Magenta))
+		for _, r := range f.Reasons {
+			lines = append(lines, render.Style("  - ", render.Dim)+r)
+		}
+	}
+	if f.Reachability != nil {
+		lines = append(lines, "", render.Style("Reachability", render.Bold, render.Yellow))
+		lines = append(lines, render.Style("  Tier: ", render.Dim)+valueOrDash(string(f.Reachability.Tier)))
+		if f.Reachability.Analyzer != "" {
+			lines = append(lines, render.Style("  Analyzer: ", render.Dim)+f.Reachability.Analyzer)
+		}
+	}
+	// For vuln findings include licenses on the affected package so the
+	// reader sees the full picture without bouncing to the Components tab.
+	if len(f.Package.Licenses) > 0 {
+		lines = append(lines, renderLicenseList(f.Package.Licenses)...)
+	}
+	return lines
+}
+
+func auditGroupDetails(key, group string, deltas []auditDelta, noun string) []string {
+	if noun == "" {
+		noun = "items"
+	} else {
+		noun = pluralize(noun)
+	}
+	lines := []string{
+		render.Style(auditGroupLabel(key, group), render.Bold, render.Red),
+		"",
+		render.Style("  Group axis: ", render.Dim) + groupLabel(group),
+		render.Style("  "+titleCase(noun)+": ", render.Dim) + fmt.Sprintf("%d", len(deltas)),
+	}
+	counts := map[string]int{"introduced": 0, "persisted": 0, "resolved": 0}
+	severityCounts := make(map[string]int)
+	auditorCounts := make(map[string]int)
+	for _, d := range deltas {
+		counts[d.status]++
+		sev := strings.ToLower(strings.TrimSpace(d.severity))
+		if sev == "" {
+			sev = "unknown"
+		}
+		severityCounts[sev]++
+		aud := strings.TrimSpace(d.finding.Auditor)
+		if aud == "" {
+			aud = strings.TrimSpace(d.finding.Source)
+		}
+		if aud == "" {
+			aud = "unknown"
+		}
+		auditorCounts[aud]++
+	}
+	lines = append(lines,
+		render.Style("  New: ", render.Dim)+fmt.Sprintf("%d", counts["introduced"]),
+		render.Style("  Old: ", render.Dim)+fmt.Sprintf("%d", counts["persisted"]),
+		render.Style("  Fixed: ", render.Dim)+fmt.Sprintf("%d", counts["resolved"]),
+	)
+	if len(severityCounts) > 1 || (len(severityCounts) == 1 && severityCounts["unknown"] == 0) {
+		lines = append(lines, "", render.Style("By severity", render.Bold, render.Magenta))
+		for _, sev := range []string{"critical", "high", "medium", "low", "unknown"} {
+			if n := severityCounts[sev]; n > 0 {
+				lines = append(lines, render.Style("  "+titleCase(sev)+": ", render.Dim)+fmt.Sprintf("%d", n))
+			}
+		}
+	}
+	if len(auditorCounts) > 0 {
+		lines = append(lines, "", render.Style("By auditor", render.Bold, render.Magenta))
+		auditors := make([]string, 0, len(auditorCounts))
+		for a := range auditorCounts {
+			auditors = append(auditors, a)
+		}
+		sort.Strings(auditors)
+		for _, a := range auditors {
+			lines = append(lines, render.Style("  "+a+": ", render.Dim)+fmt.Sprintf("%d", auditorCounts[a]))
+		}
+	}
+	return lines
+}
+
+// pluralize is a *very* dumb pluralizer that's fine for our nouns
+// ("vulnerability" → "vulnerabilities", "finding" → "findings").
+func pluralize(noun string) string {
+	if strings.HasSuffix(noun, "y") {
+		return strings.TrimSuffix(noun, "y") + "ies"
+	}
+	if strings.HasSuffix(noun, "s") {
+		return noun
+	}
+	return noun + "s"
+}
+
+// --- Licenses tab ---------------------------------------------------------
+
+type licenseDelta struct {
+	license  string
+	status   string // "introduced", "retired"
+	pkg      string
+	manifest string
+}
+
+func (m *diffModel) collectLicenseDeltas() []licenseDelta {
+	out := make([]licenseDelta, 0)
+	add := func(status, pkgLabel, manifestLabel string, licenses []output.LicenseRef) {
+		for _, lic := range licenses {
+			id := strings.TrimSpace(lic.Identifier())
+			if id == "" {
+				continue
+			}
+			out = append(out, licenseDelta{license: id, status: status, pkg: pkgLabel, manifest: manifestLabel})
+		}
+	}
+	for _, mf := range m.payload.Results.Manifests {
+		mfLabel := render.DiffManifestDisplayLabel(mf)
+		for _, change := range mf.Added {
+			add("introduced", render.DiffPackageDisplayName(change.Package), mfLabel, change.Package.Licenses)
+		}
+		for _, change := range mf.Removed {
+			add("retired", render.DiffPackageDisplayName(change.Package), mfLabel, change.Package.Licenses)
+		}
+		for _, change := range mf.Changed {
+			before := licenseSet(change.Before.Licenses)
+			after := licenseSet(change.After.Licenses)
+			for id := range after {
+				if _, ok := before[id]; !ok {
+					out = append(out, licenseDelta{license: id, status: "introduced", pkg: render.DiffPackageDisplayName(change.After), manifest: mfLabel})
+				}
+			}
+			for id := range before {
+				if _, ok := after[id]; !ok {
+					out = append(out, licenseDelta{license: id, status: "retired", pkg: render.DiffPackageDisplayName(change.Before), manifest: mfLabel})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func licenseSet(licenses []output.LicenseRef) map[string]struct{} {
+	out := make(map[string]struct{}, len(licenses))
+	for _, l := range licenses {
+		id := strings.TrimSpace(l.Identifier())
+		if id == "" {
+			continue
+		}
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// nextLicenseGroup cycles the grouping axis for the Licenses tab:
+//
+//	license  → group by SPDX id (each row = a package contributing it)
+//	status   → introduced/retired buckets
+//	manifest → grouped by manifest
+//	category → Permissive / Copyleft / Unknown / Unclassified (scan parity)
+//	recognition → recognized / unknown / unrecognized expression
+func nextLicenseGroup(group string) string {
+	switch group {
+	case "license":
+		return "status"
+	case "status":
+		return "manifest"
+	case "manifest":
+		return "category"
+	case "category":
+		return "recognition"
+	default:
+		return "license"
+	}
+}
+
+func (m *diffModel) buildLicensesTab() *listModel {
+	deltas := m.collectLicenseDeltas()
+	group := m.licenseGroup
+	if group == "" {
+		group = "license"
+	}
+	groups := make(map[string][]licenseDelta)
+	for _, d := range deltas {
+		key := licenseGroupKeyDiff(d, group)
+		groups[key] = append(groups[key], d)
+	}
+	keys := sortedLicenseGroupKeys(groups, group)
+
+	items := make([]listItem, 0)
+	for _, key := range keys {
+		groupItems := groups[key]
+		groupKey := group + ":" + key
+		isExpanded := expandedValue(m.licenseExpanded, groupKey, true)
+		items = append(items, listItem{
+			title:    fmt.Sprintf("%s (%d)", licenseGroupTitle(key, group), len(groupItems)),
+			subtitle: group,
+			details:  licenseGroupDetailsDiff(key, group, groupItems),
+			key:      groupKey,
+			canOpen:  len(groupItems) > 0,
+			expanded: isExpanded,
+		})
+		if !isExpanded {
+			continue
+		}
+		for _, d := range groupItems {
+			// Row title: when grouped *by license*, the row shows the
+			// affected package (so the user sees which packages contributed
+			// this license). For every other axis, the row shows the
+			// license name itself.
+			rowTitle := d.license
+			if group == "license" {
+				rowTitle = d.pkg
+			}
+			items = append(items, listItem{
+				title:    rowTitle,
+				subtitle: d.status,
+				// Subtitle already paints a colored status badge for
+				// introduced/retired — no extra explicit badge needed.
+				badges:  nil,
+				details: licenseDeltaDetails(d),
+				depth:   1,
+				tree:    "  ",
+			})
+		}
+	}
+
+	introduced, retired := 0, 0
+	for _, d := range deltas {
+		if d.status == "introduced" {
+			introduced++
+		} else {
+			retired++
+		}
+	}
+	controls := []string{
+		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "expand") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		render.Style("Group: ", render.Dim) + render.Style(groupLabel(group), render.BgYellow, render.Bold) +
+			render.Style(" | Introduced: ", render.Dim) + render.Style(fmt.Sprintf("%d", introduced), render.Green, render.Bold) +
+			render.Style(" | Retired: ", render.Dim) + render.Style(fmt.Sprintf("%d", retired), render.Red, render.Bold),
+	}
+	emptyState := "No license deltas were found."
+	return &listModel{
+		controls:       controls,
+		listTitle:      fmt.Sprintf("Licenses (%d)", len(deltas)),
+		detailTitle:    "License Details",
+		navigationHelp: interactiveCommonNavigationHelp,
+		filterHelp:     "Use / to search; g cycles group (license/status/manifest/category/recognition); Enter expands; 1-6 switch tabs",
+		emptyState:     emptyState,
+		items:          items,
+	}
+}
+
+func licenseGroupKeyDiff(d licenseDelta, group string) string {
+	switch group {
+	case "status":
+		return d.status
+	case "manifest":
+		if d.manifest == "" {
+			return "(unknown manifest)"
+		}
+		return d.manifest
+	case "category":
+		return strings.ToLower(licenseCategory(d.license))
+	case "recognition":
+		return licenseRecognitionKey(d.license)
+	default:
+		return d.license
+	}
+}
+
+// licenseRecognitionKey produces a stable lowercase bucket name for the
+// recognition axis. Unlike licenseRecognition (which returns ANSI-colored
+// text for display), this returns a plain key suitable for map/sort use.
+func licenseRecognitionKey(value string) string {
+	switch {
+	case isUnknownLicense(value):
+		return "unknown"
+	case looksLikeSPDXLicense(value):
+		return "recognized"
+	default:
+		return "unrecognized"
+	}
+}
+
+func licenseGroupTitle(key, group string) string {
+	switch group {
+	case "status", "category", "recognition":
+		return titleCase(key)
+	default:
+		return key
+	}
+}
+
+func sortedLicenseGroupKeys(groups map[string][]licenseDelta, group string) []string {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		switch group {
+		case "status":
+			order := map[string]int{"introduced": 0, "retired": 1}
+			return order[keys[i]] < order[keys[j]]
+		case "recognition":
+			order := map[string]int{"recognized": 0, "unrecognized": 1, "unknown": 2}
+			return order[keys[i]] < order[keys[j]]
+		case "category":
+			order := map[string]int{"permissive": 0, "copyleft": 1, "unclassified": 2, "unknown": 3}
+			ri, rj := order[keys[i]], order[keys[j]]
+			if ri != rj {
+				return ri < rj
+			}
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func licenseGroupDetailsDiff(key, group string, deltas []licenseDelta) []string {
+	counts := map[string]int{"introduced": 0, "retired": 0}
+	uniqueLicenses := make(map[string]int)
+	uniquePackages := make(map[string]int)
+	uniqueManifests := make(map[string]int)
+	for _, d := range deltas {
+		counts[d.status]++
+		uniqueLicenses[d.license]++
+		uniquePackages[d.pkg]++
+		uniqueManifests[d.manifest]++
+	}
+	lines := []string{
+		render.Style(licenseGroupTitle(key, group), render.Bold, render.Yellow),
+		"",
+		render.Style("  Group axis: ", render.Dim) + groupLabel(group),
+		render.Style("  Total events: ", render.Dim) + fmt.Sprintf("%d", len(deltas)),
+		render.Style("  Introduced: ", render.Dim) + fmt.Sprintf("%d", counts["introduced"]),
+		render.Style("  Retired: ", render.Dim) + fmt.Sprintf("%d", counts["retired"]),
+		render.Style("  Unique licenses: ", render.Dim) + fmt.Sprintf("%d", len(uniqueLicenses)),
+		render.Style("  Unique packages: ", render.Dim) + fmt.Sprintf("%d", len(uniquePackages)),
+		render.Style("  Unique manifests: ", render.Dim) + fmt.Sprintf("%d", len(uniqueManifests)),
+	}
+	// Cross-axis context: when grouped by category, surface the *unique*
+	// license IDs that landed in this bucket so the user can see which
+	// SPDX expressions contributed.
+	if (group == "category" || group == "recognition" || group == "status" || group == "manifest") && len(uniqueLicenses) > 0 {
+		ids := make([]string, 0, len(uniqueLicenses))
+		for id := range uniqueLicenses {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		lines = append(lines, "", render.Style("Licenses in this group", render.Bold, render.Magenta))
+		for _, id := range ids {
+			lines = append(lines, render.Style("  - ", render.Dim)+id+render.Style(fmt.Sprintf("  (×%d)", uniqueLicenses[id]), render.Dim))
+		}
+	}
+	return lines
+}
+
+func licenseDeltaDetails(d licenseDelta) []string {
+	plain := d.license
+	return []string{
+		render.Style("License Delta", render.Bold, render.Yellow),
+		"",
+		render.Style("  License: ", render.Dim) + valueOrDash(d.license),
+		render.Style("  Category: ", render.Dim) + licenseCategory(plain),
+		render.Style("  Recognition: ", render.Dim) + licenseRecognition(plain),
+		render.Style("  Status: ", render.Dim) + statusText(d.status),
+		render.Style("  Package: ", render.Dim) + valueOrDash(d.pkg),
+		render.Style("  Manifest: ", render.Dim) + valueOrDash(d.manifest),
+	}
+}
+
+// --- Source tab -----------------------------------------------------------
+
+// buildSourceTab plugs into the shared shell skeleton (top bar, tab strip,
+// controls, footer) and supplies a bodyOverride that fills the body region
+// with two side-by-side boxes — Base on the left, Head on the right. The
+// focused side (toggled with `g`) is the one whose key events (search,
+// expand, scroll) take effect; the unfocused side is rendered as static
+// tree text alongside it.
+func (m *diffModel) buildSourceTab() *listModel {
+	focused := m.sourceSide
+	if focused == "" {
+		focused = diffSourceBase
+	}
+	otherLabel := "Head"
+	if focused == diffSourceHead {
+		otherLabel = "Base"
+	}
+
+	// Build BOTH sides' items up front — the focused side's items also
+	// power list-level state (visibleItemIndices, expand, search) by
+	// living in the listModel.items slice.
+	baseItems := diffSourceItems(m.baseGraph, m.sourceBaseExpanded, "base")
+	headItems := diffSourceItems(m.headGraph, m.sourceHeadExpanded, "head")
+	focusedItems := baseItems
+	if focused == diffSourceHead {
+		focusedItems = headItems
+	}
+
+	controls := []string{
+		keyHint("/", "search") + " " + keyHint("g", "switch focus") + " " + keyHint("Enter", "expand") + " " + keyHint("→", "expand") + " " + keyHint("←", "collapse") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		render.Style("Focused: ", render.Dim) + render.Style(strings.ToUpper(string(focused)), render.BgYellow, render.Bold) +
+			render.Style(" | g → "+otherLabel, render.Dim) +
+			render.Style(fmt.Sprintf(" | Base nodes: %d", len(baseItems)), render.Dim) +
+			render.Style(fmt.Sprintf(" | Head nodes: %d", len(headItems)), render.Dim),
+	}
+
+	list := &listModel{
+		controls:       controls,
+		listTitle:      "Source",
+		detailTitle:    "-",
+		navigationHelp: interactiveCommonNavigationHelp + "; Enter expands/collapses source nodes",
+		filterHelp:     "Use / to search; g switches focus base/head; Enter/→/← expand & collapse; 1-6 switch tabs",
+		emptyState:     "No source graph available.",
+		items:          focusedItems,
+	}
+	list.bodyOverride = func(width, height int) []string {
+		return m.renderSourceBody(width, height, focused, baseItems, headItems, list)
+	}
+	return list
+}
+
+// renderSourceBody fills the body region with two equal-width tree boxes.
+// The focused side is rendered from the live listModel (so selection,
+// scrolling, and search highlighting work there); the other side is
+// rendered as static tree text.
+func (m *diffModel) renderSourceBody(width, height int, focused diffSourceSide, baseItems, headItems []listItem, list *listModel) []string {
+	gap := 1
+	leftWidth := (width - gap) / 2
+	rightWidth := width - leftWidth - gap
+
+	leftTitle := "Base"
+	rightTitle := "Head"
+	leftColor := render.Cyan
+	rightColor := render.Magenta
+	if focused == diffSourceBase {
+		leftTitle = "Base (focused)"
+		leftColor = render.Yellow
+	} else {
+		rightTitle = "Head (focused)"
+		rightColor = render.Yellow
+	}
+
+	leftLines := sourceBoxBody(baseItems, focused == diffSourceBase, list, leftWidth-2, height-2)
+	rightLines := sourceBoxBody(headItems, focused == diffSourceHead, list, rightWidth-2, height-2)
+
+	leftBox := boxView(leftTitle, leftLines, leftWidth, height, leftColor)
+	rightBox := boxView(rightTitle, rightLines, rightWidth, height, rightColor)
+
+	out := make([]string, 0, height)
+	for i := 0; i < height; i++ {
+		l := ""
+		r := ""
+		if i < len(leftBox) {
+			l = leftBox[i]
+		}
+		if i < len(rightBox) {
+			r = rightBox[i]
+		}
+		out = append(out, l+strings.Repeat(" ", gap)+r)
+	}
+	return out
+}
+
+// sourceBoxBody renders one side's tree content. When `live` is true, the
+// listModel's selection / scroll / search state highlights the focused row.
+func sourceBoxBody(items []listItem, live bool, list *listModel, width, height int) []string {
+	if len(items) == 0 {
+		return []string{render.Style("(empty)", render.Dim)}
+	}
+	if !live {
+		// Inactive side: simple static tree text.
+		lines := make([]string, 0, height)
+		for i, it := range items {
+			if i >= height {
+				lines = append(lines, render.Style(fmt.Sprintf("… +%d more", len(items)-i), render.Dim))
+				break
+			}
+			lines = append(lines, truncateToWidth(sourceItemPlain(it), width))
+		}
+		return lines
+	}
+	// Focused side: drive scrolling/selection from the live listModel.
+	visible := list.visibleItemIndices()
+	if len(visible) == 0 {
+		return []string{render.Style(list.emptyState, render.Yellow, render.Bold)}
+	}
+	return list.visibleListLines(width, height, visible)
+}
+
+// sourceItemPlain renders one listItem as a plain (no-highlight) tree line.
+func sourceItemPlain(it listItem) string {
+	marker := "  "
+	if it.canOpen {
+		if it.expanded {
+			marker = render.Style("▾ ", render.Cyan)
+		} else {
+			marker = render.Style("▸ ", render.Dim)
+		}
+	}
+	return it.tree + marker + it.title
+}
+
+func diffSourceItems(consolidated sdk.ConsolidatedGraph, expanded map[string]bool, sidePrefix string) []listItem {
+	items := []listItem{sourceNode(fmt.Sprintf("%s: {}", sidePrefix), "root", "", 0, true, expandedValue(expanded, "root", true))}
+	if !expandedValue(expanded, "root", true) {
+		return items
+	}
+
+	manifestCount := len(consolidated.Manifests)
+	subprojectCount := len(consolidated.Subprojects)
+	graph, _ := graphFromConsolidated(consolidated)
+	packageCount := 0
+	relationshipCnt := 0
+	if graph != nil {
+		packageCount = graph.Size()
+		relationshipCnt = relationshipCount(graph)
+	}
+	sections := []struct {
+		key   string
+		title string
+		last  bool
+	}{
+		{"subprojects", fmt.Sprintf("subprojects: [] (%d items)", subprojectCount), false},
+		{"manifests", fmt.Sprintf("manifests: [] (%d items)", manifestCount), false},
+		{"packages", fmt.Sprintf("packages: [] (%d items)", packageCount), false},
+		{"relationships", fmt.Sprintf("relationships: [] (%d items)", relationshipCnt), true},
+	}
+	for _, s := range sections {
+		tree := "├─ "
+		if s.last {
+			tree = "└─ "
+		}
+		isExpanded := expandedValue(expanded, s.key, false)
+		items = append(items, sourceNode(s.title, s.key, tree, 1, true, isExpanded))
+		if !isExpanded {
+			continue
+		}
+		prefix := "│  "
+		if s.last {
+			prefix = "   "
+		}
+		switch s.key {
+		case "subprojects":
+			for i, sub := range consolidated.Subprojects {
+				last := i == len(consolidated.Subprojects)-1
+				tree := prefix + branch(last)
+				items = append(items, sourceNode(fmt.Sprintf("%q: {detector: %q, roots: %d}", sub.Subproject.RelativePath, sub.DetectorName, len(sub.RootManifestIDs)), "subproject:"+sub.Subproject.RelativePath, tree, 2, false, false))
+			}
+		case "manifests":
+			for i, mf := range consolidated.Manifests {
+				last := i == len(consolidated.Manifests)-1
+				tree := prefix + branch(last)
+				items = append(items, sourceNode(fmt.Sprintf("%q: {detector: %q, technique: %q}", mf.Entry.Manifest.Path, mf.DetectorName, mf.Technique), "manifest:"+mf.Entry.Manifest.Path, tree, 2, false, false))
+			}
+		case "packages":
+			if graph == nil {
+				items = append(items, sourceNode("(no consolidated graph)", "", prefix+"└─ ", 2, false, false))
+				break
+			}
+			pkgs := graph.Packages()
+			sort.Slice(pkgs, func(i, j int) bool { return packageSortKey(pkgs[i]) < packageSortKey(pkgs[j]) })
+			limit := len(pkgs)
+			truncated := false
+			if limit > 200 {
+				limit = 200
+				truncated = true
+			}
+			for i := 0; i < limit; i++ {
+				pkg := pkgs[i]
+				last := i == limit-1 && !truncated
+				tree := prefix + branch(last)
+				key := "package:" + pkg.ID
+				isExp := expandedValue(expanded, key, false)
+				items = append(items, sourceNode(fmt.Sprintf("%q: {}", pkg.ID), key, tree, 2, true, isExp))
+				if !isExp {
+					continue
+				}
+				childPrefix := prefix
+				if last {
+					childPrefix += "   "
+				} else {
+					childPrefix += "│  "
+				}
+				items = append(items, sourceLeafItems(packageRawLines(pkg), childPrefix)...)
+			}
+			if truncated {
+				items = append(items, sourceNode(fmt.Sprintf("(showing 200 of %d packages)", len(pkgs)), "", prefix+"└─ ", 2, false, false))
+			}
+		case "relationships":
+			if graph == nil {
+				items = append(items, sourceNode("(no consolidated graph)", "", prefix+"└─ ", 2, false, false))
+				break
+			}
+			edges := relationshipRawLines(graph)
+			limit := len(edges)
+			truncated := false
+			if limit > 200 {
+				limit = 200
+				truncated = true
+			}
+			items = append(items, sourceLeafItems(edges[:limit], prefix)...)
+			if truncated {
+				items = append(items, sourceNode(fmt.Sprintf("(showing 200 of %d edges)", len(edges)), "", prefix+"└─ ", 2, false, false))
+			}
+		}
+	}
+	return items
+}
+
+func graphFromConsolidated(c sdk.ConsolidatedGraph) (*sdk.Graph, error) {
+	if c.Graphs == nil {
+		return nil, nil
+	}
+	return c.Graphs.ConsolidatedGraph()
 }

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -1,0 +1,1535 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// fixtureDiffPayload returns a representative DiffResponse covering every
+// aggregation surface: multiple ecosystems, multiple scopes, fuzzy + exact
+// reconciled changes, vulnerability findings, and policy-kind findings
+// (so we can exercise the kind split). The goldens for every aggregation
+// in this file are computed from this single payload.
+func fixtureDiffPayload() output.DiffResponse {
+	return output.DiffResponse{
+		Project:    output.ProjectDescriptor{Name: "demo", Path: "/tmp/demo"},
+		Comparison: output.DiffComparison{Base: "main", Head: "feature"},
+		Summary: output.DiffSummary{
+			AddedManifestCount: 1, ChangedManifestCount: 1, RemovedManifestCount: 0, UnchangedManifestCount: 0,
+			AddedPackageCount: 2, ChangedPackageCount: 2, RemovedPackageCount: 1,
+		},
+		Results: output.DiffResults{Manifests: []output.DiffManifestResult{
+			{
+				Status: "added", Path: "package.json", Ecosystem: "npm", PackageManager: "npm",
+				Added: []output.DiffPackageChange{
+					{Package: output.PackageRef{ID: "zod@3.23.0", Name: "zod", Version: "3.23.0", Scope: "runtime", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+				},
+			},
+			{
+				Status: "changed", Path: "go.mod", Ecosystem: "go", PackageManager: "gomod",
+				Added: []output.DiffPackageChange{
+					{Package: output.PackageRef{ID: "github.com/new/pkg@1.0.0", Name: "github.com/new/pkg", Version: "1.0.0", Scope: "development",
+						Licenses: []output.LicenseRef{{SPDXExpression: "Apache-2.0"}}}},
+				},
+				Changed: []output.DiffChangedPackage{
+					// Exact match (same name, version change) — no fuzzy metadata.
+					{Before: output.PackageRef{ID: "react@18.2.0", Name: "react", Version: "18.2.0", Scope: "runtime", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}},
+						After: output.PackageRef{ID: "react@19.0.0", Name: "react", Version: "19.0.0", Scope: "runtime", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+					// Fuzzy reconciled — After carries the metadata marker.
+					{Before: output.PackageRef{ID: "old-pkg@1.0.0", Name: "old-pkg", Version: "1.0.0", Licenses: []output.LicenseRef{{SPDXExpression: "BSD-2-Clause"}}},
+						After: output.PackageRef{ID: "new-pkg@1.1.0", Name: "new-pkg", Version: "1.1.0", Scope: "runtime",
+							Metadata: map[string]any{"bomly.diff.fuzzy_reconciled": true},
+							Licenses: []output.LicenseRef{{SPDXExpression: "BSD-2-Clause"}, {SPDXExpression: "MIT"}}}},
+				},
+				Removed: []output.DiffPackageChange{
+					{Package: output.PackageRef{ID: "dropped@0.1.0", Name: "dropped", Version: "0.1.0", Licenses: []output.LicenseRef{{SPDXExpression: "Apache-2.0"}}}},
+				},
+			},
+		}},
+		Audit: &output.DiffAudit{
+			Introduced: []output.AuditFinding{
+				{ID: "CVE-2024-0001", Kind: "vulnerability", Severity: "high", Source: "osv", Package: output.PackageRef{Name: "react", Version: "19.0.0"}},
+				{ID: "license:unknown-license:zod@3.23.0", Kind: string(sdk.FindingKindLicense), Severity: "unknown", Auditor: "license", Source: "license", Package: output.PackageRef{Name: "zod", Version: "3.23.0"}},
+			},
+			Persisted: []output.AuditFinding{
+				{ID: "CVE-2023-9999", Kind: "vulnerability", Severity: "medium", Source: "osv", Package: output.PackageRef{Name: "lodash", Version: "4.17.20"}},
+			},
+			Resolved: []output.AuditFinding{
+				{ID: "CVE-2022-1111", Kind: "vulnerability", Severity: "low", Source: "osv", Package: output.PackageRef{Name: "dropped", Version: "0.1.0"}},
+			},
+			// AuditSummary.Total now reflects Introduced + Persisted only
+			// (scan_output.go no longer appends Resolved). For this fixture
+			// that's 2 introduced + 1 persisted = 3.
+			AuditSummary: &output.AuditSummary{High: 1, Medium: 2, Low: 0, Total: 3},
+		},
+	}
+}
+
+func newFixtureDiffModel() *diffModel {
+	return NewDiff(fixtureDiffPayload(), sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+}
+
+// ---- diffAggregateCounts (footer) -----------------------------------------
+
+func TestDiffAggregateCounts_FromFixture(t *testing.T) {
+	m := newFixtureDiffModel()
+	c := m.diffAggregateCounts()
+
+	// Manifest deltas = Added(1) + Changed(1) + Removed(0).
+	if c.ManifestDeltas != 2 {
+		t.Errorf("ManifestDeltas = %d, want 2", c.ManifestDeltas)
+	}
+	// Package deltas = Added(2) + Changed(2) + Removed(1).
+	if c.PackageDeltas != 5 {
+		t.Errorf("PackageDeltas = %d, want 5", c.PackageDeltas)
+	}
+	// Vuln deltas: 1 introduced vuln + 1 persisted vuln + 1 resolved vuln = 3.
+	// Persisted MUST be included — that's the regression we want to lock in.
+	if c.VulnDeltas != 3 {
+		t.Errorf("VulnDeltas = %d, want 3 (Introduced+Persisted+Resolved vulnerability-kind)", c.VulnDeltas)
+	}
+	// Finding deltas: 1 policy-kind in Introduced.
+	if c.FindingDeltas != 1 {
+		t.Errorf("FindingDeltas = %d, want 1", c.FindingDeltas)
+	}
+	// Unique licenses introduced/retired:
+	//   added(zod):     MIT
+	//   added(new/pkg): Apache-2.0
+	//   changed(new-pkg adds MIT — already there? no, it's introduced via fuzzy):
+	//     before licenses = {BSD-2-Clause}, after = {BSD-2-Clause, MIT}
+	//     → MIT introduced
+	//   removed(dropped): Apache-2.0 retired
+	// Distinct SPDX ids touched: {MIT, Apache-2.0, BSD-2-Clause? no — BSD-2-Clause
+	// is in both before and after of the fuzzy change so it's neither introduced
+	// nor retired} ∪ {Apache-2.0 retired} = {MIT, Apache-2.0}.
+	if got, want := c.LicenseUniqueDeltas, 2; got != want {
+		t.Errorf("LicenseUniqueDeltas = %d, want %d (unique SPDX IDs introduced or retired)", got, want)
+	}
+}
+
+func TestDiffAggregateCounts_EmptyPayload(t *testing.T) {
+	m := NewDiff(output.DiffResponse{}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	c := m.diffAggregateCounts()
+	if c.ManifestDeltas != 0 || c.PackageDeltas != 0 || c.VulnDeltas != 0 || c.FindingDeltas != 0 || c.LicenseUniqueDeltas != 0 {
+		t.Errorf("empty payload should yield zero counts, got %+v", c)
+	}
+}
+
+func TestDiffAggregateCounts_LicenseDedup(t *testing.T) {
+	// Five packages all introduce MIT — unique count should be 1, not 5.
+	payload := output.DiffResponse{Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
+		Status: "added", Path: "pkg.json", Ecosystem: "npm",
+		Added: []output.DiffPackageChange{
+			{Package: output.PackageRef{Name: "a", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+			{Package: output.PackageRef{Name: "b", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+			{Package: output.PackageRef{Name: "c", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+			{Package: output.PackageRef{Name: "d", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+			{Package: output.PackageRef{Name: "e", Licenses: []output.LicenseRef{{SPDXExpression: "MIT"}}}},
+		},
+	}}}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	if got := m.diffAggregateCounts().LicenseUniqueDeltas; got != 1 {
+		t.Errorf("LicenseUniqueDeltas = %d, want 1", got)
+	}
+}
+
+func TestDiffFooterSummary_RendersAllFields(t *testing.T) {
+	m := newFixtureDiffModel()
+	got := m.diffFooterSummary()
+	wants := []string{"Manifests: 2", "Packages: 5", "Vulns: 3", "Licenses: 2", "Findings: 1"}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("diffFooterSummary missing %q in %q", w, got)
+		}
+	}
+}
+
+// ---- computeOverviewStats -------------------------------------------------
+
+func TestComputeOverviewStats_EcosystemsBucketed(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	// Manifest 1 ("added") has 1 package change in npm.
+	// Manifest 2 ("changed") has 1 added + 2 changed + 1 removed = 4 in go.
+	if got := stats.ecosystems["npm"]; got != 1 {
+		t.Errorf("ecosystems[npm] = %d, want 1", got)
+	}
+	if got := stats.ecosystems["go"]; got != 4 {
+		t.Errorf("ecosystems[go] = %d, want 4", got)
+	}
+	// changedTotal = sum of ecosystems.
+	if stats.changedTotal != 5 {
+		t.Errorf("changedTotal = %d, want 5", stats.changedTotal)
+	}
+}
+
+func TestComputeOverviewStats_ScopesAreStatusComposite(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	// New shape: composite keys "<status> <scope>". A user grouping the
+	// Scope pane wants "added runtime" and "removed runtime" to be visibly
+	// distinct buckets — the previous flat shape merged them.
+	//   added(zod, runtime)               → "added runtime"
+	//   added(new/pkg, development)       → "added development"
+	//   changed(react, after=runtime)     → "changed runtime"
+	//   changed(new-pkg, after=runtime)   → "changed runtime"
+	//   removed(dropped, no scope)        → "removed unset"
+	wants := map[string]int{
+		"added runtime":     1,
+		"added development": 1,
+		"changed runtime":   2,
+		"removed unset":     1,
+	}
+	for key, want := range wants {
+		if got := stats.scopes[key]; got != want {
+			t.Errorf("scopes[%q] = %d, want %d", key, got, want)
+		}
+	}
+	if total := sumCounts(stats.scopes); total != 5 {
+		t.Errorf("sumCounts(scopes) = %d, want 5 (= PackageDeltas)", total)
+	}
+}
+
+func TestComputeOverviewStats_RelationshipsScopedToChanges(t *testing.T) {
+	// Build a head graph where react is root, lodash is direct, otherwise transitive.
+	g := sdk.New()
+	react := sdk.NewPackageRef("react", "19.0.0")
+	lodash := sdk.NewPackageRef("lodash", "4.17.20")
+	if err := g.AddPackage(react); err != nil {
+		t.Fatalf("add react: %v", err)
+	}
+	if err := g.AddPackage(lodash); err != nil {
+		t.Fatalf("add lodash: %v", err)
+	}
+	if err := g.AddDependency(react.ID, lodash.ID); err != nil {
+		t.Fatalf("add dep: %v", err)
+	}
+
+	payload := output.DiffResponse{Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
+		Status: "changed", Path: "package.json", Ecosystem: "npm",
+		Changed: []output.DiffChangedPackage{
+			{Before: output.PackageRef{Name: "react", Version: "18.2.0"}, After: output.PackageRef{ID: react.ID, Name: "react", Version: "19.0.0"}},
+		},
+		Added: []output.DiffPackageChange{
+			{Package: output.PackageRef{ID: lodash.ID, Name: "lodash", Version: "4.17.20"}},
+		},
+		Removed: []output.DiffPackageChange{
+			{Package: output.PackageRef{Name: "old-pkg", Version: "1.0.0"}}, // not in head graph
+		},
+	}}}}
+
+	consolidated := sdk.ConsolidatedGraph{Graphs: sdk.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package.json"})}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, consolidated)
+	stats := m.computeOverviewStats()
+
+	// New shape: composite keys "<status> <relationship>".
+	//   changed(react) — present in head, classified root → "changed root"
+	//   added(lodash)  — present in head as react's dep    → "added direct"
+	//   removed(old-pkg) — not in any graph (test has no base graph)
+	//                                                       → "removed unknown"
+	wants := map[string]int{
+		"changed root":    1,
+		"added direct":    1,
+		"removed unknown": 1,
+	}
+	for key, want := range wants {
+		if got := stats.relationships[key]; got != want {
+			t.Errorf("relationships[%q] = %d, want %d", key, got, want)
+		}
+	}
+	// Sum must equal package-change events, NOT total head-graph packages —
+	// that's the regression we want to lock in.
+	if total := sumCounts(stats.relationships); total != 3 {
+		t.Errorf("sumCounts(relationships) = %d, want 3 (number of CHANGE events)", total)
+	}
+}
+
+func TestComputeOverviewStats_RemovedPkgUsesBaseGraphForRelationship(t *testing.T) {
+	// Build a base graph where "old-pkg" is direct (under a root); build a
+	// head graph that does NOT contain it. The Overview must classify it
+	// as "removed direct", not "removed unknown".
+	baseG := sdk.New()
+	root := sdk.NewPackageRef("root", "1")
+	old := sdk.NewPackageRef("old-pkg", "1.0.0")
+	for _, p := range []*sdk.Package{root, old} {
+		if err := baseG.AddPackage(p); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+	if err := baseG.AddDependency(root.ID, old.ID); err != nil {
+		t.Fatalf("dep: %v", err)
+	}
+
+	payload := output.DiffResponse{Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
+		Status: "changed", Path: "go.mod", Ecosystem: "go",
+		Removed: []output.DiffPackageChange{
+			{Package: output.PackageRef{ID: old.ID, Name: "old-pkg", Version: "1.0.0"}},
+		},
+	}}}}
+	base := sdk.ConsolidatedGraph{Graphs: sdk.SingleGraphContainer(baseG, sdk.ManifestMetadata{Path: "go.mod"})}
+	m := NewDiff(payload, base, sdk.ConsolidatedGraph{})
+	stats := m.computeOverviewStats()
+	if got := stats.relationships["removed direct"]; got != 1 {
+		t.Errorf("relationships[removed direct] = %d, want 1 (looked up in BASE graph)", got)
+	}
+	if got := stats.relationships["removed unknown"]; got != 0 {
+		t.Errorf("relationships[removed unknown] = %d, want 0 — base graph should rescue removed pkgs", got)
+	}
+}
+
+func TestComputeOverviewStats_FuzzyAndExactReconciliation(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	if stats.matchedExact != 1 {
+		t.Errorf("matchedExact = %d, want 1 (react)", stats.matchedExact)
+	}
+	if stats.matchedFuzzy != 1 {
+		t.Errorf("matchedFuzzy = %d, want 1 (new-pkg)", stats.matchedFuzzy)
+	}
+	// unmatched* count Added/Removed packages as-is. Fuzzy reconciliation
+	// already moved its matches out of Added/Removed into Changed, so an
+	// added entry here means it really had no peer.
+	if stats.unmatchedAdded != 2 {
+		t.Errorf("unmatchedAdded = %d, want 2", stats.unmatchedAdded)
+	}
+	if stats.unmatchedRemoved != 1 {
+		t.Errorf("unmatchedRemoved = %d, want 1", stats.unmatchedRemoved)
+	}
+}
+
+func TestComputeOverviewStats_VulnByStatusIsVulnKindOnly(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	// vulnByStatus is keyed by severity row -> { status -> count }.
+	// 3 vuln-kind findings:
+	//   high introduced   (CVE-2024-0001)
+	//   medium persisted  (CVE-2023-9999)
+	//   low resolved      (CVE-2022-1111)
+	// The POLICY-1 (medium, license-kind) finding MUST NOT appear in
+	// this table — it lives in licenseByStatus instead.
+	type cell struct{ row, status string }
+	wants := map[cell]int{
+		{"high", "introduced"}:  1,
+		{"medium", "persisted"}: 1,
+		{"low", "resolved"}:     1,
+	}
+	for k, want := range wants {
+		if got := stats.vulnByStatus[k.row][k.status]; got != want {
+			t.Errorf("vulnByStatus[%q][%q] = %d, want %d", k.row, k.status, got, want)
+		}
+	}
+	if got := stats.vulnByStatus["medium"]["introduced"]; got != 0 {
+		t.Errorf("vulnByStatus[medium][introduced] = %d, want 0 — POLICY-1 must be excluded", got)
+	}
+	total := 0
+	for _, row := range stats.vulnByStatus {
+		for _, n := range row {
+			total += n
+		}
+	}
+	if total != 3 {
+		t.Errorf("vulnByStatus total = %d, want 3 (vuln-kind, all 3 buckets)", total)
+	}
+}
+
+func TestComputeOverviewStats_FindingsByKindFromFixture(t *testing.T) {
+	// findingsByKind reads AuditFinding.Kind directly. The fixture has
+	// 3 vulnerability-kind findings and 1 license-kind finding.
+	stats := newFixtureDiffModel().computeOverviewStats()
+	if got := stats.findingsByKind["vulnerability"]; got != 3 {
+		t.Errorf("findingsByKind[vulnerability] = %d, want 3", got)
+	}
+	if got := stats.findingsByKind["license"]; got != 1 {
+		t.Errorf("findingsByKind[license] = %d, want 1", got)
+	}
+	if got := stats.findingsByKind["package"]; got != 0 {
+		t.Errorf("findingsByKind[package] = %d, want 0", got)
+	}
+	if total := sumCounts(stats.findingsByKind); total != 4 {
+		t.Errorf("sumCounts(findingsByKind) = %d, want 4", total)
+	}
+}
+
+func TestComputeOverviewStats_LicenseAndPackageByStatus(t *testing.T) {
+	// Build a payload exercising every license and package rule so the
+	// tables include rows with meaningful counts and the "(other)" row
+	// when the rule keyword isn't one we know about.
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "license:unknown-license:pkg@1", Kind: "license", Auditor: "license"},
+			{ID: "license:invalid-license:pkg@2", Kind: "license", Auditor: "license"},
+			{ID: "license:denied-license:pkg@3", Kind: "license", Auditor: "license"},
+			{ID: "package:denied-package:pkg@4", Kind: "package", Auditor: "package"},
+			{ID: "package:denied-group:pkg@5", Kind: "package", Auditor: "package"},
+			{ID: "package:suspicious-package:pkg@6", Kind: "package", Auditor: "package"},
+		},
+		Persisted: []output.AuditFinding{
+			{ID: "license:unknown-license:pkg@7", Kind: "license", Auditor: "license"},
+			// External plugin emitting a kind we don't know — must land
+			// in the "other" row.
+			{ID: "ext:weird-rule:pkg@8", Kind: "package", Auditor: "external"},
+		},
+		Resolved: []output.AuditFinding{
+			{ID: "license:denied-license:pkg@9", Kind: "license", Auditor: "license"},
+		},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	stats := m.computeOverviewStats()
+
+	// License table.
+	licenseWants := map[string]map[string]int{
+		"unknown": {"introduced": 1, "persisted": 1, "resolved": 0},
+		"invalid": {"introduced": 1, "persisted": 0, "resolved": 0},
+		"denied":  {"introduced": 1, "persisted": 0, "resolved": 1},
+	}
+	for row, want := range licenseWants {
+		for status, n := range want {
+			if got := stats.licenseByStatus[row][status]; got != n {
+				t.Errorf("licenseByStatus[%q][%q] = %d, want %d", row, status, got, n)
+			}
+		}
+	}
+
+	// Package table.
+	packageWants := map[string]map[string]int{
+		"denied":       {"introduced": 1, "persisted": 0, "resolved": 0},
+		"denied-group": {"introduced": 1, "persisted": 0, "resolved": 0},
+		"suspicious":   {"introduced": 1, "persisted": 0, "resolved": 0},
+		// External "weird-rule" lands in the "other" row.
+		"other": {"introduced": 0, "persisted": 1, "resolved": 0},
+	}
+	for row, want := range packageWants {
+		for status, n := range want {
+			if got := stats.packageByStatus[row][status]; got != n {
+				t.Errorf("packageByStatus[%q][%q] = %d, want %d", row, status, got, n)
+			}
+		}
+	}
+}
+
+func TestFindingKindOf_ClassifiesBuiltinAuditors(t *testing.T) {
+	cases := []struct {
+		f    output.AuditFinding
+		want string
+	}{
+		{output.AuditFinding{Kind: "vulnerability"}, "vulnerability"},
+		{output.AuditFinding{Kind: "license"}, "license"},
+		{output.AuditFinding{Kind: "package"}, "package"},
+		{output.AuditFinding{Kind: "vuln"}, "vulnerability"},     // alias
+		{output.AuditFinding{Kind: "advisory"}, "vulnerability"}, // alias
+		{output.AuditFinding{Kind: "cve"}, "vulnerability"},      // alias
+		// Empty Kind → fall back to id/source heuristic.
+		{output.AuditFinding{ID: "CVE-2024-0001"}, "vulnerability"},
+		{output.AuditFinding{Source: "osv"}, "vulnerability"},
+		{output.AuditFinding{Auditor: "license"}, "license"},
+		{output.AuditFinding{Auditor: "package"}, "package"},
+		// Truly unknown.
+		{output.AuditFinding{}, "other"},
+	}
+	for _, tc := range cases {
+		if got := findingKindOf(tc.f); got != tc.want {
+			t.Errorf("findingKindOf(%#v) = %q, want %q", tc.f, got, tc.want)
+		}
+	}
+}
+
+func TestFindingRule_StripsAuditorPrefixAndSuffix(t *testing.T) {
+	cases := []struct {
+		id, fallback, want string
+	}{
+		{"license:unknown-license:pkg@1", "fb", "unknown"},
+		{"license:invalid-license:pkg@1", "fb", "invalid"},
+		{"license:denied-license:pkg@1", "fb", "denied"},
+		{"package:denied-package:pkg@1", "fb", "denied"},
+		{"package:denied-group:pkg@1", "fb", "denied-group"},
+		{"package:suspicious-package:pkg@1", "fb", "suspicious"},
+		// ID with no rule chunk falls back.
+		{"singleton", "fb", "fb"},
+		{"", "fb", "fb"},
+	}
+	for _, tc := range cases {
+		got := findingRule(output.AuditFinding{ID: tc.id}, tc.fallback)
+		if got != tc.want {
+			t.Errorf("findingRule(%q) = %q, want %q", tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestComputeOverviewStats_AuditRanAndTotal(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	if !stats.auditRan {
+		t.Errorf("auditRan = false, want true")
+	}
+	// auditSummaryTotal passes through AuditSummary.Total verbatim. With
+	// the current scan_output.go that's Introduced+Persisted (not Resolved).
+	// The exit-code gate is NOT this number — see auditVerdict.FailingIntroduced.
+	if stats.auditSummaryTotal != 3 {
+		t.Errorf("auditSummaryTotal = %d, want 3 (Introduced+Persisted from fixture)", stats.auditSummaryTotal)
+	}
+
+	noAudit := NewDiff(output.DiffResponse{}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	if got := noAudit.computeOverviewStats(); got.auditRan {
+		t.Errorf("auditRan = true for payload without Audit, want false")
+	}
+}
+
+// ---- auditVerdict (mirrors diff_cmd.go:161-165) ---------------------------
+
+func TestAuditVerdict_NotEvaluatedWhenAuditMissing(t *testing.T) {
+	m := NewDiff(output.DiffResponse{}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	v := m.auditVerdict()
+	if v.Ran {
+		t.Errorf("v.Ran = true, want false")
+	}
+	if got := v.Verdict(); got != "NOT EVALUATED" {
+		t.Errorf("Verdict() = %q, want NOT EVALUATED", got)
+	}
+}
+
+func TestAuditVerdict_PassWhenNoIntroduced(t *testing.T) {
+	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{AuditSummary: &output.AuditSummary{Total: 0}}},
+		sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	v := m.auditVerdict()
+	if !v.Ran {
+		t.Errorf("v.Ran = false, want true")
+	}
+	if got := v.Verdict(); got != "PASS" {
+		t.Errorf("Verdict() = %q, want PASS", got)
+	}
+}
+
+// Regression for the diff exit-code gate (internal/cli/diff_cmd.go:161-165):
+// the gate operates on *Introduced* findings ONLY via output.FailingFindingCount.
+// A diff that resolves findings — even high-severity ones — must NOT FAIL.
+func TestAuditVerdict_ResolvedOnlyIsPass(t *testing.T) {
+	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
+		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: "vulnerability", Severity: "high", Source: "osv"}},
+		AuditSummary: &output.AuditSummary{},
+	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	v := m.auditVerdict()
+	if got := v.Verdict(); got != "PASS" {
+		t.Errorf("Verdict() = %q, want PASS (only Resolved findings; no introduced gate)", got)
+	}
+	if v.FailingIntroduced != 0 {
+		t.Errorf("FailingIntroduced = %d, want 0", v.FailingIntroduced)
+	}
+	if v.ResolvedTotal != 1 {
+		t.Errorf("ResolvedTotal = %d, want 1", v.ResolvedTotal)
+	}
+}
+
+// Persisted findings on their own also do NOT fail the diff: the gate
+// runs on Introduced only.
+func TestAuditVerdict_PersistedOnlyIsPass(t *testing.T) {
+	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
+		Persisted:    []output.AuditFinding{{ID: "CVE-2023-X", Kind: "vulnerability", Severity: "critical", Source: "osv"}},
+		AuditSummary: &output.AuditSummary{Critical: 1, Total: 1},
+	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	if got := m.auditVerdict().Verdict(); got != "PASS" {
+		t.Errorf("Verdict() = %q, want PASS (Persisted is not gated by FailingFindingCount)", got)
+	}
+}
+
+// Disposition gate: an introduced finding with Disposition="warn" must NOT
+// trip the FAIL exit; only "" (unset, historically = fail) or "fail" do.
+// Mirrors output.FailingFindingCount in internal/output/types.go.
+func TestAuditVerdict_DispositionGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		disposition string
+		wantFail    bool
+	}{
+		{"empty disposition (legacy default = fail)", "", true},
+		{"explicit fail", string(sdk.FindingDispositionFail), true},
+		{"warn does not gate exit code", string(sdk.FindingDispositionWarn), false},
+		{"unknown disposition treated as non-failing", "informational", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
+				Introduced: []output.AuditFinding{{
+					ID: "X-1", Kind: "vulnerability", Severity: "high", Source: "osv",
+					Disposition: tc.disposition,
+				}},
+				AuditSummary: &output.AuditSummary{High: 1, Total: 1},
+			}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+			v := m.auditVerdict()
+			gotFail := v.Verdict() == "FAIL"
+			if gotFail != tc.wantFail {
+				t.Errorf("Disposition=%q → Verdict=%q (FailingIntroduced=%d), want fail=%v",
+					tc.disposition, v.Verdict(), v.FailingIntroduced, tc.wantFail)
+			}
+		})
+	}
+}
+
+// When introduced findings exist but ALL are warn-only, the verdict is
+// PASS, but the renderer surfaces a "warn-only" badge so the user knows
+// findings were detected even though the exit code is clean.
+func TestAuditVerdict_WarnOnlyIntroducedYieldsPassWithCount(t *testing.T) {
+	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "W-1", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "W-2", Disposition: string(sdk.FindingDispositionWarn)},
+		},
+		AuditSummary: &output.AuditSummary{Total: 2},
+	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	v := m.auditVerdict()
+	if v.Verdict() != "PASS" {
+		t.Errorf("Verdict() = %q, want PASS", v.Verdict())
+	}
+	if v.IntroducedTotal != 2 {
+		t.Errorf("IntroducedTotal = %d, want 2", v.IntroducedTotal)
+	}
+	if v.FailingIntroduced != 0 {
+		t.Errorf("FailingIntroduced = %d, want 0 (warn does not gate)", v.FailingIntroduced)
+	}
+	if v.WarnIntroduced != 2 {
+		t.Errorf("WarnIntroduced = %d, want 2", v.WarnIntroduced)
+	}
+}
+
+func TestAuditVerdict_BucketAndKindBreakdown(t *testing.T) {
+	v := newFixtureDiffModel().auditVerdict()
+	if v.IntroducedTotal != 2 || v.PersistedTotal != 1 || v.ResolvedTotal != 1 {
+		t.Errorf("totals = %d/%d/%d, want 2/1/1", v.IntroducedTotal, v.PersistedTotal, v.ResolvedTotal)
+	}
+	if v.IntroducedVuln != 1 || v.PersistedVuln != 1 || v.ResolvedVuln != 1 {
+		t.Errorf("vuln = %d/%d/%d, want 1/1/1", v.IntroducedVuln, v.PersistedVuln, v.ResolvedVuln)
+	}
+	if v.IntroducedNonVuln != 1 || v.PersistedNonVuln != 0 || v.ResolvedNonVuln != 0 {
+		t.Errorf("nonVuln = %d/%d/%d, want 1/0/0", v.IntroducedNonVuln, v.PersistedNonVuln, v.ResolvedNonVuln)
+	}
+	if !v.HasNonVulnFindings {
+		t.Errorf("HasNonVulnFindings = false, want true (fixture has POLICY-1)")
+	}
+}
+
+// ---- collectLicenseDeltas / isFuzzyReconciled -----------------------------
+
+func TestCollectLicenseDeltas_IntroducedAndRetiredEvents(t *testing.T) {
+	m := newFixtureDiffModel()
+	deltas := m.collectLicenseDeltas()
+
+	intro, retired := 0, 0
+	uniqueIntro := map[string]struct{}{}
+	uniqueRetired := map[string]struct{}{}
+	for _, d := range deltas {
+		switch d.status {
+		case "introduced":
+			intro++
+			uniqueIntro[d.license] = struct{}{}
+		case "retired":
+			retired++
+			uniqueRetired[d.license] = struct{}{}
+		default:
+			t.Errorf("unexpected delta status %q", d.status)
+		}
+	}
+	// Events: added(zod MIT) + added(new/pkg Apache-2.0) +
+	// changed(new-pkg) introduces MIT (BSD-2-Clause in both before+after) +
+	// removed(dropped) retires Apache-2.0.
+	if intro != 3 {
+		t.Errorf("introduced events = %d, want 3", intro)
+	}
+	if retired != 1 {
+		t.Errorf("retired events = %d, want 1", retired)
+	}
+	// Unique IDs introduced: {MIT, Apache-2.0}. Retired: {Apache-2.0}.
+	if _, ok := uniqueIntro["MIT"]; !ok {
+		t.Errorf("expected MIT to be introduced")
+	}
+	if _, ok := uniqueIntro["Apache-2.0"]; !ok {
+		t.Errorf("expected Apache-2.0 to be introduced")
+	}
+	if _, ok := uniqueRetired["Apache-2.0"]; !ok {
+		t.Errorf("expected Apache-2.0 to be retired")
+	}
+	// BSD-2-Clause appears on BOTH sides of the fuzzy-changed package — it
+	// must NOT generate any introduced or retired event.
+	if _, ok := uniqueIntro["BSD-2-Clause"]; ok {
+		t.Errorf("BSD-2-Clause unchanged across fuzzy match, must not be 'introduced'")
+	}
+	if _, ok := uniqueRetired["BSD-2-Clause"]; ok {
+		t.Errorf("BSD-2-Clause unchanged across fuzzy match, must not be 'retired'")
+	}
+}
+
+func TestIsFuzzyReconciled(t *testing.T) {
+	if isFuzzyReconciled(output.PackageRef{}) {
+		t.Errorf("empty ref should not be fuzzy-reconciled")
+	}
+	if isFuzzyReconciled(output.PackageRef{Metadata: map[string]any{"bomly.diff.fuzzy_reconciled": false}}) {
+		t.Errorf("metadata=false should not be fuzzy-reconciled")
+	}
+	if !isFuzzyReconciled(output.PackageRef{Metadata: map[string]any{"bomly.diff.fuzzy_reconciled": true}}) {
+		t.Errorf("metadata=true should be fuzzy-reconciled")
+	}
+	// Non-bool value must not be treated as truthy.
+	if isFuzzyReconciled(output.PackageRef{Metadata: map[string]any{"bomly.diff.fuzzy_reconciled": "yes"}}) {
+		t.Errorf("non-bool metadata should not be fuzzy-reconciled")
+	}
+}
+
+// ---- isVulnerabilityFinding (kind classification) --------------------------
+
+func TestIsVulnerabilityFinding_KindFirstThenFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		f    output.AuditFinding
+		want bool
+	}{
+		{"Kind=vulnerability", output.AuditFinding{Kind: "vulnerability"}, true},
+		{"Kind=vuln", output.AuditFinding{Kind: "vuln"}, true},
+		{"Kind=advisory", output.AuditFinding{Kind: "advisory"}, true},
+		{"Kind=cve", output.AuditFinding{Kind: "cve"}, true},
+		{"Kind=policy", output.AuditFinding{Kind: "policy"}, false},
+		{"Kind=risk", output.AuditFinding{Kind: "risk"}, false},
+		{"Kind=license", output.AuditFinding{Kind: "license"}, false},
+		// Fallback path when Kind is empty:
+		{"empty Kind, CVE id", output.AuditFinding{ID: "CVE-2024-0001"}, true},
+		{"empty Kind, GHSA id", output.AuditFinding{ID: "GHSA-abcd"}, true},
+		{"empty Kind, OSV src", output.AuditFinding{Source: "osv"}, true},
+		{"empty Kind, grype src", output.AuditFinding{Source: "grype"}, true},
+		{"empty Kind, policy src", output.AuditFinding{Source: "policy"}, false},
+		{"empty Kind, no signal", output.AuditFinding{ID: "X-1"}, false},
+	}
+	for _, tc := range cases {
+		if got := isVulnerabilityFinding(tc.f); got != tc.want {
+			t.Errorf("%s: isVulnerabilityFinding = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// ---- classifyRelationships -------------------------------------------------
+
+func TestClassifyRelationships(t *testing.T) {
+	// Build: root1 -> child1 -> grandchild1; root2 (no children).
+	g := sdk.New()
+	root1 := sdk.NewPackageRef("root1", "1")
+	root2 := sdk.NewPackageRef("root2", "1")
+	child := sdk.NewPackageRef("child", "1")
+	grandchild := sdk.NewPackageRef("grandchild", "1")
+	for _, p := range []*sdk.Package{root1, root2, child, grandchild} {
+		if err := g.AddPackage(p); err != nil {
+			t.Fatalf("add %s: %v", p.ID, err)
+		}
+	}
+	if err := g.AddDependency(root1.ID, child.ID); err != nil {
+		t.Fatalf("add dep: %v", err)
+	}
+	if err := g.AddDependency(child.ID, grandchild.ID); err != nil {
+		t.Fatalf("add dep: %v", err)
+	}
+
+	rels := classifyRelationships(g)
+	if got := rels[root1.ID]; got != "root" {
+		t.Errorf("root1 -> %q, want root", got)
+	}
+	if got := rels[root2.ID]; got != "root" {
+		t.Errorf("root2 -> %q, want root", got)
+	}
+	if got := rels[child.ID]; got != "direct" {
+		t.Errorf("child -> %q, want direct", got)
+	}
+	if got := rels[grandchild.ID]; got != "transitive" {
+		t.Errorf("grandchild -> %q, want transitive", got)
+	}
+}
+
+// ---- diffVulnTotal / diffVulnCount ----------------------------------------
+
+func TestDiffVulnTotalAndCount(t *testing.T) {
+	p := fixtureDiffPayload()
+
+	// All vuln-kind findings = 3 (intro 1 + persisted 1 + resolved 1).
+	if got := diffVulnTotal(p); got != 3 {
+		t.Errorf("diffVulnTotal = %d, want 3", got)
+	}
+	if got := diffVulnCount(p, "introduced"); got != 1 {
+		t.Errorf("diffVulnCount(introduced) = %d, want 1", got)
+	}
+	if got := diffVulnCount(p, "persisted"); got != 1 {
+		t.Errorf("diffVulnCount(persisted) = %d, want 1", got)
+	}
+	if got := diffVulnCount(p, "resolved"); got != 1 {
+		t.Errorf("diffVulnCount(resolved) = %d, want 1", got)
+	}
+	if got := diffVulnCount(p, "nonsense"); got != 0 {
+		t.Errorf("diffVulnCount(nonsense) = %d, want 0", got)
+	}
+
+	// No audit → 0 across the board.
+	empty := output.DiffResponse{}
+	if got := diffVulnTotal(empty); got != 0 {
+		t.Errorf("diffVulnTotal(empty) = %d, want 0", got)
+	}
+}
+
+// ---- collectComponentChanges ----------------------------------------------
+
+func TestCollectComponentChanges_FlattensWithStatusAndSeverity(t *testing.T) {
+	m := newFixtureDiffModel()
+	changes := m.collectComponentChanges()
+
+	// 2 added + 2 changed + 1 removed = 5 flat entries.
+	if got, want := len(changes), 5; got != want {
+		t.Fatalf("collectComponentChanges returned %d entries, want %d", got, want)
+	}
+
+	statusCounts := map[string]int{}
+	for _, c := range changes {
+		statusCounts[c.status]++
+	}
+	if statusCounts["added"] != 2 {
+		t.Errorf("added entries = %d, want 2", statusCounts["added"])
+	}
+	if statusCounts["changed"] != 2 {
+		t.Errorf("changed entries = %d, want 2", statusCounts["changed"])
+	}
+	if statusCounts["removed"] != 1 {
+		t.Errorf("removed entries = %d, want 1", statusCounts["removed"])
+	}
+
+	// The changed react package should carry maxSeverity="high" via its
+	// attached Vulnerabilities? In our fixture it doesn't carry Vulnerabilities
+	// inline, only via Audit findings — so maxSeverity is "". This is the
+	// intended behavior: severity filter operates on PackageRef.Vulnerabilities,
+	// not on audit findings.
+	for _, c := range changes {
+		if c.pkgRef.Name == "react" && c.status == "changed" && c.maxSeverity != "" {
+			t.Errorf("react change carries no inline vuln, expected empty maxSeverity, got %q", c.maxSeverity)
+		}
+	}
+}
+
+func TestCollectComponentChanges_MaxSeverityFromInlineVulns(t *testing.T) {
+	// Add a package with inline Vulnerabilities of mixed severity; the highest
+	// should win.
+	payload := output.DiffResponse{Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
+		Status: "changed", Path: "p", Ecosystem: "npm",
+		Added: []output.DiffPackageChange{{Package: output.PackageRef{
+			Name: "vulny", Version: "1",
+			Vulnerabilities: []output.VulnerabilityRef{
+				{ID: "X-1", Severity: "low"},
+				{ID: "X-2", Severity: "critical"},
+				{ID: "X-3", Severity: "high"},
+			},
+		}}},
+	}}}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	changes := m.collectComponentChanges()
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if got, want := changes[0].maxSeverity, "critical"; got != want {
+		t.Errorf("maxSeverity = %q, want %q", got, want)
+	}
+}
+
+// ---- findingsTableLines (right-column Overview tables) --------------------
+
+func TestFindingsTableLines_VulnerabilityFromFixture(t *testing.T) {
+	stats := newFixtureDiffModel().computeOverviewStats()
+	lines := findingsTableLines("Severity", severityRowKeys(), stats.vulnByStatus, severityRowColor, 60)
+	plain := render.StripANSI(strings.Join(lines, "\n"))
+
+	// Header must include all four columns. The audit-delta columns use
+	// the short new/old/fixed labels everywhere in the diff TUI.
+	for _, col := range []string{"Severity", "New", "Old", "Fixed"} {
+		if !strings.Contains(plain, col) {
+			t.Errorf("header missing column %q in:\n%s", col, plain)
+		}
+	}
+	// Every severity row must appear (even zero rows) so the layout is
+	// stable across diffs.
+	for _, row := range []string{"Critical", "High", "Medium", "Low", "Unknown"} {
+		if !strings.Contains(plain, row) {
+			t.Errorf("expected severity row %q in:\n%s", row, plain)
+		}
+	}
+	// Total row is the implicit gut-check footer.
+	if !strings.Contains(plain, "Total") {
+		t.Errorf("expected Total footer row in:\n%s", plain)
+	}
+}
+
+func TestFindingsTableLines_KeepsZeroRowsForStableLayout(t *testing.T) {
+	// An audit with zero findings of any kind must still render the full
+	// severity table — the user expects the layout to be present even
+	// when the diff is clean.
+	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	stats := m.computeOverviewStats()
+	lines := findingsTableLines("Severity", severityRowKeys(), stats.vulnByStatus, severityRowColor, 60)
+	plain := render.StripANSI(strings.Join(lines, "\n"))
+	for _, row := range []string{"Critical", "High", "Medium", "Low", "Unknown", "Total"} {
+		if !strings.Contains(plain, row) {
+			t.Errorf("zero-finding table missing row %q in:\n%s", row, plain)
+		}
+	}
+}
+
+func TestFindingsTableLines_PackageOtherRowAbsorbsUnknownRules(t *testing.T) {
+	// External plugin emits a package-kind finding whose rule we don't
+	// recognize. computeOverviewStats must funnel it into the "Other"
+	// row so the pre-seeded table stays exhaustive.
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "ext:mystery:pkg@1", Kind: "package", Auditor: "external"},
+		},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	stats := m.computeOverviewStats()
+	if got := stats.packageByStatus["other"]["introduced"]; got != 1 {
+		t.Errorf("packageByStatus[other][introduced] = %d, want 1", got)
+	}
+	plain := render.StripANSI(strings.Join(findingsTableLines("Rule", packageRuleRowKeys(), stats.packageByStatus, ruleRowColor, 60), "\n"))
+	if !strings.Contains(plain, "Other") {
+		t.Errorf("Other row should appear in the package table, got:\n%s", plain)
+	}
+}
+
+// ---- overviewHeadline ------------------------------------------------------
+
+// TestOverviewHeadline_FailReflectsIntroducedDisposition: the audit chip
+// reads FailingIntroduced (introduced findings whose Disposition gates
+// the exit code). The fixture has 2 introduced findings, both with the
+// default empty Disposition, so both count as failing → "Audit FAIL (2
+// introduced, exit 2)".
+func TestOverviewHeadline_FailReflectsIntroducedDisposition(t *testing.T) {
+	m := newFixtureDiffModel()
+	plain := render.StripANSI(m.overviewHeadline(200))
+	for _, want := range []string{
+		"5 package changes",
+		"1 new vulnerabilities", // count of vuln-kind in Introduced
+		"Audit FAIL (2 new, exit 2)",
+		"1 fuzzy-reconciled",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("headline missing %q in: %q", want, plain)
+		}
+	}
+}
+
+func TestOverviewHeadline_PassWhenNoIntroduced(t *testing.T) {
+	p := fixtureDiffPayload()
+	p.Audit = &output.DiffAudit{AuditSummary: &output.AuditSummary{Total: 0}}
+	m := NewDiff(p, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := render.StripANSI(m.overviewHeadline(200))
+	if !strings.Contains(plain, "Audit PASS (exit 0)") {
+		t.Errorf("headline expected Audit PASS, got: %q", plain)
+	}
+}
+
+// Resolved findings on their own do not flip the verdict to FAIL —
+// regression for diff_cmd.go's new gate (Introduced only).
+func TestOverviewHeadline_ResolvedOnlyIsPass(t *testing.T) {
+	p := output.DiffResponse{Audit: &output.DiffAudit{
+		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: "vulnerability", Severity: "high"}},
+		AuditSummary: &output.AuditSummary{},
+	}}
+	m := NewDiff(p, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := render.StripANSI(m.overviewHeadline(200))
+	if !strings.Contains(plain, "Audit PASS") {
+		t.Errorf("resolved-only headline expected PASS, got: %q", plain)
+	}
+	if strings.Contains(plain, "FAIL") {
+		t.Errorf("resolved-only headline must not contain FAIL, got: %q", plain)
+	}
+}
+
+// Warn-only introduced findings pass policy but the chip surfaces the
+// count so the user knows findings exist.
+func TestOverviewHeadline_WarnOnlyIntroducedIsPassWithCount(t *testing.T) {
+	p := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "W-1", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "W-2", Disposition: string(sdk.FindingDispositionWarn)},
+		},
+		AuditSummary: &output.AuditSummary{Total: 2},
+	}}
+	m := NewDiff(p, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := render.StripANSI(m.overviewHeadline(200))
+	if !strings.Contains(plain, "Audit PASS (2 warn-only, exit 0)") {
+		t.Errorf("warn-only headline expected 'Audit PASS (2 warn-only, exit 0)', got: %q", plain)
+	}
+}
+
+func TestOverviewHeadline_NotEvaluatedWhenAuditMissing(t *testing.T) {
+	p := fixtureDiffPayload()
+	p.Audit = nil
+	m := NewDiff(p, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := render.StripANSI(m.overviewHeadline(200))
+	if !strings.Contains(plain, "Audit not run") {
+		t.Errorf("headline expected 'Audit not run', got: %q", plain)
+	}
+}
+
+// ---- audit-status label rename + dedupe ----------------------------------
+
+// TestAuditStatusLabel maps the internal audit-delta status strings to
+// their short UI labels. Locks in the user-facing vocabulary so a future
+// refactor doesn't accidentally reintroduce "introduced/persisted/resolved"
+// in the diff TUI.
+func TestAuditStatusLabel(t *testing.T) {
+	cases := []struct{ in, want, title string }{
+		{"introduced", "new", "New"},
+		{"persisted", "old", "Old"},
+		{"resolved", "fixed", "Fixed"},
+		// Other words pass through untouched (lowercased).
+		{"added", "added", "Added"},
+		{"retired", "retired", "Retired"},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		if got := auditStatusLabel(tc.in); got != tc.want {
+			t.Errorf("auditStatusLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		if got := auditStatusTitle(tc.in); got != tc.title {
+			t.Errorf("auditStatusTitle(%q) = %q, want %q", tc.in, got, tc.title)
+		}
+	}
+}
+
+// TestComponentChangeBadges_NoDuplicateStatus asserts the deduplication.
+// The row's subtitle already renders a colored status badge (via
+// statusBadge) so componentChangeBadges must NOT prepend another badge
+// whose label is the same status string — that double-coding was the bug
+// the user flagged on the Components tab.
+func TestComponentChangeBadges_NoDuplicateStatus(t *testing.T) {
+	c := flatComponentChange{
+		status:       "changed",
+		maxSeverity:  "high",
+		relationship: "direct",
+	}
+	for _, b := range componentChangeBadges(c) {
+		if strings.EqualFold(b.label, "changed") {
+			t.Errorf("componentChangeBadges leaked a duplicate %q badge: %+v", b.label, componentChangeBadges(c))
+		}
+	}
+}
+
+// TestAuditDeltaBadges_NoDuplicateStatus is the symmetric guarantee for
+// the Vulnerabilities and Findings tabs: severity becomes a badge, but
+// the status (introduced/persisted/resolved) lives only in the subtitle
+// so it isn't shown twice.
+func TestAuditDeltaBadges_NoDuplicateStatus(t *testing.T) {
+	d := auditDelta{status: "introduced", severity: "high"}
+	for _, b := range auditDeltaBadges(d) {
+		if strings.EqualFold(b.label, "introduced") || strings.EqualFold(b.label, "new") {
+			t.Errorf("auditDeltaBadges leaked a duplicate status badge: %+v", auditDeltaBadges(d))
+		}
+	}
+}
+
+// TestStatusBadge_NewOldFixed colors the renamed audit-delta labels so
+// they read at a glance. Both the short ("new"/"old"/"fixed") and the
+// legacy long forms ("introduced"/"persisted"/"resolved") render the
+// same colored badge — the long forms route through auditStatusLabel
+// internally and recurse.
+func TestStatusBadge_NewOldFixed(t *testing.T) {
+	for _, status := range []string{"new", "old", "fixed", "introduced", "persisted", "resolved", "retired"} {
+		got := render.StripANSI(statusBadge(status))
+		// Badge text is the uppercased *display* label. Long forms must
+		// translate; short forms are emitted verbatim.
+		want := strings.ToUpper(auditStatusLabel(status))
+		if !strings.Contains(got, want) {
+			t.Errorf("statusBadge(%q) = %q, want it to contain %q", status, got, want)
+		}
+	}
+}
+
+// TestDistributionLine_PreservesLongCompositeLabels guards against the
+// truncation bug on the Overview's per-relationship/per-scope panes,
+// where "1 changed runtime (100%)" used to get clipped to "1 changed
+// runtime (1...". The label area now scales with the pane width.
+func TestDistributionLine_PreservesLongCompositeLabels(t *testing.T) {
+	counts := map[string]int{
+		"changed runtime":   7,
+		"removed unknown":   18,
+		"added development": 3,
+	}
+	// Width corresponds to a typical right-column pane in a 120-col TTY.
+	lines := coloredDistributionLines(counts, 28, len(counts), 58)
+	plain := render.StripANSI(strings.Join(lines, "\n"))
+	for _, want := range []string{
+		"7 changed runtime (",
+		"18 removed unknown (",
+		"3 added development (",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("distribution truncates %q in:\n%s", want, plain)
+		}
+	}
+	// Percentages must be fully present (no "..." swallowing the closing
+	// paren).
+	for _, want := range []string{"(25%)", "(64%)", "(10%)"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("distribution drops percentage %q in:\n%s", want, plain)
+		}
+	}
+}
+
+// TestDistributionLine_FitsBoxBudget catches the regression where the
+// rendered line was longer than the box content area, causing boxView
+// to clip the bar tail. distributionLine receives `width` from a caller
+// that passes `paneWidth-2`; boxView then reserves another 2 cols for
+// horizontal padding. So every produced line must have at most
+// `width - 2` *visible* (ANSI-stripped) columns. Anything longer means
+// the bar (or label) will end with "..." inside the box.
+func TestDistributionLine_FitsBoxBudget(t *testing.T) {
+	for _, width := range []int{32, 40, 58, 72, 100, 140} {
+		counts := map[string]int{"go": 22, "npm": 5, "python": 1}
+		for _, line := range coloredDistributionLines(counts, 28, len(counts), width) {
+			visible := len([]rune(render.StripANSI(line)))
+			if visible > width-2 {
+				t.Errorf("distribution line at width=%d has %d visible cols, want <= %d.\nLine: %q",
+					width, visible, width-2, render.StripANSI(line))
+			}
+		}
+	}
+}
+
+// ---- Findings tab outcome panels ------------------------------------------
+
+// TestFindingsOutcomePanels_BucketsCoverAllKinds: now that the Findings
+// tab spans every FindingKind, the Findings Delta panel must show the
+// run-level introduced/persisted/resolved totals (not just non-vuln).
+// Fixture has:
+//
+//	Introduced: 1 vuln + 1 license
+//	Persisted:  1 vuln
+//	Resolved:   1 vuln
+//
+// Sum should be 2/1/1 — agreeing with the rows shown in the list below
+// and with AuditSummary.
+func TestFindingsOutcomePanels_BucketsCoverAllKinds(t *testing.T) {
+	panels := newFixtureDiffModel().findingsOutcomePanels()
+	plain := stripPanels(panels)
+
+	if !strings.Contains(plain, "Findings Delta") {
+		t.Fatalf("expected 'Findings Delta' panel, got:\n%s", plain)
+	}
+	for _, want := range []string{"2 New", "1 Old", "1 Fixed"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("findings outcome buckets missing %q (must cover all kinds), got:\n%s", want, plain)
+		}
+	}
+	// By Kind panel reflects the per-kind split.
+	for _, want := range []string{"3 vulnerability", "1 license"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("By Kind missing %q, got:\n%s", want, plain)
+		}
+	}
+}
+
+// TestFindingsOutcomePanels_SpansAllKinds verifies the refactor that
+// promoted the Findings tab from "non-vuln only" to "every FindingKind".
+// In this scenario:
+//
+//	Introduced: 6 vulns (all failing) + 0 license + 0 package
+//	Persisted:  0 vulns + 6 license + 0 package
+//
+// The Findings tab's outcome panel now reflects the full run (matching
+// the Vulnerabilities tab's contribution too), and the By Kind panel
+// shows vulnerability + license + package counts.
+func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
+	intro := []output.AuditFinding{}
+	for i := 0; i < 6; i++ {
+		intro = append(intro, output.AuditFinding{
+			ID:       "CVE-X-" + string(rune('A'+i)),
+			Kind:     "vulnerability",
+			Auditor:  "vulnerability",
+			Source:   "osv",
+			Severity: "high",
+		})
+	}
+	persisted := []output.AuditFinding{}
+	for i := 0; i < 6; i++ {
+		persisted = append(persisted, output.AuditFinding{
+			ID:       "license:unknown-license:pkg-" + string(rune('A'+i)),
+			Kind:     string(sdk.FindingKindLicense),
+			Auditor:  "license",
+			Source:   "license",
+			Severity: "unknown",
+		})
+	}
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced:   intro,
+		Persisted:    persisted,
+		AuditSummary: &output.AuditSummary{High: 6, Total: 12},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := stripPanels(m.findingsOutcomePanels())
+
+	// FAIL reflects all 6 introduced vulnerabilities (now that vulns are
+	// in scope on this tab too).
+	if !strings.Contains(plain, " FAIL ") {
+		t.Errorf("expected Findings tab to surface FAIL when there are introduced vulns, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "6 new finding(s) gate exit code") {
+		t.Errorf("expected '6 new finding(s) gate exit code', got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "6 vuln + 0 license/package") {
+		t.Errorf("expected explainer mentioning 6 vuln + 0 license/package, got:\n%s", plain)
+	}
+	// Findings Delta: 6 new + 6 old + 0 fixed (all kinds).
+	for _, want := range []string{"6 New", "6 Old", "0 Fixed"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("Findings Delta missing %q in:\n%s", want, plain)
+		}
+	}
+	// By Kind: vulnerabilities AND license counts both show up.
+	for _, want := range []string{"6 vulnerability", "6 license"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("By Kind panel missing %q in:\n%s", want, plain)
+		}
+	}
+}
+
+// TestFindingsOutcomePanels_PassWhenOnlyResolvedAndPersisted locks in the
+// happy path: no introduced findings of any kind → PASS, exit code 0.
+func TestFindingsOutcomePanels_PassWhenNoIntroduced(t *testing.T) {
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Persisted: []output.AuditFinding{
+			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability"},
+		},
+		Resolved: []output.AuditFinding{
+			{ID: "license:denied-license:pkg@1", Kind: "license", Auditor: "license"},
+		},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := stripPanels(m.findingsOutcomePanels())
+	if !strings.Contains(plain, " PASS ") {
+		t.Errorf("expected PASS verdict with no introduced findings, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Exit code 0 (clean)") {
+		t.Errorf("expected 'Exit code 0 (clean)', got:\n%s", plain)
+	}
+}
+
+// TestVulnsOutcomePanels_ScopedToVulns is the symmetric guarantee for
+// the Vulnerabilities tab — outcome counts come from vuln-only buckets,
+// with a run-level breadcrumb mentioning policy too.
+func TestVulnsOutcomePanels_ScopedToVulns(t *testing.T) {
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "critical"},
+			{ID: "license:unknown-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license", Source: "license", Severity: "unknown"},
+		},
+		Persisted: []output.AuditFinding{
+			{ID: "CVE-2", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "medium"},
+		},
+		AuditSummary: &output.AuditSummary{Critical: 1, Medium: 1, Total: 3},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := stripPanels(m.vulnsOutcomePanels())
+
+	// FAIL verdict reflects the 1 introduced vuln.
+	if !strings.Contains(plain, " FAIL ") {
+		t.Errorf("Vulns tab outcome should be FAIL, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "1 new vulnerability(ies) gate exit code") {
+		t.Errorf("expected vuln-scoped failing count, got:\n%s", plain)
+	}
+	// Vuln Deltas: 1/1/0 (vuln-only, not 2/1/0).
+	for _, want := range []string{"1 New", "1 Old", "0 Fixed"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("Vuln Deltas missing %q in:\n%s", want, plain)
+		}
+	}
+	// By Severity scoped to vuln-kind: 1 critical + 1 medium, no "unknown"
+	// row (POL-1's severity must not leak in).
+	if !strings.Contains(plain, "1 Critical") {
+		t.Errorf("expected '1 Critical' in severity panel, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "1 Medium") {
+		t.Errorf("expected '1 Medium' in severity panel, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "1 Unknown") {
+		t.Errorf("severity panel must not leak POL-1's 'unknown' severity, got:\n%s", plain)
+	}
+	// Run-level breadcrumb mentions BOTH kinds (vuln + license/package).
+	if !strings.Contains(plain, "1 vuln + 1 policy") {
+		t.Errorf("expected run-level breadcrumb mentioning both kinds, got:\n%s", plain)
+	}
+}
+
+// TestVulnsOutcomePanels_NotEvaluated locks in the empty-state.
+func TestVulnsOutcomePanels_NotEvaluated(t *testing.T) {
+	m := NewDiff(output.DiffResponse{}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := stripPanels(m.vulnsOutcomePanels())
+	if !strings.Contains(plain, " NOT EVALUATED ") {
+		t.Errorf("expected NOT EVALUATED outcome, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "to evaluate vulnerabilities") {
+		t.Errorf("expected vuln-flavored helper text, got:\n%s", plain)
+	}
+}
+
+// TestAuditVerdict_FailingSplitByKind verifies that the split fields used
+// by the per-tab outcome panels are populated correctly.
+func TestAuditVerdict_FailingSplitByKind(t *testing.T) {
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			// 2 failing vulns (empty Disposition = fail).
+			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability"},
+			{ID: "CVE-2", Kind: "vulnerability", Auditor: "vulnerability", Disposition: string(sdk.FindingDispositionFail)},
+			// 1 warn vuln — counted in WarnIntroduced, not FailingIntroduced*.
+			{ID: "CVE-3", Kind: "vulnerability", Auditor: "vulnerability", Disposition: string(sdk.FindingDispositionWarn)},
+			// 1 failing license-kind finding.
+			{ID: "license:denied-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license"},
+			// 1 warn license-kind finding.
+			{ID: "license:unknown-license:pkg@2", Kind: string(sdk.FindingKindLicense), Auditor: "license", Disposition: string(sdk.FindingDispositionWarn)},
+		},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	v := m.auditVerdict()
+	if v.FailingIntroduced != 3 {
+		t.Errorf("FailingIntroduced = %d, want 3", v.FailingIntroduced)
+	}
+	if v.FailingIntroducedVuln != 2 {
+		t.Errorf("FailingIntroducedVuln = %d, want 2", v.FailingIntroducedVuln)
+	}
+	if v.FailingIntroducedNonVuln != 1 {
+		t.Errorf("FailingIntroducedNonVuln = %d, want 1", v.FailingIntroducedNonVuln)
+	}
+	if v.WarnIntroduced != 2 {
+		t.Errorf("WarnIntroduced = %d, want 2", v.WarnIntroduced)
+	}
+}
+
+func TestFindingsOutcomePanels_ByKindReadsFindingKind(t *testing.T) {
+	// The "By Kind" panel must split by AuditFinding.Kind (the actual
+	// FindingKind), NOT by Auditor name. Build a payload that exercises
+	// every kind so we can see all three rows.
+	payload := output.DiffResponse{Audit: &output.DiffAudit{
+		Introduced: []output.AuditFinding{
+			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv"},
+			{ID: "license:unknown-license:pkg@1", Kind: "license", Auditor: "license", Source: "license"},
+			{ID: "license:invalid-license:pkg@2", Kind: "license", Auditor: "license", Source: "license"},
+			{ID: "package:denied-package:pkg@3", Kind: "package", Auditor: "package", Source: "package"},
+		},
+		AuditSummary: &output.AuditSummary{Total: 4},
+	}}
+	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	plain := stripPanels(m.findingsOutcomePanels())
+
+	if !strings.Contains(plain, "By Kind") {
+		t.Fatalf("expected 'By Kind' panel, got:\n%s", plain)
+	}
+	for _, want := range []string{"1 vulnerability", "2 license", "1 package"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("By Kind panel missing %q, got:\n%s", want, plain)
+		}
+	}
+}
+
+// ---- Findings tab grouping axis -------------------------------------------
+
+func TestNextFindingGroup_CyclesStatusKindPackage(t *testing.T) {
+	// Severity is intentionally excluded from the Findings axis — license
+	// and package auditors emit Severity="unknown" for everything, so
+	// "severity" grouping is degenerate. Lock that exclusion in.
+	cases := []struct{ in, want string }{
+		{"status", "kind"},
+		{"kind", "package"},
+		{"package", "status"},
+		{"", "status"},
+	}
+	for _, tc := range cases {
+		if got := nextFindingGroup(tc.in); got != tc.want {
+			t.Errorf("nextFindingGroup(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ---- License-tab category & recognition keys ------------------------------
+
+func TestLicenseGroupKey_CategoryAndRecognition(t *testing.T) {
+	cases := []struct {
+		license            string
+		wantCategory       string // licenseGroupKeyDiff(... "category")
+		wantRecognitionKey string // licenseGroupKeyDiff(... "recognition")
+	}{
+		{"MIT", "permissive", "recognized"},
+		{"Apache-2.0", "permissive", "recognized"},
+		{"GPL-3.0-only", "copyleft", "recognized"},
+		{"LGPL-2.1", "copyleft", "recognized"},
+		{"", "unknown", "unknown"},
+		// looksLikeSPDXLicense treats any value containing "-" as SPDX-like,
+		// so to cover the "unrecognized" branch we need a free-text license
+		// without a hyphen, parens, or spaces.
+		{"Proprietary", "unclassified", "unrecognized"},
+	}
+	for _, tc := range cases {
+		d := licenseDelta{license: tc.license, status: "introduced"}
+		if got := licenseGroupKeyDiff(d, "category"); got != tc.wantCategory {
+			t.Errorf("licenseGroupKeyDiff(%q, category) = %q, want %q", tc.license, got, tc.wantCategory)
+		}
+		if got := licenseGroupKeyDiff(d, "recognition"); got != tc.wantRecognitionKey {
+			t.Errorf("licenseGroupKeyDiff(%q, recognition) = %q, want %q", tc.license, got, tc.wantRecognitionKey)
+		}
+	}
+}
+
+func TestNextLicenseGroup_CyclesAllFiveAxes(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"license", "status"},
+		{"status", "manifest"},
+		{"manifest", "category"},
+		{"category", "recognition"},
+		{"recognition", "license"},
+		{"", "license"},
+	}
+	for _, tc := range cases {
+		if got := nextLicenseGroup(tc.in); got != tc.want {
+			t.Errorf("nextLicenseGroup(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ---- Detector lookup ------------------------------------------------------
+
+func TestDetectorForManifest_LooksUpInBothGraphs(t *testing.T) {
+	// Build a consolidated graph that knows about manifest "go.mod"
+	// detected by "gomod-detector". Whether it's on the head side or
+	// the base side, lookupDetector must find it.
+	g := sdk.New()
+	head := sdk.ConsolidatedGraph{
+		Graphs: sdk.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "go.mod", Kind: "go.mod"}),
+		Manifests: []sdk.ConsolidatedManifest{{
+			Entry:        sdk.GraphEntry{Manifest: sdk.ManifestMetadata{Path: "go.mod", Kind: "go.mod"}},
+			Subproject:   sdk.Subproject{RelativePath: "."},
+			DetectorName: "gomod-detector",
+		}},
+	}
+	base := sdk.ConsolidatedGraph{
+		Graphs: sdk.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package.json", Kind: "package-lock.json"}),
+		Manifests: []sdk.ConsolidatedManifest{{
+			Entry:        sdk.GraphEntry{Manifest: sdk.ManifestMetadata{Path: "package.json", Kind: "package-lock.json"}},
+			Subproject:   sdk.Subproject{RelativePath: "web/"},
+			DetectorName: "npm-detector",
+		}},
+	}
+	m := NewDiff(output.DiffResponse{}, base, head)
+
+	headMf := output.DiffManifestResult{Path: "go.mod", Subproject: "."}
+	if got := m.detectorForManifest(headMf); got != "gomod-detector" {
+		t.Errorf("detectorForManifest(go.mod) = %q, want gomod-detector", got)
+	}
+	// Base-only manifest still resolves — important because removed
+	// manifests live exclusively on the base side.
+	baseMf := output.DiffManifestResult{Path: "package.json", Subproject: "web/"}
+	if got := m.detectorForManifest(baseMf); got != "npm-detector" {
+		t.Errorf("detectorForManifest(package.json) = %q, want npm-detector", got)
+	}
+	// Unknown manifest → empty string (rendered as "-" by valueOrDash).
+	unknownMf := output.DiffManifestResult{Path: "Cargo.toml"}
+	if got := m.detectorForManifest(unknownMf); got != "" {
+		t.Errorf("detectorForManifest(Cargo.toml) = %q, want empty", got)
+	}
+}
+
+// ---- componentChangeDetails before/after deltas ---------------------------
+
+func TestComponentChangeDetails_ChangedShowsLicenseAndVulnDelta(t *testing.T) {
+	c := flatComponentChange{
+		manifest:     output.DiffManifestResult{Path: "go.mod", Ecosystem: "go"},
+		manifestName: "go.mod",
+		ecosystem:    "go",
+		status:       "changed",
+		pkgName:      "react",
+		beforeVer:    "18.2.0",
+		afterVer:     "19.0.0",
+		relationship: "direct",
+		beforePkg: output.PackageRef{
+			Name: "react", Version: "18.2.0",
+			Licenses:        []output.LicenseRef{{SPDXExpression: "MIT"}, {SPDXExpression: "BSD-2-Clause"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-OLD", Severity: "high"}},
+		},
+		pkgRef: output.PackageRef{
+			Name: "react", Version: "19.0.0",
+			Licenses:        []output.LicenseRef{{SPDXExpression: "MIT"}, {SPDXExpression: "Apache-2.0"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-NEW", Severity: "critical"}},
+		},
+	}
+	plain := render.StripANSI(strings.Join(componentChangeDetails(c), "\n"))
+
+	// Version delta visible.
+	for _, want := range []string{"Before: 18.2.0", "After:  19.0.0"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("componentChangeDetails missing %q in:\n%s", want, plain)
+		}
+	}
+	// License delta visible: MIT unchanged, BSD-2-Clause retired, Apache-2.0 new.
+	// Labels follow the new/old/fixed nomenclature used elsewhere in the diff TUI.
+	for _, want := range []string{
+		"Licenses (before → after)",
+		"MIT", "(unchanged)",
+		"BSD-2-Clause", "(retired)",
+		"Apache-2.0", "(new)",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("license delta section missing %q in:\n%s", want, plain)
+		}
+	}
+	// Vulnerability delta visible: CVE-OLD fixed, CVE-NEW new.
+	for _, want := range []string{
+		"Vulnerabilities (before → after)",
+		"CVE-OLD", "(fixed)",
+		"CVE-NEW", "(new)",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("vuln delta section missing %q in:\n%s", want, plain)
+		}
+	}
+	// Relationship is present in identity section.
+	if !strings.Contains(plain, "Relationship: direct") {
+		t.Errorf("expected 'Relationship: direct' in identity section, got:\n%s", plain)
+	}
+}
+
+func TestComponentChangeDetails_AddedRemovedShowsPlainLists(t *testing.T) {
+	added := flatComponentChange{
+		manifest: output.DiffManifestResult{Path: "go.mod", Ecosystem: "go"},
+		status:   "added", pkgName: "new-thing", relationship: "transitive",
+		pkgRef: output.PackageRef{
+			Name: "new-thing", Version: "1",
+			Licenses:        []output.LicenseRef{{SPDXExpression: "ISC"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-X", Severity: "low"}},
+		},
+	}
+	plain := render.StripANSI(strings.Join(componentChangeDetails(added), "\n"))
+
+	// Added packages show plain Licenses and Vulnerabilities sections,
+	// NOT the "(before → after)" delta form.
+	if strings.Contains(plain, "(before → after)") {
+		t.Errorf("added package should not render before/after delta sections, got:\n%s", plain)
+	}
+	for _, want := range []string{
+		"Licenses",
+		"- ISC",
+		"Vulnerabilities",
+		"CVE-X",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("added-package details missing %q in:\n%s", want, plain)
+		}
+	}
+}
+
+// stripPanels concatenates every panel's title + lines into a single
+// ANSI-stripped string for substring assertions.
+func stripPanels(panels []listPanel) string {
+	var b strings.Builder
+	for _, p := range panels {
+		b.WriteString(p.title)
+		b.WriteString("\n")
+		for _, l := range p.lines {
+			b.WriteString(l)
+			b.WriteString("\n")
+		}
+	}
+	return render.StripANSI(b.String())
+}

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -30,7 +30,9 @@ func (m *scanModel) WithEnrichEnabled(enabled bool) *scanModel {
 		return nil
 	}
 	m.enrichEnabled = enabled
-	m.list = m.buildCurrentListModel()
+	if m.shellModel != nil {
+		m.Rebuild()
+	}
 	return m
 }
 
@@ -51,7 +53,6 @@ func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, cons
 		mode:                  interactiveScanModeManifests,
 		allowManifestExit:     len(manifests) > 1,
 		findings:              findings,
-		activeView:            interactiveScanViewOverview,
 		explainQuery:          strings.TrimSpace(explainQuery),
 		sourceExpanded:        map[string]bool{"root": true},
 		componentExpanded:     map[string]bool{},
@@ -66,113 +67,41 @@ func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, cons
 		model.mode = interactiveScanModeComponents
 		model.currentManifestID = manifests[0].id
 	}
-	model.list = model.buildCurrentListModel()
+	model.shellModel = newShell(ShellSpec{
+		TopBar: model.scanTopBar,
+		Tabs: []TabSpec{
+			{ID: string(interactiveScanViewOverview), Label: "Overview", Build: model.buildOverviewListModel},
+			{ID: string(interactiveScanViewPackages), Label: "Components", Build: model.buildComponentsTreeListModel},
+			{ID: string(interactiveScanViewVulns), Label: "Vulnerabilities", Build: model.buildVulnsListModel},
+			{ID: string(interactiveScanViewLicenses), Label: "Licenses", Build: model.buildLicensesListModel},
+			{ID: string(interactiveScanViewFindings), Label: "Findings", Build: model.buildFindingsListModel},
+			{ID: string(interactiveScanViewSource), Label: "Source", Build: model.buildSourceListModel},
+		},
+		Footer: func() (string, string) {
+			return model.scanFooterSummary(), model.scanLegend()
+		},
+	})
 	return model
 }
 
+func (m *scanModel) currentScanView() scanView {
+	if m == nil || m.shellModel == nil {
+		return interactiveScanViewOverview
+	}
+	return scanView(m.ActiveTabID())
+}
+
+// View overrides shellModel.View so the Overview tab can render its custom
+// dashboard layout. All other tabs fall through to the embedded
+// shellModel's listModel rendering.
 func (m *scanModel) View(width, height int) string {
-	if m == nil || m.list == nil {
+	if m == nil || m.shellModel == nil {
 		return ""
 	}
-	if m.activeView == interactiveScanViewOverview && !m.IsSearching() {
+	if m.currentScanView() == interactiveScanViewOverview && !m.IsSearching() {
 		return m.overviewDashboardView(width, height)
 	}
-	return m.list.View(width, height)
-}
-
-func (m *scanModel) Move(delta int) {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.Move(delta)
-}
-
-func (m *scanModel) ScrollDetails(delta int) {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.ScrollDetails(delta)
-}
-
-func (m *scanModel) Home() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.Home()
-}
-
-func (m *scanModel) End() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.End()
-}
-
-func (m *scanModel) BeginSearch() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.BeginSearch()
-}
-
-func (m *scanModel) AppendSearch(value string) {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.AppendSearch(value)
-}
-
-func (m *scanModel) BackspaceSearch() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.BackspaceSearch()
-}
-
-func (m *scanModel) CancelSearch() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.CancelSearch()
-}
-
-func (m *scanModel) ConfirmSearch() {
-	if m == nil || m.list == nil {
-		return
-	}
-	m.list.ConfirmSearch()
-}
-
-func (m *scanModel) IsSearching() bool {
-	if m == nil || m.list == nil {
-		return false
-	}
-	return m.list.IsSearching()
-}
-
-func (m *scanModel) CycleView() {
-	if m == nil {
-		return
-	}
-	views := scanViews()
-	for idx, view := range views {
-		if view == m.activeView {
-			m.activeView = views[(idx+1)%len(views)]
-			m.list = m.buildCurrentListModel()
-			return
-		}
-	}
-	m.activeView = interactiveScanViewOverview
-	m.list = m.buildCurrentListModel()
-}
-
-func (m *scanModel) SelectView(index int) {
-	views := scanViews()
-	if m == nil || index < 1 || index > len(views) {
-		return
-	}
-	m.activeView = views[index-1]
-	m.list = m.buildCurrentListModel()
+	return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
 }
 
 func (m *scanModel) ToggleSelected() {
@@ -180,35 +109,35 @@ func (m *scanModel) ToggleSelected() {
 }
 
 func (m *scanModel) toggleSelectedTreeNode() {
-	if m == nil || m.list == nil {
+	if m == nil || m.List() == nil {
 		return
 	}
-	visible := m.list.visibleItemIndices()
+	visible := m.List().visibleItemIndices()
 	if len(visible) == 0 {
 		return
 	}
-	item := m.list.items[visible[m.list.selectedVisibleIndex(visible)]]
-	if m.activeView == interactiveScanViewPackages && item.canOpen && item.key != "" {
+	item := m.List().items[visible[m.List().selectedVisibleIndex(visible)]]
+	if m.currentScanView() == interactiveScanViewPackages && item.canOpen && item.key != "" {
 		m.componentExpanded[item.key] = !item.expanded
 		m.rebuildListPreserveSelection()
 		return
 	}
-	if m.activeView == interactiveScanViewVulns && item.canOpen && item.key != "" {
+	if m.currentScanView() == interactiveScanViewVulns && item.canOpen && item.key != "" {
 		m.vulnerabilityExpanded[item.key] = !item.expanded
 		m.rebuildListPreserveSelection()
 		return
 	}
-	if m.activeView == interactiveScanViewLicenses && item.canOpen && item.key != "" {
+	if m.currentScanView() == interactiveScanViewLicenses && item.canOpen && item.key != "" {
 		m.licenseExpanded[item.key] = !item.expanded
 		m.rebuildListPreserveSelection()
 		return
 	}
-	if m.activeView == interactiveScanViewFindings && item.canOpen && item.key != "" {
+	if m.currentScanView() == interactiveScanViewFindings && item.canOpen && item.key != "" {
 		m.findingExpanded[item.key] = !item.expanded
 		m.rebuildListPreserveSelection()
 		return
 	}
-	if m.activeView != interactiveScanViewSource {
+	if m.currentScanView() != interactiveScanViewSource {
 		return
 	}
 	if !item.canOpen {
@@ -231,18 +160,18 @@ func (m *scanModel) CollapseSelected() {
 }
 
 func (m *scanModel) setSelectedTreeNode(expanded bool) {
-	if m == nil || m.list == nil {
+	if m == nil || m.List() == nil {
 		return
 	}
-	visible := m.list.visibleItemIndices()
+	visible := m.List().visibleItemIndices()
 	if len(visible) == 0 {
 		return
 	}
-	item := m.list.items[visible[m.list.selectedVisibleIndex(visible)]]
+	item := m.List().items[visible[m.List().selectedVisibleIndex(visible)]]
 	if !item.canOpen || item.key == "" || item.expanded == expanded {
 		return
 	}
-	switch m.activeView {
+	switch m.currentScanView() {
 	case interactiveScanViewPackages:
 		m.componentExpanded[item.key] = expanded
 	case interactiveScanViewVulns:
@@ -268,14 +197,14 @@ func (m *scanModel) CollapseAll() {
 }
 
 func (m *scanModel) setAllTreeNodes(expanded bool) {
-	if m == nil || m.list == nil {
+	if m == nil || m.List() == nil {
 		return
 	}
-	for _, item := range m.list.items {
+	for _, item := range m.List().items {
 		if !item.canOpen || item.key == "" {
 			continue
 		}
-		switch m.activeView {
+		switch m.currentScanView() {
 		case interactiveScanViewPackages:
 			m.componentExpanded[item.key] = expanded
 		case interactiveScanViewVulns:
@@ -288,7 +217,7 @@ func (m *scanModel) setAllTreeNodes(expanded bool) {
 			m.sourceExpanded[item.key] = expanded
 		}
 	}
-	if m.activeView == interactiveScanViewPackages {
+	if m.currentScanView() == interactiveScanViewPackages {
 		m.componentExpanded["project"] = expanded
 		for _, manifest := range m.manifests {
 			m.componentExpanded["manifest:"+manifest.id] = expanded
@@ -301,7 +230,7 @@ func (m *scanModel) setAllTreeNodes(expanded bool) {
 			}
 		}
 	}
-	if m.activeView == interactiveScanViewSource {
+	if m.currentScanView() == interactiveScanViewSource {
 		for _, key := range []string{"root", "target", "manifests", "packages", "relationships"} {
 			m.sourceExpanded[key] = expanded
 		}
@@ -320,7 +249,7 @@ func (m *scanModel) CycleGroup() {
 	if m == nil {
 		return
 	}
-	switch m.activeView {
+	switch m.currentScanView() {
 	case interactiveScanViewVulns:
 		m.vulnerabilityGroup = nextFilterValue(m.vulnerabilityGroup, []string{"component", "severity", "ecosystem"})
 	case interactiveScanViewLicenses:
@@ -334,7 +263,7 @@ func (m *scanModel) CycleGroup() {
 }
 
 func (m *scanModel) CycleRelationshipFilter() {
-	if m == nil || m.activeView != interactiveScanViewPackages {
+	if m == nil || m.currentScanView() != interactiveScanViewPackages {
 		return
 	}
 	m.relationshipFilter = nextRelationshipFilter(m.relationshipFilter, m.explainMode)
@@ -342,7 +271,7 @@ func (m *scanModel) CycleRelationshipFilter() {
 }
 
 func (m *scanModel) CycleScopeFilter() {
-	if m == nil || m.activeView != interactiveScanViewPackages {
+	if m == nil || m.currentScanView() != interactiveScanViewPackages {
 		return
 	}
 	m.scopeFilter = nextScopeFilter(m.scopeFilter)
@@ -353,7 +282,7 @@ func (m *scanModel) CycleSeverityFilter() {
 	if m == nil {
 		return
 	}
-	switch m.activeView {
+	switch m.currentScanView() {
 	case interactiveScanViewVulns:
 		// always applicable
 	case interactiveScanViewPackages:
@@ -365,7 +294,7 @@ func (m *scanModel) CycleSeverityFilter() {
 }
 
 func (m *scanModel) CycleEcosystemFilter() {
-	if m == nil || m.activeView != interactiveScanViewPackages {
+	if m == nil || m.currentScanView() != interactiveScanViewPackages {
 		return
 	}
 	m.ecosystemFilter = nextFilterValue(m.ecosystemFilter, append([]string{""}, m.componentEcosystemValues()...))
@@ -400,53 +329,36 @@ func (m *scanModel) GoBack() {
 	}
 	m.mode = interactiveScanModeManifests
 	m.currentManifestID = ""
-	m.list = m.buildCurrentListModel()
+	if m.shellModel != nil {
+		m.Rebuild()
+	}
 }
 
 func (m *scanModel) CanGoBack() bool {
 	if m == nil {
 		return false
 	}
-	return m.activeView == interactiveScanViewPackages && m.mode == interactiveScanModeComponents && m.allowManifestExit
-}
-
-func (m *scanModel) buildCurrentListModel() *listModel {
-	var list *listModel
-	switch m.activeView {
-	case interactiveScanViewOverview:
-		list = m.buildOverviewListModel()
-	case interactiveScanViewVulns:
-		list = m.buildVulnsListModel()
-	case interactiveScanViewLicenses:
-		list = m.buildLicensesListModel()
-	case interactiveScanViewFindings:
-		list = m.buildFindingsListModel()
-	case interactiveScanViewSource:
-		list = m.buildSourceListModel()
-	default:
-		list = m.buildComponentsTreeListModel()
-	}
-	return m.withScanFooter(list)
+	return m.currentScanView() == interactiveScanViewPackages && m.mode == interactiveScanModeComponents && m.allowManifestExit
 }
 
 func (m *scanModel) rebuildListPreserveSelection() {
-	if m == nil {
+	if m == nil || m.shellModel == nil {
 		return
 	}
 	key, title, scrollOffset, detailOffset := "", "", 0, 0
-	if m.list != nil {
-		visible := m.list.visibleItemIndices()
+	if prev := m.List(); prev != nil {
+		visible := prev.visibleItemIndices()
 		if len(visible) > 0 {
-			item := m.list.items[visible[m.list.selectedVisibleIndex(visible)]]
+			item := prev.items[visible[prev.selectedVisibleIndex(visible)]]
 			key = item.key
 			title = item.title
 		}
-		scrollOffset = m.list.scrollOffset
-		detailOffset = m.list.detailOffset
+		scrollOffset = prev.scrollOffset
+		detailOffset = prev.detailOffset
 	}
-	next := m.buildCurrentListModel()
+	m.Rebuild()
+	next := m.List()
 	if next == nil {
-		m.list = nil
 		return
 	}
 	next.scrollOffset = scrollOffset
@@ -459,7 +371,6 @@ func (m *scanModel) rebuildListPreserveSelection() {
 			}
 		}
 	}
-	m.list = next
 }
 
 func scanViews() []scanView {
@@ -473,7 +384,13 @@ func scanViews() []scanView {
 	}
 }
 
-func (m *scanModel) scanSummaryLines(active scanView) []string {
+// scanSummaryLines used to inject the top bar + tab strip into each builder's
+// listModel.summary. The shared shellModel now owns that chrome, so this
+// returns nil; the function exists only so legacy call sites keep compiling.
+func (m *scanModel) scanSummaryLines(active scanView) []string { return nil }
+
+// scanTopBar is the ShellSpec.TopBar producer for scan/explain/diff-via-scan.
+func (m *scanModel) scanTopBar() string {
 	targetParts := []string{
 		render.Style(valueOrDash(m.project.Name), render.White, render.Bold),
 		render.Style(targetKindLabel(m.project), render.Dim),
@@ -484,14 +401,9 @@ func (m *scanModel) scanSummaryLines(active scanView) []string {
 	if strings.TrimSpace(m.project.TargetRef) != "" {
 		targetParts = append(targetParts, render.Style("ref: "+m.project.TargetRef, render.Cyan, render.Bold))
 	}
-	return []string{
-		render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
-			render.Style(m.commandLabel(), render.BgBlue, render.White, render.Bold) + " " +
-			strings.Join(targetParts, render.Style(" | ", render.Dim)),
-		"",
-		m.tabLine(active),
-		"",
-	}
+	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
+		render.Style(m.commandLabel(), render.BgBlue, render.White, render.Bold) + " " +
+		strings.Join(targetParts, render.Style(" | ", render.Dim))
 }
 
 func (m *scanModel) commandLabel() string {
@@ -504,30 +416,6 @@ func (m *scanModel) commandLabel() string {
 	default:
 		return "SCAN"
 	}
-}
-
-func (m *scanModel) tabLine(active scanView) string {
-	labels := []struct {
-		view  scanView
-		label string
-	}{
-		{interactiveScanViewOverview, "Overview"},
-		{interactiveScanViewPackages, "Components"},
-		{interactiveScanViewVulns, "Vulnerabilities"},
-		{interactiveScanViewLicenses, "Licenses"},
-		{interactiveScanViewFindings, "Findings"},
-		{interactiveScanViewSource, "Source"},
-	}
-	parts := make([]string, 0, len(labels))
-	for idx, item := range labels {
-		text := fmt.Sprintf("[%d] %s", idx+1, item.label)
-		if item.view == active {
-			parts = append(parts, render.Style(text, render.Yellow, render.Bold))
-		} else {
-			parts = append(parts, render.Style(text, render.Dim))
-		}
-	}
-	return strings.Join(parts, render.Style(" | ", render.Dim))
 }
 
 func (m *scanModel) scanStatusLine() string {
@@ -561,16 +449,6 @@ func (m *scanModel) scanFooterLines(width int) []string {
 		statusBar(m.scanFooterSummary(), width),
 		centerLine(m.scanLegend(), width),
 	}
-}
-
-func (m *scanModel) withScanFooter(list *listModel) *listModel {
-	if list == nil {
-		return nil
-	}
-	list.footerSummary = m.scanFooterSummary()
-	list.legend = m.scanLegend()
-	list.title = ""
-	return list
 }
 
 func (m *scanModel) componentControlsLine() string {
@@ -911,16 +789,16 @@ func (m *scanModel) buildOverviewListModel() *listModel {
 
 func (m *scanModel) overviewDashboardView(width, height int) string {
 	if width < 80 || height < 22 {
-		return m.list.View(width, height)
+		return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
 	}
 	var lines []string
-	for _, summaryLine := range m.scanSummaryLines(interactiveScanViewOverview) {
+	for _, summaryLine := range m.shellSummaryLines() {
 		lines = append(lines, truncateToWidth(summaryLine, width))
 	}
 	footerLines := m.scanFooterLines(width)
 	bodyHeight := height - len(lines) - len(footerLines)
 	if bodyHeight < 12 {
-		return m.list.View(width, height)
+		return m.shellModel.View(width, height) //nolint:staticcheck // explicit selector bypasses the View shadow on the embedding model
 	}
 
 	vulnerabilities := packageVulnerabilityRows(m.graphValue)
@@ -2486,11 +2364,43 @@ func distributionLine(label string, value, total, max int, color string, width i
 		percent = value * 100 / total
 	}
 	text := fmt.Sprintf("%d %s (%d%%)", value, label, percent)
-	barWidth := width - 26
+	// Scale the label column with the pane width so composite labels like
+	// "1 changed runtime (100%)" don't get truncated mid-percentage.
+	// Floor of 22 keeps short labels in narrow panes looking the same as
+	// before; cap of 40 keeps the bar visible on very wide screens.
+	//
+	// Sizing contract: this function is called by panes that have already
+	// budgeted `width` as the pane's inner width (caller passes
+	// `paneWidth-2`). boxView then reserves another 2 cols for horizontal
+	// padding, so the actual visible content area is `width-2`. Layout:
+	//
+	//   padRight(text, textWidth+2) + bar(barWidth)   ==>   total = width - 2
+	//
+	// Anything longer gets clipped by boxView and we lose the bar tail.
+	textWidth := width / 2
+	if textWidth < 22 {
+		textWidth = 22
+	}
+	if textWidth > 40 {
+		textWidth = 40
+	}
+	// Bar takes whatever's left after the label column. We prefer at
+	// least 8 cols of bar, but never at the cost of overflowing the
+	// `width-2` box budget — when the pane is genuinely narrow, the
+	// label column shrinks rather than the bar overrun the borders.
+	barWidth := width - textWidth - 4 // -2 for padRight gap, -2 for box horizontal padding
 	if barWidth < 8 {
 		barWidth = 8
+		textWidth = width - barWidth - 4
+		if textWidth < 8 {
+			textWidth = 8
+			barWidth = width - textWidth - 4
+			if barWidth < 1 {
+				barWidth = 1
+			}
+		}
 	}
-	return padRight(truncateToWidth(text, 22), 24) + coloredBarLine(value, max, barWidth, color)
+	return padRight(truncateToWidth(text, textWidth), textWidth+2) + coloredBarLine(value, max, barWidth, color)
 }
 
 func coloredBarLine(value, max, width int, color string) string {

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -1,0 +1,195 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+)
+
+// TabBuild produces the listModel that backs a single tab. The shell calls
+// it whenever the active tab is (re)rendered so the tab can read fresh
+// state from the embedding command model.
+type TabBuild func() *listModel
+
+// TabSpec describes one tab in the shared TUI shell.
+type TabSpec struct {
+	ID    string
+	Label string
+	Build TabBuild
+}
+
+// ShellSpec configures a shellModel: a top-bar line, a list of tabs, and
+// optional footer lines. Commands (scan, diff, explain) construct one and
+// embed *shellModel to inherit tab cycling, the tab strip, and listModel
+// delegation.
+type ShellSpec struct {
+	TopBar func() string
+	Tabs   []TabSpec
+	Footer func() (summary, legend string)
+}
+
+// shellModel owns the cross-command TUI chrome: which tab is active, the
+// top-bar logo, the tab strip, and forwarding of listModel-level methods
+// (search, scroll, move) to the active tab. Each command's model embeds
+// *shellModel and supplies a ShellSpec at construction.
+type shellModel struct {
+	spec    ShellSpec
+	active  int
+	list    *listModel
+	rebuild func() // optional override used by callers that need to refresh after state changes
+}
+
+func newShell(spec ShellSpec) *shellModel {
+	s := &shellModel{spec: spec}
+	s.Rebuild()
+	return s
+}
+
+// Rebuild re-invokes the active tab's Build func. Call after the embedding
+// model mutates any state that the tab reads (filters, expansion maps, ...).
+func (s *shellModel) Rebuild() {
+	if s == nil {
+		return
+	}
+	if len(s.spec.Tabs) == 0 {
+		s.list = nil
+		return
+	}
+	if s.active < 0 || s.active >= len(s.spec.Tabs) {
+		s.active = 0
+	}
+	s.list = s.spec.Tabs[s.active].Build()
+	if s.list == nil {
+		return
+	}
+	s.list.summary = append(s.shellSummaryLines(), s.list.summary...)
+	if s.spec.Footer != nil {
+		summary, legend := s.spec.Footer()
+		if strings.TrimSpace(summary) != "" {
+			s.list.footerSummary = summary
+		}
+		if strings.TrimSpace(legend) != "" {
+			s.list.legend = legend
+		}
+		s.list.title = ""
+	}
+}
+
+func (s *shellModel) shellSummaryLines() []string {
+	out := make([]string, 0, 4)
+	if s.spec.TopBar != nil {
+		if line := strings.TrimRight(s.spec.TopBar(), " "); line != "" {
+			out = append(out, line, "")
+		}
+	}
+	out = append(out, s.TabLine(), "")
+	return out
+}
+
+// TabLine renders the active-tab-highlighted "[1] Foo | [2] Bar" strip.
+func (s *shellModel) TabLine() string {
+	parts := make([]string, 0, len(s.spec.Tabs))
+	for idx, tab := range s.spec.Tabs {
+		text := fmt.Sprintf("[%d] %s", idx+1, tab.Label)
+		if idx == s.active {
+			parts = append(parts, render.Style(text, render.Yellow, render.Bold))
+		} else {
+			parts = append(parts, render.Style(text, render.Dim))
+		}
+	}
+	return strings.Join(parts, render.Style(" | ", render.Dim))
+}
+
+// ActiveTabID returns the ID string of the active tab, or "" if there are no
+// tabs. Embedding models use it to branch View() or specialize behavior.
+func (s *shellModel) ActiveTabID() string {
+	if s == nil || s.active < 0 || s.active >= len(s.spec.Tabs) {
+		return ""
+	}
+	return s.spec.Tabs[s.active].ID
+}
+
+// List exposes the active listModel so the embedding command can poke at
+// it (e.g. preserve selected index across rebuilds).
+func (s *shellModel) List() *listModel { return s.list }
+
+// CycleView advances to the next tab.
+func (s *shellModel) CycleView() {
+	if s == nil || len(s.spec.Tabs) == 0 {
+		return
+	}
+	s.active = (s.active + 1) % len(s.spec.Tabs)
+	s.Rebuild()
+}
+
+// SelectView jumps to the 1-indexed tab.
+func (s *shellModel) SelectView(index int) {
+	if s == nil || index < 1 || index > len(s.spec.Tabs) {
+		return
+	}
+	s.active = index - 1
+	s.Rebuild()
+}
+
+// View delegates to the active listModel. Embedding models can override
+// when a tab wants a custom non-list renderer (e.g. scan's overview
+// dashboard).
+func (s *shellModel) View(width, height int) string {
+	if s == nil || s.list == nil {
+		return ""
+	}
+	return s.list.View(width, height)
+}
+
+func (s *shellModel) Move(delta int) {
+	if s != nil && s.list != nil {
+		s.list.Move(delta)
+	}
+}
+func (s *shellModel) Home() {
+	if s != nil && s.list != nil {
+		s.list.Home()
+	}
+}
+func (s *shellModel) End() {
+	if s != nil && s.list != nil {
+		s.list.End()
+	}
+}
+func (s *shellModel) ScrollDetails(delta int) {
+	if s != nil && s.list != nil {
+		s.list.ScrollDetails(delta)
+	}
+}
+func (s *shellModel) BeginSearch() {
+	if s != nil && s.list != nil {
+		s.list.BeginSearch()
+	}
+}
+func (s *shellModel) AppendSearch(value string) {
+	if s != nil && s.list != nil {
+		s.list.AppendSearch(value)
+	}
+}
+func (s *shellModel) BackspaceSearch() {
+	if s != nil && s.list != nil {
+		s.list.BackspaceSearch()
+	}
+}
+func (s *shellModel) CancelSearch() {
+	if s != nil && s.list != nil {
+		s.list.CancelSearch()
+	}
+}
+func (s *shellModel) ConfirmSearch() {
+	if s != nil && s.list != nil {
+		s.list.ConfirmSearch()
+	}
+}
+func (s *shellModel) IsSearching() bool {
+	if s == nil || s.list == nil {
+		return false
+	}
+	return s.list.IsSearching()
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -115,6 +115,11 @@ type listModel struct {
 	searchMatch    bool
 	footerSummary  string
 	legend         string
+	// bodyOverride, when non-nil, replaces the standard list-and-detail body
+	// region with a caller-rendered block of `height` rows of `width` columns.
+	// The shell chrome (title, summary, controls, topPanels, footer) renders
+	// exactly as if the override were absent; only the middle band changes.
+	bodyOverride func(width, height int) []string
 }
 
 type listPanel struct {
@@ -173,6 +178,8 @@ const (
 )
 
 type scanModel struct {
+	*shellModel
+
 	titlePrefix           string
 	project               output.ProjectDescriptor
 	graphValue            *sdk.Graph
@@ -180,7 +187,6 @@ type scanModel struct {
 	manifests             []listPackageRow
 	manifestByID          map[string]listPackageRow
 	mode                  scanMode
-	activeView            scanView
 	findings              []sdk.Finding
 	enrichEnabled         bool
 	currentManifestID     string
@@ -198,7 +204,6 @@ type scanModel struct {
 	licenseExpanded       map[string]bool
 	findingGroup          string
 	findingExpanded       map[string]bool
-	list                  *listModel
 }
 
 type teaModel struct {
@@ -551,6 +556,19 @@ func (m *listModel) View(width, height int) string {
 	if len(topPanelLines) > 0 {
 		lines = append(lines, topPanelLines...)
 		lines = append(lines, "")
+	}
+
+	if m.bodyOverride != nil {
+		body := m.bodyOverride(width, bodyHeight)
+		for i := 0; i < bodyHeight; i++ {
+			if i < len(body) {
+				lines = append(lines, body[i])
+			} else {
+				lines = append(lines, "")
+			}
+		}
+		lines = append(lines, footerLines...)
+		return strings.Join(lines, "\n")
 	}
 
 	visible := m.visibleItemIndices()

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -136,18 +136,16 @@ func TestNewDiffInteractiveModel_ViewIncludesManifestChanges(t *testing.T) {
 			AddedPackageCount:    1,
 			ChangedPackageCount:  1,
 		},
-	})
+	}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 
-	view := model.View(100, 26)
+	view := model.View(140, 32)
 	for _, want := range []string{
 		"DIFF",
 		"base -> head",
 		"[1] Overview",
-		"[2] Added",
-		"package.json (npm)",
-		"Manifest Changes",
-		"Package Changes",
-		"Added packages",
+		"[2] Components",
+		"Manifests",
+		"Packages",
 	} {
 		if !strings.Contains(render.StripANSI(view), want) {
 			t.Fatalf("expected view to contain %q, got:\n%s", want, view)
@@ -770,7 +768,7 @@ func TestScanInteractiveModel_ManifestDetailsIncludeDetectorMetadata(t *testing.
 func TestScanInteractiveModel_FindingsCanGroupByEcosystem(t *testing.T) {
 	pkg := sdk.NewPackage(sdk.Package{Name: "react", Version: "18.2.0", Ecosystem: "npm"})
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, sdk.ConsolidatedGraph{}, sdk.New(), []sdk.Finding{
-		{ID: "F-1", Kind: sdk.FindingKindPolicy, Severity: "high", Package: pkg},
+		{ID: "F-1", Kind: sdk.FindingKindLicense, Severity: "high", Package: pkg},
 	})
 	model.SelectView(5)
 	for range 3 {
@@ -1270,7 +1268,7 @@ func TestBuildLicensesListModel_GroupsByUniqueLicense(t *testing.T) {
 		t.Fatalf("ConsolidatedGraph() error = %v", err)
 	}
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
-	model.activeView = interactiveScanViewLicenses
+	model.SelectView(4) // Licenses (1: Overview, 2: Components, 3: Vulns, 4: Licenses)
 	list := model.buildLicensesListModel()
 
 	if len(list.items) != 2 {
@@ -1295,53 +1293,84 @@ func TestBuildLicensesListModel_GroupsByUniqueLicense(t *testing.T) {
 	}
 }
 
-func TestNewDiffInteractiveModel_OrdersRemovedAddedChanged(t *testing.T) {
+func TestNewDiffInteractiveModel_ComponentsTabGroupsByStatusByDefault(t *testing.T) {
 	model := NewDiff(output.DiffResponse{
 		Results: output.DiffResults{Manifests: []output.DiffManifestResult{
-			{Status: "changed", Path: "b", PackageManager: "npm"},
-			{Status: "added", Path: "c", PackageManager: "npm"},
-			{Status: "removed", Path: "a", PackageManager: "npm"},
+			{Status: "changed", Path: "b", PackageManager: "npm", Added: []output.DiffPackageChange{{Package: output.PackageRef{Name: "x"}}}},
+			{Status: "added", Path: "c", PackageManager: "npm", Added: []output.DiffPackageChange{{Package: output.PackageRef{Name: "y"}}}},
+			{Status: "removed", Path: "a", PackageManager: "npm", Removed: []output.DiffPackageChange{{Package: output.PackageRef{Name: "z"}}}},
 		}},
-	})
+	}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 
-	if got, want := model.items[0].subtitle, "removed"; got != want {
-		t.Fatalf("expected first item status %q, got %q", want, got)
+	model.SelectView(2) // Components
+
+	list := model.List()
+	if list == nil {
+		t.Fatalf("expected components list to be built")
 	}
-	if got, want := model.items[1].subtitle, "added"; got != want {
-		t.Fatalf("expected second item status %q, got %q", want, got)
+	// Default grouping is "status": groups appear in Added / Changed / Removed order.
+	// Each group is followed by its members. Two of the inputs are status=added
+	// (one from `.Added` on the "added" manifest, one from `.Added` on the
+	// "changed" manifest), one is status=removed.
+	if len(list.items) < 4 {
+		t.Fatalf("expected at least 4 items (3 groups + members), got %d", len(list.items))
 	}
-	if got, want := model.items[2].subtitle, "changed"; got != want {
-		t.Fatalf("expected third item status %q, got %q", want, got)
+	if got, want := list.items[0].title, "Added (2)"; got != want {
+		t.Fatalf("expected first group %q, got %q", want, got)
+	}
+	// Verify removed group exists somewhere later.
+	foundRemoved := false
+	for _, it := range list.items {
+		if strings.HasPrefix(it.title, "Removed (") {
+			foundRemoved = true
+			break
+		}
+	}
+	if !foundRemoved {
+		t.Fatalf("expected a Removed group, got items: %+v", list.items)
 	}
 }
 
-func TestNewDiffInteractiveModel_UsesPackageTabs(t *testing.T) {
+func TestNewDiffInteractiveModel_ComponentsCycleGroupingAxis(t *testing.T) {
 	model := NewDiff(output.DiffResponse{
 		Comparison: output.DiffComparison{Base: "base", Head: "head"},
 		Results: output.DiffResults{Manifests: []output.DiffManifestResult{{
 			Status:         "changed",
 			Path:           "package.json",
 			PackageManager: "npm",
+			Ecosystem:      "npm",
 			Added:          []output.DiffPackageChange{{Package: output.PackageRef{Name: "zod", Version: "3.23.0"}}},
 			Removed:        []output.DiffPackageChange{{Package: output.PackageRef{Name: "left-pad", Version: "1.3.0"}}},
 			Changed:        []output.DiffChangedPackage{{Before: output.PackageRef{Name: "react", Version: "18.2.0"}, After: output.PackageRef{Name: "react", Version: "19.0.0"}}},
 		}}},
 		Summary: output.DiffSummary{AddedPackageCount: 1, RemovedPackageCount: 1, ChangedPackageCount: 1},
-	})
+	}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 
-	model.SelectView(2)
-	plain := render.StripANSI(model.View(100, 26))
-	if !strings.Contains(plain, "[2] Added") || !strings.Contains(plain, "zod@3.23.0") || strings.Contains(plain, "left-pad@1.3.0") {
-		t.Fatalf("expected added package tab, got:\n%s", plain)
+	model.SelectView(2) // Components
+
+	plain := render.StripANSI(model.View(140, 40))
+	// Default grouping = status. All three package changes should be visible.
+	if !strings.Contains(plain, "zod@3.23.0") {
+		t.Fatalf("expected components tab to show added package (zod), got:\n%s", plain)
 	}
-	model.SelectView(3)
-	plain = render.StripANSI(model.View(100, 26))
-	if !strings.Contains(plain, "[3] Removed") || !strings.Contains(plain, "left-pad@1.3.0") || strings.Contains(plain, "zod@3.23.0") {
-		t.Fatalf("expected removed package tab, got:\n%s", plain)
+	if !strings.Contains(plain, "left-pad@1.3.0") {
+		t.Fatalf("expected components tab to show removed package (left-pad), got:\n%s", plain)
 	}
-	model.SelectView(4)
-	plain = render.StripANSI(model.View(100, 26))
-	if !strings.Contains(plain, "[4] Changed") || !strings.Contains(plain, "react@19.0.0") || !strings.Contains(plain, "react@18.2.0") {
-		t.Fatalf("expected changed package tab, got:\n%s", plain)
+	if !strings.Contains(plain, "Group: Status") {
+		t.Fatalf("expected default group to be Status, got:\n%s", plain)
+	}
+
+	// Cycle grouping: Status -> Manifest. All three changes still visible
+	// (grouping is structural, not a filter).
+	model.CycleGroup()
+	plain = render.StripANSI(model.View(140, 40))
+	if !strings.Contains(plain, "Group: Manifest") {
+		t.Fatalf("expected group to cycle to Manifest, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "zod@3.23.0") {
+		t.Fatalf("expected manifest-group to still show zod, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "left-pad@1.3.0") {
+		t.Fatalf("expected manifest-group to still show left-pad, got:\n%s", plain)
 	}
 }

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -131,6 +131,19 @@ func statusBadge(status string) string {
 		return render.Style(label, render.BgYellow, render.Bold)
 	case "unchanged":
 		return render.Style(label, render.BgBlue, render.White)
+	case "new": // audit-delta "introduced" (display-side label)
+		return render.Style(label, render.BgRed, render.White, render.Bold)
+	case "old": // audit-delta "persisted"
+		return render.Style(label, render.BgYellow, render.Bold)
+	case "fixed": // audit-delta "resolved"
+		return render.Style(label, render.BgGreen, render.White, render.Bold)
+	case "retired": // license-delta "retired"
+		return render.Style(label, render.BgRed, render.White, render.Bold)
+	case "introduced", "persisted", "resolved":
+		// Internal data may still feed the long words through (older code
+		// paths, tests). Translate to the short equivalent here and recurse
+		// into the colored branches above for the same coloring.
+		return statusBadge(auditStatusLabel(status))
 	default:
 		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
 	}
@@ -211,6 +224,14 @@ func statusText(status string) string {
 		return render.Style(status, render.Yellow, render.Bold)
 	case "unchanged":
 		return render.Style(status, render.Cyan, render.Bold)
+	case "new":
+		return render.Style(status, render.Red, render.Bold)
+	case "old":
+		return render.Style(status, render.Yellow, render.Bold)
+	case "fixed":
+		return render.Style(status, render.Green, render.Bold)
+	case "retired":
+		return render.Style(status, render.Red, render.Bold)
 	default:
 		return render.Style(status, render.White, render.Bold)
 	}

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -1,12 +1,21 @@
 package sdk
 
-// FindingKind categorizes audit findings.
+// FindingKind categorizes audit findings by the underlying concern the
+// auditor is reporting on. Each built-in auditor emits findings of exactly
+// one kind:
+//
+//	FindingKindVulnerability — emitted by the vulnerability auditor
+//	FindingKindLicense       — emitted by the license auditor
+//	FindingKindPackage       — emitted by the package auditor
+//
+// External plugins may introduce new kinds; consumers should treat the
+// list as open.
 type FindingKind string
 
 const (
-	FindingKindRisk          FindingKind = "risk"
 	FindingKindVulnerability FindingKind = "vulnerability"
-	FindingKindPolicy        FindingKind = "policy"
+	FindingKindLicense       FindingKind = "license"
+	FindingKindPackage       FindingKind = "package"
 )
 
 // FindingDisposition controls whether a finding should fail policy evaluation


### PR DESCRIPTION
## Summary

Reshape `bomly diff --interactive` around the same six-tab skeleton scan and explain use (**Overview / Components / Vulnerabilities / Licenses / Findings / Source**) and surface the audit + reconciliation data the pipeline already computes but used to discard.

## What changed

### SDK & auditors
- Remove unused `FindingKindRisk`; rename `FindingKindPolicy` → `FindingKindLicense`; add `FindingKindPackage`. Kind now classifies the underlying concern, not the auditor.
- License/package auditors emit their respective kinds.
- License auditor skips root packages on full-graph audits (the project itself never carries a manifest-declared license).

### Shared TUI skeleton (`internal/tui/shell.go`, new)
- `shellModel` owns tab cycling, top bar, tab strip, footer rendering, and `listModel` delegation. `scanModel` / `diffModel` embed it; explain inherits via `newScanNavigator`.
- Adding a tab is now a one-line `TabSpec` instead of duplicated `CycleView` / `SelectView` code.
- `listModel` grows an optional `bodyOverride` hook so a tab can replace just the body region (used by the Source tab side-by-side trees).

### Diff TUI tabs
- **Overview**: 5 top cards (Manifests / Packages / Vulnerabilities / Licenses / Findings-by-kind) plus a headline chip with the run-level audit verdict. Right column is three per-kind tables — **Vulnerability / License / Package Findings** — each laid out as `Severity-or-Rule × New / Old / Fixed`.
- **Components**: status (Added/Changed/Removed) becomes a grouping axis; scope / relationship / severity / ecosystem filters live separately on `r` / `s` / `v` / `e`. Removed packages look up their relationship in the base graph instead of degenerating to "unknown".
- **Vulnerabilities & Findings**: audit-status displayed as `new` / `old` / `fixed` throughout. Outcome panels mirror the actual exit-code semantics in `diff_cmd.go`; per-tab counts agree with the rows they describe.
- **Licenses**: category and recognition added as grouping axes; details pane lists every SPDX id in the active group.
- **Source**: base and head consolidated graphs render side-by-side inside the shared skeleton; `g` toggles focus.

### Polish
- `distributionLine` scales label/bar columns to pane width so composite labels (`1 changed runtime (100%)`) survive without truncation, while honouring the `boxView` content-area budget (`width-2`) at every pane size.
- Component, vulnerability, license rows no longer show the same status word twice (subtitle vs explicit badge).

### Tests
- New `internal/tui/diff_aggregations_test.go` with ~40 tests pinning every aggregation — footer counts, per-kind tables, outcome panels for Vulns & Findings tabs, audit-verdict semantics, license-rule classification, distribution budget compliance, and the `new` / `old` / `fixed` label vocabulary.
- New `internal/auditors/license/auditor_test.go` guards root-skip behaviour.

## Test plan

- [ ] `make test` — clean
- [ ] `make lint` — 0 issues
- [ ] `make fmt-check` — clean
- [ ] `go build` with and without `bomly_external_syft bomly_external_grype` tags — both build
- [ ] Manual smoke: `bin/bomly.exe diff --url https://github.com/bomly-dev/example-go-gomod --base v0.9.0 --head v1.0.0 --enrich --audit --interactive`
  - all six tabs render
  - Overview headline + 5 cards + 3 right-column tables show consistent counts
  - Components tab `g/r/s/v/e` cycles work; removed pkgs show correct relationship
  - Vulnerabilities tab `New/Old/Fixed` columns line up with row count
  - Findings tab spans vuln + license + package; `g` cycles `status/kind/package`
  - Licenses tab `g` cycles `license/status/manifest/category/recognition`
  - Source tab renders base and head side-by-side; `g` toggles focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)