### PR TITLE
Enrich grype vulnerability details

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -25,7 +25,7 @@ Bomly resolves configuration in the following order, with later sources overridi
 | `enrich` | `BOMLY_ENRICH` | `bool` | - | Enrich packages with external license and vulnerability data |
 | `audit` | `BOMLY_AUDIT` | `bool` | - | Evaluate policy and create findings from package vulnerability data |
 | `reachability` | `BOMLY_REACHABILITY` | `bool` | - | Run code analysis to confirm whether vulnerabilities are reachable from application code |
-| `fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable |
+| `fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable |
 | `fail_on_scopes` | `BOMLY_FAIL_ON_SCOPES` | `[]string` | - | Dependency scopes that may produce failing findings: runtime, development, unknown |
 | `allow_vulnerability_ids` | `BOMLY_ALLOW_VULNERABILITY_IDS` | `[]string` | - | Vulnerability IDs to ignore during policy evaluation |
 | `allow_licenses` | `BOMLY_ALLOW_LICENSES` | `[]string` | - | Allowed SPDX license identifiers or expressions |
@@ -96,7 +96,7 @@ Bomly resolves configuration in the following order, with later sources overridi
 # audit: false
 # Run code analysis to confirm whether vulnerabilities are reachable from application code
 # reachability: false
-# Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable
+# Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable
 # fail_on: []
 # Dependency scopes that may produce failing findings: runtime, development, unknown
 # fail_on_scopes: []

--- a/docs/matchers/grype.md
+++ b/docs/matchers/grype.md
@@ -11,7 +11,7 @@ Uses Grype vulnerability matching against the resolved dependency graph.
 | Requires enrichment | Yes |
 | Uses network | No |
 | Cache behavior | Relies on Grype's local vulnerability database behavior. |
-| Output fields | vulnerability ID, severity, CVSS, fixed version, references |
+| Output fields | vulnerability ID, severity, CVSS, fixed version, fix state, EPSS, CWE, known exploitation, risk score, references |
 
 ## User notes
 
