### PR TITLE
Add json output shortcut

### DIFF
--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -1,7 +1,9 @@
 package opts
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/config"
@@ -94,10 +96,28 @@ func bindSelectorFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 
 func bindExecutionFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.StringVarP(&cfg.Format, "format", "f", "", "Output format: text, json, markdown, sarif")
+	BindJSONFormatFlag(flags, &cfg.Format, "Shortcut for --format json")
 	flags.StringArrayVarP(&cfg.Outputs, "output", "o", nil, "Additional output target as <format> or <format>=<path>; repeat for multiple outputs")
 	flags.BoolVar(&cfg.Interactive, "interactive", false, "Open an interactive terminal UI")
 	flags.BoolVar(&cfg.InstallFirst, "install-first", false, "Run detector-specific dependency installation before resolving graphs")
 	flags.StringArrayVar(&cfg.InstallArgs, "install-arg", nil, "Additional detector-specific install argument; may be repeated")
+}
+
+// BindJSONFormatFlag binds --json as a no-argument shortcut for setting format to json.
+func BindJSONFormatFlag(flags *pflag.FlagSet, format *string, usage string) {
+	if flags == nil {
+		return
+	}
+	flags.BoolFunc("json", usage, func(value string) error {
+		enabled, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("parse json flag: %w", err)
+		}
+		if enabled && format != nil {
+			*format = "json"
+		}
+		return nil
+	})
 }
 
 func applyFlagOverrides(dst *config.Resolved, flags config.Resolved, cmd *cobra.Command) {
@@ -168,7 +188,7 @@ func applyFlagOverrides(dst *config.Resolved, flags config.Resolved, cmd *cobra.
 	if flagChanged(cmd, "analyzers") {
 		dst.Analyzers = flags.Analyzers
 	}
-	if flagChanged(cmd, "format") {
+	if flagChanged(cmd, "format") || (flagChanged(cmd, "json") && strings.EqualFold(flags.Format, "json")) {
 		dst.Format = flags.Format
 	}
 	if flagChanged(cmd, "output") {

--- a/internal/cli/opts/flag_options_test.go
+++ b/internal/cli/opts/flag_options_test.go
@@ -39,3 +39,63 @@ func TestApplyFlagOverridesOnlyUsesChangedFlags(t *testing.T) {
 		t.Fatalf("expected changed install args to override, got %#v", dst.InstallArgs)
 	}
 }
+
+func TestApplyFlagOverridesJSONShortcut(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		startValue string
+		want       string
+	}{
+		{
+			name:       "json shortcut overrides existing format",
+			args:       []string{"--json"},
+			startValue: "markdown",
+			want:       "json",
+		},
+		{
+			name:       "json false does not override existing format",
+			args:       []string{"--json=false"},
+			startValue: "markdown",
+			want:       "markdown",
+		},
+		{
+			name:       "format wins when it appears after json",
+			args:       []string{"--json", "--format", "markdown"},
+			startValue: "text",
+			want:       "markdown",
+		},
+		{
+			name:       "json wins when it appears after format",
+			args:       []string{"--format", "markdown", "--json"},
+			startValue: "text",
+			want:       "json",
+		},
+		{
+			name:       "json false leaves preceding format override intact",
+			args:       []string{"--format", "markdown", "--json=false"},
+			startValue: "text",
+			want:       "markdown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			options := &Options{}
+			root := newTestRootCommand(t)
+			if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupExecution); err != nil {
+				t.Fatalf("BindCommandFlagGroups() error = %v", err)
+			}
+			if err := root.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+
+			dst := config.Resolved{Format: tc.startValue}
+			applyFlagOverrides(&dst, options.ResolvedConfig, root)
+
+			if dst.Format != tc.want {
+				t.Fatalf("expected format %q, got %q", tc.want, dst.Format)
+			}
+		})
+	}
+}

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -461,6 +461,50 @@ func TestCommandContextInitialize_AppliesConfigPrecedence(t *testing.T) {
 	}
 }
 
+func TestCommandContextInitialize_JSONShortcutOverridesEnvFormat(t *testing.T) {
+	t.Setenv("BOMLY_FORMAT", "markdown")
+
+	options := &Options{}
+	root := newTestRootCommand(t)
+	if err := options.Bind(root); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupExecution); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
+	}
+	if err := root.ParseFlags([]string{"--json"}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	if err := options.ResolveConfig(root); err != nil {
+		t.Fatalf("ResolveConfig() error = %v", err)
+	}
+	if got := options.GetConfig().Format; got != "json" {
+		t.Fatalf("expected --json to override env format, got %q", got)
+	}
+}
+
+func TestCommandContextInitialize_JSONFalseDoesNotOverrideEnvFormat(t *testing.T) {
+	t.Setenv("BOMLY_FORMAT", "markdown")
+
+	options := &Options{}
+	root := newTestRootCommand(t)
+	if err := options.Bind(root); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupExecution); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
+	}
+	if err := root.ParseFlags([]string{"--json=false"}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	if err := options.ResolveConfig(root); err != nil {
+		t.Fatalf("ResolveConfig() error = %v", err)
+	}
+	if got := options.GetConfig().Format; got != "markdown" {
+		t.Fatalf("expected --json=false to preserve env format, got %q", got)
+	}
+}
+
 func TestCommandContextInitialize_LoadsQuietFromConfig(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -119,6 +119,7 @@ func newPluginListCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&includeAuditors, "auditors", false, "Show auditor plugins")
 	cmd.Flags().BoolVar(&includeAnalyzers, "analyzers", false, "Show reachability analyzer plugins")
 	cmd.Flags().StringVar(&format, "format", pluginListFormatTable, "Render output format: table or json")
