### PR TITLE
[codex] Enrich diff markdown and SARIF outputs

### DIFF
--- a/.github/workflows/bomly-review.yml
+++ b/.github/workflows/bomly-review.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  security-events: write
 
 jobs:
   review:

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -78,12 +78,14 @@ bomly scan --enrich --audit --fail-on high --format sarif > bomly.sarif
 
 GitHub Code Scanning, Azure DevOps, and most IDE extensions ingest SARIF directly. See [CI integration](CI_INTEGRATION.md) for upload recipes.
 
-## SBOM output: `-o`
+## Additional output: `-o`
 
-Independent of `--format`. You can write any number of SBOM artifacts alongside the reporting output:
+Independent of `--format`. You can write review reports and SBOM artifacts alongside the primary output:
 
 ```bash
 bomly scan --format json \
+  -o markdown=summary.md \
+  -o sarif=bomly.sarif \
   -o spdx=sbom.spdx.json \
   -o cyclonedx=sbom.cdx.json
 ```
@@ -92,10 +94,12 @@ Supported targets:
 
 | `-o` value | Format |
 | --- | --- |
+| `markdown` | GitHub-flavored Markdown report |
+| `sarif` | SARIF 2.1.0 report; requires `--audit` |
 | `spdx` | SPDX 2.3 JSON |
 | `cyclonedx` | CycloneDX 1.6 JSON |
 
-See [SBOM formats](SBOM.md) for the comparison and writing rules.
+`spdx` and `cyclonedx` are supported by `scan`. `markdown` and `sarif` are supported by report-producing commands. See [SBOM formats](SBOM.md) for the SBOM comparison and writing rules.
 
 ## Combining outputs
 