@@ -19,7 +19,7 @@ The full Bomly binary links Grype support. The lite binary uses an external `gry
 
 ## What `grype` does
 
-`grype` runs Anchore's Grype vulnerability matcher against the resolved dependency graph. Grype carries its own offline vulnerability database, so it complements `osv` rather than duplicating it — Grype is the right matcher when you need consistent results across runs and full offline operation after the first DB sync.
+`grype` runs Anchore's Grype vulnerability matcher against the resolved dependency graph. Grype carries its own offline vulnerability database, so it complements `osv` rather than duplicating it -- Grype is the right matcher when you need consistent results across runs and full offline operation after the first DB sync.
 
 In the full `bomly` binary, Grype is linked in as a library and runs in-process. In `bomly-lite`, Bomly shells out to a `grype` binary on `PATH`.
 
@@ -43,17 +43,20 @@ Grype reads from a local vulnerability database that it syncs on first use and r
 | Full `bomly` binary | Anchore's database service | Managed by the linked Grype library; default `~/.cache/grype/db/` |
 | `bomly-lite` | External `grype` binary on `PATH` | Wherever the external `grype` stores it |
 
-The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls — Grype manages its own cache.
+The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls -- Grype manages its own cache.
 
 ## Output fields
 
 Each `vulnerabilities[]` entry on a package carries:
 
-- `id` — Grype's primary ID (CVE / GHSA / vendor ID)
-- `severity` — Grype's normalized severity bucket
-- `cvss` — CVSS vector when available
-- `fixed_version` — earliest fixed version per affected range
-- `references` — upstream advisory and patch links
+- `id` -- Grype's primary ID (CVE / GHSA / vendor ID)
+- `severity` -- Grype's normalized severity bucket
+- `cvss` -- CVSS vector when available
+- `fixed_in` -- best single upgrade target; `fixed_versions` carries every fixed version Grype reported
+- `fix_state` and `fix_available` -- Grype's fix status and dated fix-availability records when available
+- `epss`, `cwes`, `known_exploited`, and `risk_score` -- exploitation and weakness triage signals from the Grype database
+- `data_source`, `namespace`, and `cpes` -- source and matcher context for debugging or downstream correlation
+- `references` -- upstream advisory and patch links
 
 ## Examples
 

--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -41,6 +41,23 @@ Complete reference for the `bomly diff` JSON output.
 | `auditor` | `string` | |
 | `disposition` | `string` | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
+| `aliases` | Array<`string`> | |
+| `description` | `string` | |
+| `severity_source` | `string` | |
+| `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
+| `affected_version_range` | `string` | |
+| `references` | Array<[`Reference`](#reference)> | |
+| `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`
@@ -62,6 +79,15 @@ Complete reference for the `bomly diff` JSON output.
 | `Score` | `number` | |
 | `Version` | `string` | |
 | `Source` | `string` | |
+
+### `CWE`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `id` | `string` | |
+| `source` | `string` | |
+| `type` | `string` | |
 
 ### `CallFrame`
 
@@ -191,6 +217,38 @@ Complete reference for the `bomly diff` JSON output.
 | `added` | Array<[`DiffVulnerabilityChange`](#diffvulnerabilitychange)> | |
 | `removed` | Array<[`DiffVulnerabilityChange`](#diffvulnerabilitychange)> | |
 
+### `EPSSScore`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `epss` | `number` | |
+| `percentile` | `number` | |
+| `date` | `string` | |
+
+### `FixAvailable`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | |
+| `date` | `string` | |
+| `kind` | `string` | |
+
+### `KnownExploited`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `vendor_project` | `string` | |
+| `product` | `string` | |
+| `date_added` | `string` | |
+| `required_action` | `string` | |
+| `due_date` | `string` | |
+| `known_ransomware_campaign_use` | `string` | |
+| `notes` | `string` | |
+| `urls` | Array<`string`> | |
+| `cwes` | Array<`string`> | |
+
 ### `LicenseRef`
 
 | Field | Type | Description |
@@ -294,9 +352,19 @@ Complete reference for the `bomly diff` JSON output.
 | `reasons` | Array<`string`> | |
 | `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
 | `affected_version_range` | `string` | |
 | `references` | Array<[`Reference`](#reference)> | |
 | `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `affected_symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `reachability` | [`Reachability`](#reachability) | |
 

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -38,19 +38,185 @@
         "introduced": {
           "items": {
             "properties": {
+              "affected_version_range": {
+                "type": "string"
+              },
+              "aliases": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "auditor": {
+                "type": "string"
+              },
+              "cpes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "cvss": {
+                "items": {
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Source": {
+                      "type": "string"
+                    },
+                    "Vector": {
+                      "type": "string"
+                    },
+                    "Version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Vector",
+                    "Score",
+                    "Version",
+                    "Source"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "cwes": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "data_source": {
+                "type": "string"
+              },
+              "description": {
                 "type": "string"
               },
               "disposition": {
                 "type": "string"
               },
+              "epss": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "type": "number"
+                    },
+                    "percentile": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "epss"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_available": {
+                "items": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_state": {
+                "type": "string"
+              },
               "fixed_in": {
                 "type": "string"
+              },
+              "fixed_versions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               "id": {
                 "type": "string"
               },
+              "kev_exploited": {
+                "type": "boolean"
+              },
               "kind": {
+                "type": "string"
+              },
+              "known_exploited": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "cwes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "date_added": {
+                      "type": "string"
+                    },
+                    "due_date": {
+                      "type": "string"
+                    },
+                    "known_ransomware_campaign_use": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "type": "string"
+                    },
+                    "product": {
+                      "type": "string"
+                    },
+                    "required_action": {
+                      "type": "string"
+                    },
+                    "urls": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "vendor_project": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "namespace": {
                 "type": "string"
               },
               "package": {
@@ -171,6 +337,12 @@
                           },
                           "type": "array"
                         },
+                        "cpes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "cvss": {
                           "items": {
                             "properties": {
@@ -197,17 +369,136 @@
                           },
                           "type": "array"
                         },
+                        "cwes": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "data_source": {
+                          "type": "string"
+                        },
                         "description": {
+                          "type": "string"
+                        },
+                        "epss": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "type": "number"
+                              },
+                              "percentile": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "epss"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_available": {
+                          "items": {
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_state": {
                           "type": "string"
                         },
                         "fixed_in": {
                           "type": "string"
+                        },
+                        "fixed_versions": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
                         },
                         "id": {
                           "type": "string"
                         },
                         "kev_exploited": {
                           "type": "boolean"
+                        },
+                        "known_exploited": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "cwes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "date_added": {
+                                "type": "string"
+                              },
+                              "due_date": {
+                                "type": "string"
+                              },
+                              "known_ransomware_campaign_use": {
+                                "type": "string"
+                              },
+                              "notes": {
+                                "type": "string"
+                              },
+                              "product": {
+                                "type": "string"
+                              },
+                              "required_action": {
+                                "type": "string"
+                              },
+                              "urls": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "vendor_project": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "namespace": {
+                          "type": "string"
                         },
                         "reachability": {
                           "properties": {
@@ -380,6 +671,9 @@
                             "type": "object"
                           },
                           "type": "array"
+                        },
+                        "risk_score": {
+                          "type": "number"
                         },
                         "severity": {
                           "type": "string"
@@ -564,7 +858,31 @@
                 },
                 "type": "array"
               },
+              "references": {
+                "items": {
+                  "properties": {
+                    "Type": {
+                      "type": "string"
+                    },
+                    "URL": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "URL",
+                    "Type"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "risk_score": {
+                "type": "number"
+              },
               "severity": {
+                "type": "string"
+              },
+              "severity_source": {
                 "type": "string"
               },
               "source": {
@@ -589,19 +907,185 @@
         "persisted": {
           "items": {
             "properties": {
+              "affected_version_range": {
+                "type": "string"
+              },
+              "aliases": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "auditor": {
+                "type": "string"
+              },
+              "cpes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "cvss": {
+                "items": {
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Source": {
+                      "type": "string"
+                    },
+                    "Vector": {
+                      "type": "string"
+                    },
+                    "Version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Vector",
+                    "Score",
+                    "Version",
+                    "Source"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "cwes": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "data_source": {
+                "type": "string"
+              },
+              "description": {
                 "type": "string"
               },
               "disposition": {
                 "type": "string"
               },
+              "epss": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "type": "number"
+                    },
+                    "percentile": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "epss"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_available": {
+                "items": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_state": {
+                "type": "string"
+              },
               "fixed_in": {
                 "type": "string"
+              },
+              "fixed_versions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               "id": {
                 "type": "string"
               },
+              "kev_exploited": {
+                "type": "boolean"
+              },
               "kind": {
+                "type": "string"
+              },
+              "known_exploited": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "cwes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "date_added": {
+                      "type": "string"
+                    },
+                    "due_date": {
+                      "type": "string"
+                    },
+                    "known_ransomware_campaign_use": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "type": "string"
+                    },
+                    "product": {
+                      "type": "string"
+                    },
+                    "required_action": {
+                      "type": "string"
+                    },
+                    "urls": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "vendor_project": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "namespace": {
                 "type": "string"
               },
               "package": {
@@ -722,6 +1206,12 @@
                           },
                           "type": "array"
                         },
+                        "cpes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "cvss": {
                           "items": {
                             "properties": {
@@ -748,17 +1238,136 @@
                           },
                           "type": "array"
                         },
+                        "cwes": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "data_source": {
+                          "type": "string"
+                        },
                         "description": {
+                          "type": "string"
+                        },
+                        "epss": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "type": "number"
+                              },
+                              "percentile": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "epss"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_available": {
+                          "items": {
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_state": {
                           "type": "string"
                         },
                         "fixed_in": {
                           "type": "string"
+                        },
+                        "fixed_versions": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
                         },
                         "id": {
                           "type": "string"
                         },
                         "kev_exploited": {
                           "type": "boolean"
+                        },
+                        "known_exploited": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "cwes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "date_added": {
+                                "type": "string"
+                              },
+                              "due_date": {
+                                "type": "string"
+                              },
+                              "known_ransomware_campaign_use": {
+                                "type": "string"
+                              },
+                              "notes": {
+                                "type": "string"
+                              },
+                              "product": {
+                                "type": "string"
+                              },
+                              "required_action": {
+                                "type": "string"
+                              },
+                              "urls": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "vendor_project": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "namespace": {
+                          "type": "string"
                         },
                         "reachability": {
                           "properties": {
@@ -931,6 +1540,9 @@
                             "type": "object"
                           },
                           "type": "array"
+                        },
+                        "risk_score": {
+                          "type": "number"
                         },
                         "severity": {
                           "type": "string"
@@ -1115,7 +1727,31 @@
                 },
                 "type": "array"
               },
+              "references": {
+                "items": {
+                  "properties": {
+                    "Type": {
+                      "type": "string"
+                    },
+                    "URL": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "URL",
+                    "Type"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "risk_score": {
+                "type": "number"
+              },
               "severity": {
+                "type": "string"
+              },
+              "severity_source": {
                 "type": "string"
               },
               "source": {
@@ -1140,19 +1776,185 @@
         "resolved": {
           "items": {
             "properties": {
+              "affected_version_range": {
+                "type": "string"
+              },
+              "aliases": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "auditor": {
+                "type": "string"
+              },
+              "cpes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "cvss": {
+                "items": {
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Source": {
+                      "type": "string"
+                    },
+                    "Vector": {
+                      "type": "string"
+                    },
+                    "Version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Vector",
+                    "Score",
+                    "Version",
+                    "Source"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "cwes": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "data_source": {
+                "type": "string"
+              },
+              "description": {
                 "type": "string"
               },
               "disposition": {
                 "type": "string"
               },
+              "epss": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "type": "number"
+                    },
+                    "percentile": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "epss"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_available": {
+                "items": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_state": {
+                "type": "string"
+              },
               "fixed_in": {
                 "type": "string"
+              },
+              "fixed_versions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               "id": {
                 "type": "string"
               },
+              "kev_exploited": {
+                "type": "boolean"
+              },
               "kind": {
+                "type": "string"
+              },
+              "known_exploited": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "cwes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "date_added": {
+                      "type": "string"
+                    },
+                    "due_date": {
+                      "type": "string"
+                    },
+                    "known_ransomware_campaign_use": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "type": "string"
+                    },
+                    "product": {
+                      "type": "string"
+                    },
+                    "required_action": {
+                      "type": "string"
+                    },
+                    "urls": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "vendor_project": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "namespace": {
                 "type": "string"
               },
               "package": {
@@ -1273,6 +2075,12 @@
                           },
                           "type": "array"
                         },
+                        "cpes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "cvss": {
                           "items": {
                             "properties": {
@@ -1299,17 +2107,136 @@
                           },
                           "type": "array"
                         },
+                        "cwes": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "data_source": {
+                          "type": "string"
+                        },
                         "description": {
+                          "type": "string"
+                        },
+                        "epss": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "type": "number"
+                              },
+                              "percentile": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "epss"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_available": {
+                          "items": {
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "fix_state": {
                           "type": "string"
                         },
                         "fixed_in": {
                           "type": "string"
+                        },
+                        "fixed_versions": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
                         },
                         "id": {
                           "type": "string"
                         },
                         "kev_exploited": {
                           "type": "boolean"
+                        },
+                        "known_exploited": {
+                          "items": {
+                            "properties": {
+                              "cve": {
+                                "type": "string"
+                              },
+                              "cwes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "date_added": {
+                                "type": "string"
+                              },
+                              "due_date": {
+                                "type": "string"
+                              },
+                              "known_ransomware_campaign_use": {
+                                "type": "string"
+                              },
+                              "notes": {
+                                "type": "string"
+                              },
+                              "product": {
+                                "type": "string"
+                              },
+                              "required_action": {
+                                "type": "string"
+                              },
+                              "urls": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "vendor_project": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "namespace": {
+                          "type": "string"
                         },
                         "reachability": {
                           "properties": {
@@ -1482,6 +2409,9 @@
                             "type": "object"
                           },
                           "type": "array"
+                        },
+                        "risk_score": {
+                          "type": "number"
                         },
                         "severity": {
                           "type": "string"
@@ -1666,7 +2596,31 @@
                 },
                 "type": "array"
               },
+              "references": {
+                "items": {
+                  "properties": {
+                    "Type": {
+                      "type": "string"
+                    },
+                    "URL": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "URL",
+                    "Type"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "risk_score": {
+                "type": "number"
+              },
               "severity": {
+                "type": "string"
+              },
+              "severity_source": {
                 "type": "string"
               },
               "source": {
@@ -1898,6 +2852,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -1924,17 +2884,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -2107,6 +3186,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -2266,6 +3348,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -2292,17 +3380,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -2475,6 +3682,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -2623,6 +3833,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -2649,17 +3865,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -2832,6 +4167,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -2992,6 +4330,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -3018,17 +4362,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -3201,6 +4664,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -3382,6 +4848,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -3408,17 +4880,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -3591,6 +5182,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -3785,6 +5379,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -3811,17 +5411,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -3994,6 +5713,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"
@@ -4172,6 +5894,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -4198,17 +5926,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -4382,6 +6229,9 @@
                               },
                               "type": "array"
                             },
+                            "risk_score": {
+                              "type": "number"
+                            },
                             "severity": {
                               "type": "string"
                             },
@@ -4547,6 +6397,12 @@
                                 },
                                 "type": "array"
                               },
+                              "cpes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "cvss": {
                                 "items": {
                                   "properties": {
@@ -4573,17 +6429,136 @@
                                 },
                                 "type": "array"
                               },
+                              "cwes": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "data_source": {
+                                "type": "string"
+                              },
                               "description": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "epss": {
+                                      "type": "number"
+                                    },
+                                    "percentile": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "epss"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_available": {
+                                "items": {
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_state": {
                                 "type": "string"
                               },
                               "fixed_in": {
                                 "type": "string"
+                              },
+                              "fixed_versions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "id": {
                                 "type": "string"
                               },
                               "kev_exploited": {
                                 "type": "boolean"
+                              },
+                              "known_exploited": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "cwes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "date_added": {
+                                      "type": "string"
+                                    },
+                                    "due_date": {
+                                      "type": "string"
+                                    },
+                                    "known_ransomware_campaign_use": {
+                                      "type": "string"
+                                    },
+                                    "notes": {
+                                      "type": "string"
+                                    },
+                                    "product": {
+                                      "type": "string"
+                                    },
+                                    "required_action": {
+                                      "type": "string"
+                                    },
+                                    "urls": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "vendor_project": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "namespace": {
+                                "type": "string"
                               },
                               "reachability": {
                                 "properties": {
@@ -4756,6 +6731,9 @@
                                   "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "risk_score": {
+                                "type": "number"
                               },
                               "severity": {
                                 "type": "string"
@@ -4915,6 +6893,12 @@
                                 },
                                 "type": "array"
                               },
+                              "cpes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "cvss": {
                                 "items": {
                                   "properties": {
@@ -4941,17 +6925,136 @@
                                 },
                                 "type": "array"
                               },
+                              "cwes": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "data_source": {
+                                "type": "string"
+                              },
                               "description": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "epss": {
+                                      "type": "number"
+                                    },
+                                    "percentile": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "epss"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_available": {
+                                "items": {
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_state": {
                                 "type": "string"
                               },
                               "fixed_in": {
                                 "type": "string"
+                              },
+                              "fixed_versions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "id": {
                                 "type": "string"
                               },
                               "kev_exploited": {
                                 "type": "boolean"
+                              },
+                              "known_exploited": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "cwes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "date_added": {
+                                      "type": "string"
+                                    },
+                                    "due_date": {
+                                      "type": "string"
+                                    },
+                                    "known_ransomware_campaign_use": {
+                                      "type": "string"
+                                    },
+                                    "notes": {
+                                      "type": "string"
+                                    },
+                                    "product": {
+                                      "type": "string"
+                                    },
+                                    "required_action": {
+                                      "type": "string"
+                                    },
+                                    "urls": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "vendor_project": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "namespace": {
+                                "type": "string"
                               },
                               "reachability": {
                                 "properties": {
@@ -5124,6 +7227,9 @@
                                   "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "risk_score": {
+                                "type": "number"
                               },
                               "severity": {
                                 "type": "string"
@@ -5272,6 +7378,12 @@
                                 },
                                 "type": "array"
                               },
+                              "cpes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "cvss": {
                                 "items": {
                                   "properties": {
@@ -5298,17 +7410,136 @@
                                 },
                                 "type": "array"
                               },
+                              "cwes": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "data_source": {
+                                "type": "string"
+                              },
                               "description": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "epss": {
+                                      "type": "number"
+                                    },
+                                    "percentile": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "epss"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_available": {
+                                "items": {
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_state": {
                                 "type": "string"
                               },
                               "fixed_in": {
                                 "type": "string"
+                              },
+                              "fixed_versions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "id": {
                                 "type": "string"
                               },
                               "kev_exploited": {
                                 "type": "boolean"
+                              },
+                              "known_exploited": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "cwes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "date_added": {
+                                      "type": "string"
+                                    },
+                                    "due_date": {
+                                      "type": "string"
+                                    },
+                                    "known_ransomware_campaign_use": {
+                                      "type": "string"
+                                    },
+                                    "notes": {
+                                      "type": "string"
+                                    },
+                                    "product": {
+                                      "type": "string"
+                                    },
+                                    "required_action": {
+                                      "type": "string"
+                                    },
+                                    "urls": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "vendor_project": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "namespace": {
+                                "type": "string"
                               },
                               "reachability": {
                                 "properties": {
@@ -5481,6 +7712,9 @@
                                   "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "risk_score": {
+                                "type": "number"
                               },
                               "severity": {
                                 "type": "string"
@@ -5653,6 +7887,12 @@
                                 },
                                 "type": "array"
                               },
+                              "cpes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "cvss": {
                                 "items": {
                                   "properties": {
@@ -5679,17 +7919,136 @@
                                 },
                                 "type": "array"
                               },
+                              "cwes": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "data_source": {
+                                "type": "string"
+                              },
                               "description": {
+                                "type": "string"
+                              },
+                              "epss": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "epss": {
+                                      "type": "number"
+                                    },
+                                    "percentile": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "epss"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_available": {
+                                "items": {
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "fix_state": {
                                 "type": "string"
                               },
                               "fixed_in": {
                                 "type": "string"
+                              },
+                              "fixed_versions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "id": {
                                 "type": "string"
                               },
                               "kev_exploited": {
                                 "type": "boolean"
+                              },
+                              "known_exploited": {
+                                "items": {
+                                  "properties": {
+                                    "cve": {
+                                      "type": "string"
+                                    },
+                                    "cwes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "date_added": {
+                                      "type": "string"
+                                    },
+                                    "due_date": {
+                                      "type": "string"
+                                    },
+                                    "known_ransomware_campaign_use": {
+                                      "type": "string"
+                                    },
+                                    "notes": {
+                                      "type": "string"
+                                    },
+                                    "product": {
+                                      "type": "string"
+                                    },
+                                    "required_action": {
+                                      "type": "string"
+                                    },
+                                    "urls": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "vendor_project": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "namespace": {
+                                "type": "string"
                               },
                               "reachability": {
                                 "properties": {
@@ -5862,6 +8221,9 @@
                                   "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "risk_score": {
+                                "type": "number"
                               },
                               "severity": {
                                 "type": "string"
@@ -6037,6 +8399,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -6063,17 +8431,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -6247,6 +8734,9 @@
                               },
                               "type": "array"
                             },
+                            "risk_score": {
+                              "type": "number"
+                            },
                             "severity": {
                               "type": "string"
                             },
@@ -6324,6 +8814,12 @@
                         },
                         "type": "array"
                       },
+                      "cpes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "cvss": {
                         "items": {
                           "properties": {
@@ -6350,17 +8846,136 @@
                         },
                         "type": "array"
                       },
+                      "cwes": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "data_source": {
+                        "type": "string"
+                      },
                       "description": {
+                        "type": "string"
+                      },
+                      "epss": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "date": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "type": "number"
+                            },
+                            "percentile": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "epss"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_available": {
+                        "items": {
+                          "properties": {
+                            "date": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_state": {
                         "type": "string"
                       },
                       "fixed_in": {
                         "type": "string"
+                      },
+                      "fixed_versions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "id": {
                         "type": "string"
                       },
                       "kev_exploited": {
                         "type": "boolean"
+                      },
+                      "known_exploited": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "cwes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "date_added": {
+                              "type": "string"
+                            },
+                            "due_date": {
+                              "type": "string"
+                            },
+                            "known_ransomware_campaign_use": {
+                              "type": "string"
+                            },
+                            "notes": {
+                              "type": "string"
+                            },
+                            "product": {
+                              "type": "string"
+                            },
+                            "required_action": {
+                              "type": "string"
+                            },
+                            "urls": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "vendor_project": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "namespace": {
+                        "type": "string"
                       },
                       "reachability": {
                         "properties": {
@@ -6533,6 +9148,9 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "risk_score": {
+                        "type": "number"
                       },
                       "severity": {
                         "type": "string"
@@ -6683,6 +9301,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -6709,17 +9333,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -6893,6 +9636,9 @@
                               },
                               "type": "array"
                             },
+                            "risk_score": {
+                              "type": "number"
+                            },
                             "severity": {
                               "type": "string"
                             },
@@ -6970,6 +9716,12 @@
                         },
                         "type": "array"
                       },
+                      "cpes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "cvss": {
                         "items": {
                           "properties": {
@@ -6996,17 +9748,136 @@
                         },
                         "type": "array"
                       },
+                      "cwes": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "data_source": {
+                        "type": "string"
+                      },
                       "description": {
+                        "type": "string"
+                      },
+                      "epss": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "date": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "type": "number"
+                            },
+                            "percentile": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "epss"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_available": {
+                        "items": {
+                          "properties": {
+                            "date": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_state": {
                         "type": "string"
                       },
                       "fixed_in": {
                         "type": "string"
+                      },
+                      "fixed_versions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "id": {
                         "type": "string"
                       },
                       "kev_exploited": {
                         "type": "boolean"
+                      },
+                      "known_exploited": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "cwes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "date_added": {
+                              "type": "string"
+                            },
+                            "due_date": {
+                              "type": "string"
+                            },
+                            "known_ransomware_campaign_use": {
+                              "type": "string"
+                            },
+                            "notes": {
+                              "type": "string"
+                            },
+                            "product": {
+                              "type": "string"
+                            },
+                            "required_action": {
+                              "type": "string"
+                            },
+                            "urls": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "vendor_project": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "namespace": {
+                        "type": "string"
                       },
                       "reachability": {
                         "properties": {
@@ -7179,6 +10050,9 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "risk_score": {
+                        "type": "number"
                       },
                       "severity": {
                         "type": "string"

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -43,6 +43,23 @@ Complete reference for the `bomly explain` JSON output.
 | `auditor` | `string` | |
 | `disposition` | `string` | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
+| `aliases` | Array<`string`> | |
+| `description` | `string` | |
+| `severity_source` | `string` | |
+| `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
+| `affected_version_range` | `string` | |
+| `references` | Array<[`Reference`](#reference)> | |
+| `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`
@@ -64,6 +81,15 @@ Complete reference for the `bomly explain` JSON output.
 | `Score` | `number` | |
 | `Version` | `string` | |
 | `Source` | `string` | |
+
+### `CWE`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `id` | `string` | |
+| `source` | `string` | |
+| `type` | `string` | |
 
 ### `CallFrame`
 
@@ -91,6 +117,15 @@ Complete reference for the `bomly explain` JSON output.
 | `cyclic` | `boolean` | |
 | `cycle_to` | `string` | |
 
+### `EPSSScore`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `epss` | `number` | |
+| `percentile` | `number` | |
+| `date` | `string` | |
+
 ### `ExplainQuery`
 
 | Field | Type | Description |
@@ -107,6 +142,29 @@ Complete reference for the `bomly explain` JSON output.
 | `paths` | Array<[`DependencyPath`](#dependencypath)> | |
 | `findings` | Array<[`AuditFinding`](#auditfinding)> | |
 | `audit_summary` | [`AuditSummary`](#auditsummary) | |
+
+### `FixAvailable`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | |
+| `date` | `string` | |
+| `kind` | `string` | |
+
+### `KnownExploited`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `vendor_project` | `string` | |
+| `product` | `string` | |
+| `date_added` | `string` | |
+| `required_action` | `string` | |
+| `due_date` | `string` | |
+| `known_ransomware_campaign_use` | `string` | |
+| `notes` | `string` | |
+| `urls` | Array<`string`> | |
+| `cwes` | Array<`string`> | |
 
 ### `LicenseRef`
 
@@ -211,9 +269,19 @@ Complete reference for the `bomly explain` JSON output.
 | `reasons` | Array<`string`> | |
 | `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
 | `affected_version_range` | `string` | |
 | `references` | Array<[`Reference`](#reference)> | |
 | `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `affected_symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `reachability` | [`Reachability`](#reachability) | |
 

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -154,6 +154,12 @@
                 },
                 "type": "array"
               },
+              "cpes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "cvss": {
                 "items": {
                   "properties": {
@@ -180,17 +186,136 @@
                 },
                 "type": "array"
               },
+              "cwes": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "data_source": {
+                "type": "string"
+              },
               "description": {
+                "type": "string"
+              },
+              "epss": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "type": "number"
+                    },
+                    "percentile": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "epss"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_available": {
+                "items": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "fix_state": {
                 "type": "string"
               },
               "fixed_in": {
                 "type": "string"
+              },
+              "fixed_versions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               "id": {
                 "type": "string"
               },
               "kev_exploited": {
                 "type": "boolean"
+              },
+              "known_exploited": {
+                "items": {
+                  "properties": {
+                    "cve": {
+                      "type": "string"
+                    },
+                    "cwes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "date_added": {
+                      "type": "string"
+                    },
+                    "due_date": {
+                      "type": "string"
+                    },
+                    "known_ransomware_campaign_use": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "type": "string"
+                    },
+                    "product": {
+                      "type": "string"
+                    },
+                    "required_action": {
+                      "type": "string"
+                    },
+                    "urls": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "vendor_project": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "namespace": {
+                "type": "string"
               },
               "reachability": {
                 "properties": {
@@ -364,6 +489,9 @@
                 },
                 "type": "array"
               },
+              "risk_score": {
+                "type": "number"
+              },
               "severity": {
                 "type": "string"
               },
@@ -396,19 +524,185 @@
     "findings": {
       "items": {
         "properties": {
+          "affected_version_range": {
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "auditor": {
+            "type": "string"
+          },
+          "cpes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cvss": {
+            "items": {
+              "properties": {
+                "Score": {
+                  "type": "number"
+                },
+                "Source": {
+                  "type": "string"
+                },
+                "Vector": {
+                  "type": "string"
+                },
+                "Version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Vector",
+                "Score",
+                "Version",
+                "Source"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "cwes": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "data_source": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           },
           "disposition": {
             "type": "string"
           },
+          "epss": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string"
+                },
+                "epss": {
+                  "type": "number"
+                },
+                "percentile": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "epss"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "fix_available": {
+            "items": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "fix_state": {
+            "type": "string"
+          },
           "fixed_in": {
             "type": "string"
+          },
+          "fixed_versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "id": {
             "type": "string"
           },
+          "kev_exploited": {
+            "type": "boolean"
+          },
           "kind": {
+            "type": "string"
+          },
+          "known_exploited": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "cwes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "date_added": {
+                  "type": "string"
+                },
+                "due_date": {
+                  "type": "string"
+                },
+                "known_ransomware_campaign_use": {
+                  "type": "string"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "product": {
+                  "type": "string"
+                },
+                "required_action": {
+                  "type": "string"
+                },
+                "urls": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "vendor_project": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "namespace": {
             "type": "string"
           },
           "package": {
@@ -529,6 +823,12 @@
                       },
                       "type": "array"
                     },
+                    "cpes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "cvss": {
                       "items": {
                         "properties": {
@@ -555,17 +855,136 @@
                       },
                       "type": "array"
                     },
+                    "cwes": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "data_source": {
+                      "type": "string"
+                    },
                     "description": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string"
+                          },
+                          "epss": {
+                            "type": "number"
+                          },
+                          "percentile": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "epss"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_available": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_state": {
                       "type": "string"
                     },
                     "fixed_in": {
                       "type": "string"
+                    },
+                    "fixed_versions": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     },
                     "id": {
                       "type": "string"
                     },
                     "kev_exploited": {
                       "type": "boolean"
+                    },
+                    "known_exploited": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "cwes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "date_added": {
+                            "type": "string"
+                          },
+                          "due_date": {
+                            "type": "string"
+                          },
+                          "known_ransomware_campaign_use": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "type": "string"
+                          },
+                          "product": {
+                            "type": "string"
+                          },
+                          "required_action": {
+                            "type": "string"
+                          },
+                          "urls": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "vendor_project": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "namespace": {
+                      "type": "string"
                     },
                     "reachability": {
                       "properties": {
@@ -738,6 +1157,9 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "risk_score": {
+                      "type": "number"
                     },
                     "severity": {
                       "type": "string"
@@ -922,7 +1344,31 @@
             },
             "type": "array"
           },
+          "references": {
+            "items": {
+              "properties": {
+                "Type": {
+                  "type": "string"
+                },
+                "URL": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "URL",
+                "Type"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "risk_score": {
+            "type": "number"
+          },
           "severity": {
+            "type": "string"
+          },
+          "severity_source": {
             "type": "string"
           },
           "source": {
@@ -1112,6 +1558,12 @@
                         },
                         "type": "array"
                       },
+                      "cpes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "cvss": {
                         "items": {
                           "properties": {
@@ -1138,17 +1590,136 @@
                         },
                         "type": "array"
                       },
+                      "cwes": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "data_source": {
+                        "type": "string"
+                      },
                       "description": {
+                        "type": "string"
+                      },
+                      "epss": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "date": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "type": "number"
+                            },
+                            "percentile": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "epss"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_available": {
+                        "items": {
+                          "properties": {
+                            "date": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_state": {
                         "type": "string"
                       },
                       "fixed_in": {
                         "type": "string"
+                      },
+                      "fixed_versions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "id": {
                         "type": "string"
                       },
                       "kev_exploited": {
                         "type": "boolean"
+                      },
+                      "known_exploited": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "cwes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "date_added": {
+                              "type": "string"
+                            },
+                            "due_date": {
+                              "type": "string"
+                            },
+                            "known_ransomware_campaign_use": {
+                              "type": "string"
+                            },
+                            "notes": {
+                              "type": "string"
+                            },
+                            "product": {
+                              "type": "string"
+                            },
+                            "required_action": {
+                              "type": "string"
+                            },
+                            "urls": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "vendor_project": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "namespace": {
+                        "type": "string"
                       },
                       "reachability": {
                         "properties": {
@@ -1321,6 +1892,9 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "risk_score": {
+                        "type": "number"
                       },
                       "severity": {
                         "type": "string"
@@ -1557,6 +2131,12 @@
                       },
                       "type": "array"
                     },
+                    "cpes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "cvss": {
                       "items": {
                         "properties": {
@@ -1583,17 +2163,136 @@
                       },
                       "type": "array"
                     },
+                    "cwes": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "data_source": {
+                      "type": "string"
+                    },
                     "description": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string"
+                          },
+                          "epss": {
+                            "type": "number"
+                          },
+                          "percentile": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "epss"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_available": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_state": {
                       "type": "string"
                     },
                     "fixed_in": {
                       "type": "string"
+                    },
+                    "fixed_versions": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     },
                     "id": {
                       "type": "string"
                     },
                     "kev_exploited": {
                       "type": "boolean"
+                    },
+                    "known_exploited": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "cwes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "date_added": {
+                            "type": "string"
+                          },
+                          "due_date": {
+                            "type": "string"
+                          },
+                          "known_ransomware_campaign_use": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "type": "string"
+                          },
+                          "product": {
+                            "type": "string"
+                          },
+                          "required_action": {
+                            "type": "string"
+                          },
+                          "urls": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "vendor_project": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "namespace": {
+                      "type": "string"
                     },
                     "reachability": {
                       "properties": {
@@ -1767,6 +2466,9 @@
                       },
                       "type": "array"
                     },
+                    "risk_score": {
+                      "type": "number"
+                    },
                     "severity": {
                       "type": "string"
                     },
@@ -1802,19 +2504,185 @@
           "findings": {
             "items": {
               "properties": {
+                "affected_version_range": {
+                  "type": "string"
+                },
+                "aliases": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "auditor": {
+                  "type": "string"
+                },
+                "cpes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "cvss": {
+                  "items": {
+                    "properties": {
+                      "Score": {
+                        "type": "number"
+                      },
+                      "Source": {
+                        "type": "string"
+                      },
+                      "Vector": {
+                        "type": "string"
+                      },
+                      "Version": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "Vector",
+                      "Score",
+                      "Version",
+                      "Source"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "cwes": {
+                  "items": {
+                    "properties": {
+                      "cve": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "data_source": {
+                  "type": "string"
+                },
+                "description": {
                   "type": "string"
                 },
                 "disposition": {
                   "type": "string"
                 },
+                "epss": {
+                  "items": {
+                    "properties": {
+                      "cve": {
+                        "type": "string"
+                      },
+                      "date": {
+                        "type": "string"
+                      },
+                      "epss": {
+                        "type": "number"
+                      },
+                      "percentile": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "epss"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "fix_available": {
+                  "items": {
+                    "properties": {
+                      "date": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "fix_state": {
+                  "type": "string"
+                },
                 "fixed_in": {
                   "type": "string"
+                },
+                "fixed_versions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 },
                 "id": {
                   "type": "string"
                 },
+                "kev_exploited": {
+                  "type": "boolean"
+                },
                 "kind": {
+                  "type": "string"
+                },
+                "known_exploited": {
+                  "items": {
+                    "properties": {
+                      "cve": {
+                        "type": "string"
+                      },
+                      "cwes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "date_added": {
+                        "type": "string"
+                      },
+                      "due_date": {
+                        "type": "string"
+                      },
+                      "known_ransomware_campaign_use": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "product": {
+                        "type": "string"
+                      },
+                      "required_action": {
+                        "type": "string"
+                      },
+                      "urls": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "vendor_project": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "namespace": {
                   "type": "string"
                 },
                 "package": {
@@ -1935,6 +2803,12 @@
                             },
                             "type": "array"
                           },
+                          "cpes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "cvss": {
                             "items": {
                               "properties": {
@@ -1961,17 +2835,136 @@
                             },
                             "type": "array"
                           },
+                          "cwes": {
+                            "items": {
+                              "properties": {
+                                "cve": {
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "type": "string"
+                                },
+                                "source": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "data_source": {
+                            "type": "string"
+                          },
                           "description": {
+                            "type": "string"
+                          },
+                          "epss": {
+                            "items": {
+                              "properties": {
+                                "cve": {
+                                  "type": "string"
+                                },
+                                "date": {
+                                  "type": "string"
+                                },
+                                "epss": {
+                                  "type": "number"
+                                },
+                                "percentile": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "epss"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "fix_available": {
+                            "items": {
+                              "properties": {
+                                "date": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "fix_state": {
                             "type": "string"
                           },
                           "fixed_in": {
                             "type": "string"
+                          },
+                          "fixed_versions": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
                           },
                           "id": {
                             "type": "string"
                           },
                           "kev_exploited": {
                             "type": "boolean"
+                          },
+                          "known_exploited": {
+                            "items": {
+                              "properties": {
+                                "cve": {
+                                  "type": "string"
+                                },
+                                "cwes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "date_added": {
+                                  "type": "string"
+                                },
+                                "due_date": {
+                                  "type": "string"
+                                },
+                                "known_ransomware_campaign_use": {
+                                  "type": "string"
+                                },
+                                "notes": {
+                                  "type": "string"
+                                },
+                                "product": {
+                                  "type": "string"
+                                },
+                                "required_action": {
+                                  "type": "string"
+                                },
+                                "urls": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "vendor_project": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "namespace": {
+                            "type": "string"
                           },
                           "reachability": {
                             "properties": {
@@ -2144,6 +3137,9 @@
                               "type": "object"
                             },
                             "type": "array"
+                          },
+                          "risk_score": {
+                            "type": "number"
                           },
                           "severity": {
                             "type": "string"
@@ -2328,7 +3324,31 @@
                   },
                   "type": "array"
                 },
+                "references": {
+                  "items": {
+                    "properties": {
+                      "Type": {
+                        "type": "string"
+                      },
+                      "URL": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "URL",
+                      "Type"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "risk_score": {
+                  "type": "number"
+                },
                 "severity": {
+                  "type": "string"
+                },
+                "severity_source": {
                   "type": "string"
                 },
                 "source": {
@@ -2481,6 +3501,12 @@
                               },
                               "type": "array"
                             },
+                            "cpes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "cvss": {
                               "items": {
                                 "properties": {
@@ -2507,17 +3533,136 @@
                               },
                               "type": "array"
                             },
+                            "cwes": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data_source": {
+                              "type": "string"
+                            },
                             "description": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "epss": {
+                                    "type": "number"
+                                  },
+                                  "percentile": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "epss"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_available": {
+                              "items": {
+                                "properties": {
+                                  "date": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "fix_state": {
                               "type": "string"
                             },
                             "fixed_in": {
                               "type": "string"
+                            },
+                            "fixed_versions": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "id": {
                               "type": "string"
                             },
                             "kev_exploited": {
                               "type": "boolean"
+                            },
+                            "known_exploited": {
+                              "items": {
+                                "properties": {
+                                  "cve": {
+                                    "type": "string"
+                                  },
+                                  "cwes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "date_added": {
+                                    "type": "string"
+                                  },
+                                  "due_date": {
+                                    "type": "string"
+                                  },
+                                  "known_ransomware_campaign_use": {
+                                    "type": "string"
+                                  },
+                                  "notes": {
+                                    "type": "string"
+                                  },
+                                  "product": {
+                                    "type": "string"
+                                  },
+                                  "required_action": {
+                                    "type": "string"
+                                  },
+                                  "urls": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "vendor_project": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "type": "string"
                             },
                             "reachability": {
                               "properties": {
@@ -2690,6 +3835,9 @@
                                 "type": "object"
                               },
                               "type": "array"
+                            },
+                            "risk_score": {
+                              "type": "number"
                             },
                             "severity": {
                               "type": "string"

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -40,6 +40,23 @@ Complete reference for the `bomly scan` JSON output.
 | `auditor` | `string` | |
 | `disposition` | `string` | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
+| `aliases` | Array<`string`> | |
+| `description` | `string` | |
+| `severity_source` | `string` | |
+| `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
+| `affected_version_range` | `string` | |
+| `references` | Array<[`Reference`](#reference)> | |
+| `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `reachability` | [`Reachability`](#reachability) | |
 
 ### `AuditSummary`
@@ -62,6 +79,15 @@ Complete reference for the `bomly scan` JSON output.
 | `Version` | `string` | |
 | `Source` | `string` | |
 
+### `CWE`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `id` | `string` | |
+| `source` | `string` | |
+| `type` | `string` | |
+
 ### `CallFrame`
 
 | Field | Type | Description |
@@ -77,6 +103,38 @@ Complete reference for the `bomly scan` JSON output.
 |-------|------|-------------|
 | `sink` | [`AffectedSymbol`](#affectedsymbol) | |
 | `frames` | Array<[`CallFrame`](#callframe)> | |
+
+### `EPSSScore`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `epss` | `number` | |
+| `percentile` | `number` | |
+| `date` | `string` | |
+
+### `FixAvailable`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | |
+| `date` | `string` | |
+| `kind` | `string` | |
+
+### `KnownExploited`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve` | `string` | |
+| `vendor_project` | `string` | |
+| `product` | `string` | |
+| `date_added` | `string` | |
+| `required_action` | `string` | |
+| `due_date` | `string` | |
+| `known_ransomware_campaign_use` | `string` | |
+| `notes` | `string` | |
+| `urls` | Array<`string`> | |
+| `cwes` | Array<`string`> | |
 
 ### `LicenseRef`
 
@@ -208,9 +266,19 @@ Complete reference for the `bomly scan` JSON output.
 | `reasons` | Array<`string`> | |
 | `cvss` | Array<[`CVSSScore`](#cvssscore)> | |
 | `fixed_in` | `string` | |
+| `fixed_versions` | Array<`string`> | |
+| `fix_state` | `string` | |
+| `fix_available` | Array<[`FixAvailable`](#fixavailable)> | |
 | `affected_version_range` | `string` | |
 | `references` | Array<[`Reference`](#reference)> | |
 | `kev_exploited` | `boolean` | |
+| `known_exploited` | Array<[`KnownExploited`](#knownexploited)> | |
+| `epss` | Array<[`EPSSScore`](#epssscore)> | |
+| `cwes` | Array<[`CWE`](#cwe)> | |
+| `risk_score` | `number` | |
+| `data_source` | `string` | |
+| `namespace` | `string` | |
+| `cpes` | Array<`string`> | |
 | `affected_symbols` | Array<[`AffectedSymbol`](#affectedsymbol)> | |
 | `reachability` | [`Reachability`](#reachability) | |
 

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -39,19 +39,185 @@
     "findings": {
       "items": {
         "properties": {
+          "affected_version_range": {
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "auditor": {
+            "type": "string"
+          },
+          "cpes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cvss": {
+            "items": {
+              "properties": {
+                "Score": {
+                  "type": "number"
+                },
+                "Source": {
+                  "type": "string"
+                },
+                "Vector": {
+                  "type": "string"
+                },
+                "Version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Vector",
+                "Score",
+                "Version",
+                "Source"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "cwes": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "data_source": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           },
           "disposition": {
             "type": "string"
           },
+          "epss": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string"
+                },
+                "epss": {
+                  "type": "number"
+                },
+                "percentile": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "epss"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "fix_available": {
+            "items": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "fix_state": {
+            "type": "string"
+          },
           "fixed_in": {
             "type": "string"
+          },
+          "fixed_versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "id": {
             "type": "string"
           },
+          "kev_exploited": {
+            "type": "boolean"
+          },
           "kind": {
+            "type": "string"
+          },
+          "known_exploited": {
+            "items": {
+              "properties": {
+                "cve": {
+                  "type": "string"
+                },
+                "cwes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "date_added": {
+                  "type": "string"
+                },
+                "due_date": {
+                  "type": "string"
+                },
+                "known_ransomware_campaign_use": {
+                  "type": "string"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "product": {
+                  "type": "string"
+                },
+                "required_action": {
+                  "type": "string"
+                },
+                "urls": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "vendor_project": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "namespace": {
             "type": "string"
           },
           "package": {
@@ -172,6 +338,12 @@
                       },
                       "type": "array"
                     },
+                    "cpes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "cvss": {
                       "items": {
                         "properties": {
@@ -198,17 +370,136 @@
                       },
                       "type": "array"
                     },
+                    "cwes": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "data_source": {
+                      "type": "string"
+                    },
                     "description": {
+                      "type": "string"
+                    },
+                    "epss": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string"
+                          },
+                          "epss": {
+                            "type": "number"
+                          },
+                          "percentile": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "epss"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_available": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "fix_state": {
                       "type": "string"
                     },
                     "fixed_in": {
                       "type": "string"
+                    },
+                    "fixed_versions": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     },
                     "id": {
                       "type": "string"
                     },
                     "kev_exploited": {
                       "type": "boolean"
+                    },
+                    "known_exploited": {
+                      "items": {
+                        "properties": {
+                          "cve": {
+                            "type": "string"
+                          },
+                          "cwes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "date_added": {
+                            "type": "string"
+                          },
+                          "due_date": {
+                            "type": "string"
+                          },
+                          "known_ransomware_campaign_use": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "type": "string"
+                          },
+                          "product": {
+                            "type": "string"
+                          },
+                          "required_action": {
+                            "type": "string"
+                          },
+                          "urls": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "vendor_project": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "namespace": {
+                      "type": "string"
                     },
                     "reachability": {
                       "properties": {
@@ -381,6 +672,9 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "risk_score": {
+                      "type": "number"
                     },
                     "severity": {
                       "type": "string"
@@ -565,7 +859,31 @@
             },
             "type": "array"
           },
+          "references": {
+            "items": {
+              "properties": {
+                "Type": {
+                  "type": "string"
+                },
+                "URL": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "URL",
+                "Type"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "risk_score": {
+            "type": "number"
+          },
           "severity": {
+            "type": "string"
+          },
+          "severity_source": {
             "type": "string"
           },
           "source": {
@@ -727,6 +1045,12 @@
                         },
                         "type": "array"
                       },
+                      "cpes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "cvss": {
                         "items": {
                           "properties": {
@@ -753,17 +1077,136 @@
                         },
                         "type": "array"
                       },
+                      "cwes": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "data_source": {
+                        "type": "string"
+                      },
                       "description": {
+                        "type": "string"
+                      },
+                      "epss": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "date": {
+                              "type": "string"
+                            },
+                            "epss": {
+                              "type": "number"
+                            },
+                            "percentile": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "epss"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_available": {
+                        "items": {
+                          "properties": {
+                            "date": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "fix_state": {
                         "type": "string"
                       },
                       "fixed_in": {
                         "type": "string"
+                      },
+                      "fixed_versions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "id": {
                         "type": "string"
                       },
                       "kev_exploited": {
                         "type": "boolean"
+                      },
+                      "known_exploited": {
+                        "items": {
+                          "properties": {
+                            "cve": {
+                              "type": "string"
+                            },
+                            "cwes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "date_added": {
+                              "type": "string"
+                            },
+                            "due_date": {
+                              "type": "string"
+                            },
+                            "known_ransomware_campaign_use": {
+                              "type": "string"
+                            },
+                            "notes": {
+                              "type": "string"
+                            },
+                            "product": {
+                              "type": "string"
+                            },
+                            "required_action": {
+                              "type": "string"
+                            },
+                            "urls": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "vendor_project": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "namespace": {
+                        "type": "string"
                       },
                       "reachability": {
                         "properties": {
@@ -936,6 +1379,9 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "risk_score": {
+                        "type": "number"
                       },
                       "severity": {
                         "type": "string"

--- a/internal/auditors/vulnerability/auditor.go
+++ b/internal/auditors/vulnerability/auditor.go
@@ -77,15 +77,42 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 				SeveritySource:       vulnerability.SeveritySource,
 				CVSS:                 append([]sdk.CVSSScore(nil), vulnerability.CVSS...),
 				FixedIn:              vulnerability.FixedIn,
+				FixedVersions:        append([]string(nil), vulnerability.FixedVersions...),
+				FixState:             vulnerability.FixState,
+				FixAvailable:         append([]sdk.FixAvailable(nil), vulnerability.FixAvailable...),
 				AffectedVersionRange: vulnerability.AffectedVersionRange,
 				References:           append([]sdk.Reference(nil), vulnerability.References...),
 				KEVExploited:         vulnerability.KEVExploited,
+				KnownExploited:       cloneKnownExploited(vulnerability.KnownExploited),
+				EPSS:                 append([]sdk.EPSSScore(nil), vulnerability.EPSS...),
+				CWEs:                 append([]sdk.CWE(nil), vulnerability.CWEs...),
+				RiskScore:            vulnerability.RiskScore,
+				DataSource:           vulnerability.DataSource,
+				Namespace:            vulnerability.Namespace,
+				CPEs:                 append([]string(nil), vulnerability.CPEs...),
 				Reachability:         vulnerability.Reachability.Clone(),
 			})
 		}
 	}
 
 	return sdk.AuditResult{Graph: req.Graph, Target: req.Target, Findings: findings}, nil
+}
+
+func cloneKnownExploited(src []sdk.KnownExploited) []sdk.KnownExploited {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]sdk.KnownExploited, 0, len(src))
+	for _, item := range src {
+		if len(item.URLs) > 0 {
+			item.URLs = append([]string(nil), item.URLs...)
+		}
+		if len(item.CWEs) > 0 {
+			item.CWEs = append([]string(nil), item.CWEs...)
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 func scopeAllowed(pkg *sdk.Package, allowed []sdk.Scope) bool {

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -91,9 +91,9 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 		"| added | react@18.2.0 | 18.2.0 | unknown | - | - |",
 		"| changed | zod | 3.22.0 → 3.23.0 | unknown | - | - |",
 		"## Vulnerabilities",
-		"| ❌ | introduced | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | osv | Prototype pollution in react |",
+		"| ❌ | introduced | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | - | osv | Prototype pollution in react |",
 		"## Policy Findings",
-		"| ❌ | introduced | vulnerability | HIGH | fail | OSV-123 | react@18.2.0 | 18.2.1 | Prototype pollution in react |",
+		"| ❌ | introduced | vulnerability | HIGH | fail | OSV-123 | react@18.2.0 | 18.2.1 | - | Prototype pollution in react |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("expected Markdown report to contain %q, got:\n%s", want, report)

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -70,7 +70,7 @@ func bindAnalysisFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.BoolVar(&cfg.Enrich, "enrich", false, "Enrich packages with external license and vulnerability data")
 	flags.BoolVar(&cfg.Audit, "audit", false, "Evaluate policy and create findings from package vulnerability data")
 	flags.BoolVar(&cfg.Reachability, "reachability", false, "[Experimental] Run code analysis to confirm whether vulnerabilities are reachable from application code")
-	flags.StringArrayVar(&cfg.FailOn, "fail-on", nil, "Constraint(s) for which findings should be created. Repeatable; constraints AND together. Severity: any|low|medium|high|critical. Reachability: reachable. Example: --fail-on low --fail-on reachable")
+	flags.StringArrayVar(&cfg.FailOn, "fail-on", nil, "Constraint(s) for which findings should be created. Repeatable; constraints AND together. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable. Example: --fail-on low --fail-on reachable")
 	flags.StringArrayVar(&cfg.FailOnScopes, "fail-on-scope", nil, "Dependency scope that may produce failing findings: runtime, development, or unknown. Repeatable")
 	flags.StringArrayVar(&cfg.AllowVulnerabilityIDs, "allow-vulnerability-id", nil, "Vulnerability ID to ignore during policy evaluation. Repeatable")
 	flags.StringArrayVar(&cfg.AllowLicenses, "allow-license", nil, "Allowed SPDX license identifier or expression. Repeatable")

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -165,6 +165,16 @@ func policyTextSections(audit output.DiffAudit) []string {
 			if strings.TrimSpace(finding.Title) != "" && finding.Title != finding.ID {
 				line += ": " + finding.Title
 			}
+			var details []string
+			if fixed := fixedVersionSummary(finding.FixedIn, finding.FixedVersions); fixed != "" {
+				details = append(details, "fixed in "+fixed)
+			}
+			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
+				details = append(details, exploitability)
+			}
+			if len(details) > 0 {
+				line += " [" + strings.Join(details, "; ") + "]"
+			}
 			if color != "" {
 				line = Wrap(line, color)
 			}

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -134,12 +134,13 @@ func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabi
 			strings.ToUpper(valueOrDash(vuln.Severity)),
 			vuln.ID,
 			DiffPackageDisplayName(change.Package),
-			valueOrDash(vuln.FixedIn),
+			valueOrDash(fixedVersionSummary(vuln.FixedIn, vuln.FixedVersions)),
+			valueOrDash(exploitabilitySummary(vuln.KEVExploited, vuln.KnownExploited, vuln.RiskScore)),
 			valueOrDash(vuln.Source),
 			firstNonEmpty(vuln.Title, strings.Join(vuln.Reasons, "; ")),
 		})
 	}
-	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Change", "Severity", "ID", "Package", "Fixed In", "Source", "Title"}, rows), "")...)
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Change", "Severity", "ID", "Package", "Fixed In", "Exploitability", "Source", "Title"}, rows), "")...)
 }
 
 func diffLicenseMarkdown(payload output.DiffResponse) []string {
@@ -229,11 +230,12 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding)
 			findingDisposition(finding.Disposition),
 			valueOrDash(finding.ID),
 			DiffPackageDisplayName(finding.Package),
-			valueOrDash(finding.FixedIn),
+			valueOrDash(fixedVersionSummary(finding.FixedIn, finding.FixedVersions)),
+			valueOrDash(exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore)),
 			firstNonEmpty(finding.Title, strings.Join(finding.Reasons, "; ")),
 		})
 	}
-	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Status", "Category", "Severity", "Disposition", "ID", "Package", "Fixed In", "Title"}, rows), "")...)
+	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Status", "Category", "Severity", "Disposition", "ID", "Package", "Fixed In", "Exploitability", "Title"}, rows), "")...)
 }
 
 func findingIcon(status, severity, disposition string) string {

--- a/internal/cli/render/explain.go
+++ b/internal/cli/render/explain.go
@@ -67,6 +67,21 @@ func Explain(w io.Writer, target output.ExplainTargetResponse) error {
 			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Title:   ", Dim), ValueOrDash(vulnerability.Title)); err != nil {
 				return err
 			}
+			if fixed := fixedVersionSummary(vulnerability.FixedIn, vulnerability.FixedVersions); fixed != "" {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Fixed in:", Dim), fixed); err != nil {
+					return err
+				}
+			}
+			if exploitability := exploitabilitySummary(vulnerability.KEVExploited, vulnerability.KnownExploited, vulnerability.RiskScore); exploitability != "" {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Exploit: ", Dim), exploitability); err != nil {
+					return err
+				}
+			}
+			if epss := epssSummary(vulnerability.EPSS); epss != "" {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("EPSS:    ", Dim), epss); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -88,6 +103,16 @@ func Explain(w io.Writer, target output.ExplainTargetResponse) error {
 			}
 			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Source:  ", Dim), ValueOrDash(finding.Source)); err != nil {
 				return err
+			}
+			if fixed := fixedVersionSummary(finding.FixedIn, finding.FixedVersions); fixed != "" {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Fixed in:", Dim), fixed); err != nil {
+					return err
+				}
+			}
+			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Exploit: ", Dim), exploitability); err != nil {
+					return err
+				}
 			}
 			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Package: ", Dim), explainPackageDisplayName(finding.Package)); err != nil {
 				return err

--- a/internal/cli/render/explain_markdown.go
+++ b/internal/cli/render/explain_markdown.go
@@ -76,6 +76,20 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 			fmt.Sprintf("- Policy findings: %s", scanAuditSummaryMarkdown(target.AuditSummary)),
 			fmt.Sprintf("- Licenses: %d", len(target.Dependency.Licenses)),
 		)
+		if len(target.Dependency.Vulnerabilities) > 0 {
+			rows := make([][]string, 0, len(target.Dependency.Vulnerabilities))
+			for _, vulnerability := range target.Dependency.Vulnerabilities {
+				rows = append(rows, []string{
+					strings.ToUpper(ValueOrDash(vulnerability.Severity)),
+					valueOrDash(vulnerability.ID),
+					valueOrDash(fixedVersionSummary(vulnerability.FixedIn, vulnerability.FixedVersions)),
+					valueOrDash(exploitabilitySummary(vulnerability.KEVExploited, vulnerability.KnownExploited, vulnerability.RiskScore)),
+					valueOrDash(vulnerability.Source),
+				})
+			}
+			lines = append(lines, "")
+			lines = append(lines, markdownTable([]string{"Severity", "ID", "Fixed In", "Exploitability", "Source"}, rows)...)
+		}
 		if len(target.Findings) > 0 {
 			for _, finding := range sortDiffAuditFindings(target.Findings) {
 				title := finding.Title

--- a/internal/cli/render/scan.go
+++ b/internal/cli/render/scan.go
@@ -87,9 +87,9 @@ func Scan(manifests []output.ScanManifest, g *sdk.Graph, findings []sdk.Finding,
 		})
 		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 		if reachabilityEnabled {
-			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tREACHABILITY\tTITLE\tSOURCE")
+			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tREACHABILITY\tFIXED IN\tEXPLOITABILITY\tTITLE\tSOURCE")
 		} else {
-			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tTITLE\tSOURCE")
+			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tFIXED IN\tEXPLOITABILITY\tTITLE\tSOURCE")
 		}
 		for _, f := range sorted {
 			pkgName := "-"
@@ -106,12 +106,14 @@ func Scan(manifests []output.ScanManifest, g *sdk.Graph, findings []sdk.Finding,
 			if len(title) > 60 {
 				title = title[:57] + "..."
 			}
+			fixedIn := ValueOrDash(fixedVersionSummary(f.FixedIn, f.FixedVersions))
+			exploitability := ValueOrDash(exploitabilitySummary(f.KEVExploited, f.KnownExploited, f.RiskScore))
 			if reachabilityEnabled {
-				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-					f.Severity, f.ID, pkgName, formatReachabilityCell(f.Reachability), title, f.Source)
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					f.Severity, f.ID, pkgName, formatReachabilityCell(f.Reachability), fixedIn, exploitability, title, f.Source)
 			} else {
-				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-					f.Severity, f.ID, pkgName, title, f.Source)
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					f.Severity, f.ID, pkgName, fixedIn, exploitability, title, f.Source)
 			}
 		}
 		_ = tw.Flush()

--- a/internal/cli/render/scan_markdown.go
+++ b/internal/cli/render/scan_markdown.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/output"
 )
@@ -80,7 +81,7 @@ func scanFindingsMarkdown(payload output.ScanResponse) []string {
 	if len(payload.Findings) == 0 {
 		return []string{"No policy findings."}
 	}
-	lines := make([]string, 0, len(payload.Findings))
+	rows := make([][]string, 0, len(payload.Findings))
 	for _, finding := range sortDiffAuditFindings(payload.Findings) {
 		pkg := markdownPackageDisplayName(finding.Package)
 		if pkg == "" {
@@ -90,14 +91,17 @@ func scanFindingsMarkdown(payload output.ScanResponse) []string {
 		if title == "" {
 			title = finding.ID
 		}
-		lines = append(lines, fmt.Sprintf(
-			"- [%s] `%s`: %s",
-			markdownInline(ValueOrDash(finding.Severity)),
-			markdownInline(pkg),
-			markdownText(title),
-		))
+		rows = append(rows, []string{
+			strings.ToUpper(ValueOrDash(finding.Severity)),
+			valueOrDash(finding.ID),
+			pkg,
+			valueOrDash(fixedVersionSummary(finding.FixedIn, finding.FixedVersions)),
+			valueOrDash(exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore)),
+			valueOrDash(finding.Source),
+			title,
+		})
 	}
-	return lines
+	return markdownTable([]string{"Severity", "ID", "Package", "Fixed In", "Exploitability", "Source", "Title"}, rows)
 }
 
 func scanPackageCount(manifests []output.ScanManifest) int {

--- a/internal/cli/render/vulnerability_fields.go
+++ b/internal/cli/render/vulnerability_fields.go
@@ -1,0 +1,65 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func fixedVersionSummary(fixedIn string, versions []string) string {
+	if strings.TrimSpace(fixedIn) != "" {
+		return strings.TrimSpace(fixedIn)
+	}
+	if len(versions) == 0 {
+		return ""
+	}
+	return strings.Join(nonEmptyStrings(versions), ", ")
+}
+
+func epssSummary(values []sdk.EPSSScore) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if value.Percentile > 0 {
+			parts = append(parts, fmt.Sprintf("%.3f (p%.0f)", value.EPSS, value.Percentile*100))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%.3f", value.EPSS))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func cweSummary(values []sdk.CWE) string {
+	if len(values) == 0 {
+		return ""
+	}
+	ids := make([]string, 0, len(values))
+	for _, value := range values {
+		ids = append(ids, value.ID)
+	}
+	return strings.Join(nonEmptyStrings(ids), ", ")
+}
+
+func exploitabilitySummary(kev bool, known []sdk.KnownExploited, risk float64) string {
+	parts := make([]string, 0, 3)
+	if kev || len(known) > 0 {
+		parts = append(parts, "known exploited")
+	}
+	if risk > 0 {
+		parts = append(parts, fmt.Sprintf("risk %.1f", risk))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	return out
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ type Resolved struct {
 	Enrich                bool     `doc:"Enrich packages with external license and vulnerability data" env:"BOMLY_ENRICH"`
 	Audit                 bool     `doc:"Evaluate policy and create findings from package vulnerability data" env:"BOMLY_AUDIT"`
 	Reachability          bool     `doc:"Run code analysis to confirm whether vulnerabilities are reachable from application code" env:"BOMLY_REACHABILITY"`
-	FailOn                []string `doc:"Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable" env:"BOMLY_FAIL_ON"`
+	FailOn                []string `doc:"Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable" env:"BOMLY_FAIL_ON"`
 	FailOnScopes          []string `doc:"Dependency scopes that may produce failing findings: runtime, development, unknown" env:"BOMLY_FAIL_ON_SCOPES"`
 	AllowVulnerabilityIDs []string `doc:"Vulnerability IDs to ignore during policy evaluation" env:"BOMLY_ALLOW_VULNERABILITY_IDS"`
 	AllowLicenses         []string `doc:"Allowed SPDX license identifiers or expressions" env:"BOMLY_ALLOW_LICENSES"`

--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -15,6 +15,8 @@ import (
 	grypematch "github.com/anchore/grype/grype/match"
 	grypematcher "github.com/anchore/grype/grype/matcher"
 	grypepkg "github.com/anchore/grype/grype/pkg"
+	grypevuln "github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/cpe"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/bomly-dev/bomly-cli/internal/logging"
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -199,18 +201,6 @@ func applyMatches(matches *grypematch.Matches, g *sdk.Graph) {
 	}
 
 	for _, m := range matches.Sorted() {
-		vuln := m.Vulnerability
-		severity := "unknown"
-		description := ""
-		var urls []string
-		if vuln.Metadata != nil {
-			if vuln.Metadata.Severity != "" {
-				severity = strings.ToLower(vuln.Metadata.Severity)
-			}
-			description = vuln.Metadata.Description
-			urls = vuln.Metadata.URLs
-		}
-
 		graphPkg := pkgByID[m.Package.ID]
 		if graphPkg == nil {
 			graphPkg = &sdk.Package{
@@ -221,19 +211,153 @@ func applyMatches(matches *grypematch.Matches, g *sdk.Graph) {
 			}
 		}
 
-		title := vuln.ID
-		if description != "" {
-			title = description
-		}
-
 		graphPkg.Matched = true
-		graphPkg.Vulnerabilities = appendUniqueVulnerability(graphPkg.Vulnerabilities, sdk.PackageVulnerability{
-			ID:          vuln.ID,
-			Title:       title,
-			Severity:    severity,
-			Description: description,
-			Reasons:     append([]string(nil), urls...),
-			Source:      matcherName,
+		graphPkg.Vulnerabilities = appendOrMergeVulnerability(graphPkg.Vulnerabilities, mapBuiltinMatch(m))
+	}
+}
+
+func mapBuiltinMatch(m grypematch.Match) sdk.PackageVulnerability {
+	vuln := m.Vulnerability
+	advisory := grypeAdvisory{
+		ID:                   vuln.ID,
+		Namespace:            vuln.Namespace,
+		FixedVersions:        append([]string(nil), vuln.Fix.Versions...),
+		FixState:             string(vuln.Fix.State),
+		AffectedVersionRange: constraintString(vuln.Constraint),
+		CPEs:                 cpeStrings(vuln.CPEs),
+	}
+	if vuln.Metadata != nil {
+		advisory.DataSource = vuln.Metadata.DataSource
+		advisory.Namespace = firstNonEmpty(vuln.Metadata.Namespace, advisory.Namespace)
+		advisory.Severity = vuln.Metadata.Severity
+		advisory.SeveritySource = vuln.Metadata.Namespace
+		advisory.Description = vuln.Metadata.Description
+		advisory.URLs = append([]string(nil), vuln.Metadata.URLs...)
+		advisory.CVSS = builtinCVSS(vuln.Metadata.Cvss)
+		advisory.KnownExploited = builtinKnownExploited(vuln.Metadata.KnownExploited)
+		advisory.EPSS = builtinEPSS(vuln.Metadata.EPSS)
+		advisory.CWEs = builtinCWEs(vuln.Metadata.CWEs)
+		advisory.RiskScore = vuln.Metadata.RiskScore()
+	}
+	for _, fix := range vuln.Fix.Available {
+		advisory.FixAvailable = append(advisory.FixAvailable, sdk.FixAvailable{
+			Version: fix.Version,
+			Date:    dateString(fix.Date),
+			Kind:    fix.Kind,
 		})
 	}
+	for _, advisoryRef := range vuln.Advisories {
+		advisory.References = append(advisory.References, sdk.Reference{URL: advisoryRef.Link, Type: firstNonEmpty(advisoryRef.ID, "advisory")})
+	}
+	for _, related := range vuln.RelatedVulnerabilities {
+		if related.ID != "" {
+			advisory.Aliases = append(advisory.Aliases, related.ID)
+		}
+	}
+	return mapGrypeAdvisory(advisory)
+}
+
+func constraintString(constraint fmt.Stringer) string {
+	if constraint == nil {
+		return ""
+	}
+	return constraint.String()
+}
+
+func builtinCVSS(scores []grypevuln.Cvss) []sdk.CVSSScore {
+	if len(scores) == 0 {
+		return nil
+	}
+	out := make([]sdk.CVSSScore, 0, len(scores))
+	for _, score := range scores {
+		if score.Vector == "" && score.Metrics.BaseScore == 0 {
+			continue
+		}
+		out = append(out, sdk.CVSSScore{
+			Vector:  score.Vector,
+			Score:   score.Metrics.BaseScore,
+			Version: score.Version,
+			Source:  score.Source,
+		})
+	}
+	return out
+}
+
+func builtinKnownExploited(values []grypevuln.KnownExploited) []sdk.KnownExploited {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]sdk.KnownExploited, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.KnownExploited{
+			CVE:                        value.CVE,
+			VendorProject:              value.VendorProject,
+			Product:                    value.Product,
+			DateAdded:                  datePtrString(value.DateAdded),
+			RequiredAction:             value.RequiredAction,
+			DueDate:                    datePtrString(value.DueDate),
+			KnownRansomwareCampaignUse: value.KnownRansomwareCampaignUse,
+			Notes:                      value.Notes,
+			URLs:                       append([]string(nil), value.URLs...),
+			CWEs:                       append([]string(nil), value.CWEs...),
+		})
+	}
+	return out
+}
+
+func builtinEPSS(values []grypevuln.EPSS) []sdk.EPSSScore {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]sdk.EPSSScore, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.EPSSScore{
+			CVE:        value.CVE,
+			EPSS:       value.EPSS,
+			Percentile: value.Percentile,
+			Date:       dateString(value.Date),
+		})
+	}
+	return out
+}
+
+func builtinCWEs(values []grypevuln.CWE) []sdk.CWE {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]sdk.CWE, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.CWE{
+			CVE:    value.CVE,
+			ID:     value.CWE,
+			Source: value.Source,
+			Type:   value.Type,
+		})
+	}
+	return out
+}
+
+func cpeStrings(values []cpe.CPE) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value.Attributes.String())
+	}
+	return out
+}
+
+func dateString(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.Format(time.DateOnly)
+}
+
+func datePtrString(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return dateString(*value)
 }

--- a/internal/matchers/grype/external.go
+++ b/internal/matchers/grype/external.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/logging"
@@ -68,21 +67,103 @@ type grypeJSONOutput struct {
 }
 
 type grypeJSONMatch struct {
-	Vulnerability grypeJSONVuln     `json:"vulnerability"`
-	Artifact      grypeJSONArtifact `json:"artifact"`
+	Vulnerability          grypeJSONVuln       `json:"vulnerability"`
+	RelatedVulnerabilities []grypeJSONVulnMeta `json:"relatedVulnerabilities"`
+	MatchDetails           []grypeJSONDetail   `json:"matchDetails"`
+	Artifact               grypeJSONArtifact   `json:"artifact"`
 }
 
 type grypeJSONVuln struct {
-	ID          string   `json:"id"`
-	Severity    string   `json:"severity"`
-	Description string   `json:"description"`
-	URLs        []string `json:"urls"`
+	grypeJSONVulnMeta
+	Fix        grypeJSONFix        `json:"fix"`
+	Advisories []grypeJSONAdvisory `json:"advisories"`
+	Risk       float64             `json:"risk"`
+}
+
+type grypeJSONVulnMeta struct {
+	ID             string                  `json:"id"`
+	DataSource     string                  `json:"dataSource"`
+	Namespace      string                  `json:"namespace"`
+	Severity       string                  `json:"severity"`
+	URLs           []string                `json:"urls"`
+	Description    string                  `json:"description"`
+	CVSS           []grypeJSONCVSS         `json:"cvss"`
+	KnownExploited []grypeJSONKnownExploit `json:"knownExploited"`
+	EPSS           []grypeJSONEPSS         `json:"epss"`
+	CWEs           []grypeJSONCWE          `json:"cwes"`
+}
+
+type grypeJSONFix struct {
+	Versions  []string                `json:"versions"`
+	State     string                  `json:"state"`
+	Available []grypeJSONFixAvailable `json:"available"`
+}
+
+type grypeJSONFixAvailable struct {
+	Version string `json:"version"`
+	Date    string `json:"date"`
+	Kind    string `json:"kind"`
+}
+
+type grypeJSONAdvisory struct {
+	ID   string `json:"id"`
+	Link string `json:"link"`
+}
+
+type grypeJSONCVSS struct {
+	Source  string              `json:"source"`
+	Type    string              `json:"type"`
+	Version string              `json:"version"`
+	Vector  string              `json:"vector"`
+	Metrics grypeJSONCVSSMetric `json:"metrics"`
+}
+
+type grypeJSONCVSSMetric struct {
+	BaseScore float64 `json:"baseScore"`
+}
+
+type grypeJSONKnownExploit struct {
+	CVE                        string   `json:"cve"`
+	VendorProject              string   `json:"vendorProject"`
+	Product                    string   `json:"product"`
+	DateAdded                  string   `json:"dateAdded"`
+	RequiredAction             string   `json:"requiredAction"`
+	DueDate                    string   `json:"dueDate"`
+	KnownRansomwareCampaignUse string   `json:"knownRansomwareCampaignUse"`
+	Notes                      string   `json:"notes"`
+	URLs                       []string `json:"urls"`
+	CWEs                       []string `json:"cwes"`
+}
+
+type grypeJSONEPSS struct {
+	CVE        string  `json:"cve"`
+	EPSS       float64 `json:"epss"`
+	Percentile float64 `json:"percentile"`
+	Date       string  `json:"date"`
+}
+
+type grypeJSONCWE struct {
+	CVE    string `json:"cve"`
+	CWE    string `json:"cwe"`
+	Source string `json:"source"`
+	Type   string `json:"type"`
+}
+
+type grypeJSONDetail struct {
+	Found json.RawMessage      `json:"found"`
+	Fix   *grypeJSONFixDetails `json:"fix"`
+}
+
+type grypeJSONFixDetails struct {
+	SuggestedVersion string `json:"suggestedVersion"`
 }
 
 type grypeJSONArtifact struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	PURL    string `json:"purl"`
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	CPEs    []string `json:"cpes"`
+	PURL    string   `json:"purl"`
 }
 
 func parseGrypeJSONOutput(data []byte, g *sdk.Graph) error {
@@ -92,7 +173,11 @@ func parseGrypeJSONOutput(data []byte, g *sdk.Graph) error {
 	}
 
 	pkgByPURL := make(map[string]*sdk.Package)
+	pkgByID := make(map[string]*sdk.Package)
 	for _, p := range g.Packages() {
+		if p.ID != "" {
+			pkgByID[p.ID] = p
+		}
 		if p.PURL != "" {
 			pkgByPURL[p.PURL] = p
 		}
@@ -101,27 +186,141 @@ func parseGrypeJSONOutput(data []byte, g *sdk.Graph) error {
 	for _, m := range out.Matches {
 		graphPkg := pkgByPURL[m.Artifact.PURL]
 		if graphPkg == nil {
+			graphPkg = pkgByID[m.Artifact.ID]
+		}
+		if graphPkg == nil {
 			graphPkg = &sdk.Package{
+				ID:      m.Artifact.ID,
 				Name:    m.Artifact.Name,
 				Version: m.Artifact.Version,
 				PURL:    m.Artifact.PURL,
 			}
 		}
 
-		title := m.Vulnerability.ID
-		if m.Vulnerability.Description != "" {
-			title = m.Vulnerability.Description
-		}
-
 		graphPkg.Matched = true
-		graphPkg.Vulnerabilities = appendUniqueVulnerability(graphPkg.Vulnerabilities, sdk.PackageVulnerability{
-			ID:          m.Vulnerability.ID,
-			Title:       title,
-			Severity:    strings.ToLower(m.Vulnerability.Severity),
-			Description: m.Vulnerability.Description,
-			Reasons:     append([]string(nil), m.Vulnerability.URLs...),
-			Source:      matcherName,
-		})
+		graphPkg.Vulnerabilities = appendOrMergeVulnerability(graphPkg.Vulnerabilities, mapGrypeJSONMatch(m))
 	}
 	return nil
+}
+
+func mapGrypeJSONMatch(m grypeJSONMatch) sdk.PackageVulnerability {
+	advisory := grypeAdvisory{
+		ID:                   m.Vulnerability.ID,
+		Namespace:            m.Vulnerability.Namespace,
+		DataSource:           m.Vulnerability.DataSource,
+		Severity:             m.Vulnerability.Severity,
+		SeveritySource:       m.Vulnerability.Namespace,
+		Description:          m.Vulnerability.Description,
+		URLs:                 append([]string(nil), m.Vulnerability.URLs...),
+		CVSS:                 jsonCVSS(m.Vulnerability.CVSS),
+		FixedVersions:        append([]string(nil), m.Vulnerability.Fix.Versions...),
+		FixedIn:              suggestedFixedVersion(m.MatchDetails),
+		FixState:             m.Vulnerability.Fix.State,
+		FixAvailable:         jsonFixAvailable(m.Vulnerability.Fix.Available),
+		AffectedVersionRange: foundConstraint(m.MatchDetails),
+		References:           jsonReferences(m.Vulnerability.Advisories),
+		Aliases:              jsonAliases(m.RelatedVulnerabilities),
+		KnownExploited:       jsonKnownExploited(m.Vulnerability.KnownExploited),
+		EPSS:                 jsonEPSS(m.Vulnerability.EPSS),
+		CWEs:                 jsonCWEs(m.Vulnerability.CWEs),
+		RiskScore:            m.Vulnerability.Risk,
+		CPEs:                 append([]string(nil), m.Artifact.CPEs...),
+	}
+	return mapGrypeAdvisory(advisory)
+}
+
+func suggestedFixedVersion(details []grypeJSONDetail) string {
+	for _, detail := range details {
+		if detail.Fix != nil && detail.Fix.SuggestedVersion != "" {
+			return detail.Fix.SuggestedVersion
+		}
+	}
+	return ""
+}
+
+func foundConstraint(details []grypeJSONDetail) string {
+	for _, detail := range details {
+		var found struct {
+			Constraint string `json:"constraint"`
+		}
+		if len(detail.Found) == 0 || json.Unmarshal(detail.Found, &found) != nil {
+			continue
+		}
+		if found.Constraint != "" {
+			return found.Constraint
+		}
+	}
+	return ""
+}
+
+func jsonCVSS(values []grypeJSONCVSS) []sdk.CVSSScore {
+	out := make([]sdk.CVSSScore, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.CVSSScore{
+			Vector:  value.Vector,
+			Score:   value.Metrics.BaseScore,
+			Version: value.Version,
+			Source:  value.Source,
+		})
+	}
+	return out
+}
+
+func jsonFixAvailable(values []grypeJSONFixAvailable) []sdk.FixAvailable {
+	out := make([]sdk.FixAvailable, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.FixAvailable{Version: value.Version, Date: value.Date, Kind: value.Kind})
+	}
+	return out
+}
+
+func jsonReferences(values []grypeJSONAdvisory) []sdk.Reference {
+	out := make([]sdk.Reference, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.Reference{URL: value.Link, Type: firstNonEmpty(value.ID, "advisory")})
+	}
+	return out
+}
+
+func jsonAliases(values []grypeJSONVulnMeta) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value.ID)
+	}
+	return out
+}
+
+func jsonKnownExploited(values []grypeJSONKnownExploit) []sdk.KnownExploited {
+	out := make([]sdk.KnownExploited, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.KnownExploited{
+			CVE:                        value.CVE,
+			VendorProject:              value.VendorProject,
+			Product:                    value.Product,
+			DateAdded:                  value.DateAdded,
+			RequiredAction:             value.RequiredAction,
+			DueDate:                    value.DueDate,
+			KnownRansomwareCampaignUse: value.KnownRansomwareCampaignUse,
+			Notes:                      value.Notes,
+			URLs:                       append([]string(nil), value.URLs...),
+			CWEs:                       append([]string(nil), value.CWEs...),
+		})
+	}
+	return out
+}
+
+func jsonEPSS(values []grypeJSONEPSS) []sdk.EPSSScore {
+	out := make([]sdk.EPSSScore, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.EPSSScore{CVE: value.CVE, EPSS: value.EPSS, Percentile: value.Percentile, Date: value.Date})
+	}
+	return out
+}
+
+func jsonCWEs(values []grypeJSONCWE) []sdk.CWE {
+	out := make([]sdk.CWE, 0, len(values))
+	for _, value := range values {
+		out = append(out, sdk.CWE{CVE: value.CVE, ID: value.CWE, Source: value.Source, Type: value.Type})
+	}
+	return out
 }

