### PR TITLE
feat(tui): tab 7 keybind, Enter-to-focus details, group Posture by check

### DIFF
--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -65,6 +65,9 @@ type diffModel struct {
 	findingGroup    string
 	findingExpanded map[string]bool
 
+	postureGroup    string // "repository" (default) or "check"
+	postureExpanded map[string]bool
+
 	sourceSide         diffSourceSide
 	sourceBaseExpanded map[string]bool
 	sourceHeadExpanded map[string]bool
@@ -85,6 +88,8 @@ func NewDiff(payload output.DiffResponse, baseGraph, headGraph sdk.ConsolidatedG
 		licenseExpanded:    map[string]bool{},
 		findingGroup:       "status",
 		findingExpanded:    map[string]bool{},
+		postureGroup:       "repository",
+		postureExpanded:    map[string]bool{},
 		sourceSide:         diffSourceBase,
 		sourceBaseExpanded: map[string]bool{"root": true, "manifests": true},
 		sourceHeadExpanded: map[string]bool{"root": true, "manifests": true},
@@ -130,6 +135,8 @@ func (m *diffModel) CycleGroup() {
 		m.licenseGroup = nextLicenseGroup(m.licenseGroup)
 	case "findings":
 		m.findingGroup = nextFindingGroup(m.findingGroup)
+	case "posture":
+		m.postureGroup = cycleString(m.postureGroup, []string{"repository", "check"})
 	case "source":
 		if m.sourceSide == diffSourceBase {
 			m.sourceSide = diffSourceHead
@@ -247,6 +254,8 @@ func (m *diffModel) currentExpansionMap() map[string]bool {
 		return m.licenseExpanded
 	case "findings":
 		return m.findingExpanded
+	case "posture":
+		return m.postureExpanded
 	case "source":
 		if m.sourceSide == diffSourceBase {
 			return m.sourceBaseExpanded
@@ -392,7 +401,7 @@ func (m *diffModel) diffAggregateCounts() diffAggregateCounts {
 func (m *diffModel) diffLegend() string {
 	return strings.Join([]string{
 		keyHint("Tab", "switch"),
-		keyHint("Enter", "select"),
+		keyHint("Enter", "focus details"),
 		keyHint("→", "expand"),
 		keyHint("←", "collapse"),
 		keyHint("]", "expand all"),
@@ -1485,7 +1494,7 @@ func (m *diffModel) buildComponentsTab() *listModel {
 		listTitle:      fmt.Sprintf("Components (%d)", len(filtered)),
 		detailTitle:    "Component Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; g cycles group; r/s/v cycle relationship/scope/severity; Enter expands; 1-7 switch tabs",
+		filterHelp:     "Use / to search; g cycles group; r/s/v cycle relationship/scope/severity; → expands; Enter focuses details; 1-7 switch tabs",
 		emptyState:     "No package changes match the current filters.",
 		items:          items,
 	}
@@ -2361,7 +2370,7 @@ func (m *diffModel) buildAuditTab(cfg auditTabConfig) *listModel {
 		groupHints = "g cycles group (" + cfg.groupHints + ")"
 	}
 	controls := []string{
-		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "expand") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "focus details") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
 		render.Style("Group: ", render.Dim) + render.Style(groupLabel(group), render.BgYellow, render.Bold) +
 			render.Style(" | Count: ", render.Dim) + fmt.Sprintf("%d", len(deltas)),
 	}
@@ -2375,7 +2384,7 @@ func (m *diffModel) buildAuditTab(cfg auditTabConfig) *listModel {
 		listTitle:      fmt.Sprintf("%s (%d)", cfg.listLabel, len(deltas)),
 		detailTitle:    cfg.listLabel + " Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; " + groupHints + "; Enter expands; 1-7 switch tabs",
+		filterHelp:     "Use / to search; " + groupHints + "; → expands; Enter focuses details; 1-7 switch tabs",
 		emptyState:     emptyState,
 		items:          items,
 	}
@@ -2783,7 +2792,7 @@ func (m *diffModel) buildLicensesTab() *listModel {
 		}
 	}
 	controls := []string{
-		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "expand") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "focus details") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
 		render.Style("Group: ", render.Dim) + render.Style(groupLabel(group), render.BgYellow, render.Bold) +
 			render.Style(" | Introduced: ", render.Dim) + render.Style(fmt.Sprintf("%d", introduced), render.Green, render.Bold) +
 			render.Style(" | Retired: ", render.Dim) + render.Style(fmt.Sprintf("%d", retired), render.Red, render.Bold),
@@ -2794,7 +2803,7 @@ func (m *diffModel) buildLicensesTab() *listModel {
 		listTitle:      fmt.Sprintf("Licenses (%d)", len(deltas)),
 		detailTitle:    "License Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; g cycles group (license/status/manifest/category/recognition); Enter expands; 1-7 switch tabs",
+		filterHelp:     "Use / to search; g cycles group (license/status/manifest/category/recognition); → expands; Enter focuses details; 1-7 switch tabs",
 		emptyState:     emptyState,
 		items:          items,
 	}
@@ -2948,7 +2957,7 @@ func (m *diffModel) buildSourceTab() *listModel {
 	}
 
 	controls := []string{
-		keyHint("/", "search") + " " + keyHint("g", "switch focus") + " " + keyHint("Enter", "expand") + " " + keyHint("→", "expand") + " " + keyHint("←", "collapse") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
+		keyHint("/", "search") + " " + keyHint("g", "switch focus") + " " + keyHint("Enter", "focus details") + " " + keyHint("→", "expand") + " " + keyHint("←", "collapse") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"),
 		render.Style("Focused: ", render.Dim) + render.Style(strings.ToUpper(string(focused)), render.BgYellow, render.Bold) +
 			render.Style(" | g → "+otherLabel, render.Dim) +
 			render.Style(fmt.Sprintf(" | Base nodes: %d", len(baseItems)), render.Dim) +
@@ -2959,7 +2968,7 @@ func (m *diffModel) buildSourceTab() *listModel {
 		controls:       controls,
 		listTitle:      "Source",
 		detailTitle:    "-",
-		navigationHelp: interactiveCommonNavigationHelp + "; Enter expands/collapses source nodes",
+		navigationHelp: interactiveCommonNavigationHelp + "; → expands; Enter focuses details/collapses source nodes",
 		filterHelp:     "Use / to search; g switches focus base/head; Enter/→/← expand & collapse; 1-7 switch tabs",
 		emptyState:     "No source graph available.",
 		items:          focusedItems,

--- a/internal/tui/focus_test.go
+++ b/internal/tui/focus_test.go
@@ -1,0 +1,254 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/engine"
+	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func newScanModelWithPosture(t *testing.T, repo string, score float64) *scanModel {
+	t.Helper()
+	g := sdk.New()
+	root := sdk.NewPackageRef("demo-app", "1.0.0")
+	dep := sdk.NewPackage(sdk.Package{Name: "lib", Version: "1.0.0"})
+	dep.Scorecard = newTestScorecardTUI(repo, score,
+		sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 2, Reason: "off"},
+		sdk.PackageScorecardCheck{Name: "Code-Review", Score: 8, Reason: "ok"},
+	)
+	for _, pkg := range []*sdk.Package{root, dep} {
+		if err := g.AddPackage(pkg); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+	if err := g.AddDependency(root.ID, dep.ID); err != nil {
+		t.Fatalf("add dep: %v", err)
+	}
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo"},
+			RelativePath:    ".",
+			PrimaryDetector: "npm-detector",
+			Ecosystem:       sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph: %v", err)
+	}
+	return NewScan(output.ProjectDescriptor{Name: "demo", Path: "/tmp/demo"}, consolidated, graphValue, nil).WithEnrichEnabled(true)
+}
+
+func TestTabSeven_SwitchesToPostureTab(t *testing.T) {
+	t.Parallel()
+	model := newScanModelWithPosture(t, "github.com/example/lib", 4.0)
+	wrapper := &teaModel{inner: model, width: 160, height: 40}
+
+	if _, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}); model.ActiveTabID() != string(interactiveScanViewSource) {
+		t.Errorf("expected 7 to select Source tab; got %q", model.ActiveTabID())
+	}
+}
+
+func TestTabSix_SwitchesToPostureTab(t *testing.T) {
+	t.Parallel()
+	model := newScanModelWithPosture(t, "github.com/example/lib", 4.0)
+	wrapper := &teaModel{inner: model, width: 160, height: 40}
+
+	if _, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}); model.ActiveTabID() != string(interactiveScanViewPosture) {
+		t.Errorf("expected 6 to select Posture tab; got %q", model.ActiveTabID())
+	}
+}
+
+func TestEnter_FocusesDetailsPane(t *testing.T) {
+	t.Parallel()
+	model := newScanModelWithPosture(t, "github.com/example/lib", 4.0)
+	model.SelectView(6) // Posture
+	wrapper := &teaModel{inner: model, width: 160, height: 40}
+
+	if model.IsDetailsFocused() {
+		t.Fatal("focus should start on the main list")
+	}
+
+	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	wrapper = updated.(*teaModel)
+	if !model.IsDetailsFocused() {
+		t.Fatal("Enter should focus the details pane")
+	}
+
+	// Render should mark the active pane.
+	plain := render.StripANSI(wrapper.View())
+	if !strings.Contains(plain, "● Repository Posture") {
+		t.Errorf("expected the focused pane to render a focus marker; got:\n%s", plain)
+	}
+
+	// Esc returns focus to the list rather than engaging the quit prompt.
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	wrapper = updated.(*teaModel)
+	if model.IsDetailsFocused() {
+		t.Fatal("Esc should blur the details pane")
+	}
+	if wrapper.confirmQuit {
+		t.Fatal("Esc should not trigger quit confirmation while details pane was focused")
+	}
+}
+
+func TestArrowKeys_ScrollDetailsWhileFocused(t *testing.T) {
+	t.Parallel()
+	model := newScanModelWithPosture(t, "github.com/example/lib", 4.0)
+	model.SelectView(6) // Posture (rich details with multi-line check list)
+	wrapper := &teaModel{inner: model, width: 160, height: 40}
+
+	// Focus the details pane via Enter.
+	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	wrapper = updated.(*teaModel)
+
+	prevDetailOffset := model.List().detailOffset
+	prevSelected := model.List().selected
+
+	// Down arrow while focused must scroll the details, not move the list.
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyDown})
+	wrapper = updated.(*teaModel)
+	if model.List().detailOffset <= prevDetailOffset {
+		t.Errorf("expected details offset to advance with arrow down while focused; got %d", model.List().detailOffset)
+	}
+	if model.List().selected != prevSelected {
+		t.Errorf("list selection must not move while details pane is focused; got %d (was %d)",
+			model.List().selected, prevSelected)
+	}
+
+	// Blur and confirm down arrow goes back to moving the list.
+	if _, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyEsc}); model.IsDetailsFocused() {
+		t.Fatal("Esc should blur focus")
+	}
+}
+
+func TestTabCycle_ResetsDetailsFocus(t *testing.T) {
+	t.Parallel()
+	model := newScanModelWithPosture(t, "github.com/example/lib", 4.0)
+	model.SelectView(6)
+	model.FocusDetails()
+	if !model.IsDetailsFocused() {
+		t.Fatal("focus precondition failed")
+	}
+	model.CycleView()
+	if model.IsDetailsFocused() {
+		t.Error("CycleView must reset detail focus so the user does not land in a stale pane")
+	}
+}
+
+func TestPostureGrouping_ByCheckRendersFailingFirst(t *testing.T) {
+	t.Parallel()
+	g := sdk.New()
+	rootA := sdk.NewPackageRef("app", "1.0.0")
+	a := sdk.NewPackage(sdk.Package{Name: "a", Version: "1"})
+	a.Scorecard = newTestScorecardTUI("github.com/example/a", 6.0,
+		sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 1},
+		sdk.PackageScorecardCheck{Name: "Code-Review", Score: 9},
+	)
+	b := sdk.NewPackage(sdk.Package{Name: "b", Version: "1"})
+	b.Scorecard = newTestScorecardTUI("github.com/example/b", 4.0,
+		sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 0},
+		sdk.PackageScorecardCheck{Name: "Code-Review", Score: 7},
+	)
+	for _, pkg := range []*sdk.Package{rootA, a, b} {
+		if err := g.AddPackage(pkg); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+	if err := g.AddDependency(rootA.ID, a.ID); err != nil {
+		t.Fatalf("dep a: %v", err)
+	}
+	if err := g.AddDependency(rootA.ID, b.ID); err != nil {
+		t.Fatalf("dep b: %v", err)
+	}
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo"},
+			RelativePath:    ".",
+			PrimaryDetector: "npm-detector",
+			Ecosystem:       sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph: %v", err)
+	}
+	model := NewScan(output.ProjectDescriptor{Name: "demo", Path: "/tmp/demo"}, consolidated, graphValue, nil).WithEnrichEnabled(true)
+	model.SelectView(6)
+
+	// Cycle the group via `g`.
+	wrapper := &teaModel{inner: model, width: 200, height: 60}
+	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	wrapper = updated.(*teaModel)
+
+	plain := render.StripANSI(wrapper.View())
+	// Header should show "Checks (N)" once grouped by check.
+	if !strings.Contains(plain, "Checks (2)") {
+		t.Errorf("expected Checks (2) header in check-grouped view; got:\n%s", plain)
+	}
+	// Branch-Protection (2 failing) must sort before Code-Review (0 failing).
+	bpIdx := strings.Index(plain, "Branch-Protection")
+	crIdx := strings.Index(plain, "Code-Review")
+	if bpIdx < 0 || crIdx < 0 {
+		t.Fatalf("expected both check group headers to render; got:\n%s", plain)
+	}
+	if bpIdx > crIdx {
+		t.Errorf("expected top-failing Branch-Protection to render before Code-Review; got:\n%s", plain)
+	}
+	// Group counters should reflect 2 failing for Branch-Protection.
+	if !strings.Contains(plain, "2 failing") {
+		t.Errorf("expected Branch-Protection group to show '2 failing'; got:\n%s", plain)
+	}
+}
+
+func TestPostureDiffGrouping_ByCheckRegressionsFirst(t *testing.T) {
+	t.Parallel()
+	results := output.DiffDependencyResults{
+		Changed: []output.DiffChangedPackage{
+			{
+				Before: output.PackageRef{Name: "a", Scorecard: newTestScorecardTUI("github.com/a/repo", 7.0,
+					sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 9},
+					sdk.PackageScorecardCheck{Name: "Code-Review", Score: 8},
+				)},
+				After: output.PackageRef{Name: "a", Scorecard: newTestScorecardTUI("github.com/a/repo", 5.0,
+					sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 3}, // regression
+					sdk.PackageScorecardCheck{Name: "Code-Review", Score: 9},       // improvement
+				)},
+			},
+		},
+	}
+	payload := output.DiffResponse{
+		Comparison: output.DiffComparison{Base: "main", Head: "HEAD"},
+		Results:    output.DiffResults{Dependencies: results},
+	}
+	model := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
+	model.SelectView(6)
+	model.CycleGroup()
+
+	wrapper := &teaModel{inner: model, width: 200, height: 60}
+	plain := render.StripANSI(wrapper.View())
+	if !strings.Contains(plain, "Branch-Protection") {
+		t.Errorf("expected Branch-Protection group in check view; got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "1 ↓ regressions") {
+		t.Errorf("expected Branch-Protection group to count one regression; got:\n%s", plain)
+	}
+	bpIdx := strings.Index(plain, "Branch-Protection")
+	crIdx := strings.Index(plain, "Code-Review")
+	if bpIdx < 0 || crIdx < 0 {
+		t.Fatalf("expected both groups; got:\n%s", plain)
+	}
+	if bpIdx > crIdx {
+		t.Errorf("expected regressing Branch-Protection to render above Code-Review; got:\n%s", plain)
+	}
+}

