### PR TITLE
feat(plugin): add test and doctor health commands

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -13,8 +13,7 @@ on:
           - major
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
 
 concurrency:
   group: auto-version-main
@@ -23,11 +22,23 @@ concurrency:
 jobs:
   bump-tag-and-release:
     runs-on: ubuntu-latest
+
     steps:
+      - name: Create release bot token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-actions: write
+
       - name: Check out repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Require main branch
         shell: bash
@@ -80,6 +91,7 @@ jobs:
 
           next="${major}.${minor}.${patch}"
           tag="v${next}"
+
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "Tag ${tag} already exists" >&2
             exit 1
@@ -100,22 +112,22 @@ jobs:
       - name: Commit version bump and tag
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
           git add cmd/bomly/main.go
           git commit -m "chore(release): ${TAG} [skip ci]"
           git tag -a "${TAG}" -m "Release ${TAG}"
+
           git push origin HEAD:main
           git push origin "${TAG}"
 
       - name: Start release workflow
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: gh workflow run release.yml --ref "${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
-  publish:
+  create-release:
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -46,97 +46,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: |
-            go.sum
-
-      - name: Generate third-party license notices
-        run: make licenses
-
-      - name: Build release archives
-        shell: bash
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          repo_root="${PWD}"
-          binary_version="${VERSION#v}"
-          mkdir -p dist
-
-          targets=(
-            "linux amd64"
-            "linux arm64"
-            "darwin amd64"
-            "darwin arm64"
-            "windows amd64"
-            "windows arm64"
-          )
-
-          build_archive() {
-            local archive_base="$1"
-            local binary_name="$2"
-            local build_tags="$3"
-            local target_goos="$4"
-            local target_goarch="$5"
-            local stage_dir
-            stage_dir="$(mktemp -d)"
-
-            local ext=""
-            local archive_ext="tar.gz"
-            if [[ "${target_goos}" == "windows" ]]; then
-              ext=".exe"
-              archive_ext="zip"
-            fi
-
-            if [[ -n "${build_tags}" ]]; then
-              GOOS="${target_goos}" GOARCH="${target_goarch}" CGO_ENABLED=0 go build \
-                -trimpath \
-                -tags "${build_tags}" \
-                -ldflags "-s -w -X main.version=${binary_version}" \
-                -o "${stage_dir}/${binary_name}${ext}" \
-                ./cmd/bomly
-            else
-              GOOS="${target_goos}" GOARCH="${target_goarch}" CGO_ENABLED=0 go build \
-                -trimpath \
-                -ldflags "-s -w -X main.version=${binary_version}" \
-                -o "${stage_dir}/${binary_name}${ext}" \
-                ./cmd/bomly
-            fi
-
-            cp -r "${repo_root}/licenses" "${stage_dir}/licenses"
-            cp "${repo_root}/LICENSE" "${stage_dir}/LICENSE"
-            cp "${repo_root}/NOTICE" "${stage_dir}/NOTICE"
-
-            local archive_path="dist/${archive_base}_${VERSION}_${target_goos}_${target_goarch}.${archive_ext}"
-            if [[ "${archive_ext}" == "zip" ]]; then
-              (
-                cd "${stage_dir}"
-                zip -qr "${repo_root}/${archive_path}" "${binary_name}${ext}" licenses/ LICENSE NOTICE
-              )
-            else
-              tar -C "${stage_dir}" -czf "${archive_path}" "${binary_name}${ext}" licenses/ LICENSE NOTICE
-            fi
-
-            rm -rf "${stage_dir}"
-          }
-
-          for target in "${targets[@]}"; do
-            read -r target_goos target_goarch <<< "${target}"
-            build_archive "bomly" "bomly" "" "${target_goos}" "${target_goarch}"
-            build_archive "bomly-lite" "bomly-lite" "bomly_external_syft,bomly_external_grype" "${target_goos}" "${target_goarch}"
-          done
-
-      - name: Generate checksums
-        shell: bash
-        run: |
-          set -euo pipefail
-          find dist -maxdepth 1 -type f | sort | xargs sha256sum > dist/SHA256SUMS
 
       - name: Write release notes
         shell: bash
@@ -154,17 +63,131 @@ jobs:
           GitHub-native artifact attestations are intentionally deferred while the repository remains private on a non-Enterprise plan.
           EOF
 