+	opts.BindJSONFormatFlag(cmd.Flags(), &format, "Shortcut for --format json")
 	return cmd
 }
 

--- a/internal/cli/plugin_cmd_test.go
+++ b/internal/cli/plugin_cmd_test.go
@@ -144,6 +144,33 @@ func TestPluginList_FormatJSON(t *testing.T) {
 	}
 }
 
+func TestPluginList_JSONShortcut(t *testing.T) {
+	root := newPluginTestRoot(t)
+	cmd, _, err := root.Find([]string{"plugin", "list"})
+	if err != nil {
+		t.Fatalf("root.Find(plugin list) error = %v", err)
+	}
+	if flag := cmd.Flags().Lookup("json"); flag == nil {
+		t.Fatal("expected plugin list to expose --json")
+	}
+
+	formatJSON := runPluginListJSON(t, "plugin", "list", "--detectors", "--format", "json")
+	shortcutJSON := runPluginListJSON(t, "plugin", "list", "--detectors", "--json")
+	if string(shortcutJSON) != string(formatJSON) {
+		t.Fatalf("expected --json to match --format json\n--json: %s\n--format: %s", shortcutJSON, formatJSON)
+	}
+
+	mixedJSON := runPluginListJSON(t, "plugin", "list", "--detectors", "--format", "table", "--json")
+	if string(mixedJSON) != string(formatJSON) {
+		t.Fatalf("expected trailing --json to override table format\n--json: %s\n--format: %s", mixedJSON, formatJSON)
+	}
+
+	tableOutput := runPluginListOutput(t, "plugin", "list", "--detectors", "--json", "--format", "table")
+	if strings.Contains(tableOutput, `"detectors"`) || !strings.Contains(tableOutput, "Detectors:") {
+		t.Fatalf("expected trailing --format table to override --json, got:\n%s", tableOutput)
+	}
+}
+
 func TestPluginList_InvalidFormat(t *testing.T) {
 	root := newPluginTestRoot(t)
 
@@ -155,6 +182,29 @@ func TestPluginList_InvalidFormat(t *testing.T) {
 	if !strings.Contains(err.Error(), `parse format: unsupported format "yaml"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func runPluginListJSON(t *testing.T, args ...string) json.RawMessage {
+	t.Helper()
+	output := runPluginListOutput(t, args...)
+	var raw json.RawMessage
+	if err := json.Unmarshal([]byte(output), &raw); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput:\n%s", err, output)
+	}
+	return raw
+}
+
+func runPluginListOutput(t *testing.T, args ...string) string {
+	t.Helper()
+	root := newPluginTestRoot(t)
+	var output strings.Builder
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v", err)
+	}
+	return output.String()
 }
 
 func TestColorPluginType_HighlightsExternal(t *testing.T) {

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -198,6 +198,15 @@ func TestRoot_RegistersCoreCommands(t *testing.T) {
 			t.Fatalf("expected command %q, got %#v", commandName, cmd)
 		}
 	}
+	for _, commandName := range []string{"explain", "scan", "diff"} {
+		cmd, _, err := root.Find([]string{commandName})
+		if err != nil {
+			t.Fatalf("root.Find(%q) error = %v", commandName, err)
+		}
+		if flag := cmd.Flags().Lookup("json"); flag == nil {
+			t.Fatalf("expected command %q to expose --json", commandName)
+		}
+	}
 }
 
 func TestRootHasCommandRequiredFlags(t *testing.T) {
@@ -489,7 +498,7 @@ func TestRoot_ScanCommand_ScansRepoURLAtRef(t *testing.T) {
 	var stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"scan", "--url", repoDir, "--ref", baseSHA, "--ecosystems", "npm", "--format", "json"})
+	root.SetArgs([]string{"scan", "--url", repoDir, "--ref", baseSHA, "--ecosystems", "npm", "--json"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())


### PR DESCRIPTION
## Summary
- add `--json` as a shortcut for `--format json` on `scan`, `diff`, and `explain`
- add the same shortcut to `plugin list`
- preserve parse-order behavior when `--json` and `--format` are combined

## Validation
- `go test ./internal/cli/opts`
- `go test ./internal/cli`
- `make test`
- commit hook: `go run ./internal/tools/gofmtcheck` and `golangci-lint run`