### PR TITLE
Fix bundled Grype matcher readiness

### DIFF
--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -24,6 +24,13 @@ import (
 // clioID is the clio application identity presented when opening the Grype vulnerability DB.
 var clioID = grypeclio.Identification{Name: "grype"}
 
+// Ready reports whether the bundled Grype matcher can run. The database may be
+// downloaded during Match on first use, so a missing cache does not make the
+// matcher unavailable.
+func (a Matcher) Ready() bool {
+	return true
+}
+
 // Match attaches Grype vulnerability matches to packages in the graph.
 func (a Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResult, error) {
 	started := time.Now()
@@ -33,7 +40,7 @@ func (a Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResult
 
 	logger := a.logger()
 
-	needsDownload := !a.Ready()
+	needsDownload := !a.dbExists()
 	if needsDownload {
 		logger.Info(fmt.Sprintf("Grype vulnerability DB not found; downloading now at %s", a.dbDir()))
 	}

--- a/internal/matchers/grype/external.go
+++ b/internal/matchers/grype/external.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -15,6 +16,12 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
+
+// Ready reports whether the external grype binary is available.
+func (a Matcher) Ready() bool {
+	_, err := exec.LookPath("grype")
+	return err == nil
+}
 
 // Match attaches Grype vulnerability matches by shelling out to the grype CLI binary.
 func (a Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResult, error) {

--- a/internal/matchers/grype/matcher.go
+++ b/internal/matchers/grype/matcher.go
@@ -48,8 +48,7 @@ func (a Matcher) Descriptor() sdk.MatcherDescriptor {
 	}
 }
 
-// Ready reports whether the Grype vulnerability database directory exists on disk.
-func (a Matcher) Ready() bool {
+func (a Matcher) dbExists() bool {
 	info, err := os.Stat(a.dbDir())
 	return err == nil && info.IsDir()
 }

--- a/internal/matchers/grype/matcher_test.go
+++ b/internal/matchers/grype/matcher_test.go
@@ -38,18 +38,18 @@ func TestMatch_NilGraph_ReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestReady_FalseWhenDBDirAbsent(t *testing.T) {
+func TestReady_TrueWhenDBDirAbsent(t *testing.T) {
 	a := Matcher{Priority: 90, DBDir: filepath.Join(t.TempDir(), "nonexistent-db")}
-	if a.Ready() {
-		t.Error("Ready() = true, want false when DB dir does not exist")
+	if !a.Ready() {
+		t.Error("Ready() = false, want true because the bundled matcher can download the DB")
 	}
 }
 
-func TestReady_TrueWhenDBDirExists(t *testing.T) {
+func TestDBExists_TrueWhenDBDirExists(t *testing.T) {
 	dir := t.TempDir()
 	a := Matcher{Priority: 90, DBDir: dir}
-	if !a.Ready() {
-		t.Error("Ready() = false, want true when DB dir exists")
+	if !a.dbExists() {
+		t.Error("dbExists() = false, want true when DB dir exists")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the bundled Grype matcher report ready even when the vulnerability DB cache is empty
- keep first-run DB detection inside `Match`, where the bundled matcher already downloads the DB
- add an external-Grype `Ready` implementation that checks the `grype` binary on PATH

## Why
Dogfood PRs showed `matcher grype: not ready` on fresh GitHub runners. The engine checked `Ready()` before calling `Match()`, so the bundled matcher never reached its existing first-run DB download path.

## Validation
- `go test ./internal/matchers/grype ./internal/engine`
- `go test ./...`
- commit hook: `gofmtcheck` and `golangci-lint run`