--- a/internal/matchers/grype/external_test.go
+++ b/internal/matchers/grype/external_test.go
@@ -1,0 +1,75 @@
+//go:build bomly_external_grype
+
+package grype
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestParseGrypeJSONOutputCarriesRichFields(t *testing.T) {
+	g := sdk.New()
+	pkg := &sdk.Package{ID: "pkg-1", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"}
+	if err := g.AddPackage(pkg); err != nil {
+		t.Fatalf("AddPackage: %v", err)
+	}
+
+	data := []byte(`{
+		"matches": [{
+			"vulnerability": {
+				"id": "CVE-2020-8203",
+				"dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+				"namespace": "github:language:javascript",
+				"severity": "High",
+				"urls": ["https://example.test/advisory"],
+				"description": "Prototype pollution",
+				"cvss": [{
+					"source": "nvd",
+					"type": "CVSS",
+					"version": "3.1",
+					"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					"metrics": {"baseScore": 9.8}
+				}],
+				"knownExploited": [{
+					"cve": "CVE-2020-8203",
+					"knownRansomwareCampaignUse": "Known",
+					"urls": ["https://kev.test"]
+				}],
+				"epss": [{"cve": "CVE-2020-8203", "epss": 0.25, "percentile": 0.9, "date": "2024-05-01"}],
+				"cwes": [{"cve": "CVE-2020-8203", "cwe": "CWE-1321", "source": "nvd", "type": "primary"}],
+				"fix": {"versions": ["4.17.19"], "state": "fixed", "available": [{"version": "4.17.19", "date": "2020-07-01", "kind": "first-observed"}]},
+				"advisories": [{"id": "GHSA-p6mc-m468-83gw", "link": "https://github.com/advisories/GHSA-p6mc-m468-83gw"}],
+				"risk": 75.5
+			},
+			"relatedVulnerabilities": [{"id": "GHSA-p6mc-m468-83gw", "namespace": "github:language:javascript"}],
+			"matchDetails": [{
+				"found": {"constraint": "< 4.17.19"},
+				"fix": {"suggestedVersion": "4.17.21"}
+			}],
+			"artifact": {
+				"id": "pkg-1",
+				"name": "lodash",
+				"version": "4.17.15",
+				"purl": "pkg:npm/lodash@4.17.15",
+				"cpes": ["cpe:2.3:a:lodash:lodash:4.17.15:*:*:*:*:*:*:*"]
+			}
+		}]
+	}`)
+	if err := parseGrypeJSONOutput(data, g); err != nil {
+		t.Fatalf("parseGrypeJSONOutput: %v", err)
+	}
+	if len(pkg.Vulnerabilities) != 1 {
+		t.Fatalf("len vulnerabilities = %d, want 1", len(pkg.Vulnerabilities))
+	}
+	v := pkg.Vulnerabilities[0]
+	if v.FixedIn != "4.17.21" {
+		t.Fatalf("FixedIn = %q, want suggested version", v.FixedIn)
+	}
+	if v.AffectedVersionRange != "< 4.17.19" || len(v.FixedVersions) != 1 || v.FixState != "fixed" {
+		t.Fatalf("fix/range data missing: %#v", v)
+	}
+	if len(v.CVSS) != 1 || len(v.EPSS) != 1 || len(v.CWEs) != 1 || len(v.KnownExploited) != 1 || len(v.CPEs) != 1 {
+		t.Fatalf("rich fields missing: %#v", v)
+	}
+}

--- a/internal/matchers/grype/mapper.go
+++ b/internal/matchers/grype/mapper.go
@@ -1,0 +1,292 @@
+package grype
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+type grypeAdvisory struct {
+	ID                   string
+	Namespace            string
+	DataSource           string
+	Severity             string
+	SeveritySource       string
+	Description          string
+	URLs                 []string
+	CVSS                 []sdk.CVSSScore
+	FixedVersions        []string
+	FixedIn              string
+	FixState             string
+	FixAvailable         []sdk.FixAvailable
+	AffectedVersionRange string
+	References           []sdk.Reference
+	Aliases              []string
+	KnownExploited       []sdk.KnownExploited
+	EPSS                 []sdk.EPSSScore
+	CWEs                 []sdk.CWE
+	RiskScore            float64
+	CPEs                 []string
+}
+
+func mapGrypeAdvisory(advisory grypeAdvisory) sdk.PackageVulnerability {
+	fixedIn := strings.TrimSpace(advisory.FixedIn)
+	if fixedIn == "" && len(advisory.FixedVersions) > 0 {
+		fixedIn = strings.TrimSpace(advisory.FixedVersions[0])
+	}
+	severity := strings.ToLower(strings.TrimSpace(advisory.Severity))
+	if severity == "" {
+		severity = "unknown"
+	}
+	description := strings.TrimSpace(advisory.Description)
+	title := strings.TrimSpace(advisory.ID)
+	if description != "" {
+		title = description
+	}
+	refs := append([]sdk.Reference(nil), advisory.References...)
+	if advisory.DataSource != "" {
+		refs = appendUniqueReference(refs, sdk.Reference{URL: advisory.DataSource, Type: "data_source"})
+	}
+	for _, url := range advisory.URLs {
+		refs = appendUniqueReference(refs, sdk.Reference{URL: url, Type: "advisory"})
+	}
+
+	return sdk.PackageVulnerability{
+		ID:                   advisory.ID,
+		Title:                title,
+		Severity:             severity,
+		SeveritySource:       advisory.SeveritySource,
+		Aliases:              dedupeStrings(advisory.Aliases),
+		Description:          description,
+		Reasons:              grypeReasons(advisory, fixedIn),
+		Source:               matcherName,
+		CVSS:                 append([]sdk.CVSSScore(nil), advisory.CVSS...),
+		FixedIn:              fixedIn,
+		FixedVersions:        dedupeStrings(advisory.FixedVersions),
+		FixState:             advisory.FixState,
+		FixAvailable:         append([]sdk.FixAvailable(nil), advisory.FixAvailable...),
+		AffectedVersionRange: advisory.AffectedVersionRange,
+		References:           refs,
+		KEVExploited:         len(advisory.KnownExploited) > 0,
+		KnownExploited:       cloneKnownExploited(advisory.KnownExploited),
+		EPSS:                 append([]sdk.EPSSScore(nil), advisory.EPSS...),
+		CWEs:                 append([]sdk.CWE(nil), advisory.CWEs...),
+		RiskScore:            advisory.RiskScore,
+		DataSource:           advisory.DataSource,
+		Namespace:            advisory.Namespace,
+		CPEs:                 dedupeStrings(advisory.CPEs),
+	}
+}
+
+func grypeReasons(advisory grypeAdvisory, fixedIn string) []string {
+	reasons := make([]string, 0, 4)
+	if fixedIn != "" {
+		reasons = append(reasons, fmt.Sprintf("Fix available: upgrade to %s", fixedIn))
+	}
+	if advisory.FixState != "" {
+		reasons = append(reasons, "Fix state: "+advisory.FixState)
+	}
+	if len(advisory.Aliases) > 0 {
+		reasons = append(reasons, "Also known as: "+strings.Join(dedupeStrings(advisory.Aliases), ", "))
+	}
+	if len(advisory.URLs) > 0 {
+		reasons = append(reasons, advisory.URLs...)
+	}
+	return reasons
+}
+
+func mergePackageVulnerability(base, incoming sdk.PackageVulnerability) sdk.PackageVulnerability {
+	base.Title = firstNonEmpty(base.Title, incoming.Title)
+	base.Severity = firstNonEmpty(base.Severity, incoming.Severity)
+	base.SeveritySource = firstNonEmpty(base.SeveritySource, incoming.SeveritySource)
+	base.Description = firstNonEmpty(base.Description, incoming.Description)
+	base.FixedIn = firstNonEmpty(base.FixedIn, incoming.FixedIn)
+	base.FixState = firstNonEmpty(base.FixState, incoming.FixState)
+	base.AffectedVersionRange = firstNonEmpty(base.AffectedVersionRange, incoming.AffectedVersionRange)
+	base.DataSource = firstNonEmpty(base.DataSource, incoming.DataSource)
+	base.Namespace = firstNonEmpty(base.Namespace, incoming.Namespace)
+	if base.RiskScore == 0 {
+		base.RiskScore = incoming.RiskScore
+	}
+	base.KEVExploited = base.KEVExploited || incoming.KEVExploited
+	base.Aliases = appendUniqueStrings(base.Aliases, incoming.Aliases...)
+	base.Reasons = appendUniqueStrings(base.Reasons, incoming.Reasons...)
+	base.CVSS = appendUniqueCVSS(base.CVSS, incoming.CVSS...)
+	base.FixedVersions = appendUniqueStrings(base.FixedVersions, incoming.FixedVersions...)
+	base.FixAvailable = appendUniqueFixAvailable(base.FixAvailable, incoming.FixAvailable...)
+	base.References = appendUniqueReferences(base.References, incoming.References...)
+	base.KnownExploited = appendUniqueKnownExploited(base.KnownExploited, incoming.KnownExploited...)
+	base.EPSS = appendUniqueEPSS(base.EPSS, incoming.EPSS...)
+	base.CWEs = appendUniqueCWEs(base.CWEs, incoming.CWEs...)
+	base.CPEs = appendUniqueStrings(base.CPEs, incoming.CPEs...)
+	return base
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func dedupeStrings(values []string) []string {
+	return appendUniqueStrings(nil, values...)
+}
+
+func appendUniqueStrings(existing []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]string, 0, len(existing)+len(values))
+	for _, value := range existing {
+		key := strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	for _, value := range values {
+		key := strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func appendUniqueReference(existing []sdk.Reference, ref sdk.Reference) []sdk.Reference {
+	return appendUniqueReferences(existing, ref)
+}
+
+func appendUniqueReferences(existing []sdk.Reference, values ...sdk.Reference) []sdk.Reference {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.Reference, 0, len(existing)+len(values))
+	for _, ref := range existing {
+		key := ref.URL + "\x00" + ref.Type
+		if strings.TrimSpace(ref.URL) == "" || key == "\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, ref)
+	}
+	for _, ref := range values {
+		key := ref.URL + "\x00" + ref.Type
+		if strings.TrimSpace(ref.URL) == "" || key == "\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func appendUniqueCVSS(existing []sdk.CVSSScore, values ...sdk.CVSSScore) []sdk.CVSSScore {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.CVSSScore, 0, len(existing)+len(values))
+	for _, score := range append(existing, values...) {
+		key := score.Source + "\x00" + score.Version + "\x00" + score.Vector
+		if key == "\x00\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, score)
+	}
+	return out
+}
+
+func appendUniqueFixAvailable(existing []sdk.FixAvailable, values ...sdk.FixAvailable) []sdk.FixAvailable {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.FixAvailable, 0, len(existing)+len(values))
+	for _, fix := range append(existing, values...) {
+		key := fix.Version + "\x00" + fix.Date + "\x00" + fix.Kind
+		if key == "\x00\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, fix)
+	}
+	return out
+}
+
+func appendUniqueEPSS(existing []sdk.EPSSScore, values ...sdk.EPSSScore) []sdk.EPSSScore {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.EPSSScore, 0, len(existing)+len(values))
+	for _, epss := range append(existing, values...) {
+		key := epss.CVE + "\x00" + epss.Date
+		if key == "\x00" && epss.EPSS == 0 && epss.Percentile == 0 {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, epss)
+	}
+	return out
+}
+
+func appendUniqueCWEs(existing []sdk.CWE, values ...sdk.CWE) []sdk.CWE {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.CWE, 0, len(existing)+len(values))
+	for _, cwe := range append(existing, values...) {
+		key := cwe.CVE + "\x00" + cwe.ID + "\x00" + cwe.Source + "\x00" + cwe.Type
+		if key == "\x00\x00\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, cwe)
+	}
+	return out
+}
+
+func cloneKnownExploited(src []sdk.KnownExploited) []sdk.KnownExploited {
+	return appendUniqueKnownExploited(nil, src...)
+}
+
+func appendUniqueKnownExploited(existing []sdk.KnownExploited, values ...sdk.KnownExploited) []sdk.KnownExploited {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	out := make([]sdk.KnownExploited, 0, len(existing)+len(values))
+	for _, item := range append(existing, values...) {
+		key := item.CVE + "\x00" + item.DateAdded + "\x00" + item.Product
+		if key == "\x00\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		if len(item.URLs) > 0 {
+			item.URLs = append([]string(nil), item.URLs...)
+		}
+		if len(item.CWEs) > 0 {
+			item.CWEs = append([]string(nil), item.CWEs...)
+		}
+		out = append(out, item)
+	}
+	return out
+}