@@ -110,10 +114,12 @@ Example:
 
 ```bash
 bomly scan --enrich --audit --fail-on high \
-  --format sarif \
+  --format json \
+  -o markdown=summary.md \
+  -o sarif=bomly.sarif \
   -o spdx=sbom.spdx.json \
   -o cyclonedx=sbom.cdx.json \
-  > bomly.sarif
+  > bomly.json
 ```
 
 Detector and matcher work runs once. All outputs derive from the same in-memory graph.

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -87,8 +87,11 @@ func newDiffCmd() *cobra.Command {
 			if err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
-			if err := validateMarkdownOnlyOutputs(outputSpecs); err != nil {
+			if err := validateReportOutputs(outputSpecs); err != nil {
 				return exit.InvalidInputError("%v", err)
+			}
+			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !current.Audit {
+				return exit.InvalidInputError("-o sarif requires --audit")
 			}
 			if current.Interactive && len(outputSpecs) > 0 {
 				return exit.InvalidInputError("--output cannot be combined with --interactive")
@@ -159,11 +162,23 @@ func newDiffCmd() *cobra.Command {
 			markdownRenderer := func(w io.Writer) error {
 				return render.DiffMarkdown(w, payload)
 			}
+			sarifRenderer := func(w io.Writer) error {
+				return output.WriteSARIF(w, diffResult.Findings, "bomly", cmd.Root().Version)
+			}
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
 				for _, spec := range outputSpecs {
-					if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
-						return err
+					switch spec.Format {
+					case render.OutputFormatMarkdown:
+						if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
+							return err
+						}
+					case render.OutputFormatSARIF:
+						if err := writeRenderedOutput(streams.reportWriter(), spec, sarifRenderer); err != nil {
+							return err
+						}
+					default:
+						return exit.InvalidInputError("output format %q is only supported by scan", spec.Label)
 					}
 				}
 			}

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -52,6 +52,18 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 				Added:   []output.DiffPackageChange{{Package: output.PackageRef{Name: "react", Version: "18.2.0"}}},
 				Changed: []output.DiffChangedPackage{{After: output.PackageRef{Name: "zod", Version: "3.23.0"}, Before: output.PackageRef{Name: "zod", Version: "3.22.0"}}},
 			},
+			Vulnerabilities: output.DiffVulnerabilityResults{
+				Added: []output.DiffVulnerabilityChange{{
+					Package: output.PackageRef{Name: "react", Version: "18.2.0"},
+					Vulnerability: output.VulnerabilityRef{
+						ID:       "OSV-123",
+						Severity: "high",
+						Source:   "osv",
+						Title:    "Prototype pollution in react",
+						FixedIn:  "18.2.1",
+					},
+				}},
+			},
 		},
 		Audit: &output.DiffAudit{
 			Introduced: []output.AuditFinding{{
@@ -75,10 +87,13 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 	for _, want := range []string{
 		"# Bomly Diff Summary",
 		"Compared `main` to `feature`.",
-		"- Added: 1",
-		"- Changed: 1",
+		"**Summary:** 1 added, 1 changed, 0 removed.",
+		"| added | react@18.2.0 | 18.2.0 | unknown | - | - |",
+		"| changed | zod | 3.22.0 → 3.23.0 | unknown | - | - |",
 		"## Vulnerabilities",
-		"- [fail] `react@18.2.0`: Prototype pollution in react (patched in `18.2.1`)",
+		"| ❌ | introduced | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | osv | Prototype pollution in react |",
+		"## Policy Findings",
+		"| ❌ | introduced | vulnerability | HIGH | fail | OSV-123 | react@18.2.0 | 18.2.1 | Prototype pollution in react |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("expected Markdown report to contain %q, got:\n%s", want, report)

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -59,8 +59,11 @@ func newExplainCmd() *cobra.Command {
 			if err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
-			if err := validateMarkdownOnlyOutputs(outputSpecs); err != nil {
+			if err := validateReportOutputs(outputSpecs); err != nil {
 				return exit.InvalidInputError("%v", err)
+			}
+			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !context.ResolvedConfig.Audit {
+				return exit.InvalidInputError("-o sarif requires --audit")
 			}
 			if context.ResolvedConfig.Interactive && len(outputSpecs) > 0 {
 				return exit.InvalidInputError("--output cannot be combined with --interactive")
@@ -112,8 +115,19 @@ func newExplainCmd() *cobra.Command {
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
 				for _, spec := range outputSpecs {
-					if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
-						return err
+					switch spec.Format {
+					case render.OutputFormatMarkdown:
+						if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
+							return err
+						}
+					case render.OutputFormatSARIF:
+						if err := writeRenderedOutput(streams.reportWriter(), spec, func(w io.Writer) error {
+							return output.WriteSARIF(w, explainResult.Findings, "bomly", cmd.Root().Version)
+						}); err != nil {
+							return err
+						}
+					default:
+						return exit.InvalidInputError("output format %q is only supported by scan", spec.Label)
 					}
 				}
 			}

--- a/internal/cli/output_artifacts.go
+++ b/internal/cli/output_artifacts.go
@@ -24,6 +24,15 @@ func hasStdoutOutput(specs []render.OutputSpec) bool {
 	return false
 }
 
+func hasOutputFormat(specs []render.OutputSpec, format render.OutputFormat) bool {
+	for _, spec := range specs {
+		if spec.Format == format {
+			return true
+		}
+	}
+	return false
+}
+
 func allOutputsAreSBOM(specs []render.OutputSpec) bool {
 	if len(specs) == 0 {
 		return false
@@ -39,6 +48,17 @@ func allOutputsAreSBOM(specs []render.OutputSpec) bool {
 func validateMarkdownOnlyOutputs(specs []render.OutputSpec) error {
 	for _, spec := range specs {
 		if spec.Format != render.OutputFormatMarkdown {
+			return fmt.Errorf("output format %q is only supported by scan", spec.Label)
+		}
+	}
+	return nil
+}
+
+func validateReportOutputs(specs []render.OutputSpec) error {
+	for _, spec := range specs {
+		switch spec.Format {
+		case render.OutputFormatMarkdown, render.OutputFormatSARIF:
+		default:
 			return fmt.Errorf("output format %q is only supported by scan", spec.Label)
 		}
 	}

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -17,91 +17,308 @@ func DiffMarkdown(w io.Writer, payload output.DiffResponse) error {
 			return []string{fmt.Sprintf("Compared `%s` to `%s`.", markdownInline(payload.Comparison.Base), markdownInline(payload.Comparison.Head))}
 		},
 		Sections: []MarkdownSection[output.DiffResponse]{
+			{Title: "Overview", Lines: diffOverviewMarkdown},
 			{Title: "Dependency Changes", Lines: diffDependencyMarkdown},
-			{Title: "Vulnerabilities", Lines: func(payload output.DiffResponse) []string {
-				return diffFindingMarkdown(filterAuditFindings(payload.Audit, "vulnerability", ""))
-			}},
-			{Title: "License Policy", Lines: func(payload output.DiffResponse) []string {
-				return diffFindingMarkdown(filterAuditFindings(payload.Audit, "license", ""))
-			}},
-			{Title: "Package Policy", Lines: func(payload output.DiffResponse) []string {
-				return diffFindingMarkdown(filterAuditFindings(payload.Audit, "package", ""))
-			}},
-			{Title: "Policy Evaluation", Lines: diffPolicyEvaluationMarkdown},
+			{Title: "Vulnerabilities", Lines: diffVulnerabilityMarkdown},
+			{Title: "License Changes", Lines: diffLicenseMarkdown},
+			{Title: "Policy Findings", Lines: diffPolicyFindingsMarkdown},
 		},
 	}, payload)
 }
 
-func filterAuditFindings(audit *output.DiffAudit, auditor, idContains string) []output.AuditFinding {
-	if audit == nil {
-		return nil
+func diffOverviewMarkdown(payload output.DiffResponse) []string {
+	audit := payload.Audit
+	introduced, persisted, resolved := 0, 0, 0
+	if audit != nil {
+		introduced = len(audit.Introduced)
+		persisted = len(audit.Persisted)
+		resolved = len(audit.Resolved)
 	}
-	var findings []output.AuditFinding
-	for _, finding := range audit.Introduced {
-		if auditor != "" && finding.Auditor != auditor {
-			continue
-		}
-		if idContains != "" && !strings.Contains(finding.ID, idContains) {
-			continue
-		}
-		findings = append(findings, finding)
+	status := "✅ Pass"
+	if audit != nil && outputAuditFailingCount(audit.Introduced) > 0 {
+		status = "❌ Failing findings introduced"
+	} else if audit != nil && introduced > 0 {
+		status = "⚠️ Warnings introduced"
 	}
-	sort.Slice(findings, func(i, j int) bool {
-		if findings[i].Severity != findings[j].Severity {
-			return severityRankTable(findings[i].Severity) < severityRankTable(findings[j].Severity)
-		}
-		if findings[i].ID != findings[j].ID {
-			return findings[i].ID < findings[j].ID
-		}
-		return DiffPackageDisplayName(findings[i].Package) < DiffPackageDisplayName(findings[j].Package)
-	})
-	return findings
+	return markdownTable(
+		[]string{"Status", "Manifests", "Dependencies", "Findings", "Duration"},
+		[][]string{{
+			status,
+			fmt.Sprintf("+%d / ~%d / -%d", payload.Summary.AddedManifestCount, payload.Summary.ChangedManifestCount, payload.Summary.RemovedManifestCount),
+			fmt.Sprintf("+%d / ~%d / -%d", payload.Summary.AddedPackageCount, payload.Summary.ChangedPackageCount, payload.Summary.RemovedPackageCount),
+			fmt.Sprintf("%d introduced / %d persisted / %d resolved", introduced, persisted, resolved),
+			fmt.Sprintf("%dms", payload.Metadata.DurationMS),
+		}},
+	)
 }
 
 func diffDependencyMarkdown(payload output.DiffResponse) []string {
-	return []string{
-		fmt.Sprintf("- Added: %d", len(payload.Results.Dependencies.Added)),
-		fmt.Sprintf("- Removed: %d", len(payload.Results.Dependencies.Removed)),
-		fmt.Sprintf("- Changed: %d", len(payload.Results.Dependencies.Changed)),
+	results := payload.Results.Dependencies
+	lines := []string{
+		fmt.Sprintf("**Summary:** %d added, %d changed, %d removed.", len(results.Added), len(results.Changed), len(results.Removed)),
+		"",
 	}
+	lines = append(lines, diffAddedRemovedDependencyTable("Added Dependencies", "added", results.Added)...)
+	lines = append(lines, diffChangedDependencyTable(results.Changed)...)
+	lines = append(lines, diffAddedRemovedDependencyTable("Removed Dependencies", "removed", results.Removed)...)
+	if len(results.Added) == 0 && len(results.Changed) == 0 && len(results.Removed) == 0 {
+		return []string{"✅ No dependency changes."}
+	}
+	return trimTrailingMarkdownBlanks(lines)
 }
 
-func diffFindingMarkdown(findings []output.AuditFinding) []string {
-	lines := []string{}
-	if len(findings) == 0 {
-		return []string{"No introduced findings."}
+func diffAddedRemovedDependencyTable(title, status string, changes []output.DiffPackageChange) []string {
+	if len(changes) == 0 {
+		return nil
 	}
-	for _, finding := range findings {
-		disposition := finding.Disposition
-		if strings.TrimSpace(disposition) == "" {
-			disposition = "fail"
-		}
-		pkg := DiffPackageDisplayName(finding.Package)
-		if pkg == "" {
-			pkg = "-"
-		}
-		patched := ""
-		if strings.TrimSpace(finding.FixedIn) != "" {
-			patched = fmt.Sprintf(" (patched in `%s`)", markdownInline(finding.FixedIn))
-		}
-		lines = append(lines, fmt.Sprintf(
-			"- [%s] `%s`: %s%s",
-			markdownInline(disposition),
-			markdownInline(pkg),
-			markdownText(finding.Title),
-			patched,
-		))
+	rows := make([][]string, 0, len(changes))
+	for _, change := range sortPackageChanges(changes) {
+		pkg := change.Package
+		rows = append(rows, []string{
+			status,
+			DiffPackageDisplayName(pkg),
+			valueOrDash(pkg.Version),
+			displayScope(pkg.Scope),
+			licenseList(pkg.Licenses),
+			valueOrDash(pkg.Purl),
+		})
 	}
-	return lines
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"Change", "Package", "Version", "Scope", "Licenses", "PURL"}, rows), "")...)
 }
 
-func diffPolicyEvaluationMarkdown(payload output.DiffResponse) []string {
+func diffChangedDependencyTable(changes []output.DiffChangedPackage) []string {
+	if len(changes) == 0 {
+		return nil
+	}
+	rows := make([][]string, 0, len(changes))
+	for _, change := range sortChangedPackages(changes) {
+		name := change.After.Name
+		if strings.TrimSpace(name) == "" {
+			name = change.After.ID
+		}
+		rows = append(rows, []string{
+			"changed",
+			name,
+			fmt.Sprintf("%s → %s", valueOrDash(change.Before.Version), valueOrDash(change.After.Version)),
+			displayScope(change.After.Scope),
+			licenseList(change.After.Licenses),
+			valueOrDash(change.After.Purl),
+		})
+	}
+	return append([]string{"### Changed Dependencies", ""}, append(markdownTable([]string{"Change", "Package", "Version", "Scope", "Licenses", "PURL"}, rows), "")...)
+}
+
+func diffVulnerabilityMarkdown(payload output.DiffResponse) []string {
+	results := payload.Results.Vulnerabilities
+	lines := []string{
+		fmt.Sprintf("**Summary:** %d introduced, %d resolved.", len(results.Added), len(results.Removed)),
+		"",
+	}
+	lines = append(lines, diffVulnerabilityTable("Introduced Vulnerabilities", "introduced", results.Added)...)
+	lines = append(lines, diffVulnerabilityTable("Resolved Vulnerabilities", "resolved", results.Removed)...)
+	if len(results.Added) == 0 && len(results.Removed) == 0 {
+		return []string{"✅ No vulnerability changes."}
+	}
+	return trimTrailingMarkdownBlanks(lines)
+}
+
+func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabilityChange) []string {
+	if len(changes) == 0 {
+		return nil
+	}
+	rows := make([][]string, 0, len(changes))
+	for _, change := range sortVulnerabilityChanges(changes) {
+		vuln := change.Vulnerability
+		rows = append(rows, []string{
+			findingIcon(status, vuln.Severity, ""),
+			status,
+			strings.ToUpper(valueOrDash(vuln.Severity)),
+			vuln.ID,
+			DiffPackageDisplayName(change.Package),
+			valueOrDash(vuln.FixedIn),
+			valueOrDash(vuln.Source),
+			firstNonEmpty(vuln.Title, strings.Join(vuln.Reasons, "; ")),
+		})
+	}
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Change", "Severity", "ID", "Package", "Fixed In", "Source", "Title"}, rows), "")...)
+}
+
+func diffLicenseMarkdown(payload output.DiffResponse) []string {
+	results := payload.Results.Licenses
+	lines := []string{
+		fmt.Sprintf("**Summary:** %d added, %d changed, %d removed.", len(results.Added), len(results.Changed), len(results.Removed)),
+		"",
+	}
+	lines = append(lines, diffLicenseChangeTable("Added Licenses", "added", results.Added)...)
+	lines = append(lines, diffLicenseDeltaTable(results.Changed)...)
+	lines = append(lines, diffLicenseChangeTable("Removed Licenses", "removed", results.Removed)...)
+	if len(results.Added) == 0 && len(results.Changed) == 0 && len(results.Removed) == 0 {
+		return []string{"✅ No license changes."}
+	}
+	return trimTrailingMarkdownBlanks(lines)
+}
+
+func diffLicenseChangeTable(title, status string, changes []output.DiffLicenseChange) []string {
+	if len(changes) == 0 {
+		return nil
+	}
+	rows := make([][]string, 0, len(changes))
+	for _, change := range sortLicenseChanges(changes) {
+		rows = append(rows, []string{
+			status,
+			DiffPackageDisplayName(change.Package),
+			licenseList(change.Licenses),
+		})
+	}
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"Change", "Package", "Licenses"}, rows), "")...)
+}
+
+func diffLicenseDeltaTable(changes []output.DiffLicenseDelta) []string {
+	if len(changes) == 0 {
+		return nil
+	}
+	rows := make([][]string, 0, len(changes))
+	for _, change := range sortLicenseDeltas(changes) {
+		rows = append(rows, []string{
+			"changed",
+			DiffPackageDisplayName(change.Package),
+			licenseList(change.Before),
+			licenseList(change.After),
+		})
+	}
+	return append([]string{"### Changed Licenses", ""}, append(markdownTable([]string{"Change", "Package", "Before", "After"}, rows), "")...)
+}
+
+func diffPolicyFindingsMarkdown(payload output.DiffResponse) []string {
 	if payload.Audit == nil {
 		return []string{"Policy evaluation was not included."}
 	}
-	return []string{
-		fmt.Sprintf("- Introduced findings: %d", len(payload.Audit.Introduced)),
-		fmt.Sprintf("- Persisted findings: %d", len(payload.Audit.Persisted)),
-		fmt.Sprintf("- Resolved findings: %d", len(payload.Audit.Resolved)),
+	audit := payload.Audit
+	lines := []string{
+		fmt.Sprintf("**Summary:** %d introduced, %d persisted, %d resolved.", len(audit.Introduced), len(audit.Persisted), len(audit.Resolved)),
+		"",
 	}
+	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", audit.Introduced)...)
+	lines = append(lines, diffAuditFindingTable("Persisted Findings", "persisted", audit.Persisted)...)
+	lines = append(lines, diffAuditFindingTable("Resolved Findings", "resolved", audit.Resolved)...)
+	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
+		return []string{"✅ No policy differences were identified."}
+	}
+	return trimTrailingMarkdownBlanks(lines)
+}
+
+func diffAuditFindingTable(title, status string, findings []output.AuditFinding) []string {
+	if len(findings) == 0 {
+		return nil
+	}
+	rows := make([][]string, 0, len(findings))
+	for _, finding := range sortDiffAuditFindings(findings) {
+		rows = append(rows, []string{
+			findingIcon(status, finding.Severity, finding.Disposition),
+			status,
+			valueOrDash(finding.Auditor),
+			strings.ToUpper(valueOrDash(finding.Severity)),
+			findingDisposition(finding.Disposition),
+			valueOrDash(finding.ID),
+			DiffPackageDisplayName(finding.Package),
+			valueOrDash(finding.FixedIn),
+			firstNonEmpty(finding.Title, strings.Join(finding.Reasons, "; ")),
+		})
+	}
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Status", "Category", "Severity", "Disposition", "ID", "Package", "Fixed In", "Title"}, rows), "")...)
+}
+
+func findingIcon(status, severity, disposition string) string {
+	if status == "resolved" {
+		return "✅"
+	}
+	if strings.EqualFold(disposition, "warn") {
+		return "⚠️"
+	}
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical", "high":
+		return "❌"
+	default:
+		return "⚠️"
+	}
+}
+
+func findingDisposition(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "fail"
+	}
+	return value
+}
+
+func outputAuditFailingCount(findings []output.AuditFinding) int {
+	total := 0
+	for _, finding := range findings {
+		if finding.Disposition == "" || finding.Disposition == "fail" {
+			total++
+		}
+	}
+	return total
+}
+
+func sortPackageChanges(changes []output.DiffPackageChange) []output.DiffPackageChange {
+	sorted := append([]output.DiffPackageChange(nil), changes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return DiffPackageDisplayName(sorted[i].Package) < DiffPackageDisplayName(sorted[j].Package)
+	})
+	return sorted
+}
+
+func sortChangedPackages(changes []output.DiffChangedPackage) []output.DiffChangedPackage {
+	sorted := append([]output.DiffChangedPackage(nil), changes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return DiffPackageDisplayName(sorted[i].After) < DiffPackageDisplayName(sorted[j].After)
+	})
+	return sorted
+}
+
+func sortVulnerabilityChanges(changes []output.DiffVulnerabilityChange) []output.DiffVulnerabilityChange {
+	sorted := append([]output.DiffVulnerabilityChange(nil), changes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if severityRankTable(sorted[i].Vulnerability.Severity) != severityRankTable(sorted[j].Vulnerability.Severity) {
+			return severityRankTable(sorted[i].Vulnerability.Severity) < severityRankTable(sorted[j].Vulnerability.Severity)
+		}
+		if sorted[i].Vulnerability.ID != sorted[j].Vulnerability.ID {
+			return sorted[i].Vulnerability.ID < sorted[j].Vulnerability.ID
+		}
+		return DiffPackageDisplayName(sorted[i].Package) < DiffPackageDisplayName(sorted[j].Package)
+	})
+	return sorted
+}
+
+func sortLicenseChanges(changes []output.DiffLicenseChange) []output.DiffLicenseChange {
+	sorted := append([]output.DiffLicenseChange(nil), changes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return DiffPackageDisplayName(sorted[i].Package) < DiffPackageDisplayName(sorted[j].Package)
+	})
+	return sorted
+}
+
+func sortLicenseDeltas(changes []output.DiffLicenseDelta) []output.DiffLicenseDelta {
+	sorted := append([]output.DiffLicenseDelta(nil), changes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return DiffPackageDisplayName(sorted[i].Package) < DiffPackageDisplayName(sorted[j].Package)
+	})
+	return sorted
+}
+
+func valueOrDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return "-"
 }

