### PR TITLE
Expose reachability in report outputs

### DIFF
--- a/docs/schemas/diff.md
+++ b/docs/schemas/diff.md
@@ -270,6 +270,7 @@ Complete reference for the `bomly diff` JSON output.
 | Field | Type | Description |
 |-------|------|-------------|
 | `duration_ms` | `integer` | |
+| `reachability_enabled` | `boolean` | |
 | `analyzer_runs` | Array<`string`> | |
 | `analyzer_stats` | `object` | |
 

--- a/docs/schemas/diff.schema.json
+++ b/docs/schemas/diff.schema.json
@@ -2693,6 +2693,9 @@
         },
         "duration_ms": {
           "type": "integer"
+        },
+        "reachability_enabled": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -187,6 +187,7 @@ Complete reference for the `bomly explain` JSON output.
 | Field | Type | Description |
 |-------|------|-------------|
 | `duration_ms` | `integer` | |
+| `reachability_enabled` | `boolean` | |
 | `analyzer_runs` | Array<`string`> | |
 | `analyzer_stats` | `object` | |
 

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -1420,6 +1420,9 @@
         },
         "duration_ms": {
           "type": "integer"
+        },
+        "reachability_enabled": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/docs/schemas/scan.md
+++ b/docs/schemas/scan.md
@@ -157,6 +157,7 @@ Complete reference for the `bomly scan` JSON output.
 | Field | Type | Description |
 |-------|------|-------------|
 | `duration_ms` | `integer` | |
+| `reachability_enabled` | `boolean` | |
 | `analyzer_runs` | Array<`string`> | |
 | `analyzer_stats` | `object` | |
 

--- a/docs/schemas/scan.schema.json
+++ b/docs/schemas/scan.schema.json
@@ -1459,6 +1459,9 @@
         },
         "duration_ms": {
           "type": "integer"
+        },
+        "reachability_enabled": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -158,12 +158,13 @@ func newDiffCmd() *cobra.Command {
 				prog.CompleteStep("Evaluated policy", children)
 			}
 
-			payload := output.BuildDiffResponse(projectIdentifier, compBase, compHead, diffResult.Base.Consolidated, diffResult.Head.Consolidated, auditPayload, started)
+			reportOptions := reportOptionsFromPipelineResults(current.Reachability, diffResult.Base, diffResult.Head)
+			payload := output.BuildDiffResponse(projectIdentifier, compBase, compHead, diffResult.Base.Consolidated, diffResult.Head.Consolidated, auditPayload, started, reportOptions)
 			markdownRenderer := func(w io.Writer) error {
 				return render.DiffMarkdown(w, payload)
 			}
 			sarifRenderer := func(w io.Writer) error {
-				return output.WriteSARIF(w, diffResult.Findings, "bomly", cmd.Root().Version)
+				return output.WriteSARIF(w, diffResult.Findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Reachability})
 			}
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
@@ -188,7 +189,7 @@ func newDiffCmd() *cobra.Command {
 			}
 			if outputFormat == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return output.WriteSARIF(streams.reportWriter(), diffResult.Findings, "bomly", cmd.Root().Version)
+				return output.WriteSARIF(streams.reportWriter(), diffResult.Findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Reachability})
 			}
 			if current.Interactive {
 				prog.Stop()

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -104,7 +104,8 @@ func newExplainCmd() *cobra.Command {
 				prog.CompleteStep("Evaluated policy", auditProgressChildren(explainResult.AuditorRuns, explainResult.AuditorFindings, explainResult.AuditWarnings))
 			}
 
-			payload := output.BuildExplainResponse(context.ProjectDescriptor(), args[0], targets, started)
+			reportOptions := reportOptionsFromPipelineResults(context.ResolvedConfig.Reachability, explainResult.PipelineResult)
+			payload := output.BuildExplainResponse(context.ProjectDescriptor(), args[0], targets, started, reportOptions)
 			markdownRenderer := func(w io.Writer) error {
 				return render.ExplainMarkdown(w, payload)
 			}
@@ -122,7 +123,7 @@ func newExplainCmd() *cobra.Command {
 						}
 					case render.OutputFormatSARIF:
 						if err := writeRenderedOutput(streams.reportWriter(), spec, func(w io.Writer) error {
-							return output.WriteSARIF(w, explainResult.Findings, "bomly", cmd.Root().Version)
+							return output.WriteSARIF(w, explainResult.Findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: context.ResolvedConfig.Reachability})
 						}); err != nil {
 							return err
 						}
@@ -137,7 +138,7 @@ func newExplainCmd() *cobra.Command {
 			}
 			if context.Format == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return output.WriteSARIF(streams.reportWriter(), explainResult.Findings, "bomly", cmd.Root().Version)
+				return output.WriteSARIF(streams.reportWriter(), explainResult.Findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: context.ResolvedConfig.Reachability})
 			}
 
 			writer, closeWriter, err := context.Writer(streams.reportWriter())
@@ -159,7 +160,7 @@ func newExplainCmd() *cobra.Command {
 								return err
 							}
 						}
-						if err := render.Explain(w, target); err != nil {
+						if err := render.Explain(w, target, payload.Metadata.ReachabilityEnabled); err != nil {
 							return err
 						}
 					}

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -221,7 +221,13 @@ func (a *mcpOptionsAdapter) RunScan(ctx context.Context, req mcp.ScanRequest) (o
 	if cmdCtx.ResolvedConfig.Audit {
 		findings = pipeResult.Findings
 	}
-	return output.BuildScanResponse(cmdCtx.ProjectDescriptor(), pipeResult.Consolidated, findings, started), nil
+	return output.BuildScanResponse(
+		cmdCtx.ProjectDescriptor(),
+		pipeResult.Consolidated,
+		findings,
+		started,
+		reportOptionsFromPipelineResults(cmdCtx.ResolvedConfig.Reachability, pipeResult),
+	), nil
 }
 
 func (a *mcpOptionsAdapter) RunExplain(ctx context.Context, req mcp.ExplainRequest) (output.ExplainResponse, error) {
@@ -257,7 +263,13 @@ func (a *mcpOptionsAdapter) RunExplain(ctx context.Context, req mcp.ExplainReque
 			AuditSummary: output.SummaryFromFindings(target.Findings),
 		})
 	}
-	return output.BuildExplainResponse(cmdCtx.ProjectDescriptor(), req.Package, targets, started), nil
+	return output.BuildExplainResponse(
+		cmdCtx.ProjectDescriptor(),
+		req.Package,
+		targets,
+		started,
+		reportOptionsFromPipelineResults(cmdCtx.ResolvedConfig.Reachability, explainResult.PipelineResult),
+	), nil
 }
 
 func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (output.DiffResponse, error) {
@@ -304,7 +316,16 @@ func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (o
 		return output.DiffResponse{}, err
 	}
 
-	return output.BuildDiffResponse(projectIdentifier, req.Base, req.Head, diffResult.Base.Consolidated, diffResult.Head.Consolidated, diffAuditOutput(diffResult.Audit), started), nil
+	return output.BuildDiffResponse(
+		projectIdentifier,
+		req.Base,
+		req.Head,
+		diffResult.Base.Consolidated,
+		diffResult.Head.Consolidated,
+		diffAuditOutput(diffResult.Audit),
+		started,
+		reportOptionsFromPipelineResults(o.GetConfig().Reachability, diffResult.Base, diffResult.Head),
+	), nil
 }
 
 func (a *mcpOptionsAdapter) ListPlugins(_ context.Context) (plugin.PluginListResponse, error) {

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -39,9 +39,9 @@ func Diff(w io.Writer, payload output.DiffResponse) error {
 	}
 	lines = append(lines, dependencyTextSections(payload.Results.Dependencies)...)
 	lines = append(lines, licenseTextSections(payload.Results.Licenses)...)
-	lines = append(lines, vulnerabilityTextSections(payload.Results.Vulnerabilities)...)
+	lines = append(lines, vulnerabilityTextSections(payload.Results.Vulnerabilities, payload.Metadata.ReachabilityEnabled)...)
 	if payload.Audit != nil {
-		lines = append(lines, policyTextSections(*payload.Audit)...)
+		lines = append(lines, policyTextSections(*payload.Audit, payload.Metadata.ReachabilityEnabled)...)
 	}
 	for _, line := range lines {
 		if _, err := fmt.Fprintln(w, line); err != nil {
@@ -125,7 +125,7 @@ func licenseTextSections(results output.DiffLicenseResults) []string {
 	return append(lines, "")
 }
 
-func vulnerabilityTextSections(results output.DiffVulnerabilityResults) []string {
+func vulnerabilityTextSections(results output.DiffVulnerabilityResults, includeReachability bool) []string {
 	lines := []string{"Vulnerabilities"}
 	if len(results.Added) == 0 && len(results.Removed) == 0 {
 		return append(lines, "  No vulnerability changes.", "")
@@ -133,19 +133,21 @@ func vulnerabilityTextSections(results output.DiffVulnerabilityResults) []string
 	if len(results.Added) > 0 {
 		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
 		for _, change := range results.Added {
-			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package)), Red))
+			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
+			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s%s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Red))
 		}
 	}
 	if len(results.Removed) > 0 {
 		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
 		for _, change := range results.Removed {
-			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package)), Green))
+			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
+			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s%s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Green))
 		}
 	}
 	return append(lines, "")
 }
 