--- a/internal/matchers/grype/mapper_test.go
+++ b/internal/matchers/grype/mapper_test.go
@@ -1,0 +1,106 @@
+package grype
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestMapGrypeAdvisoryCarriesRichFields(t *testing.T) {
+	v := mapGrypeAdvisory(grypeAdvisory{
+		ID:                   "CVE-2024-1234",
+		Namespace:            "github:language:javascript",
+		DataSource:           "https://nvd.nist.gov/vuln/detail/CVE-2024-1234",
+		Severity:             "High",
+		SeveritySource:       "nvd",
+		Description:          "important vuln",
+		URLs:                 []string{"https://example.test/advisory"},
+		CVSS:                 []sdk.CVSSScore{{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", Score: 9.8, Version: "3.1", Source: "nvd"}},
+		FixedVersions:        []string{"1.2.3", "1.3.0"},
+		FixState:             "fixed",
+		FixAvailable:         []sdk.FixAvailable{{Version: "1.2.3", Date: "2024-01-02", Kind: "first-observed"}},
+		AffectedVersionRange: "< 1.2.3",
+		References:           []sdk.Reference{{URL: "https://patch.test/1", Type: "GHSA-xxxx"}},
+		Aliases:              []string{"GHSA-xxxx"},
+		KnownExploited:       []sdk.KnownExploited{{CVE: "CVE-2024-1234", KnownRansomwareCampaignUse: "Known"}},
+		EPSS:                 []sdk.EPSSScore{{CVE: "CVE-2024-1234", EPSS: 0.42, Percentile: 0.97, Date: "2024-05-01"}},
+		CWEs:                 []sdk.CWE{{CVE: "CVE-2024-1234", ID: "CWE-79", Source: "nvd", Type: "primary"}},
+		RiskScore:            88.2,
+		CPEs:                 []string{"cpe:2.3:a:example:pkg:1.0:*:*:*:*:*:*:*"},
+	})
+
+	if v.FixedIn != "1.2.3" {
+		t.Fatalf("FixedIn = %q, want 1.2.3", v.FixedIn)
+	}
+	if len(v.FixedVersions) != 2 || v.FixedVersions[1] != "1.3.0" {
+		t.Fatalf("FixedVersions = %#v", v.FixedVersions)
+	}
+	if v.Severity != "high" || v.Title != "important vuln" || v.Source != matcherName {
+		t.Fatalf("unexpected core fields: %#v", v)
+	}
+	if len(v.CVSS) != 1 || v.CVSS[0].Score != 9.8 {
+		t.Fatalf("CVSS = %#v", v.CVSS)
+	}
+	if len(v.References) != 3 {
+		t.Fatalf("References = %#v, want patch, data source, and URL refs", v.References)
+	}
+	if !v.KEVExploited || len(v.KnownExploited) != 1 {
+		t.Fatalf("known exploited data not mapped: %#v", v.KnownExploited)
+	}
+	if len(v.EPSS) != 1 || v.EPSS[0].Percentile != 0.97 {
+		t.Fatalf("EPSS = %#v", v.EPSS)
+	}
+	if len(v.CWEs) != 1 || v.CWEs[0].ID != "CWE-79" {
+		t.Fatalf("CWEs = %#v", v.CWEs)
+	}
+	if v.RiskScore != 88.2 || v.DataSource == "" || v.Namespace == "" || len(v.CPEs) != 1 {
+		t.Fatalf("rich metadata missing: %#v", v)
+	}
+}
+
+func TestMapGrypeAdvisoryPrefersSuggestedFixedIn(t *testing.T) {
+	v := mapGrypeAdvisory(grypeAdvisory{
+		ID:            "CVE-2024-1234",
+		Severity:      "medium",
+		FixedIn:       "2.0.0",
+		FixedVersions: []string{"1.2.3"},
+	})
+	if v.FixedIn != "2.0.0" {
+		t.Fatalf("FixedIn = %q, want suggested version", v.FixedIn)
+	}
+}
+
+func TestAppendOrMergeVulnerabilityUnionsFields(t *testing.T) {
+	existing := []sdk.PackageVulnerability{{
+		ID:      "CVE-1",
+		Source:  matcherName,
+		FixedIn: "1.0.0",
+		Aliases: []string{"GHSA-1"},
+		CVSS:    []sdk.CVSSScore{{Vector: "v1", Source: "nvd"}},
+		Reasons: []string{"old"},
+	}}
+	incoming := sdk.PackageVulnerability{
+		ID:             "CVE-1",
+		Source:         matcherName,
+		FixState:       "fixed",
+		FixedVersions:  []string{"1.0.0", "1.1.0"},
+		Aliases:        []string{"GHSA-1", "ALIAS-2"},
+		CVSS:           []sdk.CVSSScore{{Vector: "v2", Source: "vendor"}},
+		KnownExploited: []sdk.KnownExploited{{CVE: "CVE-1"}},
+		Reasons:        []string{"old", "new"},
+	}
+	got := appendOrMergeVulnerability(existing, incoming)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	merged := got[0]
+	if merged.FixedIn != "1.0.0" || merged.FixState != "fixed" {
+		t.Fatalf("unexpected fix fields: %#v", merged)
+	}
+	if len(merged.FixedVersions) != 2 || len(merged.Aliases) != 2 || len(merged.CVSS) != 2 || len(merged.Reasons) != 2 {
+		t.Fatalf("merge did not union fields: %#v", merged)
+	}
+	if !merged.IsExploitable() {
+		t.Fatal("merged vulnerability should be exploitable")
+	}
+}

--- a/internal/matchers/grype/matcher.go
+++ b/internal/matchers/grype/matcher.go
@@ -26,9 +26,10 @@ type Matcher struct {
 	DistConfigOverride any
 }
 
-func appendUniqueVulnerability(existing []sdk.PackageVulnerability, entry sdk.PackageVulnerability) []sdk.PackageVulnerability {
-	for _, vulnerability := range existing {
+func appendOrMergeVulnerability(existing []sdk.PackageVulnerability, entry sdk.PackageVulnerability) []sdk.PackageVulnerability {
+	for idx, vulnerability := range existing {
 		if vulnerability.Source == entry.Source && vulnerability.ID == entry.ID {
+			existing[idx] = mergePackageVulnerability(vulnerability, entry)
 			return existing
 		}
 	}

--- a/internal/matchers/grype/matcher_test.go
+++ b/internal/matchers/grype/matcher_test.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	v6dist "github.com/anchore/grype/grype/db/v6/distribution"
+	grypematch "github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	grypevuln "github.com/anchore/grype/grype/vulnerability"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -114,5 +117,47 @@ func TestGraphPkgToGrypePkg_FieldMapping(t *testing.T) {
 	}
 	if gp.PURL != "pkg:npm/lodash@4.17.15" {
 		t.Errorf("PURL = %q, want pkg:npm/lodash@4.17.15", gp.PURL)
+	}
+}
+
+func TestMapBuiltinMatchCarriesRichFields(t *testing.T) {
+	v := mapBuiltinMatch(grypematch.Match{
+		Package: grypepkg.Package{ID: "pkg-1", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"},
+		Vulnerability: grypevuln.Vulnerability{
+			Reference: grypevuln.Reference{ID: "CVE-2020-8203", Namespace: "github:language:javascript"},
+			Fix: grypevuln.Fix{
+				Versions: []string{"4.17.19"},
+				State:    grypevuln.FixStateFixed,
+				Available: []grypevuln.FixAvailable{{
+					Version: "4.17.19",
+					Date:    time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC),
+					Kind:    "first-observed",
+				}},
+			},
+			Advisories:             []grypevuln.Advisory{{ID: "GHSA-p6mc-m468-83gw", Link: "https://github.com/advisories/GHSA-p6mc-m468-83gw"}},
+			RelatedVulnerabilities: []grypevuln.Reference{{ID: "GHSA-p6mc-m468-83gw", Namespace: "github:language:javascript"}},
+			Metadata: &grypevuln.Metadata{
+				DataSource:  "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+				Namespace:   "nvd:cpe",
+				Severity:    "High",
+				Description: "Prototype pollution",
+				URLs:        []string{"https://example.test/advisory"},
+				Cvss: []grypevuln.Cvss{{
+					Source:  "nvd",
+					Version: "3.1",
+					Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Metrics: grypevuln.CvssMetrics{BaseScore: 9.8},
+				}},
+				KnownExploited: []grypevuln.KnownExploited{{CVE: "CVE-2020-8203", KnownRansomwareCampaignUse: "Known"}},
+				EPSS:           []grypevuln.EPSS{{CVE: "CVE-2020-8203", EPSS: 0.25, Percentile: 0.9, Date: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)}},
+				CWEs:           []grypevuln.CWE{{CVE: "CVE-2020-8203", CWE: "CWE-1321", Source: "nvd", Type: "primary"}},
+			},
+		},
+	})
+	if v.FixedIn != "4.17.19" || v.FixState != "fixed" {
+		t.Fatalf("fix data missing: %#v", v)
+	}
+	if len(v.CVSS) != 1 || len(v.EPSS) != 1 || len(v.CWEs) != 1 || len(v.KnownExploited) != 1 || len(v.Aliases) != 1 {
+		t.Fatalf("rich fields missing: %#v", v)
 	}
 }

--- a/internal/mcp/tool_diff.go
+++ b/internal/mcp/tool_diff.go
@@ -22,7 +22,7 @@ func registerDiffTool(s *server.MCPServer, mcpCtx MCPContext) {
 		mcplib.WithBoolean("enrich", mcplib.Description("Enrich packages with vulnerability and license data")),
 		mcplib.WithBoolean("audit", mcplib.Description("Include audit delta (introduced, resolved, and persisted findings) (requires enrich)")),
 		mcplib.WithBoolean("reachability", mcplib.Description("Run code analysis on each side and include reachability annotations on the audit delta (requires enrich)")),
-		mcplib.WithString("fail_on", mcplib.Description("Vulnerability threshold constraint, such as high or reachable")),
+		mcplib.WithString("fail_on", mcplib.Description("Vulnerability threshold constraint, such as high, reachable, or exploitable")),
 		mcplib.WithString("fail_on_scopes", mcplib.Description("Comma-separated dependency scopes that may produce failing findings")),
 		mcplib.WithString("allow_vulnerability_ids", mcplib.Description("Comma-separated vulnerability IDs to ignore")),
 		mcplib.WithString("allow_licenses", mcplib.Description("Comma-separated SPDX licenses to allow")),

--- a/internal/mcp/tool_scan.go
+++ b/internal/mcp/tool_scan.go
@@ -17,7 +17,7 @@ func registerScanTool(s *server.MCPServer, mcpCtx MCPContext) {
 		mcplib.WithBoolean("enrich", mcplib.Description("Enrich packages with vulnerability and license data from external sources")),
 		mcplib.WithBoolean("audit", mcplib.Description("Evaluate policy and produce findings from enriched vulnerability data (requires enrich)")),
 		mcplib.WithBoolean("reachability", mcplib.Description("[Experimental] Run code analysis to confirm whether vulnerabilities are reachable from application code (requires enrich)")),
-		mcplib.WithString("fail_on", mcplib.Description("Minimum severity threshold for audit findings: any, low, medium, high, critical")),
+		mcplib.WithString("fail_on", mcplib.Description("Audit finding constraint: any, low, medium, high, critical, reachable, or exploitable")),
 		mcplib.WithString("ecosystems", mcplib.Description("Ecosystem filter; supports +name/-name modifiers")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -108,13 +108,30 @@ type sarifThreadFlowLocation struct {
 // these fields give consumers everything needed to triage a finding
 // without parsing the parallel JSON output.
 type sarifProperties struct {
-	Reachability           string `json:"reachability,omitempty"`
-	ReachabilityTier       string `json:"reachability_tier,omitempty"`
-	ReachabilityReason     string `json:"reachability_reason,omitempty"`
-	Analyzer               string `json:"analyzer,omitempty"`
-	ReachabilityConfidence string `json:"reachability_confidence,omitempty"`
-	ReachabilityHops       *int   `json:"reachability_hops,omitempty"`
-	DynamicImportsDetected bool   `json:"reachability_dynamic_imports_detected,omitempty"`
+	FixedIn                string               `json:"fixed_in,omitempty"`
+	FixedVersions          []string             `json:"fixed_versions,omitempty"`
+	FixState               string               `json:"fix_state,omitempty"`
+	FixAvailable           []sdk.FixAvailable   `json:"fix_available,omitempty"`
+	SeveritySource         string               `json:"severity_source,omitempty"`
+	CVSS                   []sdk.CVSSScore      `json:"cvss,omitempty"`
+	Aliases                []string             `json:"aliases,omitempty"`
+	AffectedVersionRange   string               `json:"affected_version_range,omitempty"`
+	References             []sdk.Reference      `json:"references,omitempty"`
+	KEVExploited           bool                 `json:"kev_exploited,omitempty"`
+	KnownExploited         []sdk.KnownExploited `json:"known_exploited,omitempty"`
+	EPSS                   []sdk.EPSSScore      `json:"epss,omitempty"`
+	CWEs                   []sdk.CWE            `json:"cwes,omitempty"`
+	RiskScore              float64              `json:"risk_score,omitempty"`
+	DataSource             string               `json:"data_source,omitempty"`
+	Namespace              string               `json:"namespace,omitempty"`
+	CPEs                   []string             `json:"cpes,omitempty"`
+	Reachability           string               `json:"reachability,omitempty"`
+	ReachabilityTier       string               `json:"reachability_tier,omitempty"`
+	ReachabilityReason     string               `json:"reachability_reason,omitempty"`
+	Analyzer               string               `json:"analyzer,omitempty"`
+	ReachabilityConfidence string               `json:"reachability_confidence,omitempty"`
+	ReachabilityHops       *int                 `json:"reachability_hops,omitempty"`
+	DynamicImportsDetected bool                 `json:"reachability_dynamic_imports_detected,omitempty"`
 }
 
 // WriteSARIF writes findings as a SARIF 2.1.0 document to w.
@@ -159,23 +176,42 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion strin
 			Message:   sarifMessage{Text: msgText},
 			Locations: sarifLocationsForFinding(f, pkgName),
 		}
+		props := sarifProperties{
+			FixedIn:              f.FixedIn,
+			FixedVersions:        append([]string(nil), f.FixedVersions...),
+			FixState:             f.FixState,
+			FixAvailable:         append([]sdk.FixAvailable(nil), f.FixAvailable...),
+			SeveritySource:       f.SeveritySource,
+			CVSS:                 append([]sdk.CVSSScore(nil), f.CVSS...),
+			Aliases:              append([]string(nil), f.Aliases...),
+			AffectedVersionRange: f.AffectedVersionRange,
+			References:           append([]sdk.Reference(nil), f.References...),
+			KEVExploited:         f.KEVExploited,
+			KnownExploited:       cloneKnownExploited(f.KnownExploited),
+			EPSS:                 append([]sdk.EPSSScore(nil), f.EPSS...),
+			CWEs:                 append([]sdk.CWE(nil), f.CWEs...),
+			RiskScore:            f.RiskScore,
+			DataSource:           f.DataSource,
+			Namespace:            f.Namespace,
+			CPEs:                 append([]string(nil), f.CPEs...),
+		}
 		if f.Reachability != nil {
-			props := &sarifProperties{
-				Reachability:           string(f.Reachability.Status),
-				ReachabilityTier:       string(f.Reachability.Tier),
-				ReachabilityReason:     f.Reachability.Reason,
-				Analyzer:               f.Reachability.Analyzer,
-				ReachabilityConfidence: string(f.Reachability.Confidence),
-				DynamicImportsDetected: f.Reachability.DynamicImportsDetected,
-			}
+			props.Reachability = string(f.Reachability.Status)
+			props.ReachabilityTier = string(f.Reachability.Tier)
+			props.ReachabilityReason = f.Reachability.Reason
+			props.Analyzer = f.Reachability.Analyzer
+			props.ReachabilityConfidence = string(f.Reachability.Confidence)
+			props.DynamicImportsDetected = f.Reachability.DynamicImportsDetected
 			if f.Reachability.Hops != nil {
 				h := *f.Reachability.Hops
 				props.ReachabilityHops = &h
 			}
-			result.Properties = props
 			if flows := buildSARIFCodeFlows(f.Reachability.CallPaths); len(flows) > 0 {
 				result.CodeFlows = flows
 			}
+		}
+		if !sarifPropertiesEmpty(props) {
+			result.Properties = &props
 		}
 		results = append(results, result)
 	}
@@ -201,6 +237,33 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion strin
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(log)
+}
+
+func sarifPropertiesEmpty(props sarifProperties) bool {
+	return props.FixedIn == "" &&
+		len(props.FixedVersions) == 0 &&
+		props.FixState == "" &&
+		len(props.FixAvailable) == 0 &&
+		props.SeveritySource == "" &&
+		len(props.CVSS) == 0 &&
+		len(props.Aliases) == 0 &&
+		props.AffectedVersionRange == "" &&
+		len(props.References) == 0 &&
+		!props.KEVExploited &&
+		len(props.KnownExploited) == 0 &&
+		len(props.EPSS) == 0 &&
+		len(props.CWEs) == 0 &&
+		props.RiskScore == 0 &&
+		props.DataSource == "" &&
+		props.Namespace == "" &&
+		len(props.CPEs) == 0 &&
+		props.Reachability == "" &&
+		props.ReachabilityTier == "" &&
+		props.ReachabilityReason == "" &&
+		props.Analyzer == "" &&
+		props.ReachabilityConfidence == "" &&
+		props.ReachabilityHops == nil &&
+		!props.DynamicImportsDetected
 }
 
 // buildSARIFCodeFlows converts reachability call paths into SARIF

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -58,9 +58,19 @@ type VulnerabilityRef struct {
 	Reasons              []string             `json:"reasons,omitempty"`
 	CVSS                 []sdk.CVSSScore      `json:"cvss,omitempty"`
 	FixedIn              string               `json:"fixed_in,omitempty"`
+	FixedVersions        []string             `json:"fixed_versions,omitempty"`
+	FixState             string               `json:"fix_state,omitempty"`
+	FixAvailable         []sdk.FixAvailable   `json:"fix_available,omitempty"`
 	AffectedVersionRange string               `json:"affected_version_range,omitempty"`
 	References           []sdk.Reference      `json:"references,omitempty"`
 	KEVExploited         bool                 `json:"kev_exploited,omitempty"`
+	KnownExploited       []sdk.KnownExploited `json:"known_exploited,omitempty"`
+	EPSS                 []sdk.EPSSScore      `json:"epss,omitempty"`
+	CWEs                 []sdk.CWE            `json:"cwes,omitempty"`
+	RiskScore            float64              `json:"risk_score,omitempty"`
+	DataSource           string               `json:"data_source,omitempty"`
+	Namespace            string               `json:"namespace,omitempty"`
+	CPEs                 []string             `json:"cpes,omitempty"`
 	AffectedSymbols      []sdk.AffectedSymbol `json:"affected_symbols,omitempty"`
 	Reachability         *sdk.Reachability    `json:"reachability,omitempty"`
 }
@@ -173,6 +183,23 @@ func cloneRefMetadata(src map[string]any) map[string]any {
 	return clone
 }
 
+func cloneKnownExploited(src []sdk.KnownExploited) []sdk.KnownExploited {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]sdk.KnownExploited, 0, len(src))
+	for _, item := range src {
+		if len(item.URLs) > 0 {
+			item.URLs = append([]string(nil), item.URLs...)
+		}
+		if len(item.CWEs) > 0 {
+			item.CWEs = append([]string(nil), item.CWEs...)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
 // LicenseRefsFromGraphLicenses converts graph licenses into output-friendly values.
 func LicenseRefsFromGraphLicenses(licenses []sdk.PackageLicense) []LicenseRef {
 	if len(licenses) == 0 {
@@ -207,11 +234,21 @@ func VulnerabilityRefsFromPackageVulnerabilities(vulnerabilities []sdk.PackageVu
 			Reasons:              append([]string(nil), vulnerability.Reasons...),
 			CVSS:                 append([]sdk.CVSSScore(nil), vulnerability.CVSS...),
 			FixedIn:              vulnerability.FixedIn,
+			FixedVersions:        append([]string(nil), vulnerability.FixedVersions...),
+			FixState:             vulnerability.FixState,
+			FixAvailable:         append([]sdk.FixAvailable(nil), vulnerability.FixAvailable...),
 			AffectedSymbols:      cloneAffectedSymbols(vulnerability.AffectedSymbols),
 			Reachability:         vulnerability.Reachability.Clone(),
 			AffectedVersionRange: vulnerability.AffectedVersionRange,
 			References:           append([]sdk.Reference(nil), vulnerability.References...),
 			KEVExploited:         vulnerability.KEVExploited,
+			KnownExploited:       cloneKnownExploited(vulnerability.KnownExploited),
+			EPSS:                 append([]sdk.EPSSScore(nil), vulnerability.EPSS...),
+			CWEs:                 append([]sdk.CWE(nil), vulnerability.CWEs...),
+			RiskScore:            vulnerability.RiskScore,
+			DataSource:           vulnerability.DataSource,
+			Namespace:            vulnerability.Namespace,
+			CPEs:                 append([]string(nil), vulnerability.CPEs...),
 		})
 	}
 	return out
@@ -219,17 +256,34 @@ func VulnerabilityRefsFromPackageVulnerabilities(vulnerabilities []sdk.PackageVu
 
 // AuditFinding is the serialized form of one normalized scan finding.
 type AuditFinding struct {
-	ID           string            `json:"id"`
-	Kind         string            `json:"kind"`
-	Severity     string            `json:"severity"`
-	Package      PackageRef        `json:"package"`
-	Title        string            `json:"title"`
-	Reasons      []string          `json:"reasons,omitempty"`
-	Source       string            `json:"source"`
-	Auditor      string            `json:"auditor,omitempty"`
-	Disposition  string            `json:"disposition,omitempty"`
-	FixedIn      string            `json:"fixed_in,omitempty"`
-	Reachability *sdk.Reachability `json:"reachability,omitempty"`
+	ID                   string               `json:"id"`
+	Kind                 string               `json:"kind"`
+	Severity             string               `json:"severity"`
+	Package              PackageRef           `json:"package"`
+	Title                string               `json:"title"`
+	Reasons              []string             `json:"reasons,omitempty"`
+	Source               string               `json:"source"`
+	Auditor              string               `json:"auditor,omitempty"`
+	Disposition          string               `json:"disposition,omitempty"`
+	FixedIn              string               `json:"fixed_in,omitempty"`
+	FixedVersions        []string             `json:"fixed_versions,omitempty"`
+	FixState             string               `json:"fix_state,omitempty"`
+	FixAvailable         []sdk.FixAvailable   `json:"fix_available,omitempty"`
+	Aliases              []string             `json:"aliases,omitempty"`
+	Description          string               `json:"description,omitempty"`
+	SeveritySource       string               `json:"severity_source,omitempty"`
+	CVSS                 []sdk.CVSSScore      `json:"cvss,omitempty"`
+	AffectedVersionRange string               `json:"affected_version_range,omitempty"`
+	References           []sdk.Reference      `json:"references,omitempty"`
+	KEVExploited         bool                 `json:"kev_exploited,omitempty"`
+	KnownExploited       []sdk.KnownExploited `json:"known_exploited,omitempty"`
+	EPSS                 []sdk.EPSSScore      `json:"epss,omitempty"`
+	CWEs                 []sdk.CWE            `json:"cwes,omitempty"`
+	RiskScore            float64              `json:"risk_score,omitempty"`
+	DataSource           string               `json:"data_source,omitempty"`
+	Namespace            string               `json:"namespace,omitempty"`
+	CPEs                 []string             `json:"cpes,omitempty"`
+	Reachability         *sdk.Reachability    `json:"reachability,omitempty"`
 }
 
 // AuditSummary aggregates finding counts by severity.
@@ -247,17 +301,34 @@ func FindingsFromScan(findings []sdk.Finding) []AuditFinding {
 	result := make([]AuditFinding, 0, len(findings))
 	for _, f := range findings {
 		result = append(result, AuditFinding{
-			ID:           f.ID,
-			Kind:         string(f.Kind),
-			Severity:     f.Severity,
-			Package:      PackageFromGraphPackage(f.Package),
-			Title:        f.Title,
-			Reasons:      f.Reasons,
-			Source:       f.Source,
-			Auditor:      f.Auditor,
-			Disposition:  string(f.Disposition),
-			FixedIn:      f.FixedIn,
-			Reachability: f.Reachability.Clone(),
+			ID:                   f.ID,
+			Kind:                 string(f.Kind),
+			Severity:             f.Severity,
+			Package:              PackageFromGraphPackage(f.Package),
+			Title:                f.Title,
+			Reasons:              f.Reasons,
+			Source:               f.Source,
+			Auditor:              f.Auditor,
+			Disposition:          string(f.Disposition),
+			FixedIn:              f.FixedIn,
+			FixedVersions:        append([]string(nil), f.FixedVersions...),
+			FixState:             f.FixState,
+			FixAvailable:         append([]sdk.FixAvailable(nil), f.FixAvailable...),
+			Aliases:              append([]string(nil), f.Aliases...),
+			Description:          f.Description,
+			SeveritySource:       f.SeveritySource,
+			CVSS:                 append([]sdk.CVSSScore(nil), f.CVSS...),
+			AffectedVersionRange: f.AffectedVersionRange,
+			References:           append([]sdk.Reference(nil), f.References...),
+			KEVExploited:         f.KEVExploited,
+			KnownExploited:       cloneKnownExploited(f.KnownExploited),
+			EPSS:                 append([]sdk.EPSSScore(nil), f.EPSS...),
+			CWEs:                 append([]sdk.CWE(nil), f.CWEs...),
+			RiskScore:            f.RiskScore,
+			DataSource:           f.DataSource,
+			Namespace:            f.Namespace,
+			CPEs:                 append([]string(nil), f.CPEs...),
+			Reachability:         f.Reachability.Clone(),
 		})
 	}
 	return result

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -653,7 +653,7 @@ func matcherBehavior(name string) matcherDocBehavior {
 			RequiresEnrich: true,
 			UsesNetwork:    false,
 			Cache:          "Relies on Grype's local vulnerability database behavior.",
-			OutputFields:   []string{"vulnerability ID", "severity", "CVSS", "fixed version", "references"},
+			OutputFields:   []string{"vulnerability ID", "severity", "CVSS", "fixed version", "fix state", "EPSS", "CWE", "known exploitation", "risk score", "references"},
 			Notes:          "The full Bomly binary links Grype support. The lite binary uses an external `grype` executable on `PATH`.",
 		}
 	case "depsdev-license-checker":

--- a/internal/support/prose/matchers/grype.md
+++ b/internal/support/prose/matchers/grype.md
@@ -1,6 +1,6 @@
 ## What `grype` does
 
-`grype` runs Anchore's Grype vulnerability matcher against the resolved dependency graph. Grype carries its own offline vulnerability database, so it complements `osv` rather than duplicating it — Grype is the right matcher when you need consistent results across runs and full offline operation after the first DB sync.
+`grype` runs Anchore's Grype vulnerability matcher against the resolved dependency graph. Grype carries its own offline vulnerability database, so it complements `osv` rather than duplicating it -- Grype is the right matcher when you need consistent results across runs and full offline operation after the first DB sync.
 
 In the full `bomly` binary, Grype is linked in as a library and runs in-process. In `bomly-lite`, Bomly shells out to a `grype` binary on `PATH`.
 
@@ -24,17 +24,20 @@ Grype reads from a local vulnerability database that it syncs on first use and r
 | Full `bomly` binary | Anchore's database service | Managed by the linked Grype library; default `~/.cache/grype/db/` |
 | `bomly-lite` | External `grype` binary on `PATH` | Wherever the external `grype` stores it |
 
-The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls — Grype manages its own cache.
+The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls -- Grype manages its own cache.
 
 ## Output fields
 
 Each `vulnerabilities[]` entry on a package carries:
 
-- `id` — Grype's primary ID (CVE / GHSA / vendor ID)
-- `severity` — Grype's normalized severity bucket
-- `cvss` — CVSS vector when available
-- `fixed_version` — earliest fixed version per affected range
-- `references` — upstream advisory and patch links
+- `id` -- Grype's primary ID (CVE / GHSA / vendor ID)
+- `severity` -- Grype's normalized severity bucket
+- `cvss` -- CVSS vector when available
+- `fixed_in` -- best single upgrade target; `fixed_versions` carries every fixed version Grype reported
+- `fix_state` and `fix_available` -- Grype's fix status and dated fix-availability records when available
+- `epss`, `cwes`, `known_exploited`, and `risk_score` -- exploitation and weakness triage signals from the Grype database
+- `data_source`, `namespace`, and `cpes` -- source and matcher context for debugging or downstream correlation
+- `references` -- upstream advisory and patch links
 
 ## Examples
 

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -1749,6 +1749,12 @@ func renderVulnList(vulns []output.VulnerabilityRef) []string {
 		if v.FixedIn != "" {
 			out = append(out, render.Style("      fixed in: ", render.Dim)+v.FixedIn)
 		}
+		if v.FixState != "" {
+			out = append(out, render.Style("      fix state: ", render.Dim)+v.FixState)
+		}
+		if exploitability := exploitabilityLine(v.KEVExploited, v.KnownExploited, v.RiskScore); exploitability != "" {
+			out = append(out, render.Style("      exploitability: ", render.Dim)+exploitability)
+		}
 	}
 	return out
 }

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -1105,15 +1105,31 @@ func vulnerabilityGroupDetails(key, group string, vulnerabilities []packageVulne
 
 func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 	vulnerability := row.vulnerability
+	packageID, packageVersion, packageEcosystem, packagePURL := "", "", "", ""
+	if row.pkg != nil {
+		packageID = row.pkg.ID
+		packageVersion = row.pkg.Version
+		packageEcosystem = row.pkg.Ecosystem
+		packagePURL = row.pkg.PURL
+	}
 	lines := []string{
 		render.Style("Vulnerability", render.Bold, render.Cyan),
 		"",
 		render.Style("  ID: ", render.Dim) + valueOrDash(vulnerability.ID),
 		render.Style("  Severity: ", render.Dim) + severityText(vulnerability.Severity),
+		render.Style("  Severity source: ", render.Dim) + valueOrDash(vulnerability.SeveritySource),
 		render.Style("  Source: ", render.Dim) + valueOrDash(vulnerability.Source),
+		render.Style("  Namespace: ", render.Dim) + valueOrDash(vulnerability.Namespace),
+		render.Style("  Data source: ", render.Dim) + valueOrDash(vulnerability.DataSource),
 		render.Style("  Package: ", render.Dim) + valueOrDash(vulnerabilityPackageName(row)),
+		render.Style("  Package ID: ", render.Dim) + valueOrDash(packageID),
+		render.Style("  Installed version: ", render.Dim) + valueOrDash(packageVersion),
+		render.Style("  Ecosystem: ", render.Dim) + valueOrDash(packageEcosystem),
+		render.Style("  PURL: ", render.Dim) + valueOrDash(packagePURL),
 		render.Style("  Title: ", render.Dim) + valueOrDash(vulnerability.Title),
 		render.Style("  KEV exploited: ", render.Dim) + fmt.Sprintf("%t", vulnerability.KEVExploited),
+		render.Style("  Exploitability: ", render.Dim) + valueOrDash(exploitabilityLine(vulnerability.KEVExploited, vulnerability.KnownExploited, vulnerability.RiskScore)),
+		render.Style("  Risk score: ", render.Dim) + valueOrDash(formatFloat(vulnerability.RiskScore)),
 		"",
 		render.Style("Description", render.Bold, render.Magenta),
 		"",
@@ -1123,14 +1139,74 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		"",
 		render.Style("  Affected: ", render.Dim) + valueOrDash(vulnerability.AffectedVersionRange),
 		render.Style("  Fixed in: ", render.Dim) + valueOrDash(vulnerability.FixedIn),
+		render.Style("  Fix state: ", render.Dim) + valueOrDash(vulnerability.FixState),
+		render.Style("  Fixed versions: ", render.Dim) + valueOrDash(strings.Join(vulnerability.FixedVersions, ", ")),
 		"",
-		render.Style(fmt.Sprintf("CVSS (%d)", len(vulnerability.CVSS)), render.Bold, render.Magenta),
 	}
-	if len(vulnerability.CVSS) == 0 {
+
+	appendStringSection := func(title string, values []string) {
+		lines = append(lines, render.Style(fmt.Sprintf("%s (%d)", title, len(values)), render.Bold, render.Magenta))
+		if len(values) == 0 {
+			lines = append(lines, render.Style("  (none)", render.Dim), "")
+			return
+		}
+		lines = append(lines, indentLines(values)...)
+		lines = append(lines, "")
+	}
+
+	appendStringSection("Aliases", vulnerability.Aliases)
+
+	lines = append(lines, render.Style(fmt.Sprintf("EPSS (%d)", len(vulnerability.EPSS)), render.Bold, render.Magenta))
+	if len(vulnerability.EPSS) == 0 {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
-		for _, score := range vulnerability.CVSS {
-			lines = append(lines, render.Style("  - ", render.Dim)+fmt.Sprintf("%.1f %s %s", score.Score, valueOrDash(score.Version), valueOrDash(score.Vector)))
+		for _, epss := range vulnerability.EPSS {
+			parts := []string{
+				fmt.Sprintf("score %.3f", epss.EPSS),
+				fmt.Sprintf("percentile %.3f", epss.Percentile),
+				epss.CVE,
+				epss.Date,
+			}
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings(parts), " | "))
+		}
+	}
+	lines = append(lines, "", render.Style(fmt.Sprintf("CWEs (%d)", len(vulnerability.CWEs)), render.Bold, render.Magenta))
+	if len(vulnerability.CWEs) == 0 {
+		lines = append(lines, render.Style("  (none)", render.Dim))
+	} else {
+		for _, cwe := range vulnerability.CWEs {
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{cwe.ID, cwe.Source, cwe.Type, cwe.CVE}), " | "))
+		}
+	}
+	lines = append(lines, "", render.Style(fmt.Sprintf("Known Exploited (%d)", len(vulnerability.KnownExploited)), render.Bold, render.Magenta))
+	if len(vulnerability.KnownExploited) == 0 {
+		lines = append(lines, render.Style("  (none)", render.Dim))
+	} else {
+		for _, ke := range vulnerability.KnownExploited {
+			headParts := []string{ke.CVE, ke.VendorProject, ke.Product}
+			if ke.DateAdded != "" {
+				headParts = append(headParts, "added "+ke.DateAdded)
+			}
+			if ke.DueDate != "" {
+				headParts = append(headParts, "due "+ke.DueDate)
+			}
+			head := strings.Join(nonEmptyStrings(headParts), " | ")
+			lines = append(lines, render.Style("  - ", render.Dim)+valueOrDash(head))
+			if ke.KnownRansomwareCampaignUse != "" {
+				lines = append(lines, render.Style("    ransomware: ", render.Dim)+ke.KnownRansomwareCampaignUse)
+			}
+			if ke.RequiredAction != "" {
+				lines = append(lines, render.Style("    action: ", render.Dim)+ke.RequiredAction)
+			}
+			if ke.Notes != "" {
+				lines = append(lines, render.Style("    notes: ", render.Dim)+ke.Notes)
+			}
+			if len(ke.CWEs) > 0 {
+				lines = append(lines, render.Style("    cwes: ", render.Dim)+strings.Join(nonEmptyStrings(ke.CWEs), ", "))
+			}
+			if len(ke.URLs) > 0 {
+				lines = append(lines, render.Style("    urls: ", render.Dim)+strings.Join(nonEmptyStrings(ke.URLs), ", "))
+			}
 		}
 	}
 	lines = append(lines, "", render.Style(fmt.Sprintf("References (%d)", len(vulnerability.References)), render.Bold, render.Magenta))
@@ -1138,15 +1214,29 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
 		for _, ref := range vulnerability.References {
-			lines = append(lines, render.Style("  - ", render.Dim)+valueOrDash(ref.URL)+" "+render.Style(valueOrDash(ref.Type), render.Dim))
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{ref.Type, ref.URL}), " | "))
 		}
 	}
