### PR TITLE
Scope diff audits to changed dependencies

### DIFF
--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -101,7 +101,7 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 	}
 }
 
-func TestRenderDiffMarkdownFocusesPersistedAndResolvedFindingsOnChangedPackages(t *testing.T) {
+func TestRenderDiffMarkdownRendersScopedPolicyPayloadDirectly(t *testing.T) {
 	payload := output.DiffResponse{
 		Comparison: output.DiffComparison{Base: "main", Head: "feature"},
 		Results: output.DiffResults{
@@ -138,19 +138,21 @@ func TestRenderDiffMarkdownFocusesPersistedAndResolvedFindingsOnChangedPackages(
 
 	report := out.String()
 	for _, want := range []string{
-		"1 persisted on changed dependencies",
-		"1 resolved on changed dependencies",
-		"1 unchanged persisted and 1 unrelated resolved omitted",
-		"Persisted Findings on Changed Dependencies",
-		"Resolved Findings on Changed Dependencies",
+		"1 introduced / 2 persisted / 2 resolved",
+		"2 persisted",
+		"2 resolved",
+		"Persisted Findings",
+		"Resolved Findings",
 		"CVE-REACT",
 		"CVE-REACT-OLD",
+		"CVE-LODASH",
+		"CVE-MINIMIST",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("expected Markdown report to contain %q, got:\n%s", want, report)
 		}
 	}
-	for _, unwanted := range []string{"CVE-LODASH", "CVE-MINIMIST"} {
+	for _, unwanted := range []string{"omitted", "on Changed Dependencies"} {
 		if strings.Contains(report, unwanted) {
 			t.Fatalf("did not expect Markdown report to contain %q, got:\n%s", unwanted, report)
 		}

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -28,14 +28,13 @@ func DiffMarkdown(w io.Writer, payload output.DiffResponse) error {
 
 func diffOverviewMarkdown(payload output.DiffResponse) []string {
 	introduced, persisted, resolved := 0, 0, 0
-	policy := diffPolicyDisplayFindings(payload)
 	if payload.Audit != nil {
-		introduced = len(policy.Introduced)
-		persisted = len(policy.Persisted)
-		resolved = len(policy.Resolved)
+		introduced = len(payload.Audit.Introduced)
+		persisted = len(payload.Audit.Persisted)
+		resolved = len(payload.Audit.Resolved)
 	}
 	status := "✅ Pass"
-	if payload.Audit != nil && outputAuditFailingCount(policy.Introduced) > 0 {
+	if payload.Audit != nil && outputAuditFailingCount(payload.Audit.Introduced) > 0 {
 		status = "❌ Failing findings introduced"
 	} else if payload.Audit != nil && introduced > 0 {
 		status = "⚠️ Warnings introduced"
@@ -193,118 +192,27 @@ func diffPolicyFindingsMarkdown(payload output.DiffResponse) []string {
 	if payload.Audit == nil {
 		return []string{"Policy evaluation was not included."}
 	}
-	policy := diffPolicyDisplayFindings(payload)
+	audit := payload.Audit
 	lines := []string{
-		diffPolicySummary(policy),
+		diffPolicySummary(audit),
 		"",
 	}
-	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", policy.Introduced)...)
-	lines = append(lines, diffAuditFindingTable("Persisted Findings on Changed Dependencies", "persisted", policy.Persisted)...)
-	lines = append(lines, diffAuditFindingTable("Resolved Findings on Changed Dependencies", "resolved", policy.Resolved)...)
-	if len(policy.Introduced) == 0 && len(policy.Persisted) == 0 && len(policy.Resolved) == 0 {
+	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", audit.Introduced)...)
+	lines = append(lines, diffAuditFindingTable("Persisted Findings", "persisted", audit.Persisted)...)
+	lines = append(lines, diffAuditFindingTable("Resolved Findings", "resolved", audit.Resolved)...)
+	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
 		return []string{"✅ No policy differences were identified."}
 	}
 	return trimTrailingMarkdownBlanks(lines)
 }
 
-type diffPolicyFindings struct {
-	Introduced       []output.AuditFinding
-	Persisted        []output.AuditFinding
-	Resolved         []output.AuditFinding
-	OmittedPersisted int
-	OmittedResolved  int
-}
-
-func diffPolicyDisplayFindings(payload output.DiffResponse) diffPolicyFindings {
-	if payload.Audit == nil {
-		return diffPolicyFindings{}
-	}
-	changed := diffChangedPackageKeySet(payload.Results.Dependencies)
-	persisted := filterAuditFindingsByPackageSet(payload.Audit.Persisted, changed)
-	resolved := filterAuditFindingsByPackageSet(payload.Audit.Resolved, changed)
-	return diffPolicyFindings{
-		Introduced:       payload.Audit.Introduced,
-		Persisted:        persisted,
-		Resolved:         resolved,
-		OmittedPersisted: len(payload.Audit.Persisted) - len(persisted),
-		OmittedResolved:  len(payload.Audit.Resolved) - len(resolved),
-	}
-}
-
-func diffPolicySummary(policy diffPolicyFindings) string {
+func diffPolicySummary(audit *output.DiffAudit) string {
 	parts := []string{
-		fmt.Sprintf("%d introduced", len(policy.Introduced)),
-		fmt.Sprintf("%d persisted on changed dependencies", len(policy.Persisted)),
-		fmt.Sprintf("%d resolved on changed dependencies", len(policy.Resolved)),
-	}
-	if policy.OmittedPersisted > 0 || policy.OmittedResolved > 0 {
-		parts = append(parts, fmt.Sprintf("%d unchanged persisted and %d unrelated resolved omitted", policy.OmittedPersisted, policy.OmittedResolved))
+		fmt.Sprintf("%d introduced", len(audit.Introduced)),
+		fmt.Sprintf("%d persisted", len(audit.Persisted)),
+		fmt.Sprintf("%d resolved", len(audit.Resolved)),
 	}
 	return "**Summary:** " + strings.Join(parts, ", ") + "."
-}
-
-func diffChangedPackageKeySet(results output.DiffDependencyResults) map[string]struct{} {
-	keys := make(map[string]struct{})
-	for _, change := range results.Added {
-		addPackageKeys(keys, change.Package)
-	}
-	for _, change := range results.Removed {
-		addPackageKeys(keys, change.Package)
-	}
-	for _, change := range results.Changed {
-		addPackageKeys(keys, change.Before)
-		addPackageKeys(keys, change.After)
-	}
-	return keys
-}
-
-func filterAuditFindingsByPackageSet(findings []output.AuditFinding, packageKeys map[string]struct{}) []output.AuditFinding {
-	if len(findings) == 0 || len(packageKeys) == 0 {
-		return nil
-	}
-	filtered := make([]output.AuditFinding, 0, len(findings))
-	for _, finding := range findings {
-		if packageKeyMatches(packageKeys, finding.Package) {
-			filtered = append(filtered, finding)
-		}
-	}
-	return filtered
-}
-
-func packageKeyMatches(keys map[string]struct{}, pkg output.PackageRef) bool {
-	for _, key := range packageKeys(pkg) {
-		if _, ok := keys[key]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func addPackageKeys(keys map[string]struct{}, pkg output.PackageRef) {
-	for _, key := range packageKeys(pkg) {
-		keys[key] = struct{}{}
-	}
-}
-
-func packageKeys(pkg output.PackageRef) []string {
-	name := strings.ToLower(strings.TrimSpace(pkg.Name))
-	version := strings.ToLower(strings.TrimSpace(pkg.Version))
-	purl := strings.ToLower(strings.TrimSpace(pkg.Purl))
-	id := strings.ToLower(strings.TrimSpace(pkg.ID))
-	keys := make([]string, 0, 4)
-	if purl != "" {
-		keys = append(keys, "purl:"+purl)
-	}
-	if id != "" {
-		keys = append(keys, "id:"+id)
-	}
-	if name != "" && version != "" {
-		keys = append(keys, "name-version:"+name+"@"+version)
-	}
-	if name != "" {
-		keys = append(keys, "name:"+name)
-	}
-	return keys
 }
 
 func diffAuditFindingTable(title, status string, findings []output.AuditFinding) []string {

--- a/internal/engine/diff/diff.go
+++ b/internal/engine/diff/diff.go
@@ -3,6 +3,7 @@ package diff
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bomly-dev/bomly-cli/internal/engine"
@@ -36,6 +37,8 @@ type Result struct {
 	Findings []sdk.Finding
 }
 
+const diffAuditRootID = "bomly:diff-audit-root"
+
 // Run executes the full pipeline for base and head targets and computes audit deltas.
 func Run(ctx context.Context, req Request) (Result, error) {
 	result := Result{}
@@ -46,24 +49,106 @@ func Run(ctx context.Context, req Request) (Result, error) {
 		return result, fmt.Errorf("head diff pipeline is nil")
 	}
 
-	base, err := req.Base.Pipeline.Run(ctx, req.Base.Request)
+	base, err := req.Base.Pipeline.RunPreAudit(ctx, req.Base.Request)
 	result.Base = base
 	if err != nil {
 		return result, fmt.Errorf("base pipeline: %w", err)
 	}
 
 	req.Head.Request.BaselineGraph = base.Graph
-	head, err := req.Head.Pipeline.Run(ctx, req.Head.Request)
+	head, err := req.Head.Pipeline.RunPreAudit(ctx, req.Head.Request)
 	result.Head = head
 	if err != nil {
 		return result, fmt.Errorf("head pipeline: %w", err)
 	}
 
 	if req.Base.Request.AuditEnabled || req.Head.Request.AuditEnabled {
-		result.Audit = AuditSummary(base.Findings, head.Findings)
-		result.Findings = append(append([]sdk.Finding{}, head.Findings...), base.Findings...)
+		baseAuditGraph, headAuditGraph, err := focusedAuditGraphs(base.Graph, head.Graph)
+		if err != nil {
+			return result, fmt.Errorf("focused audit graphs: %w", err)
+		}
+		baseAudit, baseWarnings := req.Base.Pipeline.RunAuditGraph(ctx, baseAuditGraph, req.Base.Request)
+		result.Base.Findings = baseAudit.Findings
+		result.Base.RiskScores = baseAudit.RiskScores
+		result.Base.AuditorRuns = baseAudit.AuditorRuns
+		result.Base.AuditorFindings = baseAudit.AuditorFindings
+		result.Base.AuditWarnings = append(result.Base.AuditWarnings, baseWarnings...)
+
+		headAudit, headWarnings := req.Head.Pipeline.RunAuditGraph(ctx, headAuditGraph, req.Head.Request)
+		result.Head.Findings = headAudit.Findings
+		result.Head.RiskScores = headAudit.RiskScores
+		result.Head.AuditorRuns = headAudit.AuditorRuns
+		result.Head.AuditorFindings = headAudit.AuditorFindings
+		result.Head.AuditWarnings = append(result.Head.AuditWarnings, headWarnings...)
+
+		result.Audit = AuditSummary(result.Base.Findings, result.Head.Findings)
+		result.Findings = append(append([]sdk.Finding{}, result.Head.Findings...), result.Base.Findings...)
 	}
+	req.Base.Pipeline.RunPostResolveHooks(ctx, req.Base.Request, result.Base)
+	req.Head.Pipeline.RunPostResolveHooks(ctx, req.Head.Request, result.Head)
 	return result, nil
+}
+
+func focusedAuditGraphs(base, head *sdk.Graph) (*sdk.Graph, *sdk.Graph, error) {
+	graphDiff := sdk.Compare(base, head)
+	basePackages := make([]*sdk.Package, 0, len(graphDiff.Removed)+len(graphDiff.Updated))
+	headPackages := make([]*sdk.Package, 0, len(graphDiff.Added)+len(graphDiff.Updated))
+	basePackages = append(basePackages, graphDiff.Removed...)
+	headPackages = append(headPackages, graphDiff.Added...)
+	for _, change := range graphDiff.Updated {
+		basePackages = append(basePackages, change.Before)
+		headPackages = append(headPackages, change.After)
+	}
+
+	baseGraph, err := focusedAuditGraph(basePackages)
+	if err != nil {
+		return nil, nil, err
+	}
+	headGraph, err := focusedAuditGraph(headPackages)
+	if err != nil {
+		return nil, nil, err
+	}
+	return baseGraph, headGraph, nil
+}
+
+func focusedAuditGraph(packages []*sdk.Package) (*sdk.Graph, error) {
+	focused := sdk.NewWithCapacity(len(packages) + 1)
+	seen := make(map[string]struct{}, len(packages))
+	for _, pkg := range packages {
+		if pkg == nil || pkg.ID == "" {
+			continue
+		}
+		seen[pkg.ID] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return focused, nil
+	}
+
+	root := sdk.NewPackageWithID(diffAuditRootID, sdk.Package{
+		Name: "bomly-diff-audit-root",
+		Type: "application",
+	})
+	if err := focused.AddPackage(root); err != nil {
+		return nil, err
+	}
+
+	for _, pkg := range packages {
+		if pkg == nil || pkg.ID == "" {
+			continue
+		}
+		if _, exists := focused.Package(pkg.ID); !exists {
+			if err := focused.AddPackage(pkg.Clone()); err != nil && !errors.Is(err, sdk.ErrPackageAlreadyExist) {
+				return nil, err
+			}
+		}
+		if _, exists := focused.Package(pkg.ID); !exists {
+			continue
+		}
+		if err := focused.AddDependency(diffAuditRootID, pkg.ID); err != nil && !errors.Is(err, sdk.ErrSelfDependency) {
+			return nil, err
+		}
+	}
+	return focused, nil
 }
 
 // AuditSummary computes introduced, resolved, and persisted findings.

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -2,20 +2,22 @@ package diff
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/bomly-dev/bomly-cli/internal/auditors/license"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
 )
 
-func TestRun_ComputesAuditDeltas(t *testing.T) {
-	basePkg := sdk.NewPackageWithID("pkg:npm/react@18.2.0", sdk.Package{Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"})
-	headPkg := sdk.NewPackageWithID("pkg:npm/react@18.2.0", sdk.Package{Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"})
-	base := diffTestPipeline(t, basePkg, []sdk.Finding{{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Source: "osv", Package: basePkg}})
-	head := diffTestPipeline(t, headPkg, []sdk.Finding{
-		{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Source: "osv", Package: headPkg},
-		{ID: "CVE-2", Kind: sdk.FindingKindVulnerability, Source: "osv", Package: headPkg},
+func TestRun_SkipsAuditFindingsWhenNoDependencyChanges(t *testing.T) {
+	react := npmPackage("react", "18.2.0")
+	base := diffTestPipeline(t, graphFixture(t, react), map[string][]sdk.Finding{
+		react.ID: {{ID: "CVE-UNCHANGED", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+	})
+	head := diffTestPipeline(t, graphFixture(t, react.Clone()), map[string][]sdk.Finding{
+		react.ID: {{ID: "CVE-UNCHANGED", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
 	})
 
 	result, err := Run(context.Background(), Request{
@@ -25,44 +27,131 @@ func TestRun_ComputesAuditDeltas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if result.Audit == nil {
-		t.Fatal("expected diff audit")
+	assertFindingIDs(t, result.Audit.Introduced)
+	assertFindingIDs(t, result.Audit.Persisted)
+	assertFindingIDs(t, result.Audit.Resolved)
+}
+
+func TestRun_ReportsAddedPackageFindingAsIntroduced(t *testing.T) {
+	react := npmPackage("react", "18.2.0")
+	base := diffTestPipeline(t, graphFixture(t), nil)
+	head := diffTestPipeline(t, graphFixture(t, react), map[string][]sdk.Finding{
+		react.ID: {{ID: "CVE-ADDED", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+	})
+
+	result, err := Run(context.Background(), Request{
+		Base: Target{Pipeline: base, Request: diffTestRequest()},
+		Head: Target{Pipeline: head, Request: diffTestRequest()},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
-	if len(result.Audit.Introduced) != 1 || result.Audit.Introduced[0].ID != "CVE-2" {
-		t.Fatalf("expected CVE-2 introduced, got %#v", result.Audit.Introduced)
+	assertFindingIDs(t, result.Audit.Introduced, "CVE-ADDED")
+	assertFindingIDs(t, result.Audit.Resolved)
+	assertFindingIDs(t, result.Audit.Persisted)
+}
+
+func TestRun_ReportsRemovedPackageFindingAsResolved(t *testing.T) {
+	react := npmPackage("react", "18.2.0")
+	base := diffTestPipeline(t, graphFixture(t, react), map[string][]sdk.Finding{
+		react.ID: {{ID: "CVE-REMOVED", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+	})
+	head := diffTestPipeline(t, graphFixture(t), nil)
+
+	result, err := Run(context.Background(), Request{
+		Base: Target{Pipeline: base, Request: diffTestRequest()},
+		Head: Target{Pipeline: head, Request: diffTestRequest()},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
-	if len(result.Audit.Persisted) != 1 || result.Audit.Persisted[0].ID != "CVE-1" {
-		t.Fatalf("expected CVE-1 persisted, got %#v", result.Audit.Persisted)
+	assertFindingIDs(t, result.Audit.Introduced)
+	assertFindingIDs(t, result.Audit.Resolved, "CVE-REMOVED")
+	assertFindingIDs(t, result.Audit.Persisted)
+}
+
+func TestRun_AuditsOnlyVersionChangedPackages(t *testing.T) {
+	oldReact := npmPackage("react", "18.2.0")
+	newReact := npmPackage("react", "18.2.1")
+	oldLodash := npmPackage("lodash", "4.17.20")
+	newLodash := npmPackage("lodash", "4.17.20")
+	base := diffTestPipeline(t, graphFixture(t, oldReact, oldLodash), map[string][]sdk.Finding{
+		oldReact.ID:  {{ID: "CVE-REACT-OLD", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+		oldLodash.ID: {{ID: "CVE-LODASH", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+	})
+	head := diffTestPipeline(t, graphFixture(t, newReact, newLodash), map[string][]sdk.Finding{
+		newReact.ID:  {{ID: "CVE-REACT-NEW", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+		newLodash.ID: {{ID: "CVE-LODASH", Kind: sdk.FindingKindVulnerability, Source: "osv"}},
+	})
+
+	result, err := Run(context.Background(), Request{
+		Base: Target{Pipeline: base, Request: diffTestRequest()},
+		Head: Target{Pipeline: head, Request: diffTestRequest()},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
-	if len(result.Audit.Resolved) != 0 {
-		t.Fatalf("expected no resolved findings, got %#v", result.Audit.Resolved)
+	assertFindingIDs(t, result.Audit.Introduced, "CVE-REACT-NEW")
+	assertFindingIDs(t, result.Audit.Resolved, "CVE-REACT-OLD")
+	assertFindingIDs(t, result.Audit.Persisted)
+}
+
+func TestRun_UnknownLicenseFindingIsEmittedForFocusedPackage(t *testing.T) {
+	react := npmPackage("react", "18.2.0")
+	registry := engine.NewRegistry(engine.RegistryConfigs{}, *zap.NewNop())
+	registry.RegisterDetector(fakeDetector{
+		descriptor: detectorDescriptor(),
+		result: sdk.DetectionResult{
+			Graphs: engine.SingleGraphContainer(graphFixture(t, react), sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
+		},
+	})
+	registry.RegisterAuditor(license.Auditor{})
+	head := engine.NewPipeline(registry, zap.NewNop())
+	base := diffTestPipeline(t, graphFixture(t), nil)
+
+	result, err := Run(context.Background(), Request{
+		Base: Target{Pipeline: base, Request: diffTestRequest()},
+		Head: Target{Pipeline: head, Request: diffTestRequest()},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.Audit.Introduced) != 1 {
+		t.Fatalf("expected 1 introduced unknown-license finding, got %#v", result.Audit.Introduced)
+	}
+	finding := result.Audit.Introduced[0]
+	if !strings.Contains(finding.ID, "unknown-license") {
+		t.Fatalf("expected unknown-license finding, got %#v", finding)
+	}
+	if finding.Package == nil || finding.Package.ID != react.ID {
+		t.Fatalf("expected finding package %q, got %#v", react.ID, finding.Package)
 	}
 }
 
-func diffTestPipeline(t *testing.T, pkg *sdk.Package, findings []sdk.Finding) *engine.Pipeline {
+func diffTestPipeline(t *testing.T, g *sdk.Graph, findings map[string][]sdk.Finding) *engine.Pipeline {
 	t.Helper()
 	registry := engine.NewRegistry(engine.RegistryConfigs{}, *zap.NewNop())
-	g := sdk.New()
-	if err := g.AddPackage(pkg); err != nil {
-		t.Fatalf("add package: %v", err)
-	}
 	registry.RegisterDetector(fakeDetector{
-		descriptor: sdk.DetectorDescriptor{
-			Name:                "npm-detector",
-			Enabled:             true,
-			SupportedEcosystems: []sdk.Ecosystem{sdk.EcosystemNPM},
-			SupportedManagers:   []sdk.PackageManager{sdk.PackageManagerNPM},
-			SupportedModes:      []sdk.TargetMode{sdk.TargetModeFullGraph},
-		},
+		descriptor: detectorDescriptor(),
 		result: sdk.DetectionResult{
 			Graphs: engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
 		},
 	})
 	registry.RegisterAuditor(fakeAuditor{
-		descriptor: sdk.AuditorDescriptor{Name: "severity-policy", Enabled: true, SupportedModes: []sdk.TargetMode{sdk.TargetModeFullGraph}},
-		result:     sdk.AuditResult{Findings: findings},
+		descriptor:        sdk.AuditorDescriptor{Name: "severity-policy", Enabled: true, SupportedModes: []sdk.TargetMode{sdk.TargetModeFullGraph}},
+		findingsByPackage: findings,
 	})
 	return engine.NewPipeline(registry, zap.NewNop())
+}
+
+func detectorDescriptor() sdk.DetectorDescriptor {
+	return sdk.DetectorDescriptor{
+		Name:                "npm-detector",
+		Enabled:             true,
+		SupportedEcosystems: []sdk.Ecosystem{sdk.EcosystemNPM},
+		SupportedManagers:   []sdk.PackageManager{sdk.PackageManagerNPM},
+		SupportedModes:      []sdk.TargetMode{sdk.TargetModeFullGraph},
+	}
 }
 
 func diffTestRequest() engine.PipelineRequest {
@@ -75,6 +164,43 @@ func diffTestRequest() engine.PipelineRequest {
 			Ecosystem:               sdk.EcosystemNPM,
 		}},
 		AuditEnabled: true,
+	}
+}
+
+func npmPackage(name, version string) *sdk.Package {
+	purl := "pkg:npm/" + name + "@" + version
+	return sdk.NewPackageWithID(purl, sdk.Package{
+		Ecosystem: string(sdk.EcosystemNPM),
+		Name:      name,
+		Version:   version,
+		PURL:      purl,
+	})
+}
+
+func graphFixture(t *testing.T, packages ...*sdk.Package) *sdk.Graph {
+	t.Helper()
+	g := sdk.New()
+	for _, pkg := range packages {
+		if err := g.AddPackage(pkg.Clone()); err != nil {
+			t.Fatalf("add package %q: %v", pkg.ID, err)
+		}
+	}
+	return g
+}
+
+func assertFindingIDs(t *testing.T, findings []sdk.Finding, want ...string) {
+	t.Helper()
+	if len(findings) != len(want) {
+		t.Fatalf("expected finding IDs %#v, got %#v", want, findings)
+	}
+	got := make(map[string]struct{}, len(findings))
+	for _, finding := range findings {
+		got[finding.ID] = struct{}{}
+	}
+	for _, id := range want {
+		if _, ok := got[id]; !ok {
+			t.Fatalf("expected finding ID %q in %#v", id, findings)
+		}
 	}
 }
 
@@ -104,8 +230,8 @@ func (f fakeDetector) ResolveGraph(context.Context, sdk.DetectionRequest) (sdk.D
 }
 
 type fakeAuditor struct {
-	descriptor sdk.AuditorDescriptor
-	result     sdk.AuditResult
+	descriptor        sdk.AuditorDescriptor
+	findingsByPackage map[string][]sdk.Finding
 }
 
 func (f fakeAuditor) Descriptor() sdk.AuditorDescriptor {
@@ -120,6 +246,19 @@ func (f fakeAuditor) Applicable(context.Context, sdk.AuditRequest) (bool, error)
 	return true, nil
 }
 
-func (f fakeAuditor) Audit(context.Context, sdk.AuditRequest) (sdk.AuditResult, error) {
-	return f.result, nil
+func (f fakeAuditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
+	if req.Graph == nil {
+		return sdk.AuditResult{}, nil
+	}
+	var findings []sdk.Finding
+	for _, pkg := range req.Graph.Packages() {
+		if pkg == nil {
+			continue
+		}
+		for _, finding := range f.findingsByPackage[pkg.ID] {
+			finding.Package = pkg
+			findings = append(findings, finding)
+		}
+	}
+	return sdk.AuditResult{Graph: req.Graph, Findings: findings}, nil
 }

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -36,6 +36,18 @@ func NewPipeline(registry *Registry, logger *zap.Logger) *Pipeline {
 
 // Run executes the full pipeline and returns a consolidated result.
 func (p *Pipeline) Run(ctx context.Context, req PipelineRequest) (PipelineResult, error) {
+	result, err := p.RunPreAudit(ctx, req)
+	if err != nil {
+		return result, err
+	}
+	p.runAudit(ctx, &result, req)
+	p.runPost(ctx, req, result)
+	return result, nil
+}
+
+// RunPreAudit executes the pipeline through enrichment and analysis, stopping
+// before policy evaluation and post-resolve hooks.
+func (p *Pipeline) RunPreAudit(ctx context.Context, req PipelineRequest) (PipelineResult, error) {
 	result := PipelineResult{}
 	if err := p.runPre(ctx, req); err != nil {
 		return result, err
@@ -51,9 +63,35 @@ func (p *Pipeline) Run(ctx context.Context, req PipelineRequest) (PipelineResult
 	}
 	p.runMatch(ctx, &result, req)
 	p.runAnalyze(ctx, &result, req)
-	p.runAudit(ctx, &result, req)
-	p.runPost(ctx, req, result)
 	return result, nil
+}
+
+// RunAuditGraph evaluates policy for graph using req's configured auditors.
+func (p *Pipeline) RunAuditGraph(ctx context.Context, graph *sdk.Graph, req PipelineRequest) (sdk.AuditResult, []PipelineWarning) {
+	if !req.AuditEnabled || graph == nil {
+		return sdk.AuditResult{}, nil
+	}
+	if req.Progress != nil {
+		req.Progress.StartStage("Evaluating policy", 1)
+	}
+	auditResult, auditWarnings := p.audit(ctx, graph, req)
+	auditResult.Findings = DeduplicateFindings(auditResult.Findings)
+	if req.WarnOnly {
+		for idx := range auditResult.Findings {
+			if auditResult.Findings[idx].Disposition == "" || auditResult.Findings[idx].Disposition == sdk.FindingDispositionFail {
+				auditResult.Findings[idx].Disposition = sdk.FindingDispositionWarn
+			}
+		}
+	}
+	if req.Progress != nil {
+		req.Progress.CompleteStage("Evaluating policy", 1)
+	}
+	return auditResult, auditWarnings
+}
+
+// RunPostResolveHooks executes post-resolve hooks with the supplied result.
+func (p *Pipeline) RunPostResolveHooks(ctx context.Context, req PipelineRequest, result PipelineResult) {
+	p.runPost(ctx, req, result)
 }
 
 func (p *Pipeline) runPre(ctx context.Context, req PipelineRequest) error {


### PR DESCRIPTION
## Summary
- run diff base/head pipelines through enrichment and analysis before auditing
- build focused audit-only graphs for added, removed, and version-changed packages
- remove Markdown-side policy filtering now that diff audit payloads are scoped at the source

## Why
`bomly diff --audit` was filtering unrelated persisted/resolved findings at render time. This fixes the core audit path so unrelated dependency findings are never created for the diff payload in the first place, while keeping the full enriched graphs available for output and interactive views.

## Validation
- `go test ./internal/engine/diff ./internal/auditors/... ./internal/cli ./internal/cli/render`
- `go test ./...`
- commit hook: `go run ./internal/tools/gofmtcheck`
- commit hook: `golangci-lint run`