-func policyTextSections(audit output.DiffAudit) []string {
+func policyTextSections(audit output.DiffAudit, includeReachability bool) []string {
 	lines := []string{
 		"Policy Evaluation",
 		fmt.Sprintf("  Current findings: %s.", diffAuditFindingsSummary(audit.AuditSummary)),
@@ -172,6 +174,9 @@ func policyTextSections(audit output.DiffAudit) []string {
 			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
 				details = append(details, exploitability)
 			}
+			if includeReachability {
+				details = append(details, "reachability "+formatReachabilityCell(finding.Reachability))
+			}
 			if len(details) > 0 {
 				line += " [" + strings.Join(details, "; ") + "]"
 			}
@@ -188,6 +193,13 @@ func policyTextSections(audit output.DiffAudit) []string {
 		lines = append(lines, "  No policy differences were identified between the base and head dependency sets.")
 	}
 	return lines
+}
+
+func diffVulnerabilityDetails(vulnerability output.VulnerabilityRef, includeReachability bool) string {
+	if !includeReachability {
+		return ""
+	}
+	return " [" + "reachability " + formatReachabilityCell(vulnerability.Reachability) + "]"
 }
 
 func dependencyNameWidth(results output.DiffDependencyResults) int {

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -113,34 +113,45 @@ func diffVulnerabilityMarkdown(payload output.DiffResponse) []string {
 		fmt.Sprintf("**Summary:** %d introduced, %d resolved.", len(results.Added), len(results.Removed)),
 		"",
 	}
-	lines = append(lines, diffVulnerabilityTable("Introduced Vulnerabilities", "introduced", results.Added)...)
-	lines = append(lines, diffVulnerabilityTable("Resolved Vulnerabilities", "resolved", results.Removed)...)
+	lines = append(lines, diffVulnerabilityTable("Introduced Vulnerabilities", "introduced", results.Added, payload.Metadata.ReachabilityEnabled)...)
+	lines = append(lines, diffVulnerabilityTable("Resolved Vulnerabilities", "resolved", results.Removed, payload.Metadata.ReachabilityEnabled)...)
 	if len(results.Added) == 0 && len(results.Removed) == 0 {
 		return []string{"✅ No vulnerability changes."}
 	}
 	return trimTrailingMarkdownBlanks(lines)
 }
 
-func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabilityChange) []string {
+func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabilityChange, includeReachability bool) []string {
 	if len(changes) == 0 {
 		return nil
 	}
 	rows := make([][]string, 0, len(changes))
 	for _, change := range sortVulnerabilityChanges(changes) {
 		vuln := change.Vulnerability
-		rows = append(rows, []string{
+		row := []string{
 			findingIcon(status, vuln.Severity, ""),
 			status,
 			strings.ToUpper(valueOrDash(vuln.Severity)),
 			vuln.ID,
 			DiffPackageDisplayName(change.Package),
+		}
+		if includeReachability {
+			row = append(row, valueOrDash(formatReachabilityCell(vuln.Reachability)))
+		}
+		row = append(row,
 			valueOrDash(fixedVersionSummary(vuln.FixedIn, vuln.FixedVersions)),
 			valueOrDash(exploitabilitySummary(vuln.KEVExploited, vuln.KnownExploited, vuln.RiskScore)),
 			valueOrDash(vuln.Source),
 			firstNonEmpty(vuln.Title, strings.Join(vuln.Reasons, "; ")),
-		})
+		)
+		rows = append(rows, row)
 	}
-	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Change", "Severity", "ID", "Package", "Fixed In", "Exploitability", "Source", "Title"}, rows), "")...)
+	header := []string{"", "Change", "Severity", "ID", "Package"}
+	if includeReachability {
+		header = append(header, "Reachability")
+	}
+	header = append(header, "Fixed In", "Exploitability", "Source", "Title")
+	return append([]string{"### " + title, ""}, append(markdownTable(header, rows), "")...)
 }
 
 func diffLicenseMarkdown(payload output.DiffResponse) []string {
@@ -198,9 +209,9 @@ func diffPolicyFindingsMarkdown(payload output.DiffResponse) []string {
 		diffPolicySummary(audit),
 		"",
 	}
-	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", audit.Introduced)...)
-	lines = append(lines, diffAuditFindingTable("Persisted Findings", "persisted", audit.Persisted)...)
-	lines = append(lines, diffAuditFindingTable("Resolved Findings", "resolved", audit.Resolved)...)
+	lines = append(lines, diffAuditFindingTable("Introduced Findings", "introduced", audit.Introduced, payload.Metadata.ReachabilityEnabled)...)
+	lines = append(lines, diffAuditFindingTable("Persisted Findings", "persisted", audit.Persisted, payload.Metadata.ReachabilityEnabled)...)
+	lines = append(lines, diffAuditFindingTable("Resolved Findings", "resolved", audit.Resolved, payload.Metadata.ReachabilityEnabled)...)
 	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
 		return []string{"✅ No policy differences were identified."}
 	}
@@ -216,13 +227,13 @@ func diffPolicySummary(audit *output.DiffAudit) string {
 	return "**Summary:** " + strings.Join(parts, ", ") + "."
 }
 
-func diffAuditFindingTable(title, status string, findings []output.AuditFinding) []string {
+func diffAuditFindingTable(title, status string, findings []output.AuditFinding, includeReachability bool) []string {
 	if len(findings) == 0 {
 		return nil
 	}
 	rows := make([][]string, 0, len(findings))
 	for _, finding := range sortDiffAuditFindings(findings) {
-		rows = append(rows, []string{
+		row := []string{
 			findingIcon(status, finding.Severity, finding.Disposition),
 			status,
 			valueOrDash(finding.Auditor),
@@ -230,12 +241,23 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding)
 			findingDisposition(finding.Disposition),
 			valueOrDash(finding.ID),
 			DiffPackageDisplayName(finding.Package),
+		}
+		if includeReachability {
+			row = append(row, valueOrDash(formatReachabilityCell(finding.Reachability)))
+		}
+		row = append(row,
 			valueOrDash(fixedVersionSummary(finding.FixedIn, finding.FixedVersions)),
 			valueOrDash(exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore)),
 			firstNonEmpty(finding.Title, strings.Join(finding.Reasons, "; ")),
-		})
+		)
+		rows = append(rows, row)
 	}
-	return append([]string{"### " + title, ""}, append(markdownTable([]string{"", "Status", "Category", "Severity", "Disposition", "ID", "Package", "Fixed In", "Exploitability", "Title"}, rows), "")...)
+	header := []string{"", "Status", "Category", "Severity", "Disposition", "ID", "Package"}
+	if includeReachability {
+		header = append(header, "Reachability")
+	}
+	header = append(header, "Fixed In", "Exploitability", "Title")
+	return append([]string{"### " + title, ""}, append(markdownTable(header, rows), "")...)
 }
 
 func findingIcon(status, severity, disposition string) string {

--- a/internal/cli/render/explain.go
+++ b/internal/cli/render/explain.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Explain writes the human-readable explain report for one target dependency.
-func Explain(w io.Writer, target output.ExplainTargetResponse) error {
+func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabilityValue ...bool) error {
+	includeReachability := len(includeReachabilityValue) > 0 && includeReachabilityValue[0]
 	divider := Style(strings.Repeat("=", 72), Dim)
 	section := Style(strings.Repeat("-", 72), Dim)
 
@@ -82,6 +83,11 @@ func Explain(w io.Writer, target output.ExplainTargetResponse) error {
 					return err
 				}
 			}
+			if includeReachability {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Reach:   ", Dim), formatReachabilityCell(vulnerability.Reachability)); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -111,6 +117,11 @@ func Explain(w io.Writer, target output.ExplainTargetResponse) error {
 			}
 			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
 				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Exploit: ", Dim), exploitability); err != nil {
+					return err
+				}
+			}
+			if includeReachability {
+				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Reach:   ", Dim), formatReachabilityCell(finding.Reachability)); err != nil {
 					return err
 				}
 			}