--- a/internal/tui/posture.go
+++ b/internal/tui/posture.go
@@ -412,3 +412,166 @@ func postureListTitle(row postureRow, repoWidth int) string {
 	repo := truncateToWidth(row.repository, repoWidth)
 	return padRight(repo, repoWidth) + "  " + padRight(score, 8) + render.Style(fmt.Sprintf(" %d pkg", len(row.packages)), render.Dim)
 }
+
+// postureCheckGroup aggregates every repository's outcome for one
+// Scorecard check name. Groups are emitted with the highest number of
+// failing repos at the top so the most actionable checks sort first.
+type postureCheckGroup struct {
+	Name              string
+	Documentation     string
+	FailingRepos      []postureCheckGroupRow // score 0..5 (and inconclusive surfaced separately below)
+	InconclusiveRepos []postureCheckGroupRow
+	PassingRepos      []postureCheckGroupRow // score 6..10
+}
+
+type postureCheckGroupRow struct {
+	Row    postureRow
+	Score  int
+	Reason string
+}
+
+// postureCheckGroups pivots the per-repo rows onto a check axis: one
+// group per check name, with repos sorted by score asc inside each group
+// so failing repos lead. Inconclusive (-1) outcomes get their own
+// section so they neither pollute the failing count nor pretend to be
+// passing.
+func postureCheckGroups(rows []postureRow) []postureCheckGroup {
+	groups := make(map[string]*postureCheckGroup)
+	for _, row := range rows {
+		for _, check := range row.card.Checks {
+			name := strings.TrimSpace(check.Name)
+			if name == "" {
+				continue
+			}
+			entry, ok := groups[name]
+			if !ok {
+				entry = &postureCheckGroup{Name: name}
+				groups[name] = entry
+			}
+			if check.Documentation != "" && entry.Documentation == "" {
+				entry.Documentation = check.Documentation
+			}
+			gr := postureCheckGroupRow{Row: row, Score: check.Score, Reason: check.Reason}
+			switch {
+			case check.Score < 0:
+				entry.InconclusiveRepos = append(entry.InconclusiveRepos, gr)
+			case check.Score <= 5:
+				entry.FailingRepos = append(entry.FailingRepos, gr)
+			default:
+				entry.PassingRepos = append(entry.PassingRepos, gr)
+			}
+		}
+	}
+	out := make([]postureCheckGroup, 0, len(groups))
+	for _, entry := range groups {
+		sortCheckGroupRows(entry.FailingRepos)
+		sortCheckGroupRows(entry.InconclusiveRepos)
+		sortCheckGroupRows(entry.PassingRepos)
+		out = append(out, *entry)
+	}
+	// Top failing first; on ties, larger failing+inconclusive set first;
+	// on further ties, name-sorted for stable rendering.
+	sort.SliceStable(out, func(i, j int) bool {
+		if len(out[i].FailingRepos) != len(out[j].FailingRepos) {
+			return len(out[i].FailingRepos) > len(out[j].FailingRepos)
+		}
+		problemsI := len(out[i].FailingRepos) + len(out[i].InconclusiveRepos)
+		problemsJ := len(out[j].FailingRepos) + len(out[j].InconclusiveRepos)
+		if problemsI != problemsJ {
+			return problemsI > problemsJ
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func sortCheckGroupRows(rows []postureCheckGroupRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Score != rows[j].Score {
+			return rows[i].Score < rows[j].Score
+		}
+		return rows[i].Row.repository < rows[j].Row.repository
+	})
+}
+
+// postureCheckGroupTitle renders the group header for the by-check view.
+func postureCheckGroupTitle(group postureCheckGroup) string {
+	worst := 11
+	for _, r := range group.FailingRepos {
+		if r.Score < worst {
+			worst = r.Score
+		}
+	}
+	if worst == 11 {
+		// No failing repos — surface the best representative score.
+		for _, r := range group.PassingRepos {
+			if r.Score < worst {
+				worst = r.Score
+			}
+		}
+	}
+	band := postureScoreBand(float64(worst))
+	badge := postureCheckBadge(worst)
+	return render.Style(badge, postureBandColor(band)) + " " + group.Name +
+		render.Style(fmt.Sprintf("  %d failing / %d inconclusive / %d passing",
+			len(group.FailingRepos), len(group.InconclusiveRepos), len(group.PassingRepos)), render.Dim)
+}
+
+// postureCheckGroupDetails is the right-pane details when a check-group
+// header is selected: a worst-first list of every affected repository
+// and a documentation link.
+func postureCheckGroupDetails(group postureCheckGroup) []string {
+	lines := []string{
+		render.Style("Scorecard Check", render.Bold, render.Cyan),
+		"",
+		render.Style("  Name: ", render.Dim) + group.Name,
+		render.Style("  Failing repositories: ", render.Dim) + fmt.Sprintf("%d", len(group.FailingRepos)),
+		render.Style("  Inconclusive repositories: ", render.Dim) + fmt.Sprintf("%d", len(group.InconclusiveRepos)),
+		render.Style("  Passing repositories: ", render.Dim) + fmt.Sprintf("%d", len(group.PassingRepos)),
+	}
+	if group.Documentation != "" {
+		lines = append(lines, render.Style("  Documentation: ", render.Dim)+group.Documentation)
+	}
+	appendBucket := func(title string, rows []postureCheckGroupRow) {
+		if len(rows) == 0 {
+			return
+		}
+		lines = append(lines, "", render.Style(fmt.Sprintf("%s (%d)", title, len(rows)), render.Bold, render.Magenta), "")
+		for _, r := range rows {
+			band := postureScoreBand(float64(r.Score))
+			line := render.Style("  "+postureCheckBadge(r.Score), postureBandColor(band)) +
+				" " + render.Style(posturePrettyCheckScore(r.Score)+"  ", render.Dim) + r.Row.repository
+			lines = append(lines, line)
+			if reason := strings.TrimSpace(r.Reason); reason != "" {
+				lines = append(lines, render.Style("      reason: ", render.Dim)+reason)
+			}
+		}
+	}
+	appendBucket("Failing repositories", group.FailingRepos)
+	appendBucket("Inconclusive repositories", group.InconclusiveRepos)
+	appendBucket("Passing repositories", group.PassingRepos)
+	return lines
+}
+
+// postureCheckGroupRowTitle renders a single repository row inside an
+// expanded check group.
+func postureCheckGroupRowTitle(r postureCheckGroupRow, repoWidth int) string {
+	band := postureScoreBand(float64(r.Score))
+	score := posturePrettyCheckScore(r.Score)
+	repo := truncateToWidth(r.Row.repository, repoWidth)
+	return render.Style(postureCheckBadge(r.Score), postureBandColor(band)) + " " +
+		padRight(repo, repoWidth) + "  " + padRight(score, 8) +
+		render.Style(fmt.Sprintf("  agg %s", posturePrettyScore(r.Row.card.AggregateScore)), render.Dim)
+}
+
+// postureCheckGroupRowDetails renders the same per-repo details pane
+// the by-repository view uses, plus a top banner naming the check that
+// brought the user here so context is never lost.
+func postureCheckGroupRowDetails(group postureCheckGroup, r postureCheckGroupRow) []string {
+	lines := []string{
+		render.Style("Selected via check: "+group.Name, render.Dim),
+		"",
+	}
+	lines = append(lines, postureRowDetails(r.Row)...)
+	return lines
+}

--- a/internal/tui/posture_diff.go
+++ b/internal/tui/posture_diff.go
@@ -565,9 +565,216 @@ func firstNonEmptyString(values ...string) string {
 	return ""
 }
 
+// postureDiffCheckGroup pivots the diff payload onto a check axis: one
+// group per check name, with the affected repositories sorted by
+// regression magnitude (worst regressions first).
+type postureDiffCheckGroup struct {
+	Name          string
+	Documentation string
+	Rows          []postureDiffCheckRow
+	// Counters used for the header sort: a check group with many
+	// repositories regressing should sort above a group with only
+	// improvements or stable scores.
+	Regressions  int
+	Improvements int
+	Stable       int
+	Introduced   int
+	Dropped      int
+}
+
+// postureDiffCheckRow is one repository's outcome for one check, holding
+// the score on each side so the renderer can show before → after.
+type postureDiffCheckRow struct {
+	Repo   postureDiffRow
+	Before *int
+	After  *int
+}
+
+// postureDiffCheckGroups builds the by-check groups from a slice of
+// postureDiffRow values. A check appears with at most one row per repo;
+// the before/after pointers reflect what (if anything) was scored on
+// each side.
+//
+// Implementation note: rows are built in a (checkName, repo) ->
+// *postureDiffCheckRow map first, then flattened into each group's slice
+// after collection. This keeps before/after updates simple (pointer
+// mutation) and avoids re-finding-and-replacing slice entries on every
+// scan.
+func postureDiffCheckGroups(rows []postureDiffRow) []postureDiffCheckGroup {
+	type rowKey struct {
+		check string
+		repo  string
+	}
+	cells := make(map[rowKey]*postureDiffCheckRow)
+	docs := make(map[string]string)
+
+	for _, row := range rows {
+		record := func(checks []sdk.PackageScorecardCheck, side string) {
+			for i := range checks {
+				c := checks[i]
+				name := strings.TrimSpace(c.Name)
+				if name == "" {
+					continue
+				}
+				if c.Documentation != "" {
+					if _, ok := docs[name]; !ok {
+						docs[name] = c.Documentation
+					}
+				}
+				key := rowKey{check: name, repo: row.repository}
+				entry, ok := cells[key]
+				if !ok {
+					entry = &postureDiffCheckRow{Repo: row}
+					cells[key] = entry
+				}
+				score := c.Score
+				if side == "before" {
+					entry.Before = &score
+				} else {
+					entry.After = &score
+				}
+			}
+		}
+		if row.before != nil {
+			record(row.before.Checks, "before")
+		}
+		if row.after != nil {
+			record(row.after.Checks, "after")
+		}
+	}
+
+	groups := make(map[string]*postureDiffCheckGroup)
+	for key, cell := range cells {
+		group, ok := groups[key.check]
+		if !ok {
+			group = &postureDiffCheckGroup{Name: key.check, Documentation: docs[key.check]}
+			groups[key.check] = group
+		}
+		group.Rows = append(group.Rows, *cell)
+	}
+	out := make([]postureDiffCheckGroup, 0, len(groups))
+	for _, group := range groups {
+		for _, r := range group.Rows {
+			switch {
+			case r.Before == nil && r.After != nil:
+				group.Introduced++
+			case r.Before != nil && r.After == nil:
+				group.Dropped++
+			case r.Before != nil && r.After != nil:
+				switch {
+				case *r.After < *r.Before:
+					group.Regressions++
+				case *r.After > *r.Before:
+					group.Improvements++
+				default:
+					group.Stable++
+				}
+			}
+		}
+		sort.SliceStable(group.Rows, func(i, j int) bool {
+			return postureDiffCheckRowRank(group.Rows[i]) < postureDiffCheckRowRank(group.Rows[j])
+		})
+		out = append(out, *group)
+	}
+	// Worst regressions first; then most-introduced; then alphabetical.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Regressions != out[j].Regressions {
+			return out[i].Regressions > out[j].Regressions
+		}
+		if out[i].Dropped != out[j].Dropped {
+			return out[i].Dropped > out[j].Dropped
+		}
+		if out[i].Introduced != out[j].Introduced {
+			return out[i].Introduced > out[j].Introduced
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func postureDiffCheckRowRank(r postureDiffCheckRow) int {
+	switch {
+	case r.Before != nil && r.After != nil && *r.After < *r.Before:
+		return 0 // regression
+	case r.Before != nil && r.After == nil:
+		return 1 // dropped
+	case r.Before == nil && r.After != nil && *r.After <= 5:
+		return 2 // introduced failing
+	case r.Before == nil && r.After != nil:
+		return 3 // introduced passing
+	case r.Before != nil && r.After != nil && *r.After > *r.Before:
+		return 4 // improvement
+	default:
+		return 5 // stable
+	}
+}
+
+func postureDiffCheckGroupTitle(group postureDiffCheckGroup) string {
+	movement := fmt.Sprintf("%d ↓ regressions, %d ↑ improvements", group.Regressions, group.Improvements)
+	if group.Dropped > 0 || group.Introduced > 0 {
+		movement += fmt.Sprintf(", %d introduced, %d dropped", group.Introduced, group.Dropped)
+	}
+	color := render.Yellow
+	if group.Regressions > 0 || group.Dropped > 0 {
+		color = render.Red
+	} else if group.Improvements > 0 || group.Introduced > 0 {
+		color = render.Green
+	}
+	return render.Style("●", color) + " " + group.Name + render.Style("  "+movement, render.Dim)
+}
+
+func postureDiffCheckGroupDetails(group postureDiffCheckGroup) []string {
+	lines := []string{
+		render.Style("Scorecard Check (delta)", render.Bold, render.Cyan),
+		"",
+		render.Style("  Name: ", render.Dim) + group.Name,
+		render.Style("  Regressions: ", render.Dim) + fmt.Sprintf("%d", group.Regressions),
+		render.Style("  Improvements: ", render.Dim) + fmt.Sprintf("%d", group.Improvements),
+		render.Style("  Stable: ", render.Dim) + fmt.Sprintf("%d", group.Stable),
+		render.Style("  Introduced: ", render.Dim) + fmt.Sprintf("%d", group.Introduced),
+		render.Style("  Dropped: ", render.Dim) + fmt.Sprintf("%d", group.Dropped),
+	}
+	if group.Documentation != "" {
+		lines = append(lines, render.Style("  Documentation: ", render.Dim)+group.Documentation)
+	}
+	lines = append(lines, "", render.Style(fmt.Sprintf("Affected repositories (%d)", len(group.Rows)), render.Bold, render.Magenta), "")
+	for _, r := range group.Rows {
+		lines = append(lines, "  "+postureDiffCheckGroupRowTitle(r, 40))
+	}
+	return lines
+}
+
+func postureDiffCheckGroupRowTitle(r postureDiffCheckRow, repoWidth int) string {
+	repo := truncateToWidth(r.Repo.repository, repoWidth)
+	switch {
+	case r.Before == nil && r.After != nil:
+		return padRight(repo, repoWidth) + render.Style(fmt.Sprintf("  ─ → %s  (introduced)", posturePrettyCheckScore(*r.After)), render.Green)
+	case r.Before != nil && r.After == nil:
+		return padRight(repo, repoWidth) + render.Style(fmt.Sprintf("  %s → ─  (dropped)", posturePrettyCheckScore(*r.Before)), render.Red)
+	case r.Before != nil && r.After != nil && *r.After < *r.Before:
+		return padRight(repo, repoWidth) + render.Style(fmt.Sprintf("  %s → %s", posturePrettyCheckScore(*r.Before), posturePrettyCheckScore(*r.After)), render.Red)
+	case r.Before != nil && r.After != nil && *r.After > *r.Before:
+		return padRight(repo, repoWidth) + render.Style(fmt.Sprintf("  %s → %s", posturePrettyCheckScore(*r.Before), posturePrettyCheckScore(*r.After)), render.Green)
+	case r.Before != nil && r.After != nil:
+		return padRight(repo, repoWidth) + render.Style(fmt.Sprintf("  %s → %s  (stable)", posturePrettyCheckScore(*r.Before), posturePrettyCheckScore(*r.After)), render.Dim)
+	default:
+		return padRight(repo, repoWidth) + render.Style("  ─ → ─", render.Dim)
+	}
+}
+
+func postureDiffCheckGroupRowDetails(group postureDiffCheckGroup, r postureDiffCheckRow) []string {
+	lines := []string{
+		render.Style("Selected via check: "+group.Name, render.Dim),
+		"",
+	}
+	lines = append(lines, postureDiffRowDetails(r.Repo)...)
+	return lines
+}
+
 // buildPostureTab is the diffModel's TabSpec.Build for the Posture tab.
 // Layout mirrors the other diff tabs: top summary panels, single main
-// list, secondary details pane.
+// list, secondary details pane. The `g` key cycles the grouping axis
+// between "repository" (default) and "check".
 func (m *diffModel) buildPostureTab() *listModel {
 	rows := postureDiffRowsFromPayload(m.payload.Results.Dependencies)
 	repoWidth := 24
@@ -579,9 +786,20 @@ func (m *diffModel) buildPostureTab() *listModel {
 	if repoWidth > 56 {
 		repoWidth = 56
 	}
-	items := make([]listItem, 0, len(rows))
-	for _, row := range rows {
-		items = append(items, postureDiffListItem(row, repoWidth))
+
+	group := valueOrDefault(m.postureGroup, "repository")
+	var items []listItem
+	var listTitle, listHeader string
+	switch group {
+	case "check":
+		items, listTitle, listHeader = m.postureDiffItemsByCheck(rows, repoWidth)
+	default:
+		items = make([]listItem, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, postureDiffListItem(row, repoWidth))
+		}
+		listTitle = fmt.Sprintf("Repositories (%d)", len(rows))
+		listHeader = padRight("Repository", repoWidth) + "  Score"
 	}
 
 	emptyState := "No Scorecard data in either side of this diff. Re-run with --enrich --matchers +scorecard on both base and head."
@@ -590,16 +808,51 @@ func (m *diffModel) buildPostureTab() *listModel {
 	}
 
 	return &listModel{
-		listTitle:   fmt.Sprintf("Repositories (%d)", len(rows)),
-		listHeader:  padRight("Repository", repoWidth) + "  Score",
+		listTitle:   listTitle,
+		listHeader:  listHeader,
 		detailTitle: "Repository Posture",
 		topPanels: []listPanel{
 			{title: "Posture Delta", lines: postureDiffSummaryLines(rows), color: render.Yellow, weight: 1},
 			{title: "Biggest Score Movers", lines: postureDiffMoversLines(rows, 140), color: render.Red, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; ↑/↓ select; Ctrl+u/Ctrl+d scroll details; 1-7 switch tabs",
+		filterHelp:     "Use / to search; g cycles group (repository/check); Enter focuses details; 1-7 switch tabs",
 		emptyState:     emptyState,
 		items:          items,
 	}
+}
+
+// postureDiffItemsByCheck renders the by-check view for the diff:
+// expandable group headers per check name, with affected repositories
+// underneath. Each row shows the per-check before/after rather than the
+// aggregate, so deltas are pegged to the specific failing check.
+func (m *diffModel) postureDiffItemsByCheck(rows []postureDiffRow, repoWidth int) ([]listItem, string, string) {
+	groups := postureDiffCheckGroups(rows)
+	items := make([]listItem, 0, len(rows)+len(groups))
+	for _, group := range groups {
+		key := "check:" + group.Name
+		expanded := expandedValue(m.postureExpanded, key, true)
+		items = append(items, listItem{
+			title:    postureDiffCheckGroupTitle(group),
+			subtitle: "group",
+			details:  postureDiffCheckGroupDetails(group),
+			key:      key,
+			canOpen:  true,
+			expanded: expanded,
+		})
+		if !expanded {
+			continue
+		}
+		for idx, child := range group.Rows {
+			items = append(items, listItem{
+				title:   postureDiffCheckGroupRowTitle(child, repoWidth),
+				details: postureDiffCheckGroupRowDetails(group, child),
+				tree:    treePrefix(nil, idx == len(group.Rows)-1, 1),
+				depth:   1,
+			})
+		}
+	}
+	listTitle := fmt.Sprintf("Checks (%d)", len(groups))
+	listHeader := padRight("Check / Repository", repoWidth+6) + "  Before → After"
+	return items, listTitle, listHeader
 }

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -62,6 +62,8 @@ func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, cons
 		licenseExpanded:       map[string]bool{},
 		findingGroup:          "type",
 		findingExpanded:       map[string]bool{},
+		postureGroup:          "repository",
+		postureExpanded:       map[string]bool{},
 	}
 	if len(manifests) == 1 {
 		model.mode = interactiveScanModeComponents
@@ -138,6 +140,11 @@ func (m *scanModel) toggleSelectedTreeNode() {
 		m.rebuildListPreserveSelection()
 		return
 	}
+	if m.currentScanView() == interactiveScanViewPosture && item.canOpen && item.key != "" {
+		m.postureExpanded[item.key] = !item.expanded
+		m.rebuildListPreserveSelection()
+		return
+	}
 	if m.currentScanView() != interactiveScanViewSource {
 		return
 	}
@@ -181,6 +188,8 @@ func (m *scanModel) setSelectedTreeNode(expanded bool) {
 		m.licenseExpanded[item.key] = expanded
 	case interactiveScanViewFindings:
 		m.findingExpanded[item.key] = expanded
+	case interactiveScanViewPosture:
+		m.postureExpanded[item.key] = expanded
 	case interactiveScanViewSource:
 		m.sourceExpanded[item.key] = expanded
 	default:
@@ -214,6 +223,8 @@ func (m *scanModel) setAllTreeNodes(expanded bool) {
 			m.licenseExpanded[item.key] = expanded
 		case interactiveScanViewFindings:
 			m.findingExpanded[item.key] = expanded
+		case interactiveScanViewPosture:
+			m.postureExpanded[item.key] = expanded
 		case interactiveScanViewSource:
 			m.sourceExpanded[item.key] = expanded
 		}
@@ -257,6 +268,8 @@ func (m *scanModel) CycleGroup() {
 		m.licenseGroup = nextFilterValue(m.licenseGroup, []string{"license", "category", "recognition"})
 	case interactiveScanViewFindings:
 		m.findingGroup = nextFilterValue(m.findingGroup, []string{"type", "severity", "component", "ecosystem"})
+	case interactiveScanViewPosture:
+		m.postureGroup = nextFilterValue(m.postureGroup, []string{"repository", "check"})
 	default:
 		return
 	}
@@ -436,7 +449,7 @@ func (m *scanModel) scanFooterSummary() string {
 func (m *scanModel) scanLegend() string {
 	return strings.Join([]string{
 		keyHint("Tab", "switch"),
-		keyHint("Enter", "select"),
+		keyHint("Enter", "focus details"),
 		keyHint("→", "expand"),
 		keyHint("←", "collapse"),
 		keyHint("]", "expand all"),
@@ -510,7 +523,7 @@ func (m *scanModel) buildManifestListModel() *listModel {
 		listTitle:      fmt.Sprintf("Manifests (%d)", len(m.manifests)),
 		detailTitle:    "Manifest Details",
 		navigationHelp: interactiveCommonNavigationHelp + "; Enter opens selected manifest",
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; 1-7 switch tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; 1-7 switch tabs",
 		emptyState:     "No manifests were found in the dependency graph.",
 		items:          items,
 		selected:       selected,
@@ -588,7 +601,7 @@ func (m *scanModel) buildComponentsTreeListModel() *listModel {
 		listTitle:      fmt.Sprintf("Components (%d)", filteredComponentCount),
 		detailTitle:    "Component Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter/Right/Left expands and collapses; r relationship; s scope; v severity; 1-7 tabs",
+		filterHelp:     "Use / to search; →/← expand/collapse; Enter focuses details; r relationship; s scope; v severity; 1-7 tabs",
 		emptyState:     "No components were found.",
 		items:          items,
 	}
@@ -921,7 +934,7 @@ func (m *scanModel) buildVulnsListModel() *listModel {
 			{title: "Top Affected", lines: topAffectedLines(all, 5, 140), color: render.Green, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; v cycles severity filter; g groups vulnerabilities; 1-7 switch tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; v cycles severity filter; g groups vulnerabilities; 1-7 switch tabs",
 		emptyState:     emptyState,
 		items:          items,
 	}
@@ -1255,7 +1268,7 @@ func (m *scanModel) buildLicensesListModel() *listModel {
 		listHeader:     padRight("License", 22) + padRight("Components", 11) + "Percentage",
 		detailTitle:    "License Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; 1-7 switch tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; 1-7 switch tabs",
 		emptyState:     "No license information found.",
 		items:          items,
 	}
@@ -1360,13 +1373,13 @@ func (m *scanModel) buildFindingsListModel() *listModel {
 	return &listModel{
 		title:          fmt.Sprintf("%s: %s", m.titlePrefix, m.project.Name),
 		summary:        m.scanSummaryLines(interactiveScanViewFindings),
-		controls:       []string{keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "inspect") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"), render.Style("Group: ", render.Dim) + render.Style(valueOrDefault(m.findingGroup, "type"), render.BgYellow, render.Bold) + render.Style(" | Filter: ", render.Dim) + render.Style("All", render.BgYellow, render.Bold)},
+		controls:       []string{keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "focus details") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"), render.Style("Group: ", render.Dim) + render.Style(valueOrDefault(m.findingGroup, "type"), render.BgYellow, render.Bold) + render.Style(" | Filter: ", render.Dim) + render.Style("All", render.BgYellow, render.Bold)},
 		listTitle:      fmt.Sprintf("Findings (%d)", len(m.findings)),
 		listHeader:     "Finding",
 		detailTitle:    "Finding Details",
 		topPanels:      []listPanel{{title: "Findings Summary", lines: findingSummaryLines(m.findings), color: render.Red, weight: 1}},
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; 1-7 switch tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; 1-7 switch tabs",
 		emptyState:     "No findings found. Run with --audit to evaluate available vulnerability data.",
 		items:          items,
 	}
@@ -1377,14 +1390,12 @@ func (m *scanModel) buildFindingsListModel() *listModel {
 // distribution + top failing checks across the dependency set, the main
 // list lines up one row per source repository (worst-scoring first), and
 // the details pane shows the full Scorecard breakdown plus the packages
-// that resolved to the selected repo.
+// that resolved to the selected repo. The `g` key cycles between two
+// grouping axes: "repository" (default) and "check".
 func (m *scanModel) buildPostureListModel() *listModel {
 	rows := postureRowsFromGraph(m.graphValue)
-	items := make([]listItem, 0, len(rows))
 	repoWidth := 40
 	if len(rows) > 0 {
-		// Size the repo column to fit the widest visible repo, capped so
-		// the score + pkg-count columns still fit on narrow terminals.
 		maxRepo := 0
 		for _, row := range rows {
 			if len(row.repository) > maxRepo {
@@ -1399,15 +1410,17 @@ func (m *scanModel) buildPostureListModel() *listModel {
 			repoWidth = 24
 		}
 	}
-	for _, row := range rows {
-		band := postureScoreBand(row.card.AggregateScore)
-		items = append(items, listItem{
-			title: postureListTitle(row, repoWidth),
-			badges: []badge{
-				{label: strings.ToUpper(band), kind: postureBandBadgeKind(band)},
-			},
-			details: postureRowDetails(row),
-		})
+
+	group := valueOrDefault(m.postureGroup, "repository")
+	var items []listItem
+	var listTitle, listHeader string
+	switch group {
+	case "check":
+		items, listTitle, listHeader = m.postureItemsByCheck(rows, repoWidth)
+	default:
+		items = m.postureItemsByRepository(rows, repoWidth)
+		listTitle = fmt.Sprintf("Repositories (%d)", len(rows))
+		listHeader = padRight("Repository", repoWidth) + "  " + padRight("Score", 8) + "Packages"
 	}
 
 	emptyState := "No Scorecard data attached. Run with --enrich --matchers +scorecard to populate posture data."
@@ -1418,27 +1431,80 @@ func (m *scanModel) buildPostureListModel() *listModel {
 	return &listModel{
 		title:       fmt.Sprintf("%s: %s", m.titlePrefix, m.project.Name),
 		summary:     m.scanSummaryLines(interactiveScanViewPosture),
-		controls:    []string{m.postureControlsLine(), m.postureStateLine(len(rows))},
-		listTitle:   fmt.Sprintf("Repositories (%d)", len(rows)),
-		listHeader:  padRight("Repository", repoWidth) + "  " + padRight("Score", 8) + "Packages",
+		controls:    []string{m.postureControlsLine(), m.postureStateLine(group, len(rows))},
+		listTitle:   listTitle,
+		listHeader:  listHeader,
 		detailTitle: "Repository Posture",
 		topPanels: []listPanel{
 			{title: "Posture Summary", lines: postureSummaryLines(rows), color: render.Yellow, weight: 1},
 			{title: "Top Failing Checks", lines: postureTopFailingLines(rows, 140), color: render.Red, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; ↑/↓ select; Ctrl+u/Ctrl+d scroll details; 1-7 switch tabs",
+		filterHelp:     "Use / to search; g cycles group (repository/check); Enter focuses details; 1-7 switch tabs",
 		emptyState:     emptyState,
 		items:          items,
 	}
 }
 
-func (m *scanModel) postureControlsLine() string {
-	return keyHint("/", "search") + " " + keyHint("Ctrl+u/d", "scroll details")
+// postureItemsByRepository builds the default flat list of repositories.
+func (m *scanModel) postureItemsByRepository(rows []postureRow, repoWidth int) []listItem {
+	items := make([]listItem, 0, len(rows))
+	for _, row := range rows {
+		band := postureScoreBand(row.card.AggregateScore)
+		items = append(items, listItem{
+			title:   postureListTitle(row, repoWidth),
+			badges:  []badge{{label: strings.ToUpper(band), kind: postureBandBadgeKind(band)}},
+			details: postureRowDetails(row),
+		})
+	}
+	return items
 }
 
-func (m *scanModel) postureStateLine(total int) string {
-	return render.Style("Repositories: ", render.Dim) + render.Style(fmt.Sprintf("%d", total), render.BgYellow, render.Bold) +
+// postureItemsByCheck builds the by-check view: one expandable group
+// header per check name (worst failure rate first), under which the
+// affected repositories appear as child rows.
+func (m *scanModel) postureItemsByCheck(rows []postureRow, repoWidth int) ([]listItem, string, string) {
+	groups := postureCheckGroups(rows)
+	items := make([]listItem, 0, len(rows)+len(groups))
+	for _, group := range groups {
+		groupKey := "check:" + group.Name
+		expanded := expandedValue(m.postureExpanded, groupKey, true)
+		items = append(items, listItem{
+			title:    postureCheckGroupTitle(group),
+			subtitle: "group",
+			details:  postureCheckGroupDetails(group),
+			key:      groupKey,
+			canOpen:  true,
+			expanded: expanded,
+		})
+		if !expanded {
+			continue
+		}
+		all := make([]postureCheckGroupRow, 0, len(group.FailingRepos)+len(group.InconclusiveRepos)+len(group.PassingRepos))
+		all = append(all, group.FailingRepos...)
+		all = append(all, group.InconclusiveRepos...)
+		all = append(all, group.PassingRepos...)
+		for idx, r := range all {
+			items = append(items, listItem{
+				title:   postureCheckGroupRowTitle(r, repoWidth),
+				details: postureCheckGroupRowDetails(group, r),
+				tree:    treePrefix(nil, idx == len(all)-1, 1),
+				depth:   1,
+			})
+		}
+	}
+	listTitle := fmt.Sprintf("Checks (%d)", len(groups))
+	listHeader := padRight("Check / Repository", repoWidth+6) + "  " + padRight("Score", 8) + "Notes"
+	return items, listTitle, listHeader
+}
+
+func (m *scanModel) postureControlsLine() string {
+	return keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("Enter", "focus details") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all")
+}
+
+func (m *scanModel) postureStateLine(group string, total int) string {
+	return render.Style("Group: ", render.Dim) + render.Style(group, render.BgYellow, render.Bold) +
+		render.Style(" | Repositories: ", render.Dim) + render.Style(fmt.Sprintf("%d", total), render.BgYellow, render.Bold) +
 		render.Style(" | Source: ", render.Dim) + render.Style("api.scorecard.dev", render.BgYellow, render.Bold)
 }
 
@@ -1561,11 +1627,11 @@ func (m *scanModel) buildSourceListModel() *listModel {
 	return &listModel{
 		title:          fmt.Sprintf("%s: %s", m.titlePrefix, m.project.Name),
 		summary:        m.scanSummaryLines(interactiveScanViewSource),
-		controls:       []string{keyHint("/", "search") + " " + keyHint("Enter", "toggle") + " " + keyHint("→", "expand") + " " + keyHint("←", "collapse") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"), render.Style("Mode: ", render.Dim) + render.Style("JSON tree", render.BgYellow, render.Bold) + render.Style(" | Nodes: ", render.Dim) + fmt.Sprintf("%d", sourceNodeCount(m))},
+		controls:       []string{keyHint("/", "search") + " " + keyHint("Enter", "focus details") + " " + keyHint("→", "expand") + " " + keyHint("←", "collapse") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all"), render.Style("Mode: ", render.Dim) + render.Style("JSON tree", render.BgYellow, render.Bold) + render.Style(" | Nodes: ", render.Dim) + fmt.Sprintf("%d", sourceNodeCount(m))},
 		listTitle:      fmt.Sprintf("Source (%d nodes)", sourceNodeCount(m)),
 		detailTitle:    "-",
-		navigationHelp: interactiveCommonNavigationHelp + "; Enter expands/collapses source nodes",
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; 1-7 switch tabs",
+		navigationHelp: interactiveCommonNavigationHelp + "; → expands; Enter focuses details/collapses source nodes",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; 1-7 switch tabs",
 		emptyState:     "No source data is available.",
 		items:          items,
 	}
@@ -1938,7 +2004,7 @@ func (m *scanModel) buildComponentListModel(manifest listPackageRow) *listModel 
 		listTitle:      fmt.Sprintf("Components (%d)", len(rows)),
 		detailTitle:    "Component Details",
 		navigationHelp: navigationHelp,
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; r relationship; s scope; v severity; 1-7 tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; r relationship; s scope; v severity; 1-7 tabs",
 		emptyState:     "No components were found for this manifest.",
 		items:          items,
 	}
@@ -1991,7 +2057,7 @@ func (m *scanModel) buildExplainComponentListModel(manifest listPackageRow) *lis
 		listTitle:      fmt.Sprintf("Components (%d)", len(rows)),
 		detailTitle:    "Component Details",
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter keeps selection; Esc clears search; r relationship; s scope; v severity; 1-7 tabs",
+		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; r relationship; s scope; v severity; 1-7 tabs",
 		emptyState:     "No components were found for this explanation.",
 		items:          items,
 	}

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -121,6 +121,7 @@ func (s *shellModel) CycleView() {
 	}
 	s.active = (s.active + 1) % len(s.spec.Tabs)
 	s.Rebuild()
+	s.BlurDetails()
 }
 
 // SelectView jumps to the 1-indexed tab.
@@ -130,6 +131,7 @@ func (s *shellModel) SelectView(index int) {
 	}
 	s.active = index - 1
 	s.Rebuild()
+	s.BlurDetails()
 }
 
 // View delegates to the active listModel. Embedding models can override
@@ -160,6 +162,28 @@ func (s *shellModel) End() {
 func (s *shellModel) ScrollDetails(delta int) {
 	if s != nil && s.list != nil {
 		s.list.ScrollDetails(delta)
+	}
+}
+
+// IsDetailsFocused / FocusDetails / BlurDetails delegate to the active
+// listModel so the teaModel keyboard handler can drive focus uniformly
+// regardless of which command owns the embedding model.
+func (s *shellModel) IsDetailsFocused() bool {
+	if s == nil || s.list == nil {
+		return false
+	}
+	return s.list.IsDetailsFocused()
+}
+
+func (s *shellModel) FocusDetails() {
+	if s != nil && s.list != nil {
+		s.list.FocusDetails()
+	}
+}
+
+func (s *shellModel) BlurDetails() {
+	if s != nil && s.list != nil {
+		s.list.BlurDetails()
 	}
 }
 func (s *shellModel) BeginSearch() {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -77,6 +77,16 @@ type detailScrollModel interface {
 	ScrollDetails(delta int)
 }
 
+// paneFocusModel routes Enter / arrow-key behaviour through the shared
+// focus state. The teaModel keyboard handler queries this interface so
+// every command's TUI (scan, explain, diff) gets the same Enter-to-focus,
+// arrow-keys-scroll-details flow without duplicating logic per command.
+type paneFocusModel interface {
+	IsDetailsFocused() bool
+	FocusDetails()
+	BlurDetails()
+}
+
 type listItem struct {
 	title    string
 	subtitle string
@@ -115,6 +125,10 @@ type listModel struct {
 	searchMatch    bool
 	footerSummary  string
 	legend         string
+	// detailsFocused is true when the user has hit Enter on a row and the
+	// keyboard handler should treat up/down/k/j as scroll-the-details
+	// rather than move-the-selection. Esc or another Enter blurs.
+	detailsFocused bool
 	// bodyOverride, when non-nil, replaces the standard list-and-detail body
 	// region with a caller-rendered block of `height` rows of `width` columns.
 	// The shell chrome (title, summary, controls, topPanels, footer) renders
@@ -129,7 +143,7 @@ type listPanel struct {
 	weight int
 }
 
-const interactiveCommonNavigationHelp = "Up/Down or j/k move; PgUp/PgDn or Ctrl+u/Ctrl+d scroll details; Home/End or g/G jump; q quits"
+const interactiveCommonNavigationHelp = "Up/Down or j/k move; Enter focus details (Up/Down scroll, Esc back); Home/End jump; q quits"
 
 type listPackageRow struct {
 	id               string
@@ -205,6 +219,8 @@ type scanModel struct {
 	licenseExpanded       map[string]bool
 	findingGroup          string
 	findingExpanded       map[string]bool
+	postureGroup          string // "repository" (default) or "check"
+	postureExpanded       map[string]bool
 }
 
 type teaModel struct {
@@ -256,6 +272,19 @@ func terminalFile(value any) (*os.File, error) {
 
 func (m *teaModel) Init() tea.Cmd {
 	return nil
+}
+
+// detailsRouting reports whether vertical arrow keys should scroll the
+// details pane instead of moving the list selection. We require both the
+// focus interface and the scroll interface so a model that opts in to
+// one without the other doesn't get half-functioning routing.
+func (m *teaModel) detailsRouting() bool {
+	focusModel, ok := m.inner.(paneFocusModel)
+	if !ok || !focusModel.IsDetailsFocused() {
+		return false
+	}
+	_, ok = m.inner.(detailScrollModel)
+	return ok
 }
 
 func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -313,13 +342,21 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.quitting = true
 				return m, tea.Quit
 			}
-			if toggleModel, ok := m.inner.(toggleModel); ok {
-				toggleModel.ToggleSelected()
+			// Enter toggles focus between the main list and the details
+			// pane. While focused, up/down/k/j scroll the details and Esc
+			// (or another Enter) returns to the list. Tree-expand actions
+			// still live on →/l, ←, and the [/] keys.
+			if focusModel, ok := m.inner.(paneFocusModel); ok {
+				if focusModel.IsDetailsFocused() {
+					focusModel.BlurDetails()
+				} else {
+					focusModel.FocusDetails()
+				}
 			}
 			if navigationModel, ok := m.inner.(navigationModel); ok {
 				navigationModel.OpenSelected()
 			}
-		case "1", "2", "3", "4", "5", "6":
+		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
 			if tabModel, ok := m.inner.(numberedTabModel); ok {
 				tabModel.SelectView(int(msg.String()[0] - '0'))
 			}
@@ -352,9 +389,17 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				navigationModel.GoBack()
 			}
 		case "up", "k":
-			m.inner.Move(-1)
+			if m.detailsRouting() {
+				m.inner.(detailScrollModel).ScrollDetails(-1)
+			} else {
+				m.inner.Move(-1)
+			}
 		case "down", "j":
-			m.inner.Move(1)
+			if m.detailsRouting() {
+				m.inner.(detailScrollModel).ScrollDetails(1)
+			} else {
+				m.inner.Move(1)
+			}
 		case "pgup", "ctrl+u":
 			if detailModel, ok := m.inner.(detailScrollModel); ok {
 				detailModel.ScrollDetails(-1)
@@ -375,6 +420,14 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.confirmQuit && msg.String() == "esc" {
 				m.confirmQuit = false
 				return m, nil
+			}
+			// Esc has a higher-priority job when the details pane is focused:
+			// return focus to the main list, without engaging the quit prompt.
+			if msg.String() == "esc" {
+				if focusModel, ok := m.inner.(paneFocusModel); ok && focusModel.IsDetailsFocused() {
+					focusModel.BlurDetails()
+					return m, nil
+				}
 			}
 			if m.confirmQuit {
 				m.quitting = true
@@ -466,6 +519,39 @@ func (m *listModel) ScrollDetails(delta int) {
 	if m.detailOffset < 0 {
 		m.detailOffset = 0
 	}
+}
+
+// IsDetailsFocused reports whether keyboard input should be routed to the
+// details pane (arrow keys scroll details) rather than the main list
+// (arrow keys move selection).
+func (m *listModel) IsDetailsFocused() bool {
+	if m == nil {
+		return false
+	}
+	return m.detailsFocused
+}
+
+// FocusDetails pins keyboard input to the details pane. Selecting a new
+// row from the list (via tab cycling, search, or programmatic SelectView)
+// resets the focus, so users do not get stuck with a stale view.
+func (m *listModel) FocusDetails() {
+	if m == nil {
+		return
+	}
+	if strings.TrimSpace(m.detailTitle) == "-" {
+		// No details pane exists for this tab (full-width list) — focus
+		// would have nowhere to go, so it's a no-op.
+		return
+	}
+	m.detailsFocused = true
+}
+
+// BlurDetails returns keyboard focus to the main list.
+func (m *listModel) BlurDetails() {
+	if m == nil {
+		return
+	}
+	m.detailsFocused = false
 }
 
 func (m *listModel) BeginSearch() {
@@ -618,13 +704,22 @@ func (m *listModel) View(width, height int) string {
 
 	leftTitle := valueOrDefault(m.listTitle, "List")
 	rightTitle := valueOrDefault(m.detailTitle, "Details")
-	leftBox := boxView(leftTitle, listLines, listWidth, bodyHeight, render.Cyan)
+	leftColor := render.Cyan
+	rightColor := render.Magenta
+	if m.detailsFocused {
+		// Flip the active box to a high-contrast colour and dim the inactive
+		// one so the user sees at a glance which pane consumes arrow keys.
+		leftColor = render.Dim
+		rightColor = render.Yellow
+		rightTitle = "● " + rightTitle
+	}
+	leftBox := boxView(leftTitle, listLines, listWidth, bodyHeight, leftColor)
 	if strings.TrimSpace(m.detailTitle) == "-" {
 		for idx := 0; idx < bodyHeight; idx++ {
 			lines = append(lines, leftBox[idx])
 		}
 	} else {
-		rightBox := boxView(rightTitle, detailLines, detailWidth, bodyHeight, render.Magenta)
+		rightBox := boxView(rightTitle, detailLines, detailWidth, bodyHeight, rightColor)
 		for idx := 0; idx < bodyHeight; idx++ {
 			lines = append(lines, leftBox[idx]+" "+rightBox[idx])
 		}


### PR DESCRIPTION
## Summary

Three polish passes on the Posture tab that landed in #97.

- **Tab `7` works.** The hard-coded 1-6 number-key handler is now 1-9, so the new Posture tab (and any future ones) is reachable from the keyboard. `7` jumps to Source, `6` jumps to Posture.
- **Enter focuses the details pane.** Applied uniformly across scan, explain, and diff. While focused, regular up/down/k/j scroll the details; Enter or Esc returns to the list. The focused pane gets a yellow border and a `●` title marker; the inactive pane dims. Tree expand/collapse stays on `→`/`←`/`]`/`[`. Tab cycling and `SelectView` reset focus so the user never lands in a stale pane. Implemented as a new `paneFocusModel` interface on `listModel` with pass-throughs on `shellModel` and routing in `teaModel.Update` — no per-command wiring required.
- **Posture tab gains a `g`-cycled grouping axis.** Default `repository` view stays as is; new `check` view pivots onto the check axis with one expandable group header per Scorecard check, sorted with the worst failure rate first. Inside each group, repos sort failing → inconclusive → passing. Diff Posture gets the same treatment but pivots on regressions: groups sort by regression count desc, rows show before → after, drops/introductions are surfaced explicitly.

Esc has a higher-priority job when the details pane is focused: blur, **do not** engage the quit confirmation. Legend strings updated everywhere they used to claim Enter expands/inspects.

## Why a new PR

#97 was merged, so these polish items land as a fresh PR against `main`.

## Test plan

- [x] `make fmt && make lint && make test` — all clean.
- [x] New `internal/tui/focus_test.go` covers tab-7 keybind, tab-6 → Posture, Enter focuses details, arrow keys scroll details while focused, `CycleView` blurs focus, by-check grouping renders highest-failing check first (scan), and regressions-first ordering (diff).
- [x] Manual: launched the interactive TUI against this repo with `bin/bomly scan --enrich --matchers +scorecard --path . --interactive`, confirmed `7` selects Source, `6` selects Posture, Enter focuses the details pane with a visible `● Repository Posture` marker, arrow keys scroll the right pane while focused, Esc blurs without quitting, and `g` toggles to the by-check grouped view with `Branch-Protection` (most failing) at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)