--- a/internal/cli/render/sbom.go
+++ b/internal/cli/render/sbom.go
@@ -15,6 +15,7 @@ type OutputFormat string
 
 const (
 	OutputFormatMarkdown  OutputFormat = "markdown"
+	OutputFormatSARIF     OutputFormat = "sarif"
 	OutputFormatSPDX      OutputFormat = "spdx"
 	OutputFormatCycloneDX OutputFormat = "cyclonedx"
 )
@@ -38,6 +39,8 @@ func ParseOutputFormat(value string) (OutputFormat, sbom.Target, string, error) 
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "markdown", "md":
 		return OutputFormatMarkdown, "", "markdown", nil
+	case "sarif":
+		return OutputFormatSARIF, "", "sarif", nil
 	case "spdx", "spdx-json":
 		return OutputFormatSPDX, sbom.TargetSPDX23JSON, "spdx", nil
 	case "cyclonedx", "cyclonedx-json":

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -617,7 +617,7 @@ func TestRoot_DiffCommand_JSONOutputWithMarkdownOutputFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read summary file: %v", err)
 	}
-	for _, want := range []string{"# Bomly Diff Summary", "Compared `" + baseSHA + "` to `" + headSHA + "`.", "- Added: 1"} {
+	for _, want := range []string{"# Bomly Diff Summary", "Compared `" + baseSHA + "` to `" + headSHA + "`.", "**Summary:** 1 added, 1 changed, 0 removed."} {
 		if !strings.Contains(string(summary), want) {
 			t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
 		}
@@ -747,6 +747,7 @@ func TestRoot_DiffCommand_AuditUsesResolvedGitRefs(t *testing.T) {
 
 	setDynamicFakeNPMOnPath(t)
 	repoDir, baseSHA, headSHA := createGitNPMRepoHistory(t)
+	sarifPath := filepath.Join(t.TempDir(), "bomly.sarif")
 
 	root, err := newRootCmd("0.9.0-test")
 	if err != nil {
@@ -768,6 +769,7 @@ func TestRoot_DiffCommand_AuditUsesResolvedGitRefs(t *testing.T) {
 		"--matchers", "grype,osv",
 		"--auditors", "vulnerability",
 		"--format", "json",
+		"-o", "sarif=" + sarifPath,
 	})
 
 	if err := root.Execute(); err != nil {
@@ -787,6 +789,13 @@ func TestRoot_DiffCommand_AuditUsesResolvedGitRefs(t *testing.T) {
 	}
 	if summary["changed_manifest_count"] == float64(0) {
 		t.Fatalf("unexpected diff summary: %#v", summary)
+	}
+	sarifBytes, err := os.ReadFile(sarifPath)
+	if err != nil {
+		t.Fatalf("read SARIF output: %v", err)
+	}
+	if !strings.Contains(string(sarifBytes), `"version": "2.1.0"`) {
+		t.Fatalf("expected SARIF output, got:\n%s", sarifBytes)
 	}
 }
 

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -69,6 +69,9 @@ func newScanCmd() *cobra.Command {
 			if err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
+			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !commandCtx.ResolvedConfig.Audit {
+				return exit.InvalidInputError("-o sarif requires --audit")
+			}
 			if current.Interactive && hasStdoutOutput(outputSpecs) {
 				return exit.InvalidInputError("--interactive cannot be combined with stdout --output")
 			}
@@ -118,6 +121,12 @@ func newScanCmd() *cobra.Command {
 						}
 					case spec.Format == render.OutputFormatMarkdown:
 						if err := writeRenderedOutput(stdout, spec, markdownRenderer); err != nil {
+							return err
+						}
+					case spec.Format == render.OutputFormatSARIF:
+						if err := writeRenderedOutput(stdout, spec, func(w io.Writer) error {
+							return output.WriteSARIF(w, findings, "bomly", cmd.Root().Version)
+						}); err != nil {
 							return err
 						}
 					default:


### PR DESCRIPTION
## Summary

- enrich `bomly diff` Markdown with overview, dependency, vulnerability, license, and policy tables
- add `sarif` as a repeatable `-o` report output for scan/explain/diff when audit is enabled
- update Bomly Review dogfood workflow permissions for SARIF upload

## Validation

- `go test ./...`
- `go run ./internal/tools/gofmtcheck` (pre-push)
- `golangci-lint run` (pre-push)
- `npx --yes prettier --check .github/workflows/bomly-review.yml`