--- a/internal/cli/render/explain_markdown.go
+++ b/internal/cli/render/explain_markdown.go
@@ -76,19 +76,33 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 			fmt.Sprintf("- Policy findings: %s", scanAuditSummaryMarkdown(target.AuditSummary)),
 			fmt.Sprintf("- Licenses: %d", len(target.Dependency.Licenses)),
 		)
+		if payload.Metadata.ReachabilityEnabled {
+			lines = append(lines, fmt.Sprintf("- Reachability: %s", explainReachabilitySummary(target)))
+		}
 		if len(target.Dependency.Vulnerabilities) > 0 {
 			rows := make([][]string, 0, len(target.Dependency.Vulnerabilities))
 			for _, vulnerability := range target.Dependency.Vulnerabilities {
-				rows = append(rows, []string{
+				row := []string{
 					strings.ToUpper(ValueOrDash(vulnerability.Severity)),
 					valueOrDash(vulnerability.ID),
+				}
+				if payload.Metadata.ReachabilityEnabled {
+					row = append(row, valueOrDash(formatReachabilityCell(vulnerability.Reachability)))
+				}
+				row = append(row,
 					valueOrDash(fixedVersionSummary(vulnerability.FixedIn, vulnerability.FixedVersions)),
 					valueOrDash(exploitabilitySummary(vulnerability.KEVExploited, vulnerability.KnownExploited, vulnerability.RiskScore)),
 					valueOrDash(vulnerability.Source),
-				})
+				)
+				rows = append(rows, row)
 			}
+			header := []string{"Severity", "ID"}
+			if payload.Metadata.ReachabilityEnabled {
+				header = append(header, "Reachability")
+			}
+			header = append(header, "Fixed In", "Exploitability", "Source")
 			lines = append(lines, "")
-			lines = append(lines, markdownTable([]string{"Severity", "ID", "Fixed In", "Exploitability", "Source"}, rows)...)
+			lines = append(lines, markdownTable(header, rows)...)
 		}
 		if len(target.Findings) > 0 {
 			for _, finding := range sortDiffAuditFindings(target.Findings) {
@@ -96,11 +110,16 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 				if title == "" {
 					title = finding.ID
 				}
+				suffix := ""
+				if payload.Metadata.ReachabilityEnabled {
+					suffix = " (" + markdownText("reachability "+formatReachabilityCell(finding.Reachability)) + ")"
+				}
 				lines = append(lines, fmt.Sprintf(
-					"- [%s] `%s`: %s",
+					"- [%s] `%s`: %s%s",
 					markdownInline(ValueOrDash(finding.Severity)),
 					markdownInline(ValueOrDash(finding.ID)),
 					markdownText(title),
+					suffix,
 				))
 			}
 		}
@@ -109,6 +128,43 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 		}
 	}
 	return trimTrailingMarkdownBlanks(lines)
+}
+
+func explainReachabilitySummary(target output.ExplainTargetResponse) string {
+	var reachable, unreachable, unknown, notApplicable, total int
+	for _, vulnerability := range target.Dependency.Vulnerabilities {
+		if vulnerability.Reachability == nil {
+			continue
+		}
+		total++
+		switch vulnerability.Reachability.Status {
+		case "reachable":
+			reachable++
+		case "unreachable":
+			unreachable++
+		case "not_applicable":
+			notApplicable++
+		default:
+			unknown++
+		}
+	}
+	if total == 0 {
+		return "enabled (no analyzer ran on this dependency)"
+	}
+	parts := make([]string, 0, 4)
+	if reachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d reachable", reachable))
+	}
+	if unreachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d unreachable", unreachable))
+	}
+	if unknown > 0 {
+		parts = append(parts, fmt.Sprintf("%d unknown", unknown))
+	}
+	if notApplicable > 0 {
+		parts = append(parts, fmt.Sprintf("%d not_applicable", notApplicable))
+	}
+	return fmt.Sprintf("%d analyzed (%s)", total, strings.Join(parts, ", "))
 }
 
 func markdownDependencyPath(path output.DependencyPath) string {

--- a/internal/cli/render/reachability_test.go
+++ b/internal/cli/render/reachability_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -41,6 +42,158 @@ func TestScanRendersReachabilityColumnWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestScanMarkdownRendersReachabilityOnlyWhenEnabled(t *testing.T) {
+	payload := output.ScanResponse{
+		Metadata: output.Metadata{ReachabilityEnabled: true},
+		Manifests: []output.ScanManifest{{
+			Packages: []output.ScanPackage{{
+				PackageRef: output.PackageRef{
+					Name: "lib",
+					Vulnerabilities: []output.VulnerabilityRef{{
+						ID:           "CVE-2024-0001",
+						Source:       "osv",
+						Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+					}},
+				},
+			}},
+		}},
+		Findings: []output.AuditFinding{{
+			ID:           "CVE-2024-0001",
+			Severity:     "high",
+			Package:      output.PackageRef{Name: "lib"},
+			Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+		}},
+	}
+	var out bytes.Buffer
+	if err := ScanMarkdown(&out, payload); err != nil {
+		t.Fatalf("ScanMarkdown() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Reachability") || !strings.Contains(out.String(), "reachable (package)") {
+		t.Fatalf("expected reachability in enabled Markdown output; got:\n%s", out.String())
+	}
+
+	payload.Metadata.ReachabilityEnabled = false
+	out.Reset()
+	if err := ScanMarkdown(&out, payload); err != nil {
+		t.Fatalf("ScanMarkdown() error = %v", err)
+	}
+	if strings.Contains(out.String(), "Reachability") || strings.Contains(out.String(), "reachable (package)") {
+		t.Fatalf("reachability should be absent when disabled; got:\n%s", out.String())
+	}
+}
+
+func TestDiffTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
+	payload := output.DiffResponse{
+		Metadata: output.Metadata{ReachabilityEnabled: true},
+		Results: output.DiffResults{
+			Vulnerabilities: output.DiffVulnerabilityResults{
+				Added: []output.DiffVulnerabilityChange{{
+					Package: output.PackageRef{Name: "lib", Version: "1.0.0"},
+					Vulnerability: output.VulnerabilityRef{
+						ID:           "CVE-2024-0001",
+						Severity:     "high",
+						Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+					},
+				}},
+			},
+		},
+		Audit: &output.DiffAudit{
+			Introduced: []output.AuditFinding{{
+				ID:           "CVE-2024-0001",
+				Severity:     "high",
+				Package:      output.PackageRef{Name: "lib", Version: "1.0.0"},
+				Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+			}},
+		},
+	}
+	var text bytes.Buffer
+	if err := Diff(&text, payload); err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if !strings.Contains(text.String(), "reachability reachable (package)") {
+		t.Fatalf("expected reachability in enabled diff text; got:\n%s", text.String())
+	}
+	var markdown bytes.Buffer
+	if err := DiffMarkdown(&markdown, payload); err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if !strings.Contains(markdown.String(), "Reachability") || !strings.Contains(markdown.String(), "reachable (package)") {
+		t.Fatalf("expected reachability in enabled diff Markdown; got:\n%s", markdown.String())
+	}
+
+	payload.Metadata.ReachabilityEnabled = false
+	text.Reset()
+	if err := Diff(&text, payload); err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if strings.Contains(text.String(), "reachability reachable") {
+		t.Fatalf("reachability should be absent from disabled diff text; got:\n%s", text.String())
+	}
+	markdown.Reset()
+	if err := DiffMarkdown(&markdown, payload); err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if strings.Contains(markdown.String(), "Reachability") || strings.Contains(markdown.String(), "reachable (package)") {
+		t.Fatalf("reachability should be absent from disabled diff Markdown; got:\n%s", markdown.String())
+	}
+}
+
+func TestExplainTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
+	target := output.ExplainTargetResponse{
+		Project: output.ProjectDescriptor{Name: "demo"},
+		Dependency: output.PackageRef{
+			Name: "lib",
+			Vulnerabilities: []output.VulnerabilityRef{{
+				ID:           "CVE-2024-0001",
+				Source:       "osv",
+				Severity:     "high",
+				Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+			}},
+		},
+		Findings: []output.AuditFinding{{
+			ID:           "CVE-2024-0001",
+			Severity:     "high",
+			Package:      output.PackageRef{Name: "lib"},
+			Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
+		}},
+	}
+	var text bytes.Buffer
+	if err := Explain(&text, target, true); err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if !strings.Contains(text.String(), "Reach:") || !strings.Contains(text.String(), "reachable (package)") {
+		t.Fatalf("expected reachability in enabled explain text; got:\n%s", text.String())
+	}
+	text.Reset()
+	if err := Explain(&text, target, false); err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if strings.Contains(text.String(), "Reach:") || strings.Contains(text.String(), "reachable (package)") {
+		t.Fatalf("reachability should be absent from disabled explain text; got:\n%s", text.String())
+	}
+
+	payload := output.ExplainResponse{
+		Metadata: output.Metadata{ReachabilityEnabled: true},
+		Query:    output.ExplainQuery{Name: "lib"},
+		Targets:  []output.ExplainTargetResponse{target},
+	}
+	var markdown bytes.Buffer
+	if err := ExplainMarkdown(&markdown, payload); err != nil {
+		t.Fatalf("ExplainMarkdown() error = %v", err)
+	}
+	if !strings.Contains(markdown.String(), "Reachability") || !strings.Contains(markdown.String(), "reachable (package)") {
+		t.Fatalf("expected reachability in enabled explain Markdown; got:\n%s", markdown.String())
+	}
+	payload.Metadata.ReachabilityEnabled = false
+	markdown.Reset()
+	if err := ExplainMarkdown(&markdown, payload); err != nil {
+		t.Fatalf("ExplainMarkdown() error = %v", err)
+	}
+	if strings.Contains(markdown.String(), "Reachability") || strings.Contains(markdown.String(), "reachable (package)") {
+		t.Fatalf("reachability should be absent from disabled explain Markdown; got:\n%s", markdown.String())
+	}
+}
+
 func TestScanOmitsReachabilityColumnWhenDisabled(t *testing.T) {
 	g := model.New()
 	pkg := model.NewPackage(model.Package{Name: "lib", Version: "1.0.0", Ecosystem: "go"})
@@ -65,7 +218,7 @@ func TestFormatReachabilityCell(t *testing.T) {
 		in   *model.Reachability
 		want string
 	}{
-		{"nil", nil, "—"},
+		{"nil", nil, "-"},
 		{"reachable+symbol", &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierSymbol}, "reachable (symbol)"},
 		{"unknown+none", &model.Reachability{Status: model.ReachabilityUnknown, Tier: model.TierNone}, "unknown"},
 		{"unreachable, no tier", &model.Reachability{Status: model.ReachabilityUnreachable}, "unreachable"},

--- a/internal/cli/render/scan.go
+++ b/internal/cli/render/scan.go
@@ -245,11 +245,11 @@ func formatAuditSummary(summary *output.AuditSummary, auditEnabled bool) string 
 }
 
 // formatReachabilityCell renders one Reachability annotation for the