-	lines = append(lines, "", render.Style(fmt.Sprintf("Reasons (%d)", len(vulnerability.Reasons)), render.Bold, render.Magenta))
-	if len(vulnerability.Reasons) == 0 {
+	lines = append(lines, "", render.Style(fmt.Sprintf("Fix Availability (%d)", len(vulnerability.FixAvailable)), render.Bold, render.Magenta))
+	if len(vulnerability.FixAvailable) == 0 {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
-		lines = append(lines, indentLines(vulnerability.Reasons)...)
+		for _, fix := range vulnerability.FixAvailable {
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{fix.Version, fix.Date, fix.Kind}), " "))
+		}
 	}
+
+	lines = append(lines, "", render.Style(fmt.Sprintf("Affected Symbols (%d)", len(vulnerability.AffectedSymbols)), render.Bold, render.Magenta))
+	if len(vulnerability.AffectedSymbols) == 0 {
+		lines = append(lines, render.Style("  (none)", render.Dim))
+	} else {
+		for _, symbol := range vulnerability.AffectedSymbols {
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{symbol.Symbol, symbol.Kind, symbol.Package, symbol.Module}), " | "))
+		}
+	}
+	lines = append(lines, "")
+	appendStringSection("CPEs", vulnerability.CPEs)
+	appendStringSection("Reasons", vulnerability.Reasons)
 	return lines
 }
 