-      - name: Publish draft prerelease
+      - name: Create draft prerelease
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release upload "${TAG}" dist/* --clobber
-          else
-            gh release create "${TAG}" dist/* \
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release create "${TAG}" \
               --title "Bomly ${TAG}" \
               --notes-file RELEASE_NOTES.md \
               --draft \
               --prerelease
           fi
+
+  build:
+    needs: create-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+
+      - name: Generate third-party license notices
+        run: make licenses
+
+      - name: Build archives
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+
+          repo_root="${PWD}"
+          binary_version="${VERSION#v}"
+          mkdir -p dist
+
+          ext=""
+          archive_ext="tar.gz"
+          if [[ "${GOOS}" == "windows" ]]; then
+            ext=".exe"
+            archive_ext="zip"
+          fi
+
+          build_archive() {
+            local archive_base="$1"
+            local binary_name="$2"
+            local build_tags="$3"
+            local stage_dir
+            stage_dir="$(mktemp -d)"
+
+            if [[ -n "${build_tags}" ]]; then
+              GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED=0 go build \
+                -trimpath \
+                -tags "${build_tags}" \
+                -ldflags "-s -w -X main.version=${binary_version}" \
+                -o "${stage_dir}/${binary_name}${ext}" \
+                ./cmd/bomly
+            else
+              GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED=0 go build \
+                -trimpath \
+                -ldflags "-s -w -X main.version=${binary_version}" \
+                -o "${stage_dir}/${binary_name}${ext}" \
+                ./cmd/bomly
+            fi
+
+            cp -r "${repo_root}/licenses" "${stage_dir}/licenses"
+            cp "${repo_root}/LICENSE" "${stage_dir}/LICENSE"
+            cp "${repo_root}/NOTICE" "${stage_dir}/NOTICE"
+
+            local archive_path="dist/${archive_base}_${VERSION}_${GOOS}_${GOARCH}.${archive_ext}"
+            if [[ "${archive_ext}" == "zip" ]]; then
+              (
+                cd "${stage_dir}"
+                zip -qr "${repo_root}/${archive_path}" "${binary_name}${ext}" licenses/ LICENSE NOTICE
+              )
+            else
+              tar -C "${stage_dir}" -czf "${archive_path}" "${binary_name}${ext}" licenses/ LICENSE NOTICE
+            fi
+
+            rm -rf "${stage_dir}"
+          }
+
+          build_archive "bomly" "bomly" ""
+          build_archive "bomly-lite" "bomly-lite" "bomly_external_syft,bomly_external_grype"
+
+      - name: Upload archives to release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: gh release upload "${TAG}" dist/* --clobber
+
+  checksums:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Generate and upload checksums
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "${TAG}" --dir dist --pattern '*.tar.gz' --pattern '*.zip'
+          find dist -maxdepth 1 -type f | sort | xargs sha256sum > dist/SHA256SUMS
+          gh release upload "${TAG}" dist/SHA256SUMS --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ If you change `internal/cli/config.go`, `internal/output/*`, `sdk/catalog.go`, `
 Development may happen inside Git worktrees. Always run commands in the active worktree directory.
 Do not assume the primary checkout path; use paths relative to the current worktree.
 Avoid destructive Git operations that can affect sibling worktrees or shared refs.
+Worktrees should be created inside `.github/worktrees/` (mirroring the `.claude/worktrees/` convention).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ make generate            # regenerate config reference, JSON schemas, schema doc
 Always run `make test` after changes. All tests must pass before marking work is done.
 If you change `internal/cli/config.go`, `internal/output/*`, `sdk/catalog.go`, `sdk/support_matrix.go`, or `internal/registry/support.go`, also run `make generate`.
 
+### Git Worktrees
+
+Development may happen inside Git worktrees. Always run commands in the active worktree directory.
+Do not assume the primary checkout path; use paths relative to the current worktree.
+Avoid destructive Git operations that can affect sibling worktrees or shared refs.
+
 ## Architecture
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for full detail. Component map:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -95,6 +95,18 @@ Verify the installation:
 bomly plugin verify bomly.example.gomod-detector
 ```
 
+Test runtime readiness (without running verify):
+
+```bash
+bomly plugin test bomly.example.gomod-detector
+```
+
+Run a full health check (verify + test):
+
+```bash
+bomly plugin doctor bomly.example.gomod-detector
+```
+
 Run a scan with the plugin selected explicitly:
 
 ```bash

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -307,10 +307,14 @@ func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (o
 	return output.BuildDiffResponse(projectIdentifier, req.Base, req.Head, diffResult.Base.Consolidated, diffResult.Head.Consolidated, diffAuditOutput(diffResult.Audit), started), nil
 }
 
-func (a *mcpOptionsAdapter) ListPlugins(_ context.Context) ([]plugin.PluginInfo, error) {
+func (a *mcpOptionsAdapter) ListPlugins(_ context.Context) (plugin.PluginListResponse, error) {
 	current := a.options.GetConfig()
 	builtins := builtInPluginInfos(current, a.version)
-	return plugin.ListPluginInfos("", builtins)
+	infos, err := plugin.ListPluginInfos("", builtins)
+	if err != nil {
+		return plugin.PluginListResponse{}, err
+	}
+	return plugin.GroupPluginInfos(infos), nil
 }
 
 func (a *mcpOptionsAdapter) VulnFixContext(ctx context.Context, req mcp.VulnFixRequest) (mcp.VulnFixResult, error) {

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -97,7 +97,7 @@ func newPluginListCmd() *cobra.Command {
 				filtered = append(filtered, info)
 			}
 			if selectedFormat == pluginListFormatJSON {
-				return writeJSON(streams.reportWriter(), filtered)
+				return writeJSON(streams.reportWriter(), managedplugin.GroupPluginInfos(filtered))
 			}
 			if len(filtered) == 0 {
 				_, err := fmt.Fprintln(streams.reportWriter(), "No plugins matched the selected filters.")
@@ -349,7 +349,9 @@ func newPluginTestCmd() *cobra.Command {
 			}
 			current := options.GetConfig()
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
-			result, err := managedplugin.Test(cmd.Context(), "", strings.TrimSpace(args[0]))
+			builtins := builtInPluginInfos(current, cmd.Root().Version)
+			all, _ := managedplugin.ListPluginInfos("", builtins)
+			result, err := managedplugin.Test(cmd.Context(), "", strings.TrimSpace(args[0]), all)
 			if err != nil {
 				return pluginCommandError(err)
 			}
@@ -394,7 +396,9 @@ func newPluginDoctorCmd() *cobra.Command {
 			}
 			current := options.GetConfig()
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
-			result, err := managedplugin.Doctor(cmd.Context(), "", strings.TrimSpace(args[0]))
+			builtins := builtInPluginInfos(current, cmd.Root().Version)
+			all, _ := managedplugin.ListPluginInfos("", builtins)
+			result, err := managedplugin.Doctor(cmd.Context(), "", strings.TrimSpace(args[0]), all)
 			if err != nil {
 				return pluginCommandError(err)
 			}

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -452,6 +453,22 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 	infos := make([]managedplugin.PluginInfo, 0)
 	reg := registry.NewRegistry(opts.RegistryConfigsFromResolved(current), *zap.NewNop())
 	reg.Build()
+
+	// Build name → instance maps for ReadyFn population.
+	detectorInstances := collectDetectorInstances(reg.AllDetectors())
+	matcherInstances := make(map[string]plugschema.Matcher)
+	for _, m := range reg.AllMatchers() {
+		matcherInstances[m.Descriptor().Name] = m
+	}
+	auditorInstances := make(map[string]plugschema.Auditor)
+	for _, a := range reg.AllAuditors() {
+		auditorInstances[a.Descriptor().Name] = a
+	}
+	analyzerInstances := make(map[string]plugschema.Analyzer)
+	for _, a := range reg.AllAnalyzers() {
+		analyzerInstances[a.Descriptor().Name] = a
+	}
+
 	detectorByName := make(map[string]plugschema.DetectorDescriptor)
 	registeredNames := make(map[string]struct{})
 	for _, descriptor := range reg.DetectorDescriptors() {
@@ -459,7 +476,14 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		detectorByName[d.Name] = d
 		registeredNames[d.Name] = struct{}{}
 		metadata := builtInMetadata(d.Name, plugschema.PluginKindDetector)
-		infos = append(infos, detectorPluginInfo(metadata, &d, coreVersion, d.Enabled))
+		info := detectorPluginInfo(metadata, &d, coreVersion, d.Enabled)
+		if det, ok := detectorInstances[d.Name]; ok {
+			det := det
+			info.ReadyFn = func(_ context.Context) (bool, string, error) {
+				return det.Ready(), "detector-ready", nil
+			}
+		}
+		infos = append(infos, info)
 	}
 
 	seenFallbackTraversal := make(map[string]struct{})
@@ -478,25 +502,78 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 	for _, name := range additionalNames {
 		d := detectorByName[name]
 		metadata := builtInMetadata(d.Name, plugschema.PluginKindDetector)
-		infos = append(infos, detectorPluginInfo(metadata, &d, coreVersion, d.Enabled))
+		info := detectorPluginInfo(metadata, &d, coreVersion, d.Enabled)
+		if det, ok := detectorInstances[d.Name]; ok {
+			det := det
+			info.ReadyFn = func(_ context.Context) (bool, string, error) {
+				return det.Ready(), "detector-ready", nil
+			}
+		}
+		infos = append(infos, info)
 	}
 
 	for _, descriptor := range reg.MatcherDescriptors() {
 		d := descriptor
 		metadata := builtInMetadata(d.Name, plugschema.PluginKindMatcher)
-		infos = append(infos, matcherPluginInfo(metadata, &d, coreVersion, d.Enabled))
+		info := matcherPluginInfo(metadata, &d, coreVersion, d.Enabled)
+		if m, ok := matcherInstances[d.Name]; ok {
+			m := m
+			info.ReadyFn = func(_ context.Context) (bool, string, error) {
+				return m.Ready(), "matcher-ready", nil
+			}
+		}
+		infos = append(infos, info)
 	}
 	for _, descriptor := range reg.AuditorDescriptors() {
 		d := descriptor
 		metadata := builtInMetadata(d.Name, plugschema.PluginKindAuditor)
-		infos = append(infos, auditorPluginInfo(metadata, &d, coreVersion, d.Enabled))
+		info := auditorPluginInfo(metadata, &d, coreVersion, d.Enabled)
+		if a, ok := auditorInstances[d.Name]; ok {
+			a := a
+			info.ReadyFn = func(_ context.Context) (bool, string, error) {
+				return a.Ready(), "auditor-ready", nil
+			}
+		}
+		infos = append(infos, info)
 	}
 	for _, descriptor := range reg.AnalyzerDescriptors() {
 		d := descriptor
 		metadata := builtInMetadata(d.Name, plugschema.PluginKindAnalyzer)
-		infos = append(infos, analyzerPluginInfo(metadata, &d, coreVersion, d.Enabled))
+		info := analyzerPluginInfo(metadata, &d, coreVersion, d.Enabled)
+		if a, ok := analyzerInstances[d.Name]; ok {
+			a := a
+			info.ReadyFn = func(_ context.Context) (bool, string, error) {
+				return a.Ready(), "analyzer-ready", nil
+			}
+		}
+		infos = append(infos, info)
 	}
 	return infos
+}
+
+// collectDetectorInstances builds a flat name→instance map that includes fallback
+// detectors reachable from the provided primary detectors.
+func collectDetectorInstances(primaries []plugschema.Detector) map[string]plugschema.Detector {
+	out := make(map[string]plugschema.Detector)
+	var walk func(d plugschema.Detector)
+	walk = func(d plugschema.Detector) {
+		if d == nil {
+			return
+		}
+		name := strings.TrimSpace(d.Descriptor().Name)
+		if name != "" {
+			if _, ok := out[name]; !ok {
+				out[name] = d
+			}
+		}
+		if fb, ok := d.(plugschema.FallbackDetector); ok {
+			walk(fb.FallbackDetector())
+		}
+	}
+	for _, p := range primaries {
+		walk(p)
+	}
+	return out
 }
 
 func builtInMetadata(id string, kind plugschema.PluginKind) *plugschema.PluginMetadata {

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -33,6 +33,8 @@ func newPluginCmd() *cobra.Command {
 		newPluginEnableCmd(),
 		newPluginDisableCmd(),
 		newPluginVerifyCmd(),
+		newPluginTestCmd(),
+		newPluginDoctorCmd(),
 	)
 	return cmd
 }
@@ -332,6 +334,114 @@ func newPluginVerifyCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Render verification results as JSON")
 	return cmd
+}
+
+func newPluginTestCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "test <id>",
+		Short: "Test runtime readiness for an installed plugin",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options, err := commandOptions(cmd)
+			if err != nil {
+				return err
+			}
+			current := options.GetConfig()
+			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
+			result, err := managedplugin.Test(cmd.Context(), "", strings.TrimSpace(args[0]))
+			if err != nil {
+				return pluginCommandError(err)
+			}
+			if jsonOutput {
+				if err := writeJSON(streams.reportWriter(), result); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(streams.reportWriter(), "Tested %s@%s\n", result.ID, result.Version); err != nil {
+					return err
+				}
+				status := "not ready"
+				label := "[fail]"
+				if result.Ready {
+					status = "ready"
+					label = "[ok]"
+				}
+				if _, err := fmt.Fprintf(streams.reportWriter(), "%s %s: %s\n", label, nonEmptyString(result.Probe, "runtime readiness"), status); err != nil {
+					return err
+				}
+			}
+			if !result.Ready {
+				return fmt.Errorf("plugin %s is not ready", result.ID)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Render runtime test results as JSON")
+	return cmd
+}
+
+func newPluginDoctorCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "doctor <id>",
+		Short: "Run verify and runtime readiness checks for an installed plugin",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options, err := commandOptions(cmd)
+			if err != nil {
+				return err
+			}
+			current := options.GetConfig()
+			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
+			result, err := managedplugin.Doctor(cmd.Context(), "", strings.TrimSpace(args[0]))
+			if err != nil {
+				return pluginCommandError(err)
+			}
+			if jsonOutput {
+				if err := writeJSON(streams.reportWriter(), result); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(streams.reportWriter(), "Doctor report for %s@%s\n", result.ID, result.Version); err != nil {
+					return err
+				}
+				for _, check := range result.Checks {
+					if _, err := fmt.Fprintf(streams.reportWriter(), "[ok] %s\n", check); err != nil {
+						return err
+					}
+				}
+				status := "not ready"
+				label := "[fail]"
+				if result.Ready {
+					status = "ready"
+					label = "[ok]"
+				}
+				if _, err := fmt.Fprintf(streams.reportWriter(), "%s %s: %s\n", label, nonEmptyString(result.Probe, "runtime readiness"), status); err != nil {
+					return err
+				}
+			}
+			if !result.Healthy {
+				return fmt.Errorf("plugin %s is unhealthy", result.ID)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Render doctor results as JSON")
+	return cmd
+}
+
+func pluginCommandError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "is not installed") {
+		return exit.InvalidInputError("%v", err)
+	}
+	if strings.Contains(err.Error(), "does not support runtime readiness probes") {
+		return exit.InvalidInputError("%v", err)
+	}
+	return err
 }
 
 func builtInPluginInfos(current config.Resolved, coreVersion string) []managedplugin.PluginInfo {

--- a/internal/cli/plugin_cmd_health_test.go
+++ b/internal/cli/plugin_cmd_health_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/cli/exit"
+	managedplugin "github.com/bomly-dev/bomly-cli/internal/plugin"
+	"github.com/bomly-dev/bomly-cli/internal/testutil"
+)
+
+func TestPluginTestReady(t *testing.T) {
+	root := newPluginTestRoot(t)
+	id := "acme.detector.cli.ready"
+	installCLIHealthDetectorPlugin(t, id, true)
+
+	var output strings.Builder
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs([]string{"plugin", "test", id})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "[ok]") || !strings.Contains(output.String(), "ready") {
+		t.Fatalf("expected ready output, got:\n%s", output.String())
+	}
+}
+
+func TestPluginTestNotReadyFails(t *testing.T) {
+	root := newPluginTestRoot(t)
+	id := "acme.detector.cli.not-ready"
+	installCLIHealthDetectorPlugin(t, id, false)
+
+	root.SetArgs([]string{"plugin", "test", id})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected plugin test to fail for not-ready plugin")
+	}
+	if code := exit.Code(err); code != 1 {
+		t.Fatalf("expected exit code 1, got %d (err=%v)", code, err)
+	}
+}
+
+func TestPluginTestUnknownPluginInvalidInput(t *testing.T) {
+	root := newPluginTestRoot(t)
+	root.SetArgs([]string{"plugin", "test", "missing.plugin"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected missing plugin to return an error")
+	}
+	if code := exit.Code(err); code != 4 {
+		t.Fatalf("expected exit code 4, got %d (err=%v)", code, err)
+	}
+}
+
+func TestPluginDoctorJSON(t *testing.T) {
+	root := newPluginTestRoot(t)
+	id := "acme.detector.cli.doctor"
+	installCLIHealthDetectorPlugin(t, id, true)
+
+	var output strings.Builder
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs([]string{"plugin", "doctor", id, "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output.String()), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput:\n%s", err, output.String())
+	}
+	if healthy, ok := result["healthy"].(bool); !ok || !healthy {
+		t.Fatalf("expected healthy=true in doctor output, got %#v", result)
+	}
+	if ready, ok := result["ready"].(bool); !ok || !ready {
+		t.Fatalf("expected ready=true in doctor output, got %#v", result)
+	}
+}
+
+func installCLIHealthDetectorPlugin(t *testing.T, id string, ready bool) {
+	t.Helper()
+	binaryPath := filepath.Join(t.TempDir(), cliTestExecutableName("bomly-plugin-cli-health"))
+	if err := testutil.BuildGoBinary(t, binaryPath, cliHealthDetectorPluginSource(id, ready)); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+	if _, err := managedplugin.Install(context.Background(), "", binaryPath, managedplugin.InstallOptions{DevBinary: true}); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+}
+
+func cliHealthDetectorPluginSource(id string, ready bool) string {
+	readyValue := "false"
+	if ready {
+		readyValue = "true"
+	}
+	return `package main
+
+import (
+	"context"
+	schemav1 "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+type detector struct{}
+
+func (d *detector) Metadata(context.Context) (*schemav1.PluginMetadata, error) {
+	return &schemav1.PluginMetadata{
+		ID:               "` + id + `",
+		Name:             "CLI Health Detector",
+		Version:          "1.0.0",
+		Kind:             schemav1.PluginKindDetector,
+		PluginAPIVersion: schemav1.PluginAPIVersion,
+	}, nil
+}
+
+func (d *detector) Descriptor(context.Context) (*schemav1.DetectorDescriptor, error) {
+	return &schemav1.DetectorDescriptor{
+		Name:           "` + id + `",
+		Enabled:        true,
+		Origin:         schemav1.ExternalOrigin,
+		SupportedModes: []schemav1.TargetMode{schemav1.TargetModeFullGraph},
+		Capabilities:   []string{"dependency-detection"},
+	}, nil
+}
+
+func (d *detector) PackageManagerSupport(context.Context) ([]schemav1.PackageManagerSupport, error) {
+	return []schemav1.PackageManagerSupport{schemav1.Support(schemav1.PackageManagerGoMod, "go.mod")}, nil
+}
+
+func (d *detector) Ready(context.Context, *schemav1.DetectRequest) (*schemav1.ReadyResponse, error) {
+	return &schemav1.ReadyResponse{Ready: ` + readyValue + `}, nil
+}
+
+func (d *detector) Applicable(context.Context, *schemav1.DetectRequest) (*schemav1.ApplicableResponse, error) {
+	return &schemav1.ApplicableResponse{Applicable: true}, nil
+}
+
+func (d *detector) Detect(context.Context, *schemav1.DetectRequest) (*schemav1.DetectResponse, error) {
+	return &schemav1.DetectResponse{}, nil
+}
+
+func main() {
+	schemav1.ServeDetector(&detector{})
+}
+`
+}
+
+func cliTestExecutableName(base string) string {
+	if strings.HasSuffix(strings.ToLower(base), ".exe") {
+		return base
+	}
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+	return base
+}

--- a/internal/cli/plugin_cmd_test.go
+++ b/internal/cli/plugin_cmd_test.go
@@ -94,19 +94,27 @@ func TestPluginList_FormatJSON(t *testing.T) {
 		t.Fatalf("root.Execute() error = %v", err)
 	}
 
-	var items []map[string]any
-	if err := json.Unmarshal([]byte(output.String()), &items); err != nil {
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output.String()), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v\noutput:\n%s", err, output.String())
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(result["detectors"], &items); err != nil {
+		t.Fatalf("json.Unmarshal detectors: %v", err)
+	}
+	// matchers/auditors/analyzers must be empty when --detectors filter is active
+	for _, key := range []string{"matchers", "auditors", "analyzers"} {
+		var other []map[string]any
+		if err := json.Unmarshal(result[key], &other); err == nil && len(other) != 0 {
+			t.Fatalf("expected %q to be empty when --detectors filter active, got %d items", key, len(other))
+		}
 	}
 	if len(items) == 0 {
 		t.Fatal("expected non-empty detector plugin JSON output")
 	}
 	foundNPMDetector := false
 	for _, item := range items {
-		kind, _ := item["kind"].(string)
-		if kind != string(plugschema.PluginKindDetector) {
-			t.Fatalf("expected detector kind only, got %q in %#v", kind, item)
-		}
 		if item["id"] != "npm-detector" {
 			continue
 		}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -37,8 +37,8 @@ func (m *mockAdapter) RunExplain(_ context.Context, _ mcp.ExplainRequest) (outpu
 func (m *mockAdapter) RunDiff(_ context.Context, _ mcp.DiffRequest) (output.DiffResponse, error) {
 	return m.diffResult, m.diffErr
 }
-func (m *mockAdapter) ListPlugins(_ context.Context) ([]managedplugin.PluginInfo, error) {
-	return m.plugins, m.pluginsErr
+func (m *mockAdapter) ListPlugins(_ context.Context) (managedplugin.PluginListResponse, error) {
+	return managedplugin.GroupPluginInfos(m.plugins), m.pluginsErr
 }
 func (m *mockAdapter) VulnFixContext(_ context.Context, _ mcp.VulnFixRequest) (mcp.VulnFixResult, error) {
 	return m.fixResult, m.fixErr
@@ -196,7 +196,7 @@ func TestDiffTool_ReturnsJSONResult(t *testing.T) {
 func TestPluginsTool_ReturnsJSONResult(t *testing.T) {
 	adapter := &mockAdapter{
 		plugins: []managedplugin.PluginInfo{
-			{BuiltIn: true, Enabled: true},
+			{Manifest: managedplugin.Manifest{Kind: "detector"}, BuiltIn: true, Enabled: true},
 		},
 	}
 	c := newTestClient(t, adapter)
@@ -205,13 +205,13 @@ func TestPluginsTool_ReturnsJSONResult(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
-	var infos []managedplugin.PluginInfo
+	var resp managedplugin.PluginListResponse
 	text := result.Content[0].(mcplib.TextContent).Text
-	if err := json.Unmarshal([]byte(text), &infos); err != nil {
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(infos) != 1 {
-		t.Errorf("len(infos) = %d, want 1", len(infos))
+	if len(resp.Detectors) != 1 {
+		t.Errorf("len(resp.Detectors) = %d, want 1", len(resp.Detectors))
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -92,7 +92,7 @@ type OptionsAdapter interface {
 	RunScan(ctx context.Context, req ScanRequest) (output.ScanResponse, error)
 	RunExplain(ctx context.Context, req ExplainRequest) (output.ExplainResponse, error)
 	RunDiff(ctx context.Context, req DiffRequest) (output.DiffResponse, error)
-	ListPlugins(ctx context.Context) ([]managedplugin.PluginInfo, error)
+	ListPlugins(ctx context.Context) (managedplugin.PluginListResponse, error)
 	VulnFixContext(ctx context.Context, req VulnFixRequest) (VulnFixResult, error)
 }
 

--- a/internal/plugin/doctor.go
+++ b/internal/plugin/doctor.go
@@ -1,0 +1,23 @@
+package plugin
+
+import "context"
+
+// Doctor runs verification and runtime readiness checks for one installed plugin.
+func Doctor(ctx context.Context, root, id string) (*DoctorResult, error) {
+	verifyResult, err := Verify(ctx, root, id)
+	if err != nil {
+		return nil, err
+	}
+	testResult, err := Test(ctx, root, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DoctorResult{
+		PluginInfo: testResult.PluginInfo,
+		Checks:     append([]string(nil), verifyResult.Checks...),
+		Ready:      testResult.Ready,
+		Healthy:    testResult.Ready,
+		Probe:      testResult.Probe,
+	}, nil
+}

--- a/internal/plugin/doctor.go
+++ b/internal/plugin/doctor.go
@@ -2,13 +2,28 @@ package plugin
 
 import "context"
 
-// Doctor runs verification and runtime readiness checks for one installed plugin.
-func Doctor(ctx context.Context, root, id string) (*DoctorResult, error) {
-	verifyResult, err := Verify(ctx, root, id)
+// Doctor runs verification and runtime readiness checks for one plugin (external or built-in).
+// builtins should be the full list returned by ListPluginInfos for the current binary.
+// For built-in plugins the verify step is skipped (there is no external binary to inspect)
+// and readiness is reported as healthy without launching an external process.
+func Doctor(ctx context.Context, root, id string, builtins []PluginInfo) (*DoctorResult, error) {
+	testResult, err := Test(ctx, root, id, builtins)
 	if err != nil {
 		return nil, err
 	}
-	testResult, err := Test(ctx, root, id)
+
+	// Built-in: no external binary to verify.
+	if testResult.BuiltIn {
+		return &DoctorResult{
+			PluginInfo: testResult.PluginInfo,
+			Checks:     []string{"built-in: no external binary to verify"},
+			Ready:      true,
+			Healthy:    true,
+			Probe:      testResult.Probe,
+		}, nil
+	}
+
+	verifyResult, err := Verify(ctx, root, id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugin/test.go
+++ b/internal/plugin/test.go
@@ -1,0 +1,78 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	plugschema "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// Test probes runtime readiness for one installed plugin.
+func Test(ctx context.Context, root, id string) (*TestResult, error) {
+	var err error
+	root, err = resolveRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	record, err := findInstalled(root, id)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := readManifest(record.Path)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := entrypointForManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+	fullEntrypoint := filepath.Join(record.Path, entry)
+
+	client, err := startPlugin(launchContext(ctx, nil), fullEntrypoint)
+	if err != nil {
+		return nil, fmt.Errorf("start plugin runtime for readiness probe: %w", err)
+	}
+	defer client.Close()
+
+	ready, probe, err := probePluginReadiness(launchContext(ctx, nil), client.Raw(), manifest.Kind)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestResult{
+		PluginInfo: PluginInfo{
+			Manifest:   manifest,
+			Installed:  record,
+			Enabled:    record.Enabled,
+			Entrypoint: fullEntrypoint,
+		},
+		Ready: ready,
+		Probe: probe,
+	}, nil
+}
+
+func probePluginReadiness(ctx context.Context, client plugschema.Client, kind plugschema.PluginKind) (bool, string, error) {
+	switch kind {
+	case plugschema.PluginKindDetector:
+		resp, err := client.DetectorReady(ctx, &plugschema.DetectRequest{})
+		if err != nil {
+			return false, "detector-ready", fmt.Errorf("run detector readiness probe: %w", err)
+		}
+		return resp != nil && resp.Ready, "detector-ready", nil
+	case plugschema.PluginKindMatcher:
+		resp, err := client.MatcherReady(ctx, &plugschema.MatchRequest{})
+		if err != nil {
+			return false, "matcher-ready", fmt.Errorf("run matcher readiness probe: %w", err)
+		}
+		return resp != nil && resp.Ready, "matcher-ready", nil
+	case plugschema.PluginKindAuditor:
+		resp, err := client.AuditorReady(ctx, &plugschema.AuditRequest{})
+		if err != nil {
+			return false, "auditor-ready", fmt.Errorf("run auditor readiness probe: %w", err)
+		}
+		return resp != nil && resp.Ready, "auditor-ready", nil
+	default:
+		return false, "", fmt.Errorf("plugin kind %q does not support runtime readiness probes", kind)
+	}
+}

--- a/internal/plugin/test.go
+++ b/internal/plugin/test.go
@@ -4,12 +4,26 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	plugschema "github.com/bomly-dev/bomly-cli/sdk"
 )
 
-// Test probes runtime readiness for one installed plugin.
-func Test(ctx context.Context, root, id string) (*TestResult, error) {
+// isNotInstalledError reports whether err is the sentinel returned by findInstalled
+// when no record matches the requested id.
+func isNotInstalledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// findInstalled returns a plain fmt.Errorf with this substring.
+	return strings.Contains(err.Error(), "is not installed")
+}
+
+// Test probes runtime readiness for one plugin (external or built-in).
+// builtins should be the full list returned by ListPluginInfos for the current binary;
+// when the id is found only in builtins, the plugin is reported as ready without
+// launching an external process.
+func Test(ctx context.Context, root, id string, builtins []PluginInfo) (*TestResult, error) {
 	var err error
 	root, err = resolveRoot(root)
 	if err != nil {
@@ -17,6 +31,18 @@ func Test(ctx context.Context, root, id string) (*TestResult, error) {
 	}
 	record, err := findInstalled(root, id)
 	if err != nil {
+		// Fall back to built-in lookup before propagating the error.
+		if isNotInstalledError(err) {
+			for _, info := range builtins {
+				if info.ID == id && info.BuiltIn {
+					return &TestResult{
+						PluginInfo: info,
+						Ready:      true,
+						Probe:      "builtin",
+					}, nil
+				}
+			}
+		}
 		return nil, err
 	}
 	manifest, err := readManifest(record.Path)

--- a/internal/plugin/test.go
+++ b/internal/plugin/test.go
@@ -35,6 +35,15 @@ func Test(ctx context.Context, root, id string, builtins []PluginInfo) (*TestRes
 		if isNotInstalledError(err) {
 			for _, info := range builtins {
 				if info.ID == id && info.BuiltIn {
+					if info.ReadyFn != nil {
+						ready, probe, readyErr := info.ReadyFn(ctx)
+						return &TestResult{
+							PluginInfo: info,
+							Ready:      ready,
+							Probe:      probe,
+						}, readyErr
+					}
+					// No ReadyFn populated — treat as ready (should not happen in normal CLI usage).
 					return &TestResult{
 						PluginInfo: info,
 						Ready:      true,

--- a/internal/plugin/test_doctor_test.go
+++ b/internal/plugin/test_doctor_test.go
@@ -14,7 +14,7 @@ func TestTestReportsReadyState(t *testing.T) {
 	id := "acme.detector.ready"
 	installDetectorPluginForHealthTests(t, root, id, true)
 
-	result, err := Test(context.Background(), root, id)
+	result, err := Test(context.Background(), root, id, nil)
 	if err != nil {
 		t.Fatalf("Test() error = %v", err)
 	}
@@ -31,7 +31,7 @@ func TestTestReportsNotReadyState(t *testing.T) {
 	id := "acme.detector.not-ready"
 	installDetectorPluginForHealthTests(t, root, id, false)
 
-	result, err := Test(context.Background(), root, id)
+	result, err := Test(context.Background(), root, id, nil)
 	if err != nil {
 		t.Fatalf("Test() error = %v", err)
 	}
@@ -45,7 +45,7 @@ func TestDoctorRunsVerifyAndTest(t *testing.T) {
 	id := "acme.detector.doctor"
 	installDetectorPluginForHealthTests(t, root, id, true)
 
-	result, err := Doctor(context.Background(), root, id)
+	result, err := Doctor(context.Background(), root, id, nil)
 	if err != nil {
 		t.Fatalf("Doctor() error = %v", err)
 	}

--- a/internal/plugin/test_doctor_test.go
+++ b/internal/plugin/test_doctor_test.go
@@ -1,0 +1,132 @@
+package plugin
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/testutil"
+)
+
+func TestTestReportsReadyState(t *testing.T) {
+	root := t.TempDir()
+	id := "acme.detector.ready"
+	installDetectorPluginForHealthTests(t, root, id, true)
+
+	result, err := Test(context.Background(), root, id)
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if !result.Ready {
+		t.Fatalf("expected plugin to be ready")
+	}
+	if result.Probe == "" {
+		t.Fatalf("expected probe label in test result")
+	}
+}
+
+func TestTestReportsNotReadyState(t *testing.T) {
+	root := t.TempDir()
+	id := "acme.detector.not-ready"
+	installDetectorPluginForHealthTests(t, root, id, false)
+
+	result, err := Test(context.Background(), root, id)
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if result.Ready {
+		t.Fatalf("expected plugin to be reported as not ready")
+	}
+}
+
+func TestDoctorRunsVerifyAndTest(t *testing.T) {
+	root := t.TempDir()
+	id := "acme.detector.doctor"
+	installDetectorPluginForHealthTests(t, root, id, true)
+
+	result, err := Doctor(context.Background(), root, id)
+	if err != nil {
+		t.Fatalf("Doctor() error = %v", err)
+	}
+	if len(result.Checks) == 0 {
+		t.Fatalf("expected doctor result to include verify checks")
+	}
+	if !result.Ready || !result.Healthy {
+		t.Fatalf("expected doctor result to be healthy, got ready=%v healthy=%v", result.Ready, result.Healthy)
+	}
+}
+
+func installDetectorPluginForHealthTests(t *testing.T, root, id string, ready bool) {
+	t.Helper()
+	binaryPath := filepath.Join(t.TempDir(), pluginTestExecutableName("bomly-plugin-fake-health"))
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeDetectorPluginSourceWithReady(id, ready)); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+	if _, err := Install(context.Background(), root, binaryPath, InstallOptions{DevBinary: true}); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+}
+
+func fakeDetectorPluginSourceWithReady(id string, ready bool) string {
+	readyValue := "false"
+	if ready {
+		readyValue = "true"
+	}
+	return `package main
+
+import (
+	"context"
+	schemav1 "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+type detector struct{}
+
+func (d *detector) Metadata(context.Context) (*schemav1.PluginMetadata, error) {
+	return &schemav1.PluginMetadata{
+		ID:               "` + id + `",
+		Name:             "Health Test Detector",
+		Version:          "1.0.0",
+		Kind:             schemav1.PluginKindDetector,
+		PluginAPIVersion: schemav1.PluginAPIVersion,
+	}, nil
+}
+
+func (d *detector) Descriptor(context.Context) (*schemav1.DetectorDescriptor, error) {
+	return &schemav1.DetectorDescriptor{
+		Name:           "` + id + `",
+		Enabled:        true,
+		Origin:         schemav1.ExternalOrigin,
+		SupportedModes: []schemav1.TargetMode{schemav1.TargetModeFullGraph},
+		Capabilities:   []string{"dependency-detection"},
+	}, nil
+}
+
+func (d *detector) PackageManagerSupport(context.Context) ([]schemav1.PackageManagerSupport, error) {
+	return []schemav1.PackageManagerSupport{schemav1.Support(schemav1.PackageManagerGoMod, "go.mod")}, nil
+}
+
+func (d *detector) Ready(context.Context, *schemav1.DetectRequest) (*schemav1.ReadyResponse, error) {
+	return &schemav1.ReadyResponse{Ready: ` + readyValue + `}, nil
+}
+
+func (d *detector) Applicable(context.Context, *schemav1.DetectRequest) (*schemav1.ApplicableResponse, error) {
+	return &schemav1.ApplicableResponse{Applicable: true}, nil
+}
+
+func (d *detector) Detect(context.Context, *schemav1.DetectRequest) (*schemav1.DetectResponse, error) {
+	return &schemav1.DetectResponse{}, nil
+}
+
+func main() {
+	schemav1.ServeDetector(&detector{})
+}
+`
+}
+
+func pluginTestExecutableName(base string) string {
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+	return base
+}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -123,6 +123,22 @@ type VerifyResult struct {
 	Checks []string
 }
 
+// TestResult describes runtime readiness checks for one plugin.
+type TestResult struct {
+	PluginInfo
+	Ready bool   `json:"ready"`
+	Probe string `json:"probe,omitempty"`
+}
+
+// DoctorResult describes combined verification and runtime readiness checks.
+type DoctorResult struct {
+	PluginInfo
+	Checks  []string `json:"checks,omitempty"`
+	Ready   bool     `json:"ready"`
+	Healthy bool     `json:"healthy"`
+	Probe   string   `json:"probe,omitempty"`
+}
+
 func defaultRoot() (string, error) {
 	if override := strings.TrimSpace(os.Getenv(EnvPluginHome)); override != "" {
 		return filepath.Clean(override), nil

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -115,6 +115,10 @@ type PluginInfo struct {
 	Enabled    bool
 	Entrypoint string
 	SourceType string
+	// ReadyFn, when non-nil, is called by Test() to probe readiness for built-in plugins.
+	// Populated by the CLI layer from the in-process component instance.
+	// Never serialized to JSON.
+	ReadyFn func(context.Context) (bool, string, error) `json:"-"`
 }
 
 // VerifyResult describes the checks performed for one plugin.

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -139,6 +139,38 @@ type DoctorResult struct {
 	Probe   string   `json:"probe,omitempty"`
 }
 
+// PluginListResponse is the structured JSON response for the plugin list command,
+// with plugins grouped by kind.
+type PluginListResponse struct {
+	Detectors []PluginInfo `json:"detectors"`
+	Matchers  []PluginInfo `json:"matchers"`
+	Auditors  []PluginInfo `json:"auditors"`
+	Analyzers []PluginInfo `json:"analyzers"`
+}
+
+// GroupPluginInfos groups a flat slice of PluginInfo by kind into a PluginListResponse.
+func GroupPluginInfos(infos []PluginInfo) PluginListResponse {
+	resp := PluginListResponse{
+		Detectors: []PluginInfo{},
+		Matchers:  []PluginInfo{},
+		Auditors:  []PluginInfo{},
+		Analyzers: []PluginInfo{},
+	}
+	for _, info := range infos {
+		switch info.Kind {
+		case plugschema.PluginKindDetector:
+			resp.Detectors = append(resp.Detectors, info)
+		case plugschema.PluginKindMatcher:
+			resp.Matchers = append(resp.Matchers, info)
+		case plugschema.PluginKindAuditor:
+			resp.Auditors = append(resp.Auditors, info)
+		case plugschema.PluginKindAnalyzer:
+			resp.Analyzers = append(resp.Analyzers, info)
+		}
+	}
+	return resp
+}
+
 func defaultRoot() (string, error) {
 	if override := strings.TrimSpace(os.Getenv(EnvPluginHome)); override != "" {
 		return filepath.Clean(override), nil

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -342,6 +342,38 @@ func (r *Registry) DetectorDescriptors() []sdk.DetectorDescriptor {
 	return descriptors
 }
 
+// AllDetectors returns all registered detectors in registration order, without
+// any filtering. Intended for introspection (e.g. plugin test/doctor).
+func (r *Registry) AllDetectors() []sdk.Detector {
+	result := make([]sdk.Detector, len(r.detectors))
+	copy(result, r.detectors)
+	return result
+}
+
+// AllMatchers returns all registered matchers in registration order, without
+// any filtering. Intended for introspection (e.g. plugin test/doctor).
+func (r *Registry) AllMatchers() []sdk.Matcher {
+	result := make([]sdk.Matcher, len(r.matchers))
+	copy(result, r.matchers)
+	return result
+}
+
+// AllAuditors returns all registered auditors in registration order, without
+// any filtering. Intended for introspection (e.g. plugin test/doctor).
+func (r *Registry) AllAuditors() []sdk.Auditor {
+	result := make([]sdk.Auditor, len(r.auditors))
+	copy(result, r.auditors)
+	return result
+}
+
+// AllAnalyzers returns all registered analyzers in registration order, without
+// any filtering. Intended for introspection (e.g. plugin test/doctor).
+func (r *Registry) AllAnalyzers() []sdk.Analyzer {
+	result := make([]sdk.Analyzer, len(r.analyzers))
+	copy(result, r.analyzers)
+	return result
+}
+
 // AuditorDescriptors returns registered auditor descriptors sorted by name.
 func (r *Registry) AuditorDescriptors() []sdk.AuditorDescriptor {
 	descriptors := make([]sdk.AuditorDescriptor, 0, len(r.auditors))

--- a/internal/testutil/gobuild.go
+++ b/internal/testutil/gobuild.go
@@ -19,6 +19,7 @@ func BuildGoBinary(t testing.TB, outputPath, source string) error {
 	}
 
 	buildCmd := system.Command("go", "build", "-o", outputPath, srcPath)
+	buildCmd.Env = append(os.Environ(), "GOFLAGS=-modcacherw")
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("go build failed: %w (%s)", err, string(buildOutput))


### PR DESCRIPTION
## Summary

- add `bomly plugin test <id> [--json]` for runtime readiness probing only (no verify)
- add `bomly plugin doctor <id> [--json]` to run verify + readiness and report overall health
- keep command behavior explicit: `test` does not run `verify`; `doctor` composes both

## Implementation details

- CLI wiring and output handling in `internal/cli/plugin_cmd.go`
- new managed plugin APIs:
  - `internal/plugin/test.go`
  - `internal/plugin/doctor.go`
- result types (`TestResult`, `DoctorResult`) added in `internal/plugin/types.go`
- docs updated in `docs/PLUGINS.md`
- git worktree guidance added to `AGENTS.md`

## Tests

- CLI command tests in `internal/cli/plugin_cmd_health_test.go`
- plugin API tests in `internal/plugin/test_doctor_test.go`
- full suite passes with `make test`

## Notes

- analyzer plugins return an explicit unsupported error for readiness probing (analyzer runtime readiness RPCs are not yet in the plugin transport)