### PR TITLE
fix(auditors): skip typosquat check for version-bumped packages

### DIFF
--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -57,6 +57,8 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 		threshold = 0.90
 	}
 
+	baseDisplayNames := packageDisplayNames(req.BaselineGraph)
+
 	for _, pkg := range packages {
 		if pkg == nil || !scopeAllowed(pkg, a.FailOnScopes) {
 			continue
@@ -70,6 +72,12 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 			continue
 		}
 		if _, existed := baseIDs[pkg.ID]; existed || req.BaselineGraph == nil {
+			continue
+		}
+		// Skip typosquat check for packages whose name already existed in the
+		// baseline (version-agnostic). A version bump of a known package is not
+		// a typosquat candidate.
+		if _, nameExisted := baseDisplayNames[strings.ToLower(strings.TrimSpace(pkg.DisplayName()))]; nameExisted {
 			continue
 		}
 		if protected, score, ok := closestProtectedName(pkg.DisplayName(), baseNames, threshold); ok {
@@ -109,6 +117,19 @@ func packageIDs(graph *sdk.Graph) map[string]struct{} {
 		}
 	}
 	return ids
+}
+
+func packageDisplayNames(graph *sdk.Graph) map[string]struct{} {
+	names := make(map[string]struct{})
+	if graph == nil {
+		return names
+	}
+	for _, pkg := range graph.Packages() {
+		if pkg != nil {
+			names[strings.ToLower(strings.TrimSpace(pkg.DisplayName()))] = struct{}{}
+		}
+	}
+	return names
 }
 
 func protectedNames(graph *sdk.Graph, configured []string) []string {

--- a/internal/auditors/package/auditor_test.go
+++ b/internal/auditors/package/auditor_test.go
@@ -1,0 +1,272 @@
+package packageauditor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// pkg is a convenience constructor for tests.
+func pkg(id, name, version, scope string) *sdk.Package {
+	return &sdk.Package{
+		ID:      id,
+		Name:    name,
+		Version: version,
+		Scope:   scope,
+		PURL:    id,
+	}
+}
+
+// graphOf builds a Graph from the provided packages, panicking on error.
+func graphOf(pkgs ...*sdk.Package) *sdk.Graph {
+	g := sdk.New()
+	for _, p := range pkgs {
+		if err := g.AddPackage(p); err != nil {
+			panic(err)
+		}
+	}
+	return g
+}
+
+func findingIDs(findings []sdk.Finding) []string {
+	ids := make([]string, len(findings))
+	for i, f := range findings {
+		ids[i] = f.ID
+	}
+	return ids
+}
+
+func findingKinds(findings []sdk.Finding) map[string]string {
+	out := make(map[string]string, len(findings))
+	for _, f := range findings {
+		out[f.ID] = string(f.Disposition)
+	}
+	return out
+}
+
+func TestAudit(t *testing.T) {
+	const (
+		idContainerdV2Old = "pkg:golang/github.com/containerd/containerd/v2@v2.2.2"
+		idContainerdV2New = "pkg:golang/github.com/containerd/containerd/v2@v2.2.4"
+		idContainerdAPI   = "pkg:golang/github.com/containerd/containerd/api@v1.0.0"
+		idFake            = "pkg:golang/github.com/acme/fake@v1.0.0"
+		idDenied          = "pkg:golang/github.com/evil/malware@v1.0.0"
+		idDeniedGroup     = "pkg:golang/github.com/blocked/tool@v1.0.0"
+	)
+
+	pkgContainerdV2Old := pkg(idContainerdV2Old, "github.com/containerd/containerd/v2", "v2.2.2", "runtime")
+	pkgContainerdV2New := pkg(idContainerdV2New, "github.com/containerd/containerd/v2", "v2.2.4", "runtime")
+	pkgContainerdAPI := pkg(idContainerdAPI, "github.com/containerd/containerd/api", "v1.0.0", "runtime")
+	pkgFake := pkg(idFake, "github.com/acme/fake", "v1.0.0", "runtime")
+	pkgDenied := pkg(idDenied, "github.com/evil/malware", "v1.0.0", "runtime")
+	pkgDeniedGroup := pkg(idDeniedGroup, "github.com/blocked/tool", "v1.0.0", "runtime")
+
+	tests := []struct {
+		name             string
+		auditor          Auditor
+		graph            *sdk.Graph
+		baseline         *sdk.Graph
+		wantFindingCount int
+		wantFindingIDs   []string
+		wantDisposition  map[string]string // finding ID → disposition
+	}{
+		{
+			// Core regression: a version bump of an existing package must never
+			// produce a typosquat finding, even when its name is highly similar to
+			// another package already in the baseline.
+			name: "version bump of existing package is not flagged as typosquat",
+			auditor: Auditor{
+				ProtectedPackages:  []string{},
+				TyposquatThreshold: 0.90,
+			},
+			graph:            graphOf(pkgContainerdV2New),
+			baseline:         graphOf(pkgContainerdV2Old, pkgContainerdAPI),
+			wantFindingCount: 0,
+		},
+		{
+			// A genuinely new package (not present in base at all) that is highly
+			// similar to a protected name must be flagged.
+			name: "new package similar to protected name is flagged",
+			auditor: Auditor{
+				ProtectedPackages:  []string{"github.com/containerd/containerd/api"},
+				TyposquatThreshold: 0.90,
+			},
+			// head introduces containerd/v2 for the first time; base is empty.
+			graph:            graphOf(pkgContainerdV2New),
+			baseline:         sdk.New(),
+			wantFindingCount: 1,
+			wantFindingIDs: []string{
+				"package:suspicious-package:" + idContainerdV2New,
+			},
+		},
+		{
+			// A new package similar to a baseline package is flagged.
+			name: "new package similar to baseline package name is flagged",
+			auditor: Auditor{
+				TyposquatThreshold: 0.90,
+			},
+			// base has containerd/api; head introduces a new, similar name.
+			graph:            graphOf(pkgContainerdV2New),
+			baseline:         graphOf(pkgContainerdAPI),
+			wantFindingCount: 1,
+			wantFindingIDs: []string{
+				"package:suspicious-package:" + idContainerdV2New,
+			},
+		},
+		{
+			// When the exact package ID (name + version) is unchanged the check
+			// is skipped entirely.
+			name: "unchanged package (same ID) produces no finding",
+			auditor: Auditor{
+				ProtectedPackages:  []string{"github.com/containerd/containerd/api"},
+				TyposquatThreshold: 0.90,
+			},
+			graph:            graphOf(pkgContainerdV2Old),
+			baseline:         graphOf(pkgContainerdV2Old),
+			wantFindingCount: 0,
+		},
+		{
+			// When there is no baseline the typosquat check is skipped for all
+			// packages (we have no diff context).
+			name: "no baseline skips typosquat check",
+			auditor: Auditor{
+				ProtectedPackages:  []string{"github.com/containerd/containerd/api"},
+				TyposquatThreshold: 0.90,
+			},
+			graph:            graphOf(pkgContainerdV2New),
+			baseline:         nil,
+			wantFindingCount: 0,
+		},
+		{
+			// An explicitly denied package triggers a fail finding regardless of
+			// baseline presence.
+			name: "denied package is flagged with fail disposition",
+			auditor: Auditor{
+				DenyPackages: []string{"pkg:golang/github.com/evil/malware"},
+			},
+			graph:    graphOf(pkgDenied),
+			baseline: sdk.New(),
+			wantFindingIDs: []string{
+				"package:denied-package:" + idDenied,
+			},
+			wantFindingCount: 1,
+			wantDisposition: map[string]string{
+				"package:denied-package:" + idDenied: string(sdk.FindingDispositionFail),
+			},
+		},
+		{
+			// An explicitly denied group triggers a fail finding.
+			name: "denied group is flagged with fail disposition",
+			auditor: Auditor{
+				DenyGroups: []string{"pkg:golang/github.com/blocked"},
+			},
+			graph:    graphOf(pkgDeniedGroup),
+			baseline: sdk.New(),
+			wantFindingIDs: []string{
+				"package:denied-group:" + idDeniedGroup,
+			},
+			wantFindingCount: 1,
+			wantDisposition: map[string]string{
+				"package:denied-group:" + idDeniedGroup: string(sdk.FindingDispositionFail),
+			},
+		},
+		{
+			// TyposquatMode "fail" escalates disposition to fail.
+			name: "typosquat mode fail escalates disposition",
+			auditor: Auditor{
+				ProtectedPackages:  []string{"github.com/containerd/containerd/api"},
+				TyposquatThreshold: 0.90,
+				TyposquatMode:      "fail",
+			},
+			graph:            graphOf(pkgContainerdV2New),
+			baseline:         sdk.New(),
+			wantFindingCount: 1,
+			wantDisposition: map[string]string{
+				"package:suspicious-package:" + idContainerdV2New: string(sdk.FindingDispositionFail),
+			},
+		},
+		{
+			// FailOnScopes restricts findings to matching-scope packages; packages
+			// with a different scope produce no finding.
+			name: "package outside FailOnScopes produces no finding",
+			auditor: Auditor{
+				DenyPackages: []string{"pkg:golang/github.com/evil/malware"},
+				FailOnScopes: []sdk.Scope{sdk.ScopeDevelopment},
+			},
+			// pkgDenied has scope "runtime" which is not in FailOnScopes.
+			graph:            graphOf(pkgDenied),
+			baseline:         sdk.New(),
+			wantFindingCount: 0,
+		},
+		{
+			// FailOnScopes: a matching scope does produce a finding.
+			name: "package inside FailOnScopes is checked",
+			auditor: Auditor{
+				DenyPackages: []string{"pkg:golang/github.com/evil/malware"},
+				FailOnScopes: []sdk.Scope{sdk.ScopeRuntime},
+			},
+			graph:            graphOf(pkgDenied),
+			baseline:         sdk.New(),
+			wantFindingCount: 1,
+		},
+		{
+			// Unrelated new package that does not resemble any protected name
+			// produces no finding.
+			name: "unrelated new package produces no finding",
+			auditor: Auditor{
+				ProtectedPackages:  []string{"github.com/containerd/containerd/api"},
+				TyposquatThreshold: 0.90,
+			},
+			graph:            graphOf(pkgFake),
+			baseline:         sdk.New(),
+			wantFindingCount: 0,
+		},
+		{
+			// Nil graph returns an empty result without panicking.
+			name:             "nil graph returns empty result",
+			auditor:          Auditor{},
+			graph:            nil,
+			baseline:         nil,
+			wantFindingCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sdk.AuditRequest{
+				Graph:         tc.graph,
+				BaselineGraph: tc.baseline,
+			}
+			result, err := tc.auditor.Audit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Audit() error = %v", err)
+			}
+			if got := len(result.Findings); got != tc.wantFindingCount {
+				t.Errorf("finding count = %d, want %d; findings: %v", got, tc.wantFindingCount, findingIDs(result.Findings))
+			}
+			for _, wantID := range tc.wantFindingIDs {
+				found := false
+				for _, f := range result.Findings {
+					if f.ID == wantID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected finding %q not present; got: %v", wantID, findingIDs(result.Findings))
+				}
+			}
+			if tc.wantDisposition != nil {
+				dispositions := findingKinds(result.Findings)
+				for wantID, wantDisp := range tc.wantDisposition {
+					if got, ok := dispositions[wantID]; !ok {
+						t.Errorf("finding %q not present", wantID)
+					} else if got != wantDisp {
+						t.Errorf("finding %q disposition = %q, want %q", wantID, got, wantDisp)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The package auditor was producing false-positive `possible-typosquat` findings for packages that were simply being **version-bumped** in a diff. For example, upgrading `github.com/containerd/containerd/v2` from `v2.2.2` → `v2.2.4` raised a warning that the name was 0.92 similar to `github.com/containerd/containerd/api` — a package already in the baseline.

### Root cause

The existing guard skipped packages whose **exact purl+version ID** was present in the baseline:

```go
if _, existed := baseIDs[pkg.ID]; existed || req.BaselineGraph == nil {
    continue
}
```

A version bump produces a new ID (`@v2.2.4` ≠ `@v2.2.2`), so the package passed the guard and was fed into the fuzzy-match check against all other baseline package names, including unrelated ones with similar names.

## Fix

Added `packageDisplayNames` to build a case-insensitive set of **display names** (version-agnostic) from the baseline graph. The typosquat check is now skipped for any package whose name already appears in that set — a version bump of a known package is never a typosquat candidate. Only genuinely new package names (not present in the baseline at all) are fuzzy-matched.

## Tests

Added a table-driven test suite in `internal/auditors/package/auditor_test.go` covering:

- **Version bump of existing package is not flagged** (regression case)
- New package similar to a configured protected name → flagged
- New package similar to a baseline package name → flagged
- Unchanged package (same ID) → not flagged
- No baseline → typosquat check skipped entirely
- Denied package → `denied-package` finding with `fail` disposition
- Denied group → `denied-group` finding with `fail` disposition
- `TyposquatMode: "fail"` escalates disposition
- `FailOnScopes` filtering (inside and outside scope)
- Unrelated new package → no finding
- Nil graph → no panic, empty result