@@ -1364,6 +1454,13 @@ func findingDetails(finding sdk.Finding) []string {
 		render.Style("  Package: ", render.Dim) + valueOrDash(pkg),
 		render.Style("  Title: ", render.Dim) + valueOrDash(finding.Title),
 		render.Style("  Source: ", render.Dim) + valueOrDash(finding.Source),
+		render.Style("  Namespace: ", render.Dim) + valueOrDash(finding.Namespace),
+		render.Style("  Data source: ", render.Dim) + valueOrDash(finding.DataSource),
+		render.Style("  Fixed in: ", render.Dim) + valueOrDash(finding.FixedIn),
+		render.Style("  Fix state: ", render.Dim) + valueOrDash(finding.FixState),
+		render.Style("  Exploitability: ", render.Dim) + valueOrDash(exploitabilityLine(finding.KEVExploited, finding.KnownExploited, finding.RiskScore)),
+		render.Style("  EPSS: ", render.Dim) + valueOrDash(epssLine(finding.EPSS)),
+		render.Style("  CWEs: ", render.Dim) + valueOrDash(cweLine(finding.CWEs)),
 		render.Style("  Description: ", render.Dim) + valueOrDash(finding.Description),
 		"",
 		render.Style(fmt.Sprintf("Reasons (%d)", len(finding.Reasons)), render.Bold, render.Magenta),

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
@@ -15,6 +16,56 @@ func wrapTextLines(value string, width int) []string { return render.WrapTextLin
 func truncateToWidth(value string, width int) string { return render.TruncateToWidth(value, width) }
 func padRight(value string, width int) string        { return render.PadRight(value, width) }
 func valueOrDash(value string) string                { return render.ValueOrDash(value) }
+
+func formatFloat(value float64) string {
+	if value == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f", value)
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	return out
+}
+
+func epssLine(values []sdk.EPSSScore) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, fmt.Sprintf("%.3f p%.0f", value.EPSS, value.Percentile*100))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func cweLine(values []sdk.CWE) string {
+	if len(values) == 0 {
+		return ""
+	}
+	ids := make([]string, 0, len(values))
+	for _, value := range values {
+		ids = append(ids, value.ID)
+	}
+	return strings.Join(nonEmptyStrings(ids), ", ")
+}
+
+func exploitabilityLine(kev bool, known []sdk.KnownExploited, risk float64) string {
+	parts := make([]string, 0, 2)
+	if kev || len(known) > 0 {
+		parts = append(parts, "known exploited")
+	}
+	if risk > 0 {
+		parts = append(parts, fmt.Sprintf("risk %.1f", risk))
+	}
+	return strings.Join(parts, ", ")
+}
 
 func boxView(title string, content []string, width, height int, color string) []string {
 	if width < 4 {

--- a/sdk/language_test.go
+++ b/sdk/language_test.go
@@ -132,8 +132,18 @@ func TestReachabilityClone(t *testing.T) {
 
 func TestPackageVulnerabilityCloneCarriesNewFields(t *testing.T) {
 	v := PackageVulnerability{
-		ID:     "CVE-2024-1234",
-		Source: "osv",
+		ID:            "CVE-2024-1234",
+		Source:        "osv",
+		FixedVersions: []string{"1.2.3"},
+		FixAvailable:  []FixAvailable{{Version: "1.2.3", Date: "2024-01-02"}},
+		KnownExploited: []KnownExploited{{
+			CVE:  "CVE-2024-1234",
+			URLs: []string{"https://kev.example"},
+			CWEs: []string{"CWE-79"},
+		}},
+		EPSS: []EPSSScore{{CVE: "CVE-2024-1234", EPSS: 0.5}},
+		CWEs: []CWE{{CVE: "CVE-2024-1234", ID: "CWE-79"}},
+		CPEs: []string{"cpe:2.3:a:example:pkg:1.0:*:*:*:*:*:*:*"},
 		AffectedSymbols: []AffectedSymbol{
 			{Symbol: "ParseURL", Package: "net/url"},
 		},
@@ -146,6 +156,18 @@ func TestPackageVulnerabilityCloneCarriesNewFields(t *testing.T) {
 	}
 	if clone.Reachability == v.Reachability {
 		t.Error("Clone did not deep-copy Reachability pointer")
+	}
+	clone.FixedVersions[0] = "mutated"
+	if v.FixedVersions[0] != "1.2.3" {
+		t.Error("Clone did not deep-copy FixedVersions")
+	}
+	clone.KnownExploited[0].URLs[0] = "mutated"
+	if v.KnownExploited[0].URLs[0] != "https://kev.example" {
+		t.Error("Clone did not deep-copy KnownExploited URLs")
+	}
+	clone.CPEs[0] = "mutated"
+	if v.CPEs[0] == "mutated" {
+		t.Error("Clone did not deep-copy CPEs")
 	}
 }
 

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -15,6 +15,9 @@ const (
 	// ReachabilityConstraint matches when a vulnerability's reachability
 	// status equals the constraint Value (currently only "reachable").
 	ReachabilityConstraint FailOnKind = "reachability"
+	// ExploitabilityConstraint matches when a vulnerability has known
+	// exploitation metadata.
+	ExploitabilityConstraint FailOnKind = "exploitability"
 )
 
 // FailOnConstraint is one parsed --fail-on value. The policy auditor
@@ -48,6 +51,11 @@ const (
 	ReachabilityValueReachable = "reachable"
 )
 
+// Exploitability constraint values currently supported.
+const (
+	ExploitabilityValueExploitable = "exploitable"
+)
+
 var validSeverityValues = map[string]struct{}{
 	SeverityAny:      {},
 	SeverityLow:      {},
@@ -60,10 +68,15 @@ var validReachabilityValues = map[string]struct{}{
 	ReachabilityValueReachable: {},
 }
 
+var validExploitabilityValues = map[string]struct{}{
+	ExploitabilityValueExploitable: {},
+}
+
 // ParseFailOn parses one raw --fail-on value into a typed constraint.
 // Severity tokens (any|low|medium|high|critical) yield a SeverityConstraint.
-// "reachable" yields a ReachabilityConstraint. Empty input returns the zero
-// value with no error so callers can treat empty repeats as no-ops.
+// "reachable" yields a ReachabilityConstraint. "exploitable" yields an
+// ExploitabilityConstraint. Empty input returns the zero value with no error
+// so callers can treat empty repeats as no-ops.
 func ParseFailOn(raw string) (FailOnConstraint, error) {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
 	if normalized == "" {
@@ -75,7 +88,10 @@ func ParseFailOn(raw string) (FailOnConstraint, error) {
 	if _, ok := validReachabilityValues[normalized]; ok {
 		return FailOnConstraint{Kind: ReachabilityConstraint, Value: normalized}, nil
 	}
-	return FailOnConstraint{}, fmt.Errorf("unsupported --fail-on value %q (accepted: any, low, medium, high, critical, reachable)", raw)
+	if _, ok := validExploitabilityValues[normalized]; ok {
+		return FailOnConstraint{Kind: ExploitabilityConstraint, Value: normalized}, nil
+	}
+	return FailOnConstraint{}, fmt.Errorf("unsupported --fail-on value %q (accepted: any, low, medium, high, critical, reachable, exploitable)", raw)
 }
 
 // ParseFailOnList parses every raw value, skipping empty entries. It returns
@@ -145,6 +161,10 @@ func (v PackageVulnerability) MatchesConstraints(constraints []FailOnConstraint)
 			if v.Reachability == nil || v.Reachability.Status != ReachabilityReachable {
 				return false
 			}
+		case ExploitabilityConstraint:
+			if !v.IsExploitable() {
+				return false
+			}
 		default:
 			// Unknown kinds are treated as no-op rather than as
 			// rejection so future constraint kinds can be added without
@@ -152,4 +172,10 @@ func (v PackageVulnerability) MatchesConstraints(constraints []FailOnConstraint)
 		}
 	}
 	return true
+}
+
+// IsExploitable reports whether advisory metadata says this vulnerability is
+// known exploitable.
+func (v PackageVulnerability) IsExploitable() bool {
+	return v.KEVExploited || len(v.KnownExploited) > 0
 }

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -15,6 +15,8 @@ func TestParseFailOn(t *testing.T) {
 		{"any", SeverityConstraint, "any", false},
 		{"reachable", ReachabilityConstraint, "reachable", false},
 		{"REACHABLE", ReachabilityConstraint, "reachable", false},
+		{"exploitable", ExploitabilityConstraint, "exploitable", false},
+		{"EXPLOITABLE", ExploitabilityConstraint, "exploitable", false},
 		{"", "", "", false},
 		{"bogus", "", "", true},
 	}
@@ -37,19 +39,22 @@ func TestParseFailOn(t *testing.T) {
 }
 
 func TestParseFailOnListSkipsEmptyAggregatesErrors(t *testing.T) {
-	raw := []string{"low", "", "reachable", "bogus"}
+	raw := []string{"low", "", "reachable", "exploitable", "bogus"}
 	out, err := ParseFailOnList(raw)
 	if err == nil {
 		t.Fatal("expected error for bogus entry")
 	}
-	if len(out) != 2 {
-		t.Fatalf("got %d valid constraints, want 2: %+v", len(out), out)
+	if len(out) != 3 {
+		t.Fatalf("got %d valid constraints, want 3: %+v", len(out), out)
 	}
 	if out[0].Kind != SeverityConstraint || out[0].Value != "low" {
 		t.Errorf("first constraint = %+v", out[0])
 	}
 	if out[1].Kind != ReachabilityConstraint || out[1].Value != "reachable" {
 		t.Errorf("second constraint = %+v", out[1])
+	}
+	if out[2].Kind != ExploitabilityConstraint || out[2].Value != "exploitable" {
+		t.Errorf("third constraint = %+v", out[2])
 	}
 }
 
@@ -87,9 +92,14 @@ func TestMatchesConstraints(t *testing.T) {
 		Severity:     "low",
 		Reachability: &Reachability{Status: ReachabilityReachable},
 	}
+	highExploitable := PackageVulnerability{
+		Severity:       "high",
+		KnownExploited: []KnownExploited{{CVE: "CVE-2024-1234"}},
+	}
 
 	sevHigh := FailOnConstraint{Kind: SeverityConstraint, Value: "high"}
 	reach := FailOnConstraint{Kind: ReachabilityConstraint, Value: "reachable"}
+	exploit := FailOnConstraint{Kind: ExploitabilityConstraint, Value: "exploitable"}
 
 	cases := []struct {
 		name string
@@ -105,6 +115,9 @@ func TestMatchesConstraints(t *testing.T) {
 		{"severity ok but no analyzer ran", highNoReach, []FailOnConstraint{sevHigh, reach}, false},
 		{"reach-only matches reachable", highReachable, []FailOnConstraint{reach}, true},
 		{"reach-only excludes nil", highNoReach, []FailOnConstraint{reach}, false},
+		{"exploitable-only matches known exploited", highExploitable, []FailOnConstraint{exploit}, true},
+		{"exploitable-only excludes no signal", highNoReach, []FailOnConstraint{exploit}, false},
+		{"severity and exploitable", highExploitable, []FailOnConstraint{sevHigh, exploit}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -41,6 +41,43 @@ type Reference struct {
 	Type string
 }
 
+// FixAvailable captures one version/date/kind tuple for an available fix.
+type FixAvailable struct {
+	Version string `json:"version,omitempty"`
+	Date    string `json:"date,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+}
+
+// EPSSScore captures Exploit Prediction Scoring System data for a vulnerability.
+type EPSSScore struct {
+	CVE        string  `json:"cve,omitempty"`
+	EPSS       float64 `json:"epss"`
+	Percentile float64 `json:"percentile,omitempty"`
+	Date       string  `json:"date,omitempty"`
+}
+
+// CWE identifies a Common Weakness Enumeration entry for a vulnerability.
+type CWE struct {
+	CVE    string `json:"cve,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Source string `json:"source,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+// KnownExploited captures CISA KEV-style known exploitation metadata.
+type KnownExploited struct {
+	CVE                        string   `json:"cve,omitempty"`
+	VendorProject              string   `json:"vendor_project,omitempty"`
+	Product                    string   `json:"product,omitempty"`
+	DateAdded                  string   `json:"date_added,omitempty"`
+	RequiredAction             string   `json:"required_action,omitempty"`
+	DueDate                    string   `json:"due_date,omitempty"`
+	KnownRansomwareCampaignUse string   `json:"known_ransomware_campaign_use,omitempty"`
+	Notes                      string   `json:"notes,omitempty"`
+	URLs                       []string `json:"urls,omitempty"`
+	CWEs                       []string `json:"cwes,omitempty"`
+}
+
 // SourcePosition is the canonical (file, line, column) tuple used wherever the
 // SDK needs to point at a source location. Used by call frames, affected
 // symbols, and (additively) by PackageLocation for declaration sites.
@@ -293,19 +330,29 @@ func (r *Reachability) Clone() *Reachability {
 
 // PackageVulnerability describes first-class vulnerability enrichment attached to one package.
 type PackageVulnerability struct {
-	ID                   string      `json:"id"`
-	Source               string      `json:"source"`
-	Title                string      `json:"title,omitempty"`
-	Severity             string      `json:"severity,omitempty"`
-	SeveritySource       string      `json:"severity_source,omitempty"`
-	Aliases              []string    `json:"aliases,omitempty"`
-	Description          string      `json:"description,omitempty"`
-	Reasons              []string    `json:"reasons,omitempty"`
-	CVSS                 []CVSSScore `json:"cvss,omitempty"`
-	FixedIn              string      `json:"fixed_in,omitempty"`
-	AffectedVersionRange string      `json:"affected_version_range,omitempty"`
-	References           []Reference `json:"references,omitempty"`
-	KEVExploited         bool        `json:"kev_exploited,omitempty"`
+	ID                   string           `json:"id"`
+	Source               string           `json:"source"`
+	Title                string           `json:"title,omitempty"`
+	Severity             string           `json:"severity,omitempty"`
+	SeveritySource       string           `json:"severity_source,omitempty"`
+	Aliases              []string         `json:"aliases,omitempty"`
+	Description          string           `json:"description,omitempty"`
+	Reasons              []string         `json:"reasons,omitempty"`
+	CVSS                 []CVSSScore      `json:"cvss,omitempty"`
+	FixedIn              string           `json:"fixed_in,omitempty"`
+	FixedVersions        []string         `json:"fixed_versions,omitempty"`
+	FixState             string           `json:"fix_state,omitempty"`
+	FixAvailable         []FixAvailable   `json:"fix_available,omitempty"`
+	AffectedVersionRange string           `json:"affected_version_range,omitempty"`
+	References           []Reference      `json:"references,omitempty"`
+	KEVExploited         bool             `json:"kev_exploited,omitempty"`
+	KnownExploited       []KnownExploited `json:"known_exploited,omitempty"`
+	EPSS                 []EPSSScore      `json:"epss,omitempty"`
+	CWEs                 []CWE            `json:"cwes,omitempty"`
+	RiskScore            float64          `json:"risk_score,omitempty"`
+	DataSource           string           `json:"data_source,omitempty"`
+	Namespace            string           `json:"namespace,omitempty"`
+	CPEs                 []string         `json:"cpes,omitempty"`
 	// AffectedSymbols lists the symbols the matcher reports as vulnerable.
 	// Optional — most advisories do not include symbol-level data. When
 	// present, reachability analyzers use this list to narrow their search.
@@ -329,8 +376,35 @@ func (v PackageVulnerability) Clone() PackageVulnerability {
 	if len(v.CVSS) > 0 {
 		clone.CVSS = append([]CVSSScore(nil), v.CVSS...)
 	}
+	if len(v.FixedVersions) > 0 {
+		clone.FixedVersions = append([]string(nil), v.FixedVersions...)
+	}
+	if len(v.FixAvailable) > 0 {
+		clone.FixAvailable = append([]FixAvailable(nil), v.FixAvailable...)
+	}
 	if len(v.References) > 0 {
 		clone.References = append([]Reference(nil), v.References...)
+	}
+	if len(v.KnownExploited) > 0 {
+		clone.KnownExploited = make([]KnownExploited, 0, len(v.KnownExploited))
+		for _, ke := range v.KnownExploited {
+			if len(ke.URLs) > 0 {
+				ke.URLs = append([]string(nil), ke.URLs...)
+			}
+			if len(ke.CWEs) > 0 {
+				ke.CWEs = append([]string(nil), ke.CWEs...)
+			}
+			clone.KnownExploited = append(clone.KnownExploited, ke)
+		}
+	}
+	if len(v.EPSS) > 0 {
+		clone.EPSS = append([]EPSSScore(nil), v.EPSS...)
+	}
+	if len(v.CWEs) > 0 {
+		clone.CWEs = append([]CWE(nil), v.CWEs...)
+	}
+	if len(v.CPEs) > 0 {
+		clone.CPEs = append([]string(nil), v.CPEs...)
 	}
 	if len(v.AffectedSymbols) > 0 {
 		clone.AffectedSymbols = make([]AffectedSymbol, 0, len(v.AffectedSymbols))
@@ -362,10 +436,20 @@ type Finding struct {
 	SeveritySource       string
 	CVSS                 []CVSSScore
 	FixedIn              string
+	FixedVersions        []string
+	FixState             string
+	FixAvailable         []FixAvailable
 	AffectedVersionRange string
 	References           []Reference
 	VEXJustification     string
 	KEVExploited         bool
+	KnownExploited       []KnownExploited
+	EPSS                 []EPSSScore
+	CWEs                 []CWE
+	RiskScore            float64
+	DataSource           string
+	Namespace            string
+	CPEs                 []string
 	// Reachability mirrors the underlying PackageVulnerability.Reachability.
 	// Populated by the policy auditor when reachability data is present on
 	// the source vulnerability.


### PR DESCRIPTION
## Summary

- Enrich Grype vulnerability mapping for both builtin and external matchers with fix versions/state, EPSS, CWE, KEV, risk, namespace, data source, aliases, references, and CPE details.
- Populate `fixed_in` from suggested fixes or available fixed versions, and merge duplicate vulnerability matches instead of losing richer metadata.
- Add `--fail-on exploitable` support across policy parsing, CLI/config help, and MCP scan/diff tools.
- Expand JSON/SARIF schemas and docs, while keeping CVSS out of human text/markdown/TUI summaries and adding richer advisory details to the interactive vulnerability pane.

## Why

Grype already returns much richer advisory data than Bomly preserved. The most visible bug was that `fixed_in` stayed empty in many outputs because the matcher did not map Grype fix data into Bomly's internal vulnerability model.

## Impact

JSON and SARIF consumers now receive substantially more vulnerability metadata. Human outputs emphasize actionable fields such as severity, fixed versions, exploitability, EPSS, and fix state without showing raw CVSS scores. Policy users can fail scans specifically on known exploited vulnerabilities via `--fail-on exploitable`.

## Validation

- `make generate`
- `go test ./internal/matchers/grype`
- `go test -tags bomly_external_grype ./internal/matchers/grype`
- `go test ./internal/cli/render ./internal/tui`
- `go test ./internal/cli`
- `make test`

Note: `.vscode/launch.json` has an unrelated local modification and is intentionally excluded from this PR.