-// findings table. Returns "—" when no analyzer ran (nil reachability) so
+// findings table. Returns "-" when no analyzer ran (nil reachability) so
 // the column reads cleanly when only a subset of findings is annotated.
 func formatReachabilityCell(r *sdk.Reachability) string {
 	if r == nil {
-		return "—"
+		return "-"
 	}
 	if r.Tier == "" || r.Tier == sdk.TierNone {
 		return string(r.Status)

--- a/internal/cli/render/scan_markdown.go
+++ b/internal/cli/render/scan_markdown.go
@@ -33,11 +33,15 @@ func ScanMarkdown(w io.Writer, payload output.ScanResponse) error {
 }
 
 func scanSummaryMarkdown(payload output.ScanResponse) []string {
-	return []string{
+	lines := []string{
 		fmt.Sprintf("- Manifests: %d", len(payload.Manifests)),
 		fmt.Sprintf("- Packages: %d", scanPackageCount(payload.Manifests)),
 		fmt.Sprintf("- Policy findings: %s", scanAuditSummaryMarkdown(payload.AuditSummary)),
 	}
+	if payload.Metadata.ReachabilityEnabled {
+		lines = append(lines, fmt.Sprintf("- Reachability: %s", scanReachabilitySummaryMarkdown(payload.Manifests)))
+	}
+	return lines
 }
 
 func scanManifestMarkdown(payload output.ScanResponse) []string {
@@ -91,17 +95,28 @@ func scanFindingsMarkdown(payload output.ScanResponse) []string {
 		if title == "" {
 			title = finding.ID
 		}
-		rows = append(rows, []string{
+		row := []string{
 			strings.ToUpper(ValueOrDash(finding.Severity)),
 			valueOrDash(finding.ID),
 			pkg,
+		}
+		if payload.Metadata.ReachabilityEnabled {
+			row = append(row, valueOrDash(formatReachabilityCell(finding.Reachability)))
+		}
+		row = append(row,
 			valueOrDash(fixedVersionSummary(finding.FixedIn, finding.FixedVersions)),
 			valueOrDash(exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore)),
 			valueOrDash(finding.Source),
 			title,
-		})
+		)
+		rows = append(rows, row)
 	}
-	return markdownTable([]string{"Severity", "ID", "Package", "Fixed In", "Exploitability", "Source", "Title"}, rows)
+	header := []string{"Severity", "ID", "Package"}
+	if payload.Metadata.ReachabilityEnabled {
+		header = append(header, "Reachability")
+	}
+	header = append(header, "Fixed In", "Exploitability", "Source", "Title")
+	return markdownTable(header, rows)
 }
 
 func scanPackageCount(manifests []output.ScanManifest) int {
@@ -134,4 +149,45 @@ func scanAuditSummaryMarkdown(summary *output.AuditSummary) string {
 		return "none"
 	}
 	return formatAuditSummary(summary, true)
+}
+
+func scanReachabilitySummaryMarkdown(manifests []output.ScanManifest) string {
+	var reachable, unreachable, unknown, notApplicable, total int
+	for _, manifest := range manifests {
+		for _, pkg := range manifest.Packages {
+			for _, vuln := range pkg.Vulnerabilities {
+				if vuln.Reachability == nil {
+					continue
+				}
+				total++
+				switch vuln.Reachability.Status {
+				case "reachable":
+					reachable++
+				case "unreachable":
+					unreachable++
+				case "not_applicable":
+					notApplicable++
+				default:
+					unknown++
+				}
+			}
+		}
+	}
+	if total == 0 {
+		return "enabled (no analyzer ran on any vulnerability)"
+	}
+	parts := make([]string, 0, 4)
+	if reachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d reachable", reachable))
+	}
+	if unreachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d unreachable", unreachable))
+	}
+	if unknown > 0 {
+		parts = append(parts, fmt.Sprintf("%d unknown", unknown))
+	}
+	if notApplicable > 0 {
+		parts = append(parts, fmt.Sprintf("%d not_applicable", notApplicable))
+	}
+	return fmt.Sprintf("%d analyzed (%s)", total, strings.Join(parts, ", "))
 }

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -99,8 +99,8 @@ func newScanCmd() *cobra.Command {
 				findings = pipeResult.Findings
 				prog.CompleteStep("Evaluated policy", auditProgressChildren(pipeResult.AuditorRuns, pipeResult.AuditorFindings, pipeResult.AuditWarnings))
 			}
-			payload := output.BuildScanResponse(commandCtx.ProjectDescriptor(), consolidated, findings, started).
-				WithAnalyzerRuns(pipeResult.AnalyzerRuns, pipeResult.AnalyzerStats)
+			reportOptions := reportOptionsFromPipelineResults(commandCtx.ResolvedConfig.Reachability, pipeResult)
+			payload := output.BuildScanResponse(commandCtx.ProjectDescriptor(), consolidated, findings, started, reportOptions)
 			markdownRenderer := func(w io.Writer) error {
 				return render.ScanMarkdown(w, payload)
 			}
@@ -125,7 +125,7 @@ func newScanCmd() *cobra.Command {
 						}
 					case spec.Format == render.OutputFormatSARIF:
 						if err := writeRenderedOutput(stdout, spec, func(w io.Writer) error {
-							return output.WriteSARIF(w, findings, "bomly", cmd.Root().Version)
+							return output.WriteSARIF(w, findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: commandCtx.ResolvedConfig.Reachability})
 						}); err != nil {
 							return err
 						}
@@ -141,7 +141,7 @@ func newScanCmd() *cobra.Command {
 
 			if graphOutputFormat == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return output.WriteSARIF(streams.reportWriter(), findings, "bomly", cmd.Root().Version)
+				return output.WriteSARIF(streams.reportWriter(), findings, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: commandCtx.ResolvedConfig.Reachability})
 			}
 
 			if commandCtx.ResolvedConfig.Interactive {

--- a/internal/cli/scan_output.go
+++ b/internal/cli/scan_output.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"sort"
+
+	"github.com/bomly-dev/bomly-cli/internal/engine"
 	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -16,6 +19,40 @@ func diffAuditOutput(audit *diffengine.Audit) *output.DiffAudit {
 		Resolved:     output.FindingsFromScan(audit.Resolved),
 		Persisted:    output.FindingsFromScan(audit.Persisted),
 		AuditSummary: output.SummaryFromFindings(combined),
+	}
+}
+
+func reportOptionsFromPipelineResults(enabled bool, results ...engine.PipelineResult) output.ReportOptions {
+	if !enabled {
+		return output.ReportOptions{}
+	}
+	runsSeen := make(map[string]struct{})
+	stats := make(map[string]sdk.ReachabilityStats)
+	for _, result := range results {
+		for _, run := range result.AnalyzerRuns {
+			if run == "" {
+				continue
+			}
+			runsSeen[run] = struct{}{}
+		}
+		for name, value := range result.AnalyzerStats {
+			current := stats[name]
+			current.Reachable += value.Reachable
+			current.Unreachable += value.Unreachable
+			current.Unknown += value.Unknown
+			current.NotApplicable += value.NotApplicable
+			stats[name] = current
+		}
+	}
+	runs := make([]string, 0, len(runsSeen))
+	for run := range runsSeen {
+		runs = append(runs, run)
+	}
+	sort.Strings(runs)
+	return output.ReportOptions{
+		ReachabilityEnabled: true,
+		AnalyzerRuns:        runs,
+		AnalyzerStats:       stats,
 	}
 }
 

--- a/internal/cli/scan_output_test.go
+++ b/internal/cli/scan_output_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/engine"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestReportOptionsFromPipelineResultsCombinesAnalyzerMetadata(t *testing.T) {
+	options := reportOptionsFromPipelineResults(true,
+		engine.PipelineResult{
+			AnalyzerRuns: []string{"jsreach", "govulncheck"},
+			AnalyzerStats: map[string]sdk.ReachabilityStats{
+				"jsreach": {Reachable: 1, Unknown: 2},
+			},
+		},
+		engine.PipelineResult{
+			AnalyzerRuns: []string{"pyreach", "jsreach"},
+			AnalyzerStats: map[string]sdk.ReachabilityStats{
+				"jsreach": {Reachable: 3, Unreachable: 4},
+				"pyreach": {NotApplicable: 5},
+			},
+		},
+	)
+	if !options.ReachabilityEnabled {
+		t.Fatal("reachability should be enabled")
+	}
+	wantRuns := []string{"govulncheck", "jsreach", "pyreach"}
+	for idx, want := range wantRuns {
+		if idx >= len(options.AnalyzerRuns) || options.AnalyzerRuns[idx] != want {
+			t.Fatalf("AnalyzerRuns = %#v, want %#v", options.AnalyzerRuns, wantRuns)
+		}
+	}
+	if got := options.AnalyzerStats["jsreach"]; got.Reachable != 4 || got.Unreachable != 4 || got.Unknown != 2 {
+		t.Fatalf("combined jsreach stats = %#v", got)
+	}
+	if got := options.AnalyzerStats["pyreach"]; got.NotApplicable != 5 {
+		t.Fatalf("combined pyreach stats = %#v", got)
+	}
+}
+
+func TestReportOptionsFromPipelineResultsDisabledOmitsAnalyzerMetadata(t *testing.T) {
+	options := reportOptionsFromPipelineResults(false, engine.PipelineResult{
+		AnalyzerRuns:  []string{"jsreach"},
+		AnalyzerStats: map[string]sdk.ReachabilityStats{"jsreach": {Reachable: 1}},
+	})
+	if options.ReachabilityEnabled || len(options.AnalyzerRuns) > 0 || len(options.AnalyzerStats) > 0 {
+		t.Fatalf("disabled options should be empty: %#v", options)
+	}
+}

--- a/internal/engine/pipeline_explain.go
+++ b/internal/engine/pipeline_explain.go
@@ -53,6 +53,7 @@ func (p *Pipeline) RunExplain(ctx context.Context, req ExplainRequest) (ExplainR
 		return ExplainResult{PipelineResult: base}, err
 	}
 	p.runMatch(ctx, &base, pipeReq)
+	p.runAnalyze(ctx, &base, pipeReq)
 
 	result := ExplainResult{PipelineResult: base}
 	focusedResults := make([]sdk.DetectionResult, 0, len(base.Consolidated.Manifests))

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -134,9 +134,18 @@ type sarifProperties struct {
 	DynamicImportsDetected bool                 `json:"reachability_dynamic_imports_detected,omitempty"`
 }
 
+// SARIFOptions controls optional experimental data in SARIF output.
+type SARIFOptions struct {
+	IncludeReachability bool
+}
+
 // WriteSARIF writes findings as a SARIF 2.1.0 document to w.
 // toolName and toolVersion are used to populate the driver section.
-func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion string) error {
+func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion string, options ...SARIFOptions) error {
+	includeReachability := false
+	if len(options) > 0 {
+		includeReachability = options[0].IncludeReachability
+	}
 	// Deduplicate rules by finding ID.
 	seen := map[string]bool{}
 	var rules []sarifRule
@@ -195,7 +204,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion strin
 			Namespace:            f.Namespace,
 			CPEs:                 append([]string(nil), f.CPEs...),
 		}
-		if f.Reachability != nil {
+		if includeReachability && f.Reachability != nil {
 			props.Reachability = string(f.Reachability.Status)
 			props.ReachabilityTier = string(f.Reachability.Tier)
 			props.ReachabilityReason = f.Reachability.Reason

--- a/internal/output/sarif_reachability_test.go
+++ b/internal/output/sarif_reachability_test.go
@@ -38,7 +38,7 @@ func TestWriteSARIFEmitsCodeFlowsAndPropertiesForReachableFinding(t *testing.T) 
 	}
 
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, findings, "bomly", "test"); err != nil {
+	if err := WriteSARIF(&buf, findings, "bomly", "test", SARIFOptions{IncludeReachability: true}); err != nil {
 		t.Fatalf("WriteSARIF error: %v", err)
 	}
 
@@ -55,6 +55,43 @@ func TestWriteSARIFEmitsCodeFlowsAndPropertiesForReachableFinding(t *testing.T) 
 	}
 	if !strings.Contains(buf.String(), `"main.go"`) {
 		t.Errorf("expected call frame URI 'main.go'; got:\n%s", buf.String())
+	}
+}
+
+func TestWriteSARIFOmitsReachabilityWhenDisabled(t *testing.T) {
+	pkg := &model.Package{Name: "lib", Version: "1.0.0", Ecosystem: "go"}
+	findings := []model.Finding{
+		{
+			ID:       "GHSA-test",
+			Kind:     model.FindingKindVulnerability,
+			Package:  pkg,
+			Severity: "high",
+			Title:    "vuln",
+			Source:   "osv",
+			FixedIn:  "1.0.1",
+			Reachability: &model.Reachability{
+				Status: model.ReachabilityReachable,
+				Tier:   model.TierSymbol,
+				CallPaths: []model.CallPath{{
+					Sink:   model.AffectedSymbol{Symbol: "Decode", Package: "lib"},
+					Frames: []model.CallFrame{{Function: "main", Package: "main", Position: model.SourcePosition{File: "main.go", Line: 12}}},
+				}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, findings, "bomly", "test", SARIFOptions{IncludeReachability: false}); err != nil {
+		t.Fatalf("WriteSARIF error: %v", err)
+	}
+	if strings.Contains(buf.String(), `"codeFlows"`) {
+		t.Errorf("codeFlows should be absent when reachability is disabled; got:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), `"reachability"`) {
+		t.Errorf("reachability properties should be absent when disabled; got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"fixed_in": "1.0.1"`) {
+		t.Errorf("non-reachability SARIF properties should still be emitted; got:\n%s", buf.String())
 	}
 }
 

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -12,9 +12,18 @@ const SchemaVersion = "1.0"
 
 // Metadata captures execution metadata shared by all command outputs.
 type Metadata struct {
-	DurationMS    int64                            `json:"duration_ms"`
-	AnalyzerRuns  []string                         `json:"analyzer_runs,omitempty"`
-	AnalyzerStats map[string]sdk.ReachabilityStats `json:"analyzer_stats,omitempty"`
+	DurationMS          int64                            `json:"duration_ms"`
+	ReachabilityEnabled bool                             `json:"reachability_enabled,omitempty"`
+	AnalyzerRuns        []string                         `json:"analyzer_runs,omitempty"`
+	AnalyzerStats       map[string]sdk.ReachabilityStats `json:"analyzer_stats,omitempty"`
+}
+
+// ReportOptions controls optional experimental data in structured command
+// outputs.
+type ReportOptions struct {
+	ReachabilityEnabled bool
+	AnalyzerRuns        []string
+	AnalyzerStats       map[string]sdk.ReachabilityStats
 }
 
 // ProjectDescriptor describes the project being analyzed.
@@ -159,6 +168,16 @@ func PackageFromGraphPackage(pkg *sdk.Package) PackageRef {
 		Licenses:        LicenseRefsFromGraphLicenses(pkg.Licenses),
 		Vulnerabilities: VulnerabilityRefsFromPackageVulnerabilities(pkg.Vulnerabilities),
 	}
+}
+
+func (p PackageRef) withoutReachability() PackageRef {
+	if len(p.Vulnerabilities) > 0 {
+		p.Vulnerabilities = append([]VulnerabilityRef(nil), p.Vulnerabilities...)
+		for idx := range p.Vulnerabilities {
+			p.Vulnerabilities[idx].Reachability = nil
+		}
+	}
+	return p
 }
 
 func cloneAffectedSymbols(src []sdk.AffectedSymbol) []sdk.AffectedSymbol {
@@ -332,6 +351,12 @@ func FindingsFromScan(findings []sdk.Finding) []AuditFinding {
 		})
 	}
 	return result
+}
+
+func (f AuditFinding) withoutReachability() AuditFinding {
+	f.Reachability = nil
+	f.Package = f.Package.withoutReachability()
+	return f
 }
 
 // FailingFindingCount reports how many findings should fail policy evaluation.

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -176,7 +176,7 @@ type ExplainTargetResponse struct {
 // BuildScanResponse constructs the structured scan payload from consolidated
 // manifest selections and findings. Reachability metadata (analyzer runs and
 // per-analyzer stats) is attached afterwards via ScanResponse.WithAnalyzerRuns.
-func BuildScanResponse(project ProjectDescriptor, consolidated sdk.ConsolidatedGraph, findings []sdk.Finding, started time.Time) ScanResponse {
+func BuildScanResponse(project ProjectDescriptor, consolidated sdk.ConsolidatedGraph, findings []sdk.Finding, started time.Time, options ...ReportOptions) ScanResponse {
 	response := ScanResponse{
 		SchemaVersion: SchemaVersion,
 		Command:       "scan",
@@ -188,7 +188,7 @@ func BuildScanResponse(project ProjectDescriptor, consolidated sdk.ConsolidatedG
 		response.Findings = FindingsFromScan(findings)
 		response.AuditSummary = SummaryFromFindings(findings)
 	}
-	return response
+	return response.WithReportOptions(firstReportOptions(options))
 }
 
 // WithAnalyzerRuns annotates a ScanResponse with analyzer run names and
@@ -196,14 +196,27 @@ func BuildScanResponse(project ProjectDescriptor, consolidated sdk.ConsolidatedG
 // can be chained from BuildScanResponse callers without intermediate
 // state.
 func (r ScanResponse) WithAnalyzerRuns(runs []string, stats map[string]sdk.ReachabilityStats) ScanResponse {
-	if len(runs) > 0 {
-		r.Metadata.AnalyzerRuns = append([]string(nil), runs...)
+	return r.WithReportOptions(ReportOptions{
+		ReachabilityEnabled: len(runs) > 0 || len(stats) > 0,
+		AnalyzerRuns:        runs,
+		AnalyzerStats:       stats,
+	})
+}
+
+// WithReportOptions annotates a ScanResponse with optional report data and
+// strips experimental reachability annotations when the flag is disabled.
+func (r ScanResponse) WithReportOptions(options ReportOptions) ScanResponse {
+	r.Metadata = metadataWithReportOptions(r.Metadata, options)
+	if options.ReachabilityEnabled {
+		return r
 	}
-	if len(stats) > 0 {
-		r.Metadata.AnalyzerStats = make(map[string]sdk.ReachabilityStats, len(stats))
-		for k, v := range stats {
-			r.Metadata.AnalyzerStats[k] = v
+	for manifestIdx := range r.Manifests {
+		for packageIdx := range r.Manifests[manifestIdx].Packages {
+			r.Manifests[manifestIdx].Packages[packageIdx].PackageRef = r.Manifests[manifestIdx].Packages[packageIdx].withoutReachability()
 		}
+	}
+	for idx := range r.Findings {
+		r.Findings[idx] = r.Findings[idx].withoutReachability()
 	}
 	return r
 }
@@ -279,7 +292,7 @@ func normalizeManifestPathAgainstBase(basePath, candidate string) (string, bool)
 }
 
 // BuildExplainResponse constructs the structured explain payload from resolved targets.
-func BuildExplainResponse(project ProjectDescriptor, query string, targets []ExplainTargetResponse, started time.Time) ExplainResponse {
+func BuildExplainResponse(project ProjectDescriptor, query string, targets []ExplainTargetResponse, started time.Time, options ...ReportOptions) ExplainResponse {
 	response := ExplainResponse{
 		SchemaVersion: SchemaVersion,
 		Command:       "explain",
@@ -294,13 +307,13 @@ func BuildExplainResponse(project ProjectDescriptor, query string, targets []Exp
 		response.Findings = targets[0].Findings
 		response.AuditSummary = targets[0].AuditSummary
 	}
-	return response
+	return response.WithReportOptions(firstReportOptions(options))
 }
 
 // BuildDiffResponse constructs the structured diff payload from consolidated manifest selections.
-func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, headConsolidated sdk.ConsolidatedGraph, audit *DiffAudit, started time.Time) DiffResponse {
+func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, headConsolidated sdk.ConsolidatedGraph, audit *DiffAudit, started time.Time, options ...ReportOptions) DiffResponse {
 	results, summary := diffResultsFromConsolidated(baseConsolidated, headConsolidated)
-	return DiffResponse{
+	response := DiffResponse{
 		SchemaVersion: SchemaVersion,
 		Command:       "diff",
 		Project: ProjectDescriptor{
@@ -316,6 +329,183 @@ func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, h
 		Audit:      audit,
 		Metadata:   Metadata{DurationMS: time.Since(started).Milliseconds()},
 	}
+	return response.WithReportOptions(firstReportOptions(options))
+}
+
+// WithReportOptions annotates a DiffResponse with optional report data and
+// strips experimental reachability annotations when the flag is disabled.
+func (r DiffResponse) WithReportOptions(options ReportOptions) DiffResponse {
+	r.Metadata = metadataWithReportOptions(r.Metadata, options)
+	if options.ReachabilityEnabled {
+		return r
+	}
+	r.Results.Dependencies = stripDiffDependencyReachability(r.Results.Dependencies)
+	r.Results.Licenses = stripDiffLicenseReachability(r.Results.Licenses)
+	r.Results.Vulnerabilities = stripDiffVulnerabilityReachability(r.Results.Vulnerabilities)
+	for idx := range r.Results.Manifests {
+		r.Results.Manifests[idx] = stripDiffManifestReachability(r.Results.Manifests[idx])
+	}
+	if r.Audit != nil {
+		audit := *r.Audit
+		audit.Introduced = append([]AuditFinding(nil), audit.Introduced...)
+		audit.Resolved = append([]AuditFinding(nil), audit.Resolved...)
+		audit.Persisted = append([]AuditFinding(nil), audit.Persisted...)
+		r.Audit = &audit
+		for idx := range r.Audit.Introduced {
+			r.Audit.Introduced[idx] = r.Audit.Introduced[idx].withoutReachability()
+		}
+		for idx := range r.Audit.Resolved {
+			r.Audit.Resolved[idx] = r.Audit.Resolved[idx].withoutReachability()
+		}
+		for idx := range r.Audit.Persisted {
+			r.Audit.Persisted[idx] = r.Audit.Persisted[idx].withoutReachability()
+		}
+	}
+	return r
+}
+
+// WithReportOptions annotates an ExplainResponse with optional report data
+// and strips experimental reachability annotations when the flag is disabled.
+func (r ExplainResponse) WithReportOptions(options ReportOptions) ExplainResponse {
+	r.Metadata = metadataWithReportOptions(r.Metadata, options)
+	if options.ReachabilityEnabled {
+		return r
+	}
+	r.Dependency = r.Dependency.withoutReachability()
+	r.Paths = copyDependencyPaths(r.Paths)
+	for pathIdx := range r.Paths {
+		for packageIdx := range r.Paths[pathIdx].Packages {
+			r.Paths[pathIdx].Packages[packageIdx] = r.Paths[pathIdx].Packages[packageIdx].withoutReachability()
+		}
+	}
+	r.Findings = append([]AuditFinding(nil), r.Findings...)
+	for idx := range r.Findings {
+		r.Findings[idx] = r.Findings[idx].withoutReachability()
+	}
+	r.Targets = copyExplainTargets(r.Targets)
+	for targetIdx := range r.Targets {
+		r.Targets[targetIdx] = stripExplainTargetReachability(r.Targets[targetIdx])
+	}
+	return r
+}
+
+func firstReportOptions(options []ReportOptions) ReportOptions {
+	if len(options) == 0 {
+		return ReportOptions{}
+	}
+	return options[0]
+}
+
+func metadataWithReportOptions(metadata Metadata, options ReportOptions) Metadata {
+	metadata.ReachabilityEnabled = false
+	metadata.AnalyzerRuns = nil
+	metadata.AnalyzerStats = nil
+	if !options.ReachabilityEnabled {
+		return metadata
+	}
+	metadata.ReachabilityEnabled = true
+	if len(options.AnalyzerRuns) > 0 {
+		metadata.AnalyzerRuns = append([]string(nil), options.AnalyzerRuns...)
+		sort.Strings(metadata.AnalyzerRuns)
+	}
+	if len(options.AnalyzerStats) > 0 {
+		metadata.AnalyzerStats = make(map[string]sdk.ReachabilityStats, len(options.AnalyzerStats))
+		for k, v := range options.AnalyzerStats {
+			metadata.AnalyzerStats[k] = v
+		}
+	}
+	return metadata
+}
+
+func stripDiffDependencyReachability(results DiffDependencyResults) DiffDependencyResults {
+	for idx := range results.Added {
+		results.Added[idx].Package = results.Added[idx].Package.withoutReachability()
+	}
+	for idx := range results.Removed {
+		results.Removed[idx].Package = results.Removed[idx].Package.withoutReachability()
+	}
+	for idx := range results.Changed {
+		results.Changed[idx].After = results.Changed[idx].After.withoutReachability()
+		results.Changed[idx].Before = results.Changed[idx].Before.withoutReachability()
+	}
+	return results
+}
+
+func stripDiffLicenseReachability(results DiffLicenseResults) DiffLicenseResults {
+	for idx := range results.Added {
+		results.Added[idx].Package = results.Added[idx].Package.withoutReachability()
+	}
+	for idx := range results.Removed {
+		results.Removed[idx].Package = results.Removed[idx].Package.withoutReachability()
+	}
+	for idx := range results.Changed {
+		results.Changed[idx].Package = results.Changed[idx].Package.withoutReachability()
+	}
+	return results
+}
+
+func stripDiffVulnerabilityReachability(results DiffVulnerabilityResults) DiffVulnerabilityResults {
+	for idx := range results.Added {
+		results.Added[idx].Package = results.Added[idx].Package.withoutReachability()
+		results.Added[idx].Vulnerability.Reachability = nil
+	}
+	for idx := range results.Removed {
+		results.Removed[idx].Package = results.Removed[idx].Package.withoutReachability()
+		results.Removed[idx].Vulnerability.Reachability = nil
+	}
+	return results
+}
+
+func stripDiffManifestReachability(result DiffManifestResult) DiffManifestResult {
+	for idx := range result.Added {
+		result.Added[idx].Package = result.Added[idx].Package.withoutReachability()
+	}
+	for idx := range result.Removed {
+		result.Removed[idx].Package = result.Removed[idx].Package.withoutReachability()
+	}
+	for idx := range result.Changed {
+		result.Changed[idx].After = result.Changed[idx].After.withoutReachability()
+		result.Changed[idx].Before = result.Changed[idx].Before.withoutReachability()
+	}
+	return result
+}
+
+func stripExplainTargetReachability(target ExplainTargetResponse) ExplainTargetResponse {
+	target.Dependency = target.Dependency.withoutReachability()
+	target.Paths = copyDependencyPaths(target.Paths)
+	for pathIdx := range target.Paths {
+		for packageIdx := range target.Paths[pathIdx].Packages {
+			target.Paths[pathIdx].Packages[packageIdx] = target.Paths[pathIdx].Packages[packageIdx].withoutReachability()
+		}
+	}
+	target.Findings = append([]AuditFinding(nil), target.Findings...)
+	for idx := range target.Findings {
+		target.Findings[idx] = target.Findings[idx].withoutReachability()
+	}
+	return target
+}
+
+func copyDependencyPaths(paths []DependencyPath) []DependencyPath {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := append([]DependencyPath(nil), paths...)
+	for idx := range out {
+		out[idx].Packages = append([]PackageRef(nil), out[idx].Packages...)
+	}
+	return out
+}
+
+func copyExplainTargets(targets []ExplainTargetResponse) []ExplainTargetResponse {
+	if len(targets) == 0 {
+		return nil
+	}
+	out := append([]ExplainTargetResponse(nil), targets...)
+	for idx := range out {
+		out[idx].Paths = copyDependencyPaths(out[idx].Paths)
+		out[idx].Findings = append([]AuditFinding(nil), out[idx].Findings...)
+	}
+	return out
 }
 
 type diffManifestSnapshot struct {

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -60,6 +60,73 @@ func TestBuildScanResponseIncludesAuditData(t *testing.T) {
 	}
 }
 
+func TestBuildScanResponseGatesReachability(t *testing.T) {
+	g := newViewTestGraph(t)
+	pkg, ok := g.Package("react@18.2.0")
+	if !ok {
+		t.Fatal("react package not found")
+	}
+	pkg.Vulnerabilities = []sdk.PackageVulnerability{{
+		ID:     "OSV-REACH",
+		Source: "osv",
+		Reachability: &sdk.Reachability{
+			Status:   sdk.ReachabilityReachable,
+			Tier:     sdk.TierPackage,
+			Analyzer: "jsreach",
+		},
+	}}
+	results := []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{RelativePath: ".", PrimaryDetector: "npm-detector", DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM}, Ecosystem: sdk.EcosystemNPM},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    g,
+			Manifest: sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"},
+		}}},
+	}}
+	consolidated, err := consolidation.ConsolidateGraphs(results)
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs() error = %v", err)
+	}
+	finding := sdk.Finding{
+		ID:           "OSV-REACH",
+		Kind:         sdk.FindingKindVulnerability,
+		Package:      pkg,
+		Source:       "osv",
+		Reachability: pkg.Vulnerabilities[0].Reachability,
+	}
+
+	disabled := output.BuildScanResponse(output.ProjectDescriptor{Name: "demo"}, consolidated, []sdk.Finding{finding}, time.Now().Add(-time.Second))
+	if disabled.Metadata.ReachabilityEnabled {
+		t.Fatal("reachability metadata should be omitted when disabled")
+	}
+	if got := scanPackageByName(t, disabled.Manifests[0].Packages, "react").Vulnerabilities[0].Reachability; got != nil {
+		t.Fatalf("disabled scan package reachability leaked: %#v", got)
+	}
+	if got := disabled.Findings[0].Reachability; got != nil {
+		t.Fatalf("disabled scan finding reachability leaked: %#v", got)
+	}
+
+	enabled := output.BuildScanResponse(output.ProjectDescriptor{Name: "demo"}, consolidated, []sdk.Finding{finding}, time.Now().Add(-time.Second), output.ReportOptions{
+		ReachabilityEnabled: true,
+		AnalyzerRuns:        []string{"jsreach"},
+		AnalyzerStats:       map[string]sdk.ReachabilityStats{"jsreach": {Reachable: 1}},
+	})
+	if !enabled.Metadata.ReachabilityEnabled {
+		t.Fatal("reachability metadata should be set when enabled")
+	}
+	if len(enabled.Metadata.AnalyzerRuns) != 1 || enabled.Metadata.AnalyzerRuns[0] != "jsreach" {
+		t.Fatalf("unexpected analyzer runs: %#v", enabled.Metadata.AnalyzerRuns)
+	}
+	if enabled.Metadata.AnalyzerStats["jsreach"].Reachable != 1 {
+		t.Fatalf("unexpected analyzer stats: %#v", enabled.Metadata.AnalyzerStats)
+	}
+	if got := scanPackageByName(t, enabled.Manifests[0].Packages, "react").Vulnerabilities[0].Reachability; got == nil || got.Status != sdk.ReachabilityReachable {
+		t.Fatalf("enabled scan package reachability missing: %#v", got)
+	}
+	if got := enabled.Findings[0].Reachability; got == nil || got.Status != sdk.ReachabilityReachable {
+		t.Fatalf("enabled scan finding reachability missing: %#v", got)
+	}
+}
+
 func TestBuildScanResponseDeduplicatesManifestAndPrefersNative(t *testing.T) {
 	projectRoot := "/tmp/demo"
 	manifestPath := filepath.Join(projectRoot, "package-lock.json")
@@ -206,6 +273,48 @@ func TestBuildExplainResponseFlattensSingleTarget(t *testing.T) {
 	}
 }
 
+func TestBuildExplainResponseGatesReachability(t *testing.T) {
+	targets := []output.ExplainTargetResponse{{
+		Project: output.ProjectDescriptor{Name: "demo"},
+		Dependency: output.PackageRef{
+			Name: "react",
+			ID:   "react@18.2.0",
+			Vulnerabilities: []output.VulnerabilityRef{{
+				ID:           "OSV-REACH",
+				Source:       "osv",
+				Reachability: &sdk.Reachability{Status: sdk.ReachabilityReachable, Tier: sdk.TierPackage},
+			}},
+		},
+		Paths: []output.DependencyPath{{Packages: []output.PackageRef{{
+			Name: "react",
+			ID:   "react@18.2.0",
+			Vulnerabilities: []output.VulnerabilityRef{{
+				ID:           "OSV-REACH",
+				Source:       "osv",
+				Reachability: &sdk.Reachability{Status: sdk.ReachabilityReachable, Tier: sdk.TierPackage},
+			}},
+		}}}},
+		Findings: []output.AuditFinding{{
+			ID:           "OSV-REACH",
+			Kind:         "vulnerability",
+			Package:      output.PackageRef{Name: "react"},
+			Reachability: &sdk.Reachability{Status: sdk.ReachabilityReachable, Tier: sdk.TierPackage},
+		}},
+	}}
+	disabled := output.BuildExplainResponse(output.ProjectDescriptor{Name: "demo"}, "react", targets, time.Now().Add(-time.Second))
+	if disabled.Dependency.Vulnerabilities[0].Reachability != nil || disabled.Targets[0].Findings[0].Reachability != nil {
+		t.Fatalf("disabled explain reachability leaked: %#v", disabled)
+	}
+
+	enabled := output.BuildExplainResponse(output.ProjectDescriptor{Name: "demo"}, "react", targets, time.Now().Add(-time.Second), output.ReportOptions{ReachabilityEnabled: true})
+	if !enabled.Metadata.ReachabilityEnabled {
+		t.Fatal("reachability metadata should be set when enabled")
+	}
+	if got := enabled.Dependency.Vulnerabilities[0].Reachability; got == nil || got.Status != sdk.ReachabilityReachable {
+		t.Fatalf("enabled explain reachability missing: %#v", got)
+	}
+}
+
 func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 	baseGraph := newViewTestGraph(t)
 	headGraph := newViewTestGraph(t)
@@ -254,6 +363,81 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 	}
 	if len(response.Results.Manifests) != 1 || response.Results.Manifests[0].Status != "changed" {
 		t.Fatalf("unexpected manifest results: %#v", response.Results.Manifests)
+	}
+}
+
+func TestBuildDiffResponseGatesReachability(t *testing.T) {
+	baseGraph := newViewTestGraph(t)
+	headGraph := newViewTestGraph(t)
+	pkg := sdk.NewPackageRef("newpkg", "1.0.0")
+	pkg.Vulnerabilities = []sdk.PackageVulnerability{{
+		ID:           "OSV-REACH",
+		Source:       "osv",
+		Reachability: &sdk.Reachability{Status: sdk.ReachabilityReachable, Tier: sdk.TierPackage},
+	}}
+	if err := headGraph.AddPackage(pkg); err != nil {
+		t.Fatalf("add package: %v", err)
+	}
+	if err := headGraph.AddDependency("app@1.0.0", pkg.ID); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	baseConsolidated, err := consolidation.ConsolidateGraphs([]sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{RelativePath: ".", PrimaryDetector: "npm-detector", DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM}, Ecosystem: sdk.EcosystemNPM},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    baseGraph,
+			Manifest: sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"},
+		}}},
+	}})
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(base) error = %v", err)
+	}
+	headConsolidated, err := consolidation.ConsolidateGraphs([]sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{RelativePath: ".", PrimaryDetector: "npm-detector", DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM}, Ecosystem: sdk.EcosystemNPM},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    headGraph,
+			Manifest: sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"},
+		}}},
+	}})
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(head) error = %v", err)
+	}
+	audit := &output.DiffAudit{
+		Introduced: []output.AuditFinding{{
+			ID:           "OSV-REACH",
+			Kind:         "vulnerability",
+			Package:      output.PackageFromGraphPackage(pkg),
+			Reachability: pkg.Vulnerabilities[0].Reachability,
+		}},
+	}
+	disabled := output.BuildDiffResponse("/tmp/demo", "base", "head", baseConsolidated, headConsolidated, audit, time.Now().Add(-time.Second))
+	if disabled.Audit.Introduced[0].Reachability != nil {
+		t.Fatalf("disabled diff audit reachability leaked: %#v", disabled.Audit.Introduced[0].Reachability)
+	}
+	for _, change := range disabled.Results.Vulnerabilities.Added {
+		if change.Vulnerability.Reachability != nil {
+			t.Fatalf("disabled diff vulnerability reachability leaked: %#v", change.Vulnerability.Reachability)
+		}
+	}
+
+	enabled := output.BuildDiffResponse("/tmp/demo", "base", "head", baseConsolidated, headConsolidated, audit, time.Now().Add(-time.Second), output.ReportOptions{ReachabilityEnabled: true})
+	if !enabled.Metadata.ReachabilityEnabled {
+		t.Fatal("reachability metadata should be set when enabled")
+	}
+	if enabled.Audit.Introduced[0].Reachability == nil {
+		t.Fatal("enabled diff audit reachability missing")
+	}
+	found := false
+	for _, change := range enabled.Results.Vulnerabilities.Added {
+		if change.Vulnerability.ID == "OSV-REACH" {
+			found = true
+			if change.Vulnerability.Reachability == nil {
+				t.Fatal("enabled diff vulnerability reachability missing")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected diff vulnerability change for OSV-REACH")
 	}
 }
 
@@ -686,4 +870,15 @@ func newViewTestGraph(t *testing.T) *sdk.Graph {
 		t.Fatalf("add dependency: %v", err)
 	}
 	return g
+}
+
+func scanPackageByName(t *testing.T, packages []output.ScanPackage, name string) output.ScanPackage {
+	t.Helper()
+	for _, pkg := range packages {
+		if pkg.Name == name {
+			return pkg
+		}
+	}
+	t.Fatalf("package %q not found in %#v", name, packages)
+	return output.ScanPackage{}
 }


### PR DESCRIPTION
## Summary
- gate reachability data in structured scan, diff, and explain payloads behind the resolved `--reachability` flag
- expose reachability metadata in JSON and SARIF only when requested, while preserving non-reachability SARIF properties
- add concise reachability rendering for text and Markdown scan/diff/explain reports
- run reachability analysis in the explain pipeline so `bomly explain --reachability` has annotations to render
- regenerate report schemas/docs for `metadata.reachability_enabled`

## Validation
- `make generate`
- `make test`
- pre-commit lint hook: `golangci-lint run` via commit hook