### PR TITLE
Focus diff Markdown policy findings

### DIFF
--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -101,6 +101,62 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 	}
 }
 
+func TestRenderDiffMarkdownFocusesPersistedAndResolvedFindingsOnChangedPackages(t *testing.T) {
+	payload := output.DiffResponse{
+		Comparison: output.DiffComparison{Base: "main", Head: "feature"},
+		Results: output.DiffResults{
+			Dependencies: output.DiffDependencyResults{
+				Changed: []output.DiffChangedPackage{{
+					Before: output.PackageRef{Name: "react", Version: "18.2.0"},
+					After:  output.PackageRef{Name: "react", Version: "18.2.1"},
+				}},
+			},
+		},
+		Audit: &output.DiffAudit{
+			Introduced: []output.AuditFinding{{
+				ID:          "license:unknown",
+				Auditor:     "license",
+				Disposition: "warn",
+				Package:     output.PackageRef{Name: "new-package", Version: "1.0.0"},
+				Title:       "Package license is unknown",
+			}},
+			Persisted: []output.AuditFinding{
+				{ID: "CVE-REACT", Auditor: "vulnerability", Severity: "medium", Package: output.PackageRef{Name: "react", Version: "18.2.1"}, Title: "React finding"},
+				{ID: "CVE-LODASH", Auditor: "vulnerability", Severity: "medium", Package: output.PackageRef{Name: "lodash", Version: "4.17.20"}, Title: "Unrelated finding"},
+			},
+			Resolved: []output.AuditFinding{
+				{ID: "CVE-REACT-OLD", Auditor: "vulnerability", Severity: "medium", Package: output.PackageRef{Name: "react", Version: "18.2.0"}, Title: "Old React finding"},
+				{ID: "CVE-MINIMIST", Auditor: "vulnerability", Severity: "medium", Package: output.PackageRef{Name: "minimist", Version: "1.2.5"}, Title: "Unrelated resolved finding"},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := render.DiffMarkdown(&out, payload); err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+
+	report := out.String()
+	for _, want := range []string{
+		"1 persisted on changed dependencies",
+		"1 resolved on changed dependencies",
+		"1 unchanged persisted and 1 unrelated resolved omitted",
+		"Persisted Findings on Changed Dependencies",
+		"Resolved Findings on Changed Dependencies",
+		"CVE-REACT",
+		"CVE-REACT-OLD",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("expected Markdown report to contain %q, got:\n%s", want, report)
+		}
+	}
+	for _, unwanted := range []string{"CVE-LODASH", "CVE-MINIMIST"} {
+		if strings.Contains(report, unwanted) {
+			t.Fatalf("did not expect Markdown report to contain %q, got:\n%s", unwanted, report)
+		}
+	}
+}
+
 func TestWriteRenderedOutputCreatesParentDirectory(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "summary.md")
 	if err := writeRenderedOutput(bytes.NewBuffer(nil), render.OutputSpec{Format: render.OutputFormatMarkdown, Label: "markdown", Path: path}, func(w io.Writer) error {

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -27,17 +27,17 @@ func DiffMarkdown(w io.Writer, payload output.DiffResponse) error {
 }
 
 func diffOverviewMarkdown(payload output.DiffResponse) []string {
-	audit := payload.Audit
 	introduced, persisted, resolved := 0, 0, 0
-	if audit != nil {
-		introduced = len(audit.Introduced)
-		persisted = len(audit.Persisted)
-		resolved = len(audit.Resolved)
+	policy := diffPolicyDisplayFindings(payload)
+	if payload.Audit != nil {
+		introduced = len(policy.Introduced)
+		persisted = len(policy.Persisted)
+		resolved = len(policy.Resolved)
 	}
 	status := "✅ Pass"
-	if audit != nil && outputAuditFailingCount(audit.Introduced) > 0 {
+	if payload.Audit != nil && outputAuditFailingCount(policy.Introduced) > 0 {
 		status = "❌ Failing findings introduced"
-	} else if audit != nil && introduced > 0 {
+	} else if payload.Audit != nil && introduced > 0 {
 		status = "⚠️ Warnings introduced"
 	}
 	return markdownTable(
@@ -193,18 +193,118 @@ func diffPolicyFindingsMarkdown(payload output.DiffResponse) []string {
 	if payload.Audit == nil {
 		return []string{"Policy evaluation was not included."}
 	}
-	audit := payload.Audit
+	policy := diffPolicyDisplayFindings(payload)
 	lines := []string{
-		fmt.Sprintf("**Summary:** %d introduced, %d persisted, %d resolved.", len(audit.Introduced), len(audit.Persisted), len(audit.Resolved)),
+		diffPolicySummary(policy),
 		"",
 	}
-	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", audit.Introduced)...)
-	lines = append(lines, diffAuditFindingTable("Persisted Findings", "persisted", audit.Persisted)...)
-	lines = append(lines, diffAuditFindingTable("Resolved Findings", "resolved", audit.Resolved)...)
-	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
+	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", policy.Introduced)...)
+	lines = append(lines, diffAuditFindingTable("Persisted Findings on Changed Dependencies", "persisted", policy.Persisted)...)
+	lines = append(lines, diffAuditFindingTable("Resolved Findings on Changed Dependencies", "resolved", policy.Resolved)...)
+	if len(policy.Introduced) == 0 && len(policy.Persisted) == 0 && len(policy.Resolved) == 0 {
 		return []string{"✅ No policy differences were identified."}
 	}
 	return trimTrailingMarkdownBlanks(lines)
+}
+
+type diffPolicyFindings struct {
+	Introduced       []output.AuditFinding
+	Persisted        []output.AuditFinding
+	Resolved         []output.AuditFinding
+	OmittedPersisted int
+	OmittedResolved  int
+}
+
+func diffPolicyDisplayFindings(payload output.DiffResponse) diffPolicyFindings {
+	if payload.Audit == nil {
+		return diffPolicyFindings{}
+	}
+	changed := diffChangedPackageKeySet(payload.Results.Dependencies)
+	persisted := filterAuditFindingsByPackageSet(payload.Audit.Persisted, changed)
+	resolved := filterAuditFindingsByPackageSet(payload.Audit.Resolved, changed)
+	return diffPolicyFindings{
+		Introduced:       payload.Audit.Introduced,
+		Persisted:        persisted,
+		Resolved:         resolved,
+		OmittedPersisted: len(payload.Audit.Persisted) - len(persisted),
+		OmittedResolved:  len(payload.Audit.Resolved) - len(resolved),
+	}
+}
+
+func diffPolicySummary(policy diffPolicyFindings) string {
+	parts := []string{
+		fmt.Sprintf("%d introduced", len(policy.Introduced)),
+		fmt.Sprintf("%d persisted on changed dependencies", len(policy.Persisted)),
+		fmt.Sprintf("%d resolved on changed dependencies", len(policy.Resolved)),
+	}
+	if policy.OmittedPersisted > 0 || policy.OmittedResolved > 0 {
+		parts = append(parts, fmt.Sprintf("%d unchanged persisted and %d unrelated resolved omitted", policy.OmittedPersisted, policy.OmittedResolved))
+	}
+	return "**Summary:** " + strings.Join(parts, ", ") + "."
+}
+
+func diffChangedPackageKeySet(results output.DiffDependencyResults) map[string]struct{} {
+	keys := make(map[string]struct{})
+	for _, change := range results.Added {
+		addPackageKeys(keys, change.Package)
+	}
+	for _, change := range results.Removed {
+		addPackageKeys(keys, change.Package)
+	}
+	for _, change := range results.Changed {
+		addPackageKeys(keys, change.Before)
+		addPackageKeys(keys, change.After)
+	}
+	return keys
+}
+
+func filterAuditFindingsByPackageSet(findings []output.AuditFinding, packageKeys map[string]struct{}) []output.AuditFinding {
+	if len(findings) == 0 || len(packageKeys) == 0 {
+		return nil
+	}
+	filtered := make([]output.AuditFinding, 0, len(findings))
+	for _, finding := range findings {
+		if packageKeyMatches(packageKeys, finding.Package) {
+			filtered = append(filtered, finding)
+		}
+	}
+	return filtered
+}
+
+func packageKeyMatches(keys map[string]struct{}, pkg output.PackageRef) bool {
+	for _, key := range packageKeys(pkg) {
+		if _, ok := keys[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func addPackageKeys(keys map[string]struct{}, pkg output.PackageRef) {
+	for _, key := range packageKeys(pkg) {
+		keys[key] = struct{}{}
+	}
+}
+
+func packageKeys(pkg output.PackageRef) []string {
+	name := strings.ToLower(strings.TrimSpace(pkg.Name))
+	version := strings.ToLower(strings.TrimSpace(pkg.Version))
+	purl := strings.ToLower(strings.TrimSpace(pkg.Purl))
+	id := strings.ToLower(strings.TrimSpace(pkg.ID))
+	keys := make([]string, 0, 4)
+	if purl != "" {
+		keys = append(keys, "purl:"+purl)
+	}
+	if id != "" {
+		keys = append(keys, "id:"+id)
+	}
+	if name != "" && version != "" {
+		keys = append(keys, "name-version:"+name+"@"+version)
+	}
+	if name != "" {
+		keys = append(keys, "name:"+name)
+	}
+	return keys
 }
 
 func diffAuditFindingTable(title, status string, findings []output.AuditFinding) []string {


### PR DESCRIPTION
## Summary
- keep introduced policy findings visible in diff Markdown
- filter persisted and resolved policy finding tables to packages that were actually added, removed, or version-changed
- include omitted counts so unchanged/unrelated finding totals remain transparent without flooding PR comments

## Why
Dogfood PR comments were bloated with persisted and resolved findings from packages unrelated to the dependency diff, hiding the useful review signal.

## Validation
- `go test ./internal/cli ./internal/cli/render`
- `go test ./internal/plugin` after a transient Windows temp rename failure in the full suite
- full `go test ./...` was run; all packages passed except that transient `internal/plugin` run, which passed on rerun
- commit hook: `gofmtcheck` and `golangci-lint run`