### PR TITLE
Fix plugin list smoke assertion

### DIFF
--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -224,7 +224,13 @@ func assertPluginListed(t *testing.T, raw string, pluginID string) {
 	t.Helper()
 	var items []map[string]any
 	if err := json.Unmarshal([]byte(raw), &items); err != nil {
-		t.Fatalf("decode plugin list output: %v\nraw:\n%s", err, raw)
+		var grouped map[string][]map[string]any
+		if groupedErr := json.Unmarshal([]byte(raw), &grouped); groupedErr != nil {
+			t.Fatalf("decode plugin list output: %v; grouped decode: %v\nraw:\n%s", err, groupedErr, raw)
+		}
+		for _, group := range grouped {
+			items = append(items, group...)
+		}
 	}
 	for _, item := range items {
 		if item["id"] == pluginID {


### PR DESCRIPTION
## Summary

- Update the plugin smoke test helper to accept the current grouped `plugin list --format json` output shape.
- Preserve compatibility with the older flat-array JSON shape so the assertion remains tolerant across branch skew.

## Root Cause

`bomly plugin list --format json` now emits plugins grouped by kind (`detectors`, `matchers`, `auditors`, `analyzers`), while the smoke assertion still decoded the response as a flat array.

## Validation

- `go test -tags "smoke" ./test/smoke/ -run TestPluginWorkflows -v -count=1`
- `make test`