### PR TITLE
[codex] Add shared HTTP proxy and plugin config support

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -50,6 +50,9 @@ Bomly resolves configuration in the following order, with later sources overridi
 | `config` | `BOMLY_CONFIG` | `string` | - | Explicit YAML config file path |
 | `quiet` | `BOMLY_QUIET` | `bool` | - | Suppress all non-error output |
 | `verbosity` | `BOMLY_VERBOSE` | `int` | - | Verbosity level (0=normal, 1=verbose, 2+=debug) |
+| `http_proxy` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL used by Bomly and managed plugins |
+| `http_no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy |
+| `plugins` | `-` | `map[string]map[string]any` | - | Per-plugin configuration keyed by managed plugin ID |
 
 ## OSV matcher settings
 
@@ -154,6 +157,12 @@ Bomly resolves configuration in the following order, with later sources overridi
 # quiet: false
 # Verbosity level (0=normal, 1=verbose, 2+=debug)
 # verbosity: 0
+# Outbound HTTP proxy URL used by Bomly and managed plugins
+# http_proxy: ""
+# Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy
+# http_no_proxy: ""
+# Per-plugin configuration keyed by managed plugin ID
+# plugins: {}
 
 # OSV matcher settings
 # Base URL for the OSV vulnerability API

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -52,6 +52,12 @@ Bomly resolves configuration in the following order, with later sources overridi
 | `verbosity` | `BOMLY_VERBOSE` | `int` | - | Verbosity level (0=normal, 1=verbose, 2+=debug) |
 | `http_proxy` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL used by Bomly and managed plugins |
 | `http_no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy |
+| `http_proxy_type` | `BOMLY_HTTP_PROXY_TYPE` | `string` | http | Outbound proxy type when using host/port proxy settings: http, https, or socks5 |
+| `http_proxy_host` | `BOMLY_HTTP_PROXY_HOST` | `string` | - | Outbound proxy hostname or IP address used when http_proxy is not set |
+| `http_proxy_port` | `BOMLY_HTTP_PROXY_PORT` | `int` | - | Outbound proxy port used with http_proxy_host |
+| `http_proxy_username` | `BOMLY_HTTP_PROXY_USERNAME` | `string` | - | Username for proxy authentication when using host/port proxy settings |
+| `http_proxy_password` | `BOMLY_HTTP_PROXY_PASSWORD` | `string` | - | Password for proxy authentication when using host/port proxy settings |
+| `http_ca_cert_file` | `BOMLY_HTTP_CA_CERT_FILE` | `string` | - | PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies |
 | `plugins` | `-` | `map[string]map[string]any` | - | Per-plugin configuration keyed by managed plugin ID |
 
 ## OSV matcher settings
@@ -161,6 +167,18 @@ Bomly resolves configuration in the following order, with later sources overridi
 # http_proxy: ""
 # Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy
 # http_no_proxy: ""
+# Outbound proxy type when using host/port proxy settings: http, https, or socks5
+# http_proxy_type: http
+# Outbound proxy hostname or IP address used when http_proxy is not set
+# http_proxy_host: ""
+# Outbound proxy port used with http_proxy_host
+# http_proxy_port: 0
+# Username for proxy authentication when using host/port proxy settings
+# http_proxy_username: ""
+# Password for proxy authentication when using host/port proxy settings
+# http_proxy_password: ""
+# PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies
+# http_ca_cert_file: ""
 # Per-plugin configuration keyed by managed plugin ID
 # plugins: {}
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -31,14 +31,26 @@ Enabled plugins are loaded during runtime preparation in local and CI workflows.
 
 Bomly passes the active plugin API version, the explicit `BOMLY_CONFIG` path when one was provided, proxy settings, and the enabled plugin's own config to managed plugin subprocesses.
 
-Proxy settings can be configured with Bomly config keys or environment variables:
+Proxy settings can be configured with a direct proxy URL:
 
 ```yaml
 http_proxy: http://proxy.example:8080
 http_no_proxy: localhost,127.0.0.1,.corp.example
 ```
 
-Equivalent environment variables are `BOMLY_HTTP_PROXY` and `BOMLY_HTTP_NO_PROXY`. When those are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values to plugin subprocesses using the standard proxy environment variable names.
+For environments that manage proxy details separately, Bomly also accepts decomposed proxy settings:
+
+```yaml
+http_proxy_type: http # http, https, or socks5
+http_proxy_host: proxy.example
+http_proxy_port: 8080
+http_proxy_username: my-user
+http_proxy_password: my-password
+http_no_proxy: localhost,127.0.0.1,.corp.example
+http_ca_cert_file: /path/to/proxy-ca-chain.pem
+```
+
+Equivalent environment variables are `BOMLY_HTTP_PROXY`, `BOMLY_HTTP_NO_PROXY`, `BOMLY_HTTP_PROXY_TYPE`, `BOMLY_HTTP_PROXY_HOST`, `BOMLY_HTTP_PROXY_PORT`, `BOMLY_HTTP_PROXY_USERNAME`, `BOMLY_HTTP_PROXY_PASSWORD`, and `BOMLY_HTTP_CA_CERT_FILE`. When Bomly proxy fields are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values to plugin subprocesses using the standard proxy environment variable names.
 
 Per-plugin configuration lives under `plugins.<plugin-id>`:
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -73,7 +73,15 @@ if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
 }
 ```
 
-Plugins that make outbound HTTP calls should use `sdk.NewHTTPClient(sdk.HTTPClientConfigFromEnv())` so Bomly proxy settings and standard proxy environment variables are handled consistently.
+Plugins that make outbound HTTP calls should create one process-local provider with `sdk.NewHTTPClientProviderFromEnv()` and reuse it for timeout-specific clients. This keeps proxy settings consistent while preserving Go's HTTP connection pooling:
+
+```go
+provider, err := sdk.NewHTTPClientProviderFromEnv()
+if err != nil {
+    return err
+}
+client := provider.Client(20 * time.Second)
+```
 
 ## Plugin Layout
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -27,6 +27,42 @@ Installed external plugins are disabled by default. They do not participate in s
 
 Enabled plugins are loaded during runtime preparation in local and CI workflows. Treat `bomly plugin enable` as the trust decision for running that external binary.
 
+## Configuration And Proxy Support
+
+Bomly passes the active plugin API version, the explicit `BOMLY_CONFIG` path when one was provided, proxy settings, and the enabled plugin's own config to managed plugin subprocesses.
+
+Proxy settings can be configured with Bomly config keys or environment variables:
+
+```yaml
+http_proxy: http://proxy.example:8080
+http_no_proxy: localhost,127.0.0.1,.corp.example
+```
+
+Equivalent environment variables are `BOMLY_HTTP_PROXY` and `BOMLY_HTTP_NO_PROXY`. When those are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values to plugin subprocesses using the standard proxy environment variable names.
+
+Per-plugin configuration lives under `plugins.<plugin-id>`:
+
+```yaml
+plugins:
+  acme.matcher:
+    api_base: https://api.example.com
+```
+
+External plugins can read only their own config through the SDK:
+
+```go
+type config struct {
+    APIBase string `json:"api_base"`
+}
+
+var cfg config
+if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
+    return err
+}
+```
+
+Plugins that make outbound HTTP calls should use `sdk.NewHTTPClient(sdk.HTTPClientConfigFromEnv())` so Bomly proxy settings and standard proxy environment variables are handled consistently.
+
 ## Plugin Layout
 
 External plugin packages include a `bomly-plugin.json` manifest and a platform entrypoint binary.

--- a/examples/plugins/go-module-detector/main.go
+++ b/examples/plugins/go-module-detector/main.go
@@ -18,6 +18,10 @@ const (
 
 type detector struct{}
 
+type pluginConfig struct {
+	APIBase string `json:"api_base"`
+}
+
 func (d *detector) Metadata(context.Context) (*sdk.PluginMetadata, error) {
 	return &sdk.PluginMetadata{
 		ID:               pluginID,
@@ -46,6 +50,11 @@ func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerS
 }
 
 func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
+	var cfg pluginConfig
+	if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
+		return nil, err
+	}
+	_ = cfg
 	return &sdk.ReadyResponse{Ready: true}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/zap v1.28.0
+	golang.org/x/net v0.53.0
 	golang.org/x/term v0.43.0
 	golang.org/x/vuln v1.3.0
 	google.golang.org/grpc v1.81.1
@@ -304,7 +305,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -362,11 +362,17 @@ func (o *Options) OutputFormat() (output.Format, error) {
 func (o *Options) PluginLaunchContext(ctx context.Context) context.Context {
 	current := o.GetConfig()
 	return plugin.WithLaunchOptions(ctx, plugin.LaunchOptions{
-		ConfigPath:    current.Config,
-		Verbosity:     current.Verbosity,
-		HTTPProxy:     current.HTTPProxy,
-		HTTPNoProxy:   current.HTTPNoProxy,
-		PluginConfigs: current.Plugins,
+		ConfigPath:        current.Config,
+		Verbosity:         current.Verbosity,
+		HTTPProxy:         current.HTTPProxy,
+		HTTPNoProxy:       current.HTTPNoProxy,
+		HTTPProxyType:     current.HTTPProxyType,
+		HTTPProxyHost:     current.HTTPProxyHost,
+		HTTPProxyPort:     current.HTTPProxyPort,
+		HTTPProxyUsername: current.HTTPProxyUsername,
+		HTTPProxyPassword: current.HTTPProxyPassword,
+		HTTPCACertFile:    current.HTTPCACertFile,
+		PluginConfigs:     current.Plugins,
 	})
 }
 

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	matcherFilter   sdk.MatcherFilter
 	analyzerFilter  sdk.AnalyzerFilter
 	ecosystemFilter sdk.EcosystemFilter
+	httpProvider    *sdk.HTTPClientProvider
 	Format          output.Format
 	outputPath      string
 	verbose         bool
@@ -229,7 +230,17 @@ func (o *Options) PrepareForExecutionTarget(ctx context.Context, logger *zap.Log
 		return Options{}, exit.InvalidInputError("%v", err)
 	}
 
-	scanRegistry := engine.NewRegistry(RegistryConfigsFromResolved(resolved), *logger)
+	httpProvider, err := sdk.NewHTTPClientProvider(httpClientConfigFromResolved(resolved))
+	if err != nil {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		return Options{}, exit.InvalidInputError("configure HTTP client: %v", err)
+	}
+
+	registryConfigs := RegistryConfigsFromResolved(resolved)
+	registryConfigs.HTTPClientProvider = httpProvider
+	scanRegistry := engine.NewRegistry(registryConfigs, *logger)
 	scanRegistry.Build()
 
 	if err := o.registerInstalledPluginMetadata(ctx, scanRegistry); err != nil {
@@ -325,6 +336,7 @@ func (o *Options) PrepareForExecutionTarget(ctx context.Context, logger *zap.Log
 		matcherFilter:   matcherFilter,
 		analyzerFilter:  analyzerFilter,
 		ecosystemFilter: ecosystemFilter,
+		httpProvider:    httpProvider,
 		ResolvedConfig:  resolved,
 		Format:          format,
 		verbose:         resolved.Verbosity > 0,
@@ -361,19 +373,37 @@ func (o *Options) OutputFormat() (output.Format, error) {
 
 func (o *Options) PluginLaunchContext(ctx context.Context) context.Context {
 	current := o.GetConfig()
+	httpProvider := o.httpProvider
+	if httpProvider == nil {
+		httpProvider, _ = sdk.NewHTTPClientProvider(httpClientConfigFromResolved(current))
+	}
 	return plugin.WithLaunchOptions(ctx, plugin.LaunchOptions{
-		ConfigPath:        current.Config,
-		Verbosity:         current.Verbosity,
-		HTTPProxy:         current.HTTPProxy,
-		HTTPNoProxy:       current.HTTPNoProxy,
-		HTTPProxyType:     current.HTTPProxyType,
-		HTTPProxyHost:     current.HTTPProxyHost,
-		HTTPProxyPort:     current.HTTPProxyPort,
-		HTTPProxyUsername: current.HTTPProxyUsername,
-		HTTPProxyPassword: current.HTTPProxyPassword,
-		HTTPCACertFile:    current.HTTPCACertFile,
-		PluginConfigs:     current.Plugins,
+		ConfigPath:         current.Config,
+		Verbosity:          current.Verbosity,
+		HTTPProxy:          current.HTTPProxy,
+		HTTPNoProxy:        current.HTTPNoProxy,
+		HTTPProxyType:      current.HTTPProxyType,
+		HTTPProxyHost:      current.HTTPProxyHost,
+		HTTPProxyPort:      current.HTTPProxyPort,
+		HTTPProxyUsername:  current.HTTPProxyUsername,
+		HTTPProxyPassword:  current.HTTPProxyPassword,
+		HTTPCACertFile:     current.HTTPCACertFile,
+		HTTPClientProvider: httpProvider,
+		PluginConfigs:      current.Plugins,
 	})
+}
+
+func httpClientConfigFromResolved(current config.Resolved) sdk.HTTPClientConfig {
+	return sdk.HTTPClientConfig{
+		ProxyURL:      current.HTTPProxy,
+		NoProxy:       current.HTTPNoProxy,
+		ProxyType:     current.HTTPProxyType,
+		ProxyHost:     current.HTTPProxyHost,
+		ProxyPort:     current.HTTPProxyPort,
+		ProxyUsername: current.HTTPProxyUsername,
+		ProxyPassword: current.HTTPProxyPassword,
+		CACertFile:    current.HTTPCACertFile,
+	}
 }
 
 // ProjectDescriptor returns a descriptor for the main project being analyzed,

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -362,8 +362,11 @@ func (o *Options) OutputFormat() (output.Format, error) {
 func (o *Options) PluginLaunchContext(ctx context.Context) context.Context {
 	current := o.GetConfig()
 	return plugin.WithLaunchOptions(ctx, plugin.LaunchOptions{
-		ConfigPath: current.Config,
-		Verbosity:  current.Verbosity,
+		ConfigPath:    current.Config,
+		Verbosity:     current.Verbosity,
+		HTTPProxy:     current.HTTPProxy,
+		HTTPNoProxy:   current.HTTPNoProxy,
+		PluginConfigs: current.Plugins,
 	})
 }
 

--- a/internal/cli/opts/registry.go
+++ b/internal/cli/opts/registry.go
@@ -45,5 +45,11 @@ func RegistryConfigsFromResolved(cfg config.Resolved) engine.RegistryConfigs {
 		ScorecardCacheTTL:     cfg.ScorecardCacheTTL,
 		HTTPProxy:             cfg.HTTPProxy,
 		HTTPNoProxy:           cfg.HTTPNoProxy,
+		HTTPProxyType:         cfg.HTTPProxyType,
+		HTTPProxyHost:         cfg.HTTPProxyHost,
+		HTTPProxyPort:         cfg.HTTPProxyPort,
+		HTTPProxyUsername:     cfg.HTTPProxyUsername,
+		HTTPProxyPassword:     cfg.HTTPProxyPassword,
+		HTTPCACertFile:        cfg.HTTPCACertFile,
 	}
 }

--- a/internal/cli/opts/registry.go
+++ b/internal/cli/opts/registry.go
@@ -43,5 +43,7 @@ func RegistryConfigsFromResolved(cfg config.Resolved) engine.RegistryConfigs {
 		ScorecardAPIBase:      cfg.ScorecardAPIBase,
 		ScorecardCacheDir:     cfg.ScorecardCacheDir,
 		ScorecardCacheTTL:     cfg.ScorecardCacheTTL,
+		HTTPProxy:             cfg.HTTPProxy,
+		HTTPNoProxy:           cfg.HTTPNoProxy,
 	}
 }

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -219,7 +219,7 @@ func newPluginInstallCmd() *cobra.Command {
 			}
 			current := options.GetConfig()
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
-			result, err := managedplugin.Install(cmd.Context(), "", args[0], managedplugin.InstallOptions{
+			result, err := managedplugin.Install(options.PluginLaunchContext(cmd.Context()), "", args[0], managedplugin.InstallOptions{
 				DevBinary:            devBinary,
 				Checksum:             checksum,
 				InsecureSkipChecksum: insecureSkipChecksum,
@@ -315,7 +315,7 @@ func newPluginVerifyCmd() *cobra.Command {
 			}
 			current := options.GetConfig()
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
-			result, err := managedplugin.Verify(cmd.Context(), "", strings.TrimSpace(args[0]))
+			result, err := managedplugin.Verify(options.PluginLaunchContext(cmd.Context()), "", strings.TrimSpace(args[0]))
 			if err != nil {
 				return err
 			}
@@ -352,7 +352,7 @@ func newPluginTestCmd() *cobra.Command {
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
 			builtins := builtInPluginInfos(current, cmd.Root().Version)
 			all, _ := managedplugin.ListPluginInfos("", builtins)
-			result, err := managedplugin.Test(cmd.Context(), "", strings.TrimSpace(args[0]), all)
+			result, err := managedplugin.Test(options.PluginLaunchContext(cmd.Context()), "", strings.TrimSpace(args[0]), all)
 			if err != nil {
 				return pluginCommandError(err)
 			}
@@ -399,7 +399,7 @@ func newPluginDoctorCmd() *cobra.Command {
 			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
 			builtins := builtInPluginInfos(current, cmd.Root().Version)
 			all, _ := managedplugin.ListPluginInfos("", builtins)
-			result, err := managedplugin.Doctor(cmd.Context(), "", strings.TrimSpace(args[0]), all)
+			result, err := managedplugin.Doctor(options.PluginLaunchContext(cmd.Context()), "", strings.TrimSpace(args[0]), all)
 			if err != nil {
 				return pluginCommandError(err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,12 @@ type Resolved struct {
 	LoadedFiles           []string
 	HTTPProxy             string                    `doc:"Outbound HTTP proxy URL used by Bomly and managed plugins" env:"BOMLY_HTTP_PROXY"`
 	HTTPNoProxy           string                    `doc:"Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy" env:"BOMLY_HTTP_NO_PROXY"`
+	HTTPProxyType         string                    `doc:"Outbound proxy type when using host/port proxy settings: http, https, or socks5" env:"BOMLY_HTTP_PROXY_TYPE" default:"http"`
+	HTTPProxyHost         string                    `doc:"Outbound proxy hostname or IP address used when http_proxy is not set" env:"BOMLY_HTTP_PROXY_HOST"`
+	HTTPProxyPort         int                       `doc:"Outbound proxy port used with http_proxy_host" env:"BOMLY_HTTP_PROXY_PORT"`
+	HTTPProxyUsername     string                    `doc:"Username for proxy authentication when using host/port proxy settings" env:"BOMLY_HTTP_PROXY_USERNAME"`
+	HTTPProxyPassword     string                    `doc:"Password for proxy authentication when using host/port proxy settings" env:"BOMLY_HTTP_PROXY_PASSWORD"`
+	HTTPCACertFile        string                    `doc:"PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies" env:"BOMLY_HTTP_CA_CERT_FILE"`
 	Plugins               map[string]map[string]any `doc:"Per-plugin configuration keyed by managed plugin ID"`
 
 	// OSV matcher settings
@@ -119,6 +125,12 @@ type File struct {
 	Verbose               *bool                     `yaml:"verbose,omitempty"`
 	HTTPProxy             *string                   `yaml:"http_proxy,omitempty"`
 	HTTPNoProxy           *string                   `yaml:"http_no_proxy,omitempty"`
+	HTTPProxyType         *string                   `yaml:"http_proxy_type,omitempty"`
+	HTTPProxyHost         *string                   `yaml:"http_proxy_host,omitempty"`
+	HTTPProxyPort         *int                      `yaml:"http_proxy_port,omitempty"`
+	HTTPProxyUsername     *string                   `yaml:"http_proxy_username,omitempty"`
+	HTTPProxyPassword     *string                   `yaml:"http_proxy_password,omitempty"`
+	HTTPCACertFile        *string                   `yaml:"http_ca_cert_file,omitempty"`
 	Plugins               map[string]map[string]any `yaml:"plugins,omitempty"`
 
 	// OSV matcher settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,9 @@ type Resolved struct {
 	Quiet                 bool     `doc:"Suppress all non-error output" env:"BOMLY_QUIET"`
 	Verbosity             int      `doc:"Verbosity level (0=normal, 1=verbose, 2+=debug)" env:"BOMLY_VERBOSE"`
 	LoadedFiles           []string
+	HTTPProxy             string                    `doc:"Outbound HTTP proxy URL used by Bomly and managed plugins" env:"BOMLY_HTTP_PROXY"`
+	HTTPNoProxy           string                    `doc:"Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy" env:"BOMLY_HTTP_NO_PROXY"`
+	Plugins               map[string]map[string]any `doc:"Per-plugin configuration keyed by managed plugin ID"`
 
 	// OSV matcher settings
 	OsvAPIBase  string `doc:"Base URL for the OSV vulnerability API" env:"BOMLY_OSV_API_BASE" default:"https://api.osv.dev"`
@@ -80,40 +83,43 @@ type Resolved struct {
 // configref generator parses this struct's yaml tags to map each Resolved
 // field to its corresponding YAML key in the reference docs.
 type File struct {
-	Path                  *string    `yaml:"path,omitempty"`
-	Container             *string    `yaml:"container,omitempty"`
-	URL                   *string    `yaml:"url,omitempty"`
-	Ref                   *string    `yaml:"ref,omitempty"`
-	SBOM                  *bool      `yaml:"sbom,omitempty"`
-	Enrich                *bool      `yaml:"enrich,omitempty"`
-	Audit                 *bool      `yaml:"audit,omitempty"`
-	Reachability          *bool      `yaml:"reachability,omitempty"`
-	FailOn                FailOnList `yaml:"fail_on,omitempty"`
-	FailOnScopes          []string   `yaml:"fail_on_scopes,omitempty"`
-	AllowVulnerabilityIDs []string   `yaml:"allow_vulnerability_ids,omitempty"`
-	AllowLicenses         []string   `yaml:"allow_licenses,omitempty"`
-	DenyLicenses          []string   `yaml:"deny_licenses,omitempty"`
-	LicenseExemptPackages []string   `yaml:"license_exempt_packages,omitempty"`
-	DenyPackages          []string   `yaml:"deny_packages,omitempty"`
-	DenyGroups            []string   `yaml:"deny_groups,omitempty"`
-	ProtectedPackages     []string   `yaml:"protected_packages,omitempty"`
-	TyposquatThreshold    *string    `yaml:"typosquat_threshold,omitempty"`
-	TyposquatMode         *string    `yaml:"typosquat_mode,omitempty"`
-	WarnOnly              *bool      `yaml:"warn_only,omitempty"`
-	Analyzers             *string    `yaml:"analyzers,omitempty"`
-	Format                *string    `yaml:"format,omitempty"`
-	Outputs               []string   `yaml:"outputs,omitempty"`
-	Interactive           *bool      `yaml:"interactive,omitempty"`
-	Ecosystems            *string    `yaml:"ecosystems,omitempty"`
-	Detectors             *string    `yaml:"detectors,omitempty"`
-	Auditors              *string    `yaml:"auditors,omitempty"`
-	Matchers              *string    `yaml:"matchers,omitempty"`
-	InstallFirst          *bool      `yaml:"install_first,omitempty"`
-	InstallArgs           []string   `yaml:"install_args,omitempty"`
-	Config                *string    `yaml:"config,omitempty"`
-	Quiet                 *bool      `yaml:"quiet,omitempty"`
-	Verbosity             *int       `yaml:"verbosity,omitempty"`
-	Verbose               *bool      `yaml:"verbose,omitempty"`
+	Path                  *string                   `yaml:"path,omitempty"`
+	Container             *string                   `yaml:"container,omitempty"`
+	URL                   *string                   `yaml:"url,omitempty"`
+	Ref                   *string                   `yaml:"ref,omitempty"`
+	SBOM                  *bool                     `yaml:"sbom,omitempty"`
+	Enrich                *bool                     `yaml:"enrich,omitempty"`
+	Audit                 *bool                     `yaml:"audit,omitempty"`
+	Reachability          *bool                     `yaml:"reachability,omitempty"`
+	FailOn                FailOnList                `yaml:"fail_on,omitempty"`
+	FailOnScopes          []string                  `yaml:"fail_on_scopes,omitempty"`
+	AllowVulnerabilityIDs []string                  `yaml:"allow_vulnerability_ids,omitempty"`
+	AllowLicenses         []string                  `yaml:"allow_licenses,omitempty"`
+	DenyLicenses          []string                  `yaml:"deny_licenses,omitempty"`
+	LicenseExemptPackages []string                  `yaml:"license_exempt_packages,omitempty"`
+	DenyPackages          []string                  `yaml:"deny_packages,omitempty"`
+	DenyGroups            []string                  `yaml:"deny_groups,omitempty"`
+	ProtectedPackages     []string                  `yaml:"protected_packages,omitempty"`
+	TyposquatThreshold    *string                   `yaml:"typosquat_threshold,omitempty"`
+	TyposquatMode         *string                   `yaml:"typosquat_mode,omitempty"`
+	WarnOnly              *bool                     `yaml:"warn_only,omitempty"`
+	Analyzers             *string                   `yaml:"analyzers,omitempty"`
+	Format                *string                   `yaml:"format,omitempty"`
+	Outputs               []string                  `yaml:"outputs,omitempty"`
+	Interactive           *bool                     `yaml:"interactive,omitempty"`
+	Ecosystems            *string                   `yaml:"ecosystems,omitempty"`
+	Detectors             *string                   `yaml:"detectors,omitempty"`
+	Auditors              *string                   `yaml:"auditors,omitempty"`
+	Matchers              *string                   `yaml:"matchers,omitempty"`
+	InstallFirst          *bool                     `yaml:"install_first,omitempty"`
+	InstallArgs           []string                  `yaml:"install_args,omitempty"`
+	Config                *string                   `yaml:"config,omitempty"`
+	Quiet                 *bool                     `yaml:"quiet,omitempty"`
+	Verbosity             *int                      `yaml:"verbosity,omitempty"`
+	Verbose               *bool                     `yaml:"verbose,omitempty"`
+	HTTPProxy             *string                   `yaml:"http_proxy,omitempty"`
+	HTTPNoProxy           *string                   `yaml:"http_no_proxy,omitempty"`
+	Plugins               map[string]map[string]any `yaml:"plugins,omitempty"`
 
 	// OSV matcher settings
 	OsvAPIBase  *string `yaml:"osv_api_base,omitempty"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -52,7 +52,7 @@ func LoadFile(path string) (*File, error) {
 }
 
 func normalizeFilePaths(cfg *File, baseDir string) {
-	for _, target := range []*string{cfg.Path, cfg.Config} {
+	for _, target := range []*string{cfg.Path, cfg.Config, cfg.HTTPCACertFile} {
 		if target == nil || strings.TrimSpace(*target) == "" || filepath.IsAbs(*target) {
 			continue
 		}
@@ -158,7 +158,11 @@ func ApplyEnvOverrides(dst *Resolved) {
 				fv.SetBool(b)
 			}
 		case reflect.Int:
-			applyVerbosityEnv(fv, val)
+			if t.Field(i).Name == "Verbosity" {
+				applyVerbosityEnv(fv, val)
+			} else if parsed, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				fv.SetInt(int64(parsed))
+			}
 		case reflect.Slice:
 			fv.Set(reflect.ValueOf(parseCSV(val)))
 		}
@@ -236,6 +240,9 @@ func Validate(cfg Resolved) error {
 	if err := validateProxyURL(cfg.HTTPProxy); err != nil {
 		return err
 	}
+	if err := validateProxyFields(cfg); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -250,6 +257,32 @@ func validateProxyURL(value string) error {
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return fmt.Errorf("invalid http_proxy URL: must be absolute")
+	}
+	switch strings.ToLower(strings.TrimSpace(parsed.Scheme)) {
+	case "http", "https", "socks", "socks5":
+	default:
+		return fmt.Errorf("unsupported http_proxy scheme %q (accepted: http, https, socks5)", parsed.Scheme)
+	}
+	return nil
+}
+
+func validateProxyFields(cfg Resolved) error {
+	switch strings.ToLower(strings.TrimSpace(cfg.HTTPProxyType)) {
+	case "", "http", "https", "socks", "socks5":
+	default:
+		return fmt.Errorf("unsupported http_proxy_type value %q (accepted: http, https, socks5)", cfg.HTTPProxyType)
+	}
+	if strings.TrimSpace(cfg.HTTPProxyHost) == "" {
+		if cfg.HTTPProxyPort != 0 {
+			return fmt.Errorf("http_proxy_port requires http_proxy_host")
+		}
+		if strings.TrimSpace(cfg.HTTPProxyUsername) != "" || strings.TrimSpace(cfg.HTTPProxyPassword) != "" {
+			return fmt.Errorf("http_proxy_username and http_proxy_password require http_proxy_host")
+		}
+		return nil
+	}
+	if cfg.HTTPProxyPort <= 0 || cfg.HTTPProxyPort > 65535 {
+		return fmt.Errorf("http_proxy_port must be between 1 and 65535")
 	}
 	return nil
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -112,6 +114,18 @@ func ApplyFileConfig(dst *Resolved, src File) {
 	if len(src.Outputs) > 0 {
 		dst.Outputs = append([]string(nil), src.Outputs...)
 	}
+	if len(src.Plugins) > 0 {
+		if dst.Plugins == nil {
+			dst.Plugins = make(map[string]map[string]any, len(src.Plugins))
+		}
+		for id, pluginConfig := range src.Plugins {
+			trimmedID := strings.TrimSpace(id)
+			if trimmedID == "" {
+				continue
+			}
+			dst.Plugins[trimmedID] = clonePluginConfig(pluginConfig)
+		}
+	}
 	// Verbose is a legacy shorthand; map it to Verbosity=1 if not already set.
 	if src.Verbose != nil && *src.Verbose && dst.Verbosity == 0 {
 		dst.Verbosity = 1
@@ -219,7 +233,48 @@ func Validate(cfg Resolved) error {
 	default:
 		return fmt.Errorf("unsupported --typosquat-mode value %q (accepted: warn, fail)", cfg.TyposquatMode)
 	}
+	if err := validateProxyURL(cfg.HTTPProxy); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateProxyURL(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("invalid http_proxy URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid http_proxy URL: must be absolute")
+	}
+	return nil
+}
+
+func clonePluginConfig(value map[string]any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		out := make(map[string]any, len(value))
+		for key, item := range value {
+			out[key] = item
+		}
+		return out
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		copyValue := make(map[string]any, len(value))
+		for key, item := range value {
+			copyValue[key] = item
+		}
+		return copyValue
+	}
+	return out
 }
 
 func parseBool(s string) (bool, bool) {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -11,6 +11,12 @@ func TestLoadFileAndEnvProxyPrecedence(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`
 http_proxy: http://file-proxy.example:8080
 http_no_proxy: file.internal
+http_proxy_type: socks5
+http_proxy_host: split-proxy.example
+http_proxy_port: 1080
+http_proxy_username: agent
+http_proxy_password: secret
+http_ca_cert_file: certs/proxy-ca.pem
 plugins:
   acme.matcher:
     api_base: https://api.file.example
@@ -31,18 +37,32 @@ plugins:
 	if resolved.HTTPNoProxy != "file.internal" {
 		t.Fatalf("HTTPNoProxy = %q", resolved.HTTPNoProxy)
 	}
+	if resolved.HTTPProxyType != "socks5" || resolved.HTTPProxyHost != "split-proxy.example" || resolved.HTTPProxyPort != 1080 {
+		t.Fatalf("decomposed proxy config = %#v", resolved)
+	}
+	if resolved.HTTPProxyUsername != "agent" || resolved.HTTPProxyPassword != "secret" {
+		t.Fatalf("proxy auth config = %#v", resolved)
+	}
+	if want := filepath.Join(filepath.Dir(path), "certs", "proxy-ca.pem"); resolved.HTTPCACertFile != want {
+		t.Fatalf("HTTPCACertFile = %q, want %q", resolved.HTTPCACertFile, want)
+	}
 	if got := resolved.Plugins["acme.matcher"]["api_base"]; got != "https://api.file.example" {
 		t.Fatalf("plugin api_base = %#v", got)
 	}
 
 	t.Setenv("BOMLY_HTTP_PROXY", "http://env-proxy.example:8080")
 	t.Setenv("BOMLY_HTTP_NO_PROXY", "env.internal")
+	t.Setenv("BOMLY_HTTP_PROXY_HOST", "env-split-proxy.example")
+	t.Setenv("BOMLY_HTTP_PROXY_PORT", "3128")
 	ApplyEnvOverrides(&resolved)
 	if resolved.HTTPProxy != "http://env-proxy.example:8080" {
 		t.Fatalf("HTTPProxy after env = %q", resolved.HTTPProxy)
 	}
 	if resolved.HTTPNoProxy != "env.internal" {
 		t.Fatalf("HTTPNoProxy after env = %q", resolved.HTTPNoProxy)
+	}
+	if resolved.HTTPProxyHost != "env-split-proxy.example" || resolved.HTTPProxyPort != 3128 {
+		t.Fatalf("decomposed proxy after env = %#v", resolved)
 	}
 	if got := resolved.Plugins["acme.matcher"]["batch_size"]; got != float64(10) {
 		t.Fatalf("plugin batch_size = %#v", got)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFileAndEnvProxyPrecedence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+http_proxy: http://file-proxy.example:8080
+http_no_proxy: file.internal
+plugins:
+  acme.matcher:
+    api_base: https://api.file.example
+    batch_size: 10
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fileCfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	var resolved Resolved
+	ApplyFileConfig(&resolved, *fileCfg)
+	if resolved.HTTPProxy != "http://file-proxy.example:8080" {
+		t.Fatalf("HTTPProxy = %q", resolved.HTTPProxy)
+	}
+	if resolved.HTTPNoProxy != "file.internal" {
+		t.Fatalf("HTTPNoProxy = %q", resolved.HTTPNoProxy)
+	}
+	if got := resolved.Plugins["acme.matcher"]["api_base"]; got != "https://api.file.example" {
+		t.Fatalf("plugin api_base = %#v", got)
+	}
+
+	t.Setenv("BOMLY_HTTP_PROXY", "http://env-proxy.example:8080")
+	t.Setenv("BOMLY_HTTP_NO_PROXY", "env.internal")
+	ApplyEnvOverrides(&resolved)
+	if resolved.HTTPProxy != "http://env-proxy.example:8080" {
+		t.Fatalf("HTTPProxy after env = %q", resolved.HTTPProxy)
+	}
+	if resolved.HTTPNoProxy != "env.internal" {
+		t.Fatalf("HTTPNoProxy after env = %q", resolved.HTTPNoProxy)
+	}
+	if got := resolved.Plugins["acme.matcher"]["batch_size"]; got != float64(10) {
+		t.Fatalf("plugin batch_size = %#v", got)
+	}
+}
+
+func TestApplyFileConfigMergesPluginConfigsByID(t *testing.T) {
+	resolved := Resolved{}
+	ApplyFileConfig(&resolved, File{Plugins: map[string]map[string]any{
+		"acme.one": {"value": "one"},
+	}})
+	ApplyFileConfig(&resolved, File{Plugins: map[string]map[string]any{
+		"acme.two": {"value": "two"},
+	}})
+	if _, ok := resolved.Plugins["acme.one"]; !ok {
+		t.Fatalf("expected first plugin config to remain")
+	}
+	if got := resolved.Plugins["acme.two"]["value"]; got != "two" {
+		t.Fatalf("second plugin config = %#v", got)
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -63,3 +63,35 @@ func TestValidateRejectsInvalidHTTPProxy(t *testing.T) {
 		t.Fatalf("error = %q, want invalid http_proxy URL", err.Error())
 	}
 }
+
+func TestValidateRejectsInvalidHTTPProxyFields(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Resolved
+		want string
+	}{
+		{
+			name: "unsupported type",
+			cfg:  Resolved{HTTPProxyType: "ftp", HTTPProxyHost: "proxy.example", HTTPProxyPort: 8080},
+			want: "unsupported http_proxy_type",
+		},
+		{
+			name: "port without host",
+			cfg:  Resolved{HTTPProxyPort: 8080},
+			want: "http_proxy_port requires http_proxy_host",
+		},
+		{
+			name: "host without port",
+			cfg:  Resolved{HTTPProxyHost: "proxy.example"},
+			want: "http_proxy_port must be between 1 and 65535",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -53,3 +53,13 @@ func TestValidateExistingMutualExclusions(t *testing.T) {
 		t.Error("--quiet + --verbose should still error")
 	}
 }
+
+func TestValidateRejectsInvalidHTTPProxy(t *testing.T) {
+	err := Validate(Resolved{HTTPProxy: "proxy.example:8080"})
+	if err == nil {
+		t.Fatal("Validate returned nil for invalid proxy URL")
+	}
+	if !strings.Contains(err.Error(), "invalid http_proxy URL") {
+		t.Fatalf("error = %q, want invalid http_proxy URL", err.Error())
+	}
+}

--- a/internal/matchers/clearlydefined/matcher.go
+++ b/internal/matchers/clearlydefined/matcher.go
@@ -94,7 +94,10 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client = &http.Client{Timeout: 20 * time.Second}
+		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: 20 * time.Second})
+		if err != nil {
+			return nil, fmt.Errorf("clearlydefined checker: create HTTP client: %w", err)
+		}
 	}
 	return &Checker{
 		client: client,

--- a/internal/matchers/clearlydefined/matcher.go
+++ b/internal/matchers/clearlydefined/matcher.go
@@ -29,11 +29,12 @@ const (
 
 // Config configures the ClearlyDefined checker.
 type Config struct {
-	APIBase  string
-	CacheDir string
-	CacheTTL time.Duration
-	Logger   *zap.Logger
-	Client   *http.Client
+	APIBase            string
+	CacheDir           string
+	CacheTTL           time.Duration
+	Logger             *zap.Logger
+	Client             *http.Client
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultConfig returns a production-ready ClearlyDefined checker config.
@@ -94,10 +95,14 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: 20 * time.Second})
-		if err != nil {
-			return nil, fmt.Errorf("clearlydefined checker: create HTTP client: %w", err)
+		provider := config.HTTPClientProvider
+		if provider == nil {
+			provider, err = sdk.NewHTTPClientProviderFromEnv()
+			if err != nil {
+				return nil, fmt.Errorf("clearlydefined checker: create HTTP client provider: %w", err)
+			}
 		}
+		client = provider.Client(20 * time.Second)
 	}
 	return &Checker{
 		client: client,

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -32,11 +32,12 @@ const (
 
 // Config configures the deps.dev license checker.
 type Config struct {
-	APIBase  string
-	CacheDir string
-	CacheTTL time.Duration
-	Logger   *zap.Logger
-	Client   *http.Client
+	APIBase            string
+	CacheDir           string
+	CacheTTL           time.Duration
+	Logger             *zap.Logger
+	Client             *http.Client
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultConfig returns a production-ready deps.dev checker config.
@@ -103,10 +104,14 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: 20 * time.Second})
-		if err != nil {
-			return nil, fmt.Errorf("deps.dev checker: create HTTP client: %w", err)
+		provider := config.HTTPClientProvider
+		if provider == nil {
+			provider, err = sdk.NewHTTPClientProviderFromEnv()
+			if err != nil {
+				return nil, fmt.Errorf("deps.dev checker: create HTTP client provider: %w", err)
+			}
 		}
+		client = provider.Client(20 * time.Second)
 	}
 	return &Checker{
 		client: client,

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -103,7 +103,10 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client = &http.Client{Timeout: 20 * time.Second}
+		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: 20 * time.Second})
+		if err != nil {
+			return nil, fmt.Errorf("deps.dev checker: create HTTP client: %w", err)
+		}
 	}
 	return &Checker{
 		client: client,

--- a/internal/matchers/eol/matcher.go
+++ b/internal/matchers/eol/matcher.go
@@ -93,7 +93,10 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client = &http.Client{Timeout: config.Timeout}
+		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
+		if err != nil {
+			return nil, fmt.Errorf("eol checker: create HTTP client: %w", err)
+		}
 	}
 
 	return &Checker{

--- a/internal/matchers/eol/matcher.go
+++ b/internal/matchers/eol/matcher.go
@@ -35,12 +35,13 @@ const (
 
 // Config configures the EOL enrichment matcher.
 type Config struct {
-	APIBase  string
-	CacheDir string
-	CacheTTL time.Duration
-	Timeout  time.Duration
-	Logger   *zap.Logger
-	Client   *http.Client
+	APIBase            string
+	CacheDir           string
+	CacheTTL           time.Duration
+	Timeout            time.Duration
+	Logger             *zap.Logger
+	Client             *http.Client
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultConfig returns a production-ready EOL checker config.
@@ -93,10 +94,14 @@ func New(config Config) (*Checker, error) {
 	}
 	client := config.Client
 	if client == nil {
-		client, err = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
-		if err != nil {
-			return nil, fmt.Errorf("eol checker: create HTTP client: %w", err)
+		provider := config.HTTPClientProvider
+		if provider == nil {
+			provider, err = sdk.NewHTTPClientProviderFromEnv()
+			if err != nil {
+				return nil, fmt.Errorf("eol checker: create HTTP client provider: %w", err)
+			}
 		}
+		client = provider.Client(config.Timeout)
 	}
 
 	return &Checker{

--- a/internal/matchers/osv/client.go
+++ b/internal/matchers/osv/client.go
@@ -21,10 +21,11 @@ const (
 
 // ClientConfig configures the OSV HTTP client.
 type ClientConfig struct {
-	APIBase    string
-	Timeout    time.Duration
-	BatchSize  int
-	HTTPClient *http.Client
+	APIBase            string
+	Timeout            time.Duration
+	BatchSize          int
+	HTTPClient         *http.Client
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultClientConfig returns a production-ready default config.
@@ -55,7 +56,14 @@ func NewClient(config ClientConfig) *Client {
 	}
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
+		provider := config.HTTPClientProvider
+		if provider == nil {
+			provider, _ = sdk.NewHTTPClientProviderFromEnv()
+			if provider == nil {
+				provider, _ = sdk.NewHTTPClientProvider(sdk.HTTPClientConfig{})
+			}
+		}
+		httpClient = provider.Client(config.Timeout)
 	}
 	return &Client{
 		http:   httpClient,

--- a/internal/matchers/osv/client.go
+++ b/internal/matchers/osv/client.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
 const (
@@ -19,9 +21,10 @@ const (
 
 // ClientConfig configures the OSV HTTP client.
 type ClientConfig struct {
-	APIBase   string
-	Timeout   time.Duration
-	BatchSize int
+	APIBase    string
+	Timeout    time.Duration
+	BatchSize  int
+	HTTPClient *http.Client
 }
 
 // DefaultClientConfig returns a production-ready default config.
@@ -50,8 +53,12 @@ func NewClient(config ClientConfig) *Client {
 	if config.BatchSize == 0 {
 		config.BatchSize = defaultBatchSize
 	}
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
+	}
 	return &Client{
-		http:   &http.Client{Timeout: config.Timeout},
+		http:   httpClient,
 		config: config,
 	}
 }

--- a/internal/matchers/osv/kev.go
+++ b/internal/matchers/osv/kev.go
@@ -50,7 +50,11 @@ func FetchKEVCatalog(cache *audcache.FileCache, clients ...*http.Client) (*KEVCa
 		client = clients[0]
 	}
 	if client == nil {
-		client, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: kevFetchTimeout})
+		provider, _ := sdk.NewHTTPClientProviderFromEnv()
+		if provider == nil {
+			provider, _ = sdk.NewHTTPClientProvider(sdk.HTTPClientConfig{})
+		}
+		client = provider.Client(kevFetchTimeout)
 	}
 	resp, err := client.Get(kevURL) // #nosec G107 — constant URL
 	if err != nil {

--- a/internal/matchers/osv/kev.go
+++ b/internal/matchers/osv/kev.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	audcache "github.com/bomly-dev/bomly-cli/internal/matchers/cache"
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
 const (
@@ -35,7 +36,7 @@ type kevEntry struct {
 // FetchKEVCatalog downloads the CISA KEV catalog, using the provided cache when available.
 // Cache may be nil — in that case the catalog is always fetched fresh.
 // Returns (nil, nil) if the request fails — callers treat absence as informational.
-func FetchKEVCatalog(cache *audcache.FileCache) (*KEVCatalog, error) {
+func FetchKEVCatalog(cache *audcache.FileCache, clients ...*http.Client) (*KEVCatalog, error) {
 	cacheKeyObj := audcache.NewKey(kevCacheKey, "", "", "")
 
 	if cache != nil {
@@ -44,7 +45,13 @@ func FetchKEVCatalog(cache *audcache.FileCache) (*KEVCatalog, error) {
 		}
 	}
 
-	client := &http.Client{Timeout: kevFetchTimeout}
+	var client *http.Client
+	if len(clients) > 0 {
+		client = clients[0]
+	}
+	if client == nil {
+		client, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: kevFetchTimeout})
+	}
 	resp, err := client.Get(kevURL) // #nosec G107 — constant URL
 	if err != nil {
 		return nil, fmt.Errorf("fetch kev catalog: %w", err)

--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -46,6 +47,10 @@ type Config struct {
 	Logger *zap.Logger
 	// Stderr is used for progress messages. Maybe nil.
 	Stderr io.Writer
+	// Client overrides the OSV HTTP client. Maybe nil.
+	Client *http.Client
+	// KEVClient overrides the CISA KEV HTTP client. Maybe nil.
+	KEVClient *http.Client
 }
 
 // DefaultConfig returns a production-ready OSV matcher config.
@@ -138,6 +143,7 @@ func New(config Config) (*Matcher, error) {
 	if config.APIBase != "" {
 		clientConfig.APIBase = config.APIBase
 	}
+	clientConfig.HTTPClient = config.Client
 
 	c, err := cache.NewFileCache(config.CacheDir, config.CacheTTL)
 	if err != nil {
@@ -323,7 +329,7 @@ func (a *Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResul
 	// Optional KEV enrichment pass.
 	if a.config.EnableKEV && len(enriched) > 0 {
 		a.logger.Debug("osv: starting KEV enrichment")
-		catalog, err := FetchKEVCatalog(a.kevCache)
+		catalog, err := FetchKEVCatalog(a.kevCache, a.config.KEVClient)
 		if err != nil {
 			a.logger.Warn("osv: kev catalog unavailable", zap.Error(err))
 			if a.config.Stderr != nil {

--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -51,6 +51,8 @@ type Config struct {
 	Client *http.Client
 	// KEVClient overrides the CISA KEV HTTP client. Maybe nil.
 	KEVClient *http.Client
+	// HTTPClientProvider supplies shared HTTP clients when Client/KEVClient are nil.
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultConfig returns a production-ready OSV matcher config.
@@ -144,6 +146,10 @@ func New(config Config) (*Matcher, error) {
 		clientConfig.APIBase = config.APIBase
 	}
 	clientConfig.HTTPClient = config.Client
+	clientConfig.HTTPClientProvider = config.HTTPClientProvider
+	if config.KEVClient == nil && config.HTTPClientProvider != nil {
+		config.KEVClient = config.HTTPClientProvider.Client(kevFetchTimeout)
+	}
 
 	c, err := cache.NewFileCache(config.CacheDir, config.CacheTTL)
 	if err != nil {

--- a/internal/matchers/scorecard/client.go
+++ b/internal/matchers/scorecard/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
 const (
@@ -53,7 +55,7 @@ func NewClient(config ClientConfig) *Client {
 	}
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: config.Timeout}
+		httpClient, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
 	}
 	return &Client{http: httpClient, config: config}
 }

--- a/internal/matchers/scorecard/client.go
+++ b/internal/matchers/scorecard/client.go
@@ -25,10 +25,11 @@ var ErrProjectNotScored = errors.New("scorecard: project not scored")
 
 // ClientConfig configures the Scorecard HTTP client.
 type ClientConfig struct {
-	APIBase    string
-	Timeout    time.Duration
-	UserAgent  string
-	HTTPClient *http.Client
+	APIBase            string
+	Timeout            time.Duration
+	UserAgent          string
+	HTTPClient         *http.Client
+	HTTPClientProvider *sdk.HTTPClientProvider
 }
 
 // DefaultClientConfig returns a production-ready default config.
@@ -55,7 +56,14 @@ func NewClient(config ClientConfig) *Client {
 	}
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient, _ = sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: config.Timeout})
+		provider := config.HTTPClientProvider
+		if provider == nil {
+			provider, _ = sdk.NewHTTPClientProviderFromEnv()
+			if provider == nil {
+				provider, _ = sdk.NewHTTPClientProvider(sdk.HTTPClientConfig{})
+			}
+		}
+		httpClient = provider.Client(config.Timeout)
 	}
 	return &Client{http: httpClient, config: config}
 }

--- a/internal/plugin/env_test.go
+++ b/internal/plugin/env_test.go
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestPluginEnvIncludesProxyAndPluginConfig(t *testing.T) {
+	env, cleanup, err := pluginEnv(LaunchOptions{
+		ConfigPath:  "/tmp/bomly.yaml",
+		HTTPProxy:   "http://proxy.example:8080",
+		HTTPNoProxy: "localhost,.corp.example",
+		PluginConfigs: map[string]map[string]any{
+			"acme.matcher": {"api_base": "https://api.example.com"},
+		},
+	}, "acme.matcher")
+	if err != nil {
+		t.Fatalf("pluginEnv() error = %v", err)
+	}
+	defer cleanup()
+
+	values := envMap(env)
+	if values[EnvPluginAPIVersion] != sdk.PluginAPIVersion {
+		t.Fatalf("api version env = %q", values[EnvPluginAPIVersion])
+	}
+	if values[EnvPluginConfig] != "/tmp/bomly.yaml" {
+		t.Fatalf("config env = %q", values[EnvPluginConfig])
+	}
+	if values[sdk.EnvPluginID] != "acme.matcher" {
+		t.Fatalf("plugin id env = %q", values[sdk.EnvPluginID])
+	}
+	if values[sdk.EnvHTTPProxy] != "http://proxy.example:8080" || values["HTTPS_PROXY"] != "http://proxy.example:8080" {
+		t.Fatalf("proxy env = %#v", values)
+	}
+	if values[sdk.EnvHTTPNoProxy] != "localhost,.corp.example" || values["NO_PROXY"] != "localhost,.corp.example" {
+		t.Fatalf("no-proxy env = %#v", values)
+	}
+
+	configPath := values[sdk.EnvPluginConfigFile]
+	if configPath == "" {
+		t.Fatalf("missing plugin config file env")
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read plugin config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode plugin config: %v", err)
+	}
+	if cfg["api_base"] != "https://api.example.com" {
+		t.Fatalf("plugin config = %#v", cfg)
+	}
+	cleanup()
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup to remove config file, stat err = %v", err)
+	}
+}
+
+func TestPluginEnvForwardsStandardProxyEnvWhenBomlyProxyUnset(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://standard.example:8080")
+	t.Setenv("NO_PROXY", "localhost")
+	env, cleanup, err := pluginEnv(LaunchOptions{}, "acme.matcher")
+	if err != nil {
+		t.Fatalf("pluginEnv() error = %v", err)
+	}
+	defer cleanup()
+	values := envMap(env)
+	if values["HTTP_PROXY"] != "http://standard.example:8080" {
+		t.Fatalf("HTTP_PROXY = %q", values["HTTP_PROXY"])
+	}
+	if values["NO_PROXY"] != "localhost" {
+		t.Fatalf("NO_PROXY = %q", values["NO_PROXY"])
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, item := range env {
+		key, value, _ := strings.Cut(item, "=")
+		out[key] = value
+	}
+	return out
+}

--- a/internal/plugin/env_test.go
+++ b/internal/plugin/env_test.go
@@ -11,9 +11,14 @@ import (
 
 func TestPluginEnvIncludesProxyAndPluginConfig(t *testing.T) {
 	env, cleanup, err := pluginEnv(LaunchOptions{
-		ConfigPath:  "/tmp/bomly.yaml",
-		HTTPProxy:   "http://proxy.example:8080",
-		HTTPNoProxy: "localhost,.corp.example",
+		ConfigPath:        "/tmp/bomly.yaml",
+		HTTPProxyType:     "socks5",
+		HTTPProxyHost:     "proxy.example",
+		HTTPProxyPort:     1080,
+		HTTPProxyUsername: "agent",
+		HTTPProxyPassword: "secret",
+		HTTPNoProxy:       "localhost,.corp.example",
+		HTTPCACertFile:    "/tmp/proxy-ca.pem",
 		PluginConfigs: map[string]map[string]any{
 			"acme.matcher": {"api_base": "https://api.example.com"},
 		},
@@ -33,8 +38,17 @@ func TestPluginEnvIncludesProxyAndPluginConfig(t *testing.T) {
 	if values[sdk.EnvPluginID] != "acme.matcher" {
 		t.Fatalf("plugin id env = %q", values[sdk.EnvPluginID])
 	}
-	if values[sdk.EnvHTTPProxy] != "http://proxy.example:8080" || values["HTTPS_PROXY"] != "http://proxy.example:8080" {
+	if values[sdk.EnvHTTPProxy] != "socks5://agent:secret@proxy.example:1080" || values["HTTPS_PROXY"] != "socks5://agent:secret@proxy.example:1080" {
 		t.Fatalf("proxy env = %#v", values)
+	}
+	if values[sdk.EnvHTTPProxyType] != "socks5" || values[sdk.EnvHTTPProxyHost] != "proxy.example" || values[sdk.EnvHTTPProxyPort] != "1080" {
+		t.Fatalf("split proxy env = %#v", values)
+	}
+	if values[sdk.EnvHTTPProxyUsername] != "agent" || values[sdk.EnvHTTPProxyPassword] != "secret" {
+		t.Fatalf("proxy auth env = %#v", values)
+	}
+	if values[sdk.EnvHTTPCACertFile] != "/tmp/proxy-ca.pem" {
+		t.Fatalf("CA cert env = %#v", values)
 	}
 	if values[sdk.EnvHTTPNoProxy] != "localhost,.corp.example" || values["NO_PROXY"] != "localhost,.corp.example" {
 		t.Fatalf("no-proxy env = %#v", values)

--- a/internal/plugin/github_release.go
+++ b/internal/plugin/github_release.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	githubReleaseAPIBase = "https://api.github.com"
-	pluginHTTPClient     = http.DefaultClient
+	pluginHTTPClient     *http.Client
 )
 
 type githubReleaseResponse struct {
@@ -77,7 +77,11 @@ func resolveGitHubRelease(ctx context.Context, source string) (githubReleaseReso
 		return githubReleaseResolution{}, fmt.Errorf("create GitHub release request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := pluginHTTPClient.Do(req)
+	client, err := githubReleaseHTTPClient(ctx)
+	if err != nil {
+		return githubReleaseResolution{}, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return githubReleaseResolution{}, fmt.Errorf("fetch GitHub release metadata: %w", err)
 	}
@@ -94,7 +98,7 @@ func resolveGitHubRelease(ctx context.Context, source string) (githubReleaseReso
 	if err != nil {
 		return githubReleaseResolution{}, err
 	}
-	checksum, ok := selectGitHubReleaseChecksum(asset.Name, release.Assets)
+	checksum, ok := selectGitHubReleaseChecksum(ctx, asset.Name, release.Assets)
 	return githubReleaseResolution{
 		DownloadURL:      asset.BrowserDownloadURL,
 		ExpectedChecksum: checksum,
@@ -146,13 +150,13 @@ func assetMatchesPlatform(name string) bool {
 	return strings.Contains(name, runtime.GOOS) && strings.Contains(name, runtime.GOARCH)
 }
 
-func selectGitHubReleaseChecksum(assetName string, assets []githubReleaseAsset) (string, bool) {
+func selectGitHubReleaseChecksum(ctx context.Context, assetName string, assets []githubReleaseAsset) (string, bool) {
 	for _, asset := range assets {
 		lower := strings.ToLower(asset.Name)
 		if lower != "sha256sums" && lower != "sha256sums.txt" {
 			continue
 		}
-		value, err := fetchChecksumLine(asset.BrowserDownloadURL, assetName)
+		value, err := fetchChecksumLine(ctx, asset.BrowserDownloadURL, assetName)
 		if err == nil && value != "" {
 			return value, true
 		}
@@ -160,13 +164,17 @@ func selectGitHubReleaseChecksum(assetName string, assets []githubReleaseAsset) 
 	return "", false
 }
 
-func fetchChecksumLine(downloadURL, assetName string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+func fetchChecksumLine(ctx context.Context, downloadURL, assetName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Accept", "application/octet-stream")
-	resp, err := pluginHTTPClient.Do(req)
+	client, err := githubReleaseHTTPClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -190,4 +198,11 @@ func fetchChecksumLine(downloadURL, assetName string) (string, error) {
 		}
 	}
 	return "", errors.New("checksum not found")
+}
+
+func githubReleaseHTTPClient(ctx context.Context) (*http.Client, error) {
+	if pluginHTTPClient != nil {
+		return pluginHTTPClient, nil
+	}
+	return httpClientFromLaunchContext(ctx, 0)
 }

--- a/internal/plugin/http_test.go
+++ b/internal/plugin/http_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/testutil"
 	plugschema "github.com/bomly-dev/bomly-cli/sdk"
@@ -63,5 +64,28 @@ func TestInstallRemoteArchiveUsesConfiguredProxy(t *testing.T) {
 	}
 	if result.Manifest.ID != "acme.detector.proxy" {
 		t.Fatalf("installed id = %q", result.Manifest.ID)
+	}
+}
+
+func TestHTTPClientFromLaunchContextUsesSharedProvider(t *testing.T) {
+	provider, err := plugschema.NewHTTPClientProvider(plugschema.HTTPClientConfig{ProxyURL: "http://proxy.example:8080"})
+	if err != nil {
+		t.Fatalf("NewHTTPClientProvider() error = %v", err)
+	}
+	ctx := WithLaunchOptions(context.Background(), LaunchOptions{HTTPClientProvider: provider})
+
+	first, err := httpClientFromLaunchContext(ctx, 15*time.Second)
+	if err != nil {
+		t.Fatalf("httpClientFromLaunchContext() first error = %v", err)
+	}
+	second, err := httpClientFromLaunchContext(ctx, 30*time.Second)
+	if err != nil {
+		t.Fatalf("httpClientFromLaunchContext() second error = %v", err)
+	}
+	if first.Transport != second.Transport {
+		t.Fatalf("plugin launch clients do not share transport")
+	}
+	if first.Timeout != 15*time.Second || second.Timeout != 30*time.Second {
+		t.Fatalf("timeouts = %v/%v, want 15s/30s", first.Timeout, second.Timeout)
 	}
 }

--- a/internal/plugin/http_test.go
+++ b/internal/plugin/http_test.go
@@ -1,0 +1,67 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/testutil"
+	plugschema "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestInstallRemoteArchiveUsesConfiguredProxy(t *testing.T) {
+	root := t.TempDir()
+	binaryName := "bomly-plugin-proxy"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(t.TempDir(), binaryName)
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeDetectorPluginSource("acme.detector.proxy")); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+	manifest := withCanonicalManifestDefaults(Manifest{
+		ID:      "acme.detector.proxy",
+		Name:    "Acme Proxy Detector",
+		Version: "1.0.0",
+		Kind:    plugschema.PluginKindDetector,
+		Entrypoint: map[string]string{
+			platformKey(): filepath.ToSlash(filepath.Join("bin", filepath.Base(binaryPath))),
+		},
+		DetectorDescriptor: &plugschema.DetectorDescriptor{
+			Name:           "acme.detector.proxy",
+			Enabled:        true,
+			Origin:         plugschema.ExternalOrigin,
+			SupportedModes: []plugschema.TargetMode{plugschema.TargetModeFullGraph, plugschema.TargetModeComponent},
+			PackageManagerSupport: []plugschema.PackageManagerSupport{
+				plugschema.Support(plugschema.PackageManagerGoMod, "go.mod"),
+			},
+		},
+	}, "http://plugins.example/bomly-plugin-proxy"+archiveSuffix())
+	archiveBytes := buildPluginArchive(t, manifest, binaryPath)
+	checksum := checksumForBytes(archiveBytes)
+
+	proxyHits := 0
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHits++
+		if r.URL.Host != "plugins.example" {
+			t.Fatalf("proxy request host = %q", r.URL.Host)
+		}
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer proxy.Close()
+
+	ctx := WithLaunchOptions(context.Background(), LaunchOptions{HTTPProxy: proxy.URL})
+	result, err := Install(ctx, root, "http://plugins.example/bomly-plugin-proxy"+archiveSuffix(), InstallOptions{Checksum: checksum})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if proxyHits == 0 {
+		t.Fatalf("expected install download to use configured proxy")
+	}
+	if result.Manifest.ID != "acme.detector.proxy" {
+		t.Fatalf("installed id = %q", result.Manifest.ID)
+	}
+}

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/plugin/runtime/hashicorp"
 	plugschema "github.com/bomly-dev/bomly-cli/sdk"
@@ -135,7 +137,7 @@ func installDevBinary(ctx context.Context, tempDir, source string) (Manifest, st
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, binaryPath, metadata.Kind)
+	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, binaryPath, metadata.Kind, metadata.ID)
 	if err != nil {
 		return Manifest{}, "", err
 	}
@@ -169,7 +171,11 @@ func installRemoteArchive(ctx context.Context, tempDir, source string, opts Inst
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("create plugin download request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClientFromLaunchContext(ctx, 0)
+	if err != nil {
+		return Manifest{}, "", err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("download plugin archive: %w", err)
 	}
@@ -237,11 +243,11 @@ func installArchiveAtPath(ctx context.Context, tempDir, archivePath, source, exp
 	if _, err := os.Stat(fullEntrypoint); err != nil {
 		return Manifest{}, "", fmt.Errorf("plugin entrypoint %q is missing: %w", entry, err)
 	}
-	metadata, err := fetchRuntimeMetadata(ctx, fullEntrypoint)
+	metadata, err := fetchRuntimeMetadata(ctx, fullEntrypoint, manifest.ID)
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, fullEntrypoint, metadata.Kind)
+	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, fullEntrypoint, metadata.Kind, metadata.ID)
 	if err != nil {
 		return Manifest{}, "", err
 	}
@@ -425,8 +431,8 @@ func normalizeWindowsExecutableForLaunch(tempDir, binaryPath string) (string, er
 	return launchPath, nil
 }
 
-func fetchRuntimeMetadata(ctx context.Context, executable string) (*plugschema.PluginMetadata, error) {
-	client, err := startPlugin(ctx, executable)
+func fetchRuntimeMetadata(ctx context.Context, executable string, pluginID ...string) (*plugschema.PluginMetadata, error) {
+	client, err := startPlugin(ctx, executable, firstString(pluginID))
 	if err != nil {
 		return nil, err
 	}
@@ -438,8 +444,8 @@ func fetchRuntimeMetadata(ctx context.Context, executable string) (*plugschema.P
 	return metadata, nil
 }
 
-func fetchRuntimeDescriptors(ctx context.Context, executable string, kind plugschema.PluginKind) (*plugschema.DetectorDescriptor, []plugschema.PackageManagerSupport, *plugschema.MatcherDescriptor, *plugschema.AuditorDescriptor, error) {
-	client, err := startPlugin(ctx, executable)
+func fetchRuntimeDescriptors(ctx context.Context, executable string, kind plugschema.PluginKind, pluginID ...string) (*plugschema.DetectorDescriptor, []plugschema.PackageManagerSupport, *plugschema.MatcherDescriptor, *plugschema.AuditorDescriptor, error) {
+	client, err := startPlugin(ctx, executable, firstString(pluginID))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -464,15 +470,134 @@ func fetchRuntimeDescriptors(ctx context.Context, executable string, kind plugsc
 	}
 }
 
-func startPlugin(ctx context.Context, executable string) (*hashicorp.Client, error) {
-	options, _ := LaunchOptionsFromContext(ctx)
-	return hashicorp.Start(ctx, executable, pluginEnv(options), options.Verbosity)
+type runtimeClient struct {
+	client  *hashicorp.Client
+	cleanup func()
 }
 
-func pluginEnv(options LaunchOptions) []string {
+func (c *runtimeClient) Raw() plugschema.Client {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	return c.client.Raw()
+}
+
+func (c *runtimeClient) Close() {
+	if c == nil {
+		return
+	}
+	if c.client != nil {
+		c.client.Close()
+	}
+	if c.cleanup != nil {
+		c.cleanup()
+	}
+}
+
+func startPlugin(ctx context.Context, executable, pluginID string) (*runtimeClient, error) {
+	options, _ := LaunchOptionsFromContext(ctx)
+	env, cleanup, err := pluginEnv(options, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := hashicorp.Start(ctx, executable, env, options.Verbosity)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	return &runtimeClient{client: client, cleanup: cleanup}, nil
+}
+
+func pluginEnv(options LaunchOptions, pluginID string) ([]string, func(), error) {
 	env := []string{
 		EnvPluginAPIVersion + "=" + plugschema.PluginAPIVersion,
 		EnvPluginConfig + "=" + strings.TrimSpace(options.ConfigPath),
 	}
+	if strings.TrimSpace(pluginID) != "" {
+		env = append(env, plugschema.EnvPluginID+"="+strings.TrimSpace(pluginID))
+	}
+	env = append(env, proxyEnv(options)...)
+	cleanup := func() {}
+	if config, ok := options.PluginConfigs[strings.TrimSpace(pluginID)]; ok && config != nil {
+		path, remove, err := writePluginConfigFile(config)
+		if err != nil {
+			return nil, cleanup, err
+		}
+		cleanup = remove
+		env = append(env, plugschema.EnvPluginConfigFile+"="+path)
+	}
+	return env, cleanup, nil
+}
+
+func proxyEnv(options LaunchOptions) []string {
+	env := make([]string, 0, 8)
+	if proxy := strings.TrimSpace(options.HTTPProxy); proxy != "" {
+		env = append(env,
+			plugschema.EnvHTTPProxy+"="+proxy,
+			"HTTP_PROXY="+proxy,
+			"HTTPS_PROXY="+proxy,
+			"http_proxy="+proxy,
+			"https_proxy="+proxy,
+		)
+	} else {
+		env = appendExistingEnv(env, "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
+	}
+	if noProxy := strings.TrimSpace(options.HTTPNoProxy); noProxy != "" {
+		env = append(env,
+			plugschema.EnvHTTPNoProxy+"="+noProxy,
+			"NO_PROXY="+noProxy,
+			"no_proxy="+noProxy,
+		)
+	} else {
+		env = appendExistingEnv(env, "NO_PROXY", "no_proxy")
+	}
 	return env
+}
+
+func appendExistingEnv(env []string, names ...string) []string {
+	for _, name := range names {
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			continue
+		}
+		env = append(env, name+"="+value)
+	}
+	return env
+}
+
+func writePluginConfigFile(config map[string]any) (string, func(), error) {
+	file, err := os.CreateTemp("", "bomly-plugin-config-*.json")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create plugin config file: %w", err)
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(config); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("encode plugin config file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("close plugin config file: %w", err)
+	}
+	return path, cleanup, nil
+}
+
+func httpClientFromLaunchContext(ctx context.Context, timeout time.Duration) (*http.Client, error) {
+	options, _ := LaunchOptionsFromContext(ctx)
+	return plugschema.NewHTTPClient(plugschema.HTTPClientConfig{
+		ProxyURL: options.HTTPProxy,
+		NoProxy:  options.HTTPNoProxy,
+		Timeout:  timeout,
+	})
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -531,7 +532,9 @@ func pluginEnv(options LaunchOptions, pluginID string) ([]string, func(), error)
 
 func proxyEnv(options LaunchOptions) []string {
 	env := make([]string, 0, 8)
-	if proxy := strings.TrimSpace(options.HTTPProxy); proxy != "" {
+	proxyConfig := launchHTTPConfig(options, 0)
+	proxy, err := proxyConfig.EffectiveProxyURL()
+	if err == nil && strings.TrimSpace(proxy) != "" {
 		env = append(env,
 			plugschema.EnvHTTPProxy+"="+proxy,
 			"HTTP_PROXY="+proxy,
@@ -542,7 +545,7 @@ func proxyEnv(options LaunchOptions) []string {
 	} else {
 		env = appendExistingEnv(env, "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
 	}
-	if noProxy := strings.TrimSpace(options.HTTPNoProxy); noProxy != "" {
+	if noProxy := strings.TrimSpace(proxyConfig.NoProxy); noProxy != "" {
 		env = append(env,
 			plugschema.EnvHTTPNoProxy+"="+noProxy,
 			"NO_PROXY="+noProxy,
@@ -550,6 +553,29 @@ func proxyEnv(options LaunchOptions) []string {
 		)
 	} else {
 		env = appendExistingEnv(env, "NO_PROXY", "no_proxy")
+	}
+	env = appendProxyConfigEnv(env, options)
+	return env
+}
+
+func appendProxyConfigEnv(env []string, options LaunchOptions) []string {
+	if value := strings.TrimSpace(options.HTTPProxyType); value != "" {
+		env = append(env, plugschema.EnvHTTPProxyType+"="+value)
+	}
+	if value := strings.TrimSpace(options.HTTPProxyHost); value != "" {
+		env = append(env, plugschema.EnvHTTPProxyHost+"="+value)
+	}
+	if options.HTTPProxyPort > 0 {
+		env = append(env, plugschema.EnvHTTPProxyPort+"="+strconv.Itoa(options.HTTPProxyPort))
+	}
+	if value := strings.TrimSpace(options.HTTPProxyUsername); value != "" {
+		env = append(env, plugschema.EnvHTTPProxyUsername+"="+value)
+	}
+	if options.HTTPProxyPassword != "" {
+		env = append(env, plugschema.EnvHTTPProxyPassword+"="+options.HTTPProxyPassword)
+	}
+	if value := strings.TrimSpace(options.HTTPCACertFile); value != "" {
+		env = append(env, plugschema.EnvHTTPCACertFile+"="+value)
 	}
 	return env
 }
@@ -588,11 +614,21 @@ func writePluginConfigFile(config map[string]any) (string, func(), error) {
 
 func httpClientFromLaunchContext(ctx context.Context, timeout time.Duration) (*http.Client, error) {
 	options, _ := LaunchOptionsFromContext(ctx)
-	return plugschema.NewHTTPClient(plugschema.HTTPClientConfig{
-		ProxyURL: options.HTTPProxy,
-		NoProxy:  options.HTTPNoProxy,
-		Timeout:  timeout,
-	})
+	return plugschema.NewHTTPClient(launchHTTPConfig(options, timeout))
+}
+
+func launchHTTPConfig(options LaunchOptions, timeout time.Duration) plugschema.HTTPClientConfig {
+	return plugschema.HTTPClientConfig{
+		ProxyURL:      options.HTTPProxy,
+		NoProxy:       options.HTTPNoProxy,
+		ProxyType:     options.HTTPProxyType,
+		ProxyHost:     options.HTTPProxyHost,
+		ProxyPort:     options.HTTPProxyPort,
+		ProxyUsername: options.HTTPProxyUsername,
+		ProxyPassword: options.HTTPProxyPassword,
+		CACertFile:    options.HTTPCACertFile,
+		Timeout:       timeout,
+	}
 }
 
 func firstString(values []string) string {

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -614,7 +614,14 @@ func writePluginConfigFile(config map[string]any) (string, func(), error) {
 
 func httpClientFromLaunchContext(ctx context.Context, timeout time.Duration) (*http.Client, error) {
 	options, _ := LaunchOptionsFromContext(ctx)
-	return plugschema.NewHTTPClient(launchHTTPConfig(options, timeout))
+	if options.HTTPClientProvider != nil {
+		return options.HTTPClientProvider.Client(timeout), nil
+	}
+	provider, err := plugschema.NewHTTPClientProvider(launchHTTPConfig(options, 0))
+	if err != nil {
+		return nil, err
+	}
+	return provider.Client(timeout), nil
 }
 
 func launchHTTPConfig(options LaunchOptions, timeout time.Duration) plugschema.HTTPClientConfig {

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -73,7 +73,7 @@ func (d externalDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 
 func (d externalDetector) Ready() bool {
 	ctx := launchContext(context.Background(), d.launchCtx)
-	client, err := startPlugin(ctx, d.info.Entrypoint)
+	client, err := startPlugin(ctx, d.info.Entrypoint, d.info.ID)
 	if err != nil {
 		return false
 	}
@@ -87,7 +87,7 @@ func (d externalDetector) Ready() bool {
 
 func (d externalDetector) Applicable(ctx context.Context, req sdk.DetectionRequest) (bool, error) {
 	ctx = launchContext(ctx, d.launchCtx)
-	client, err := startPlugin(ctx, d.info.Entrypoint)
+	client, err := startPlugin(ctx, d.info.Entrypoint, d.info.ID)
 	if err != nil {
 		return false, err
 	}
@@ -101,7 +101,7 @@ func (d externalDetector) Applicable(ctx context.Context, req sdk.DetectionReque
 
 func (d externalDetector) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	ctx = launchContext(ctx, d.launchCtx)
-	client, err := startPlugin(ctx, d.info.Entrypoint)
+	client, err := startPlugin(ctx, d.info.Entrypoint, d.info.ID)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (d externalDetector) Install(ctx context.Context, req sdk.DetectionRequest)
 
 func (d externalDetector) ResolveGraph(ctx context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
 	ctx = launchContext(ctx, d.launchCtx)
-	client, err := startPlugin(ctx, d.info.Entrypoint)
+	client, err := startPlugin(ctx, d.info.Entrypoint, d.info.ID)
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
@@ -152,7 +152,7 @@ func (m externalMatcher) Descriptor() sdk.MatcherDescriptor {
 
 func (m externalMatcher) Ready() bool {
 	ctx := launchContext(context.Background(), m.launchCtx)
-	client, err := startPlugin(ctx, m.info.Entrypoint)
+	client, err := startPlugin(ctx, m.info.Entrypoint, m.info.ID)
 	if err != nil {
 		return false
 	}
@@ -163,7 +163,7 @@ func (m externalMatcher) Ready() bool {
 
 func (m externalMatcher) Applicable(ctx context.Context, req sdk.MatchRequest) (bool, error) {
 	ctx = launchContext(ctx, m.launchCtx)
-	client, err := startPlugin(ctx, m.info.Entrypoint)
+	client, err := startPlugin(ctx, m.info.Entrypoint, m.info.ID)
 	if err != nil {
 		return false, err
 	}
@@ -174,7 +174,7 @@ func (m externalMatcher) Applicable(ctx context.Context, req sdk.MatchRequest) (
 
 func (m externalMatcher) Match(ctx context.Context, req sdk.MatchRequest) (sdk.MatchResult, error) {
 	ctx = launchContext(ctx, m.launchCtx)
-	client, err := startPlugin(ctx, m.info.Entrypoint)
+	client, err := startPlugin(ctx, m.info.Entrypoint, m.info.ID)
 	if err != nil {
 		return sdk.MatchResult{}, err
 	}
@@ -211,7 +211,7 @@ func (a externalAuditor) Descriptor() sdk.AuditorDescriptor {
 
 func (a externalAuditor) Ready() bool {
 	ctx := launchContext(context.Background(), a.launchCtx)
-	client, err := startPlugin(ctx, a.info.Entrypoint)
+	client, err := startPlugin(ctx, a.info.Entrypoint, a.info.ID)
 	if err != nil {
 		return false
 	}
@@ -222,7 +222,7 @@ func (a externalAuditor) Ready() bool {
 
 func (a externalAuditor) Applicable(ctx context.Context, req sdk.AuditRequest) (bool, error) {
 	ctx = launchContext(ctx, a.launchCtx)
-	client, err := startPlugin(ctx, a.info.Entrypoint)
+	client, err := startPlugin(ctx, a.info.Entrypoint, a.info.ID)
 	if err != nil {
 		return false, err
 	}
@@ -233,7 +233,7 @@ func (a externalAuditor) Applicable(ctx context.Context, req sdk.AuditRequest) (
 
 func (a externalAuditor) Audit(ctx context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
 	ctx = launchContext(ctx, a.launchCtx)
-	client, err := startPlugin(ctx, a.info.Entrypoint)
+	client, err := startPlugin(ctx, a.info.Entrypoint, a.info.ID)
 	if err != nil {
 		return sdk.AuditResult{}, err
 	}

--- a/internal/plugin/test.go
+++ b/internal/plugin/test.go
@@ -64,7 +64,7 @@ func Test(ctx context.Context, root, id string, builtins []PluginInfo) (*TestRes
 	}
 	fullEntrypoint := filepath.Join(record.Path, entry)
 
-	client, err := startPlugin(launchContext(ctx, nil), fullEntrypoint)
+	client, err := startPlugin(launchContext(ctx, nil), fullEntrypoint, manifest.ID)
 	if err != nil {
 		return nil, fmt.Errorf("start plugin runtime for readiness probe: %w", err)
 	}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -30,17 +30,18 @@ const (
 
 // LaunchOptions carries launch context for managed external plugins.
 type LaunchOptions struct {
-	ConfigPath        string
-	Verbosity         int
-	HTTPProxy         string
-	HTTPNoProxy       string
-	HTTPProxyType     string
-	HTTPProxyHost     string
-	HTTPProxyPort     int
-	HTTPProxyUsername string
-	HTTPProxyPassword string
-	HTTPCACertFile    string
-	PluginConfigs     map[string]map[string]any
+	ConfigPath         string
+	Verbosity          int
+	HTTPProxy          string
+	HTTPNoProxy        string
+	HTTPProxyType      string
+	HTTPProxyHost      string
+	HTTPProxyPort      int
+	HTTPProxyUsername  string
+	HTTPProxyPassword  string
+	HTTPCACertFile     string
+	HTTPClientProvider *plugschema.HTTPClientProvider
+	PluginConfigs      map[string]map[string]any
 }
 
 type launchOptionsKey struct{}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -30,8 +30,11 @@ const (
 
 // LaunchOptions carries launch context for managed external plugins.
 type LaunchOptions struct {
-	ConfigPath string
-	Verbosity  int
+	ConfigPath    string
+	Verbosity     int
+	HTTPProxy     string
+	HTTPNoProxy   string
+	PluginConfigs map[string]map[string]any
 }
 
 type launchOptionsKey struct{}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -30,11 +30,17 @@ const (
 
 // LaunchOptions carries launch context for managed external plugins.
 type LaunchOptions struct {
-	ConfigPath    string
-	Verbosity     int
-	HTTPProxy     string
-	HTTPNoProxy   string
-	PluginConfigs map[string]map[string]any
+	ConfigPath        string
+	Verbosity         int
+	HTTPProxy         string
+	HTTPNoProxy       string
+	HTTPProxyType     string
+	HTTPProxyHost     string
+	HTTPProxyPort     int
+	HTTPProxyUsername string
+	HTTPProxyPassword string
+	HTTPCACertFile    string
+	PluginConfigs     map[string]map[string]any
 }
 
 type launchOptionsKey struct{}

--- a/internal/plugin/verify.go
+++ b/internal/plugin/verify.go
@@ -41,11 +41,11 @@ func Verify(ctx context.Context, root, id string) (*VerifyResult, error) {
 		}
 		checks = append(checks, "checksum matches")
 	}
-	metadata, err := fetchRuntimeMetadata(ctx, fullEntrypoint)
+	metadata, err := fetchRuntimeMetadata(ctx, fullEntrypoint, manifest.ID)
 	if err != nil {
 		return nil, err
 	}
-	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, fullEntrypoint, metadata.Kind)
+	detectorDescriptor, packageManagerSupport, matcherDescriptor, auditorDescriptor, err := fetchRuntimeDescriptors(ctx, fullEntrypoint, metadata.Kind, metadata.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -170,8 +169,7 @@ func (r *Registry) registerGrypeMatcher() {
 func (r *Registry) registerOSVMatcher() {
 	osvCfg := osvmatcher.DefaultConfig()
 	osvCfg.Logger = r.logger
-	osvCfg.Client = r.httpClient(30 * time.Second)
-	osvCfg.KEVClient = r.httpClient(15 * time.Second)
+	osvCfg.HTTPClientProvider = r.httpClientProvider()
 	if r.configs.OsvAPIBase != "" {
 		osvCfg.APIBase = r.configs.OsvAPIBase
 	}
@@ -209,7 +207,7 @@ func (r *Registry) registerOSVMatcher() {
 func (r *Registry) registerEOLMatcher() {
 	eolCfg := eol.DefaultConfig()
 	eolCfg.Logger = r.logger
-	eolCfg.Client = r.httpClient(15 * time.Second)
+	eolCfg.HTTPClientProvider = r.httpClientProvider()
 	if r.configs.EOLAPIBase != "" {
 		eolCfg.APIBase = r.configs.EOLAPIBase
 	}
@@ -241,7 +239,7 @@ func (r *Registry) registerEOLMatcher() {
 func (r *Registry) registerDepsDevMatcher() {
 	depsDevCfg := depsdev.DefaultConfig()
 	depsDevCfg.Logger = r.logger
-	depsDevCfg.Client = r.httpClient(20 * time.Second)
+	depsDevCfg.HTTPClientProvider = r.httpClientProvider()
 	depsDevChecker, err := depsdev.New(depsDevCfg)
 	if err != nil {
 		r.logger.Warn("deps.dev license checker unavailable", zap.Error(err))
@@ -270,9 +268,9 @@ func (r *Registry) registerScorecardMatcher() {
 		}
 	}
 	scoreCfg.ClientConfig = &scorecard.ClientConfig{
-		APIBase:    scoreCfg.APIBase,
-		Timeout:    15 * time.Second,
-		HTTPClient: r.httpClient(15 * time.Second),
+		APIBase:            scoreCfg.APIBase,
+		Timeout:            15 * time.Second,
+		HTTPClientProvider: r.httpClientProvider(),
 	}
 	scoreMatcher, err := scorecard.New(scoreCfg)
 	if err != nil {
@@ -292,7 +290,7 @@ func (r *Registry) registerScorecardMatcher() {
 func (r *Registry) registerClearlyDefinedMatcher() {
 	clearlyDefinedCfg := clearlydefined.DefaultConfig()
 	clearlyDefinedCfg.Logger = r.logger
-	clearlyDefinedCfg.Client = r.httpClient(20 * time.Second)
+	clearlyDefinedCfg.HTTPClientProvider = r.httpClientProvider()
 	clearlyDefinedChecker, err := clearlydefined.New(clearlyDefinedCfg)
 	if err != nil {
 		r.logger.Warn("ClearlyDefined license checker unavailable", zap.Error(err))
@@ -302,10 +300,6 @@ func (r *Registry) registerClearlyDefinedMatcher() {
 		}
 		r.logger.Debug("ClearlyDefined matcher configured")
 	}
-}
-
-func (r *Registry) httpClient(timeout time.Duration) *http.Client {
-	return r.httpClientProvider().Client(timeout)
 }
 
 func (r *Registry) httpClientProvider() *sdk.HTTPClientProvider {

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -76,6 +76,7 @@ type RegistryConfigs struct {
 	HTTPProxyUsername     string
 	HTTPProxyPassword     string
 	HTTPCACertFile        string
+	HTTPClientProvider    *sdk.HTTPClientProvider
 }
 
 // RegistryFilter narrows a registry down to the runtime-relevant selections.
@@ -114,6 +115,7 @@ type Registry struct {
 	matchers       []sdk.Matcher
 	analyzers      []sdk.Analyzer
 	discoveryPlans map[string]DetectorDiscoveryPlan
+	httpProvider   *sdk.HTTPClientProvider
 }
 
 // NewRegistry creates an empty registry.
@@ -122,6 +124,7 @@ func NewRegistry(configs RegistryConfigs, logger zap.Logger) *Registry {
 		logger:         &logger,
 		configs:        configs,
 		discoveryPlans: make(map[string]DetectorDiscoveryPlan),
+		httpProvider:   configs.HTTPClientProvider,
 	}
 }
 
@@ -302,7 +305,14 @@ func (r *Registry) registerClearlyDefinedMatcher() {
 }
 
 func (r *Registry) httpClient(timeout time.Duration) *http.Client {
-	client, err := sdk.NewHTTPClient(sdk.HTTPClientConfig{
+	return r.httpClientProvider().Client(timeout)
+}
+
+func (r *Registry) httpClientProvider() *sdk.HTTPClientProvider {
+	if r.httpProvider != nil {
+		return r.httpProvider
+	}
+	provider, err := sdk.NewHTTPClientProvider(sdk.HTTPClientConfig{
 		ProxyURL:      r.configs.HTTPProxy,
 		NoProxy:       r.configs.HTTPNoProxy,
 		ProxyType:     r.configs.HTTPProxyType,
@@ -311,14 +321,13 @@ func (r *Registry) httpClient(timeout time.Duration) *http.Client {
 		ProxyUsername: r.configs.HTTPProxyUsername,
 		ProxyPassword: r.configs.HTTPProxyPassword,
 		CACertFile:    r.configs.HTTPCACertFile,
-		Timeout:       timeout,
 	})
-	if err == nil {
-		return client
+	if err != nil {
+		r.logger.Warn("http client proxy configuration invalid; using environment defaults", zap.Error(err))
+		provider, _ = sdk.NewHTTPClientProvider(sdk.HTTPClientConfig{})
 	}
-	r.logger.Warn("http client proxy configuration invalid; using environment defaults", zap.Error(err))
-	fallback, _ := sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: timeout})
-	return fallback
+	r.httpProvider = provider
+	return r.httpProvider
 }
 
 // RegisterMatcher adds a matcher to the registry.
@@ -631,6 +640,7 @@ func (r *Registry) DiscoveryPlans() map[string]DetectorDiscoveryPlan {
 // matcher, and ecosystem selections.
 func (r *Registry) Filter(filter RegistryFilter) *Registry {
 	filtered := NewRegistry(r.configs, *r.logger)
+	filtered.httpProvider = r.httpProvider
 
 	allowedDetectors := make(map[string]struct{}, len(r.detectors))
 	for _, detector := range r.detectors {

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -70,6 +70,12 @@ type RegistryConfigs struct {
 	ScorecardCacheTTL     string
 	HTTPProxy             string
 	HTTPNoProxy           string
+	HTTPProxyType         string
+	HTTPProxyHost         string
+	HTTPProxyPort         int
+	HTTPProxyUsername     string
+	HTTPProxyPassword     string
+	HTTPCACertFile        string
 }
 
 // RegistryFilter narrows a registry down to the runtime-relevant selections.
@@ -297,9 +303,15 @@ func (r *Registry) registerClearlyDefinedMatcher() {
 
 func (r *Registry) httpClient(timeout time.Duration) *http.Client {
 	client, err := sdk.NewHTTPClient(sdk.HTTPClientConfig{
-		ProxyURL: r.configs.HTTPProxy,
-		NoProxy:  r.configs.HTTPNoProxy,
-		Timeout:  timeout,
+		ProxyURL:      r.configs.HTTPProxy,
+		NoProxy:       r.configs.HTTPNoProxy,
+		ProxyType:     r.configs.HTTPProxyType,
+		ProxyHost:     r.configs.HTTPProxyHost,
+		ProxyPort:     r.configs.HTTPProxyPort,
+		ProxyUsername: r.configs.HTTPProxyUsername,
+		ProxyPassword: r.configs.HTTPProxyPassword,
+		CACertFile:    r.configs.HTTPCACertFile,
+		Timeout:       timeout,
 	})
 	if err == nil {
 		return client

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -67,6 +68,8 @@ type RegistryConfigs struct {
 	ScorecardAPIBase      string
 	ScorecardCacheDir     string
 	ScorecardCacheTTL     string
+	HTTPProxy             string
+	HTTPNoProxy           string
 }
 
 // RegistryFilter narrows a registry down to the runtime-relevant selections.
@@ -158,6 +161,8 @@ func (r *Registry) registerGrypeMatcher() {
 func (r *Registry) registerOSVMatcher() {
 	osvCfg := osvmatcher.DefaultConfig()
 	osvCfg.Logger = r.logger
+	osvCfg.Client = r.httpClient(30 * time.Second)
+	osvCfg.KEVClient = r.httpClient(15 * time.Second)
 	if r.configs.OsvAPIBase != "" {
 		osvCfg.APIBase = r.configs.OsvAPIBase
 	}
@@ -195,6 +200,7 @@ func (r *Registry) registerOSVMatcher() {
 func (r *Registry) registerEOLMatcher() {
 	eolCfg := eol.DefaultConfig()
 	eolCfg.Logger = r.logger
+	eolCfg.Client = r.httpClient(15 * time.Second)
 	if r.configs.EOLAPIBase != "" {
 		eolCfg.APIBase = r.configs.EOLAPIBase
 	}
@@ -226,6 +232,7 @@ func (r *Registry) registerEOLMatcher() {
 func (r *Registry) registerDepsDevMatcher() {
 	depsDevCfg := depsdev.DefaultConfig()
 	depsDevCfg.Logger = r.logger
+	depsDevCfg.Client = r.httpClient(20 * time.Second)
 	depsDevChecker, err := depsdev.New(depsDevCfg)
 	if err != nil {
 		r.logger.Warn("deps.dev license checker unavailable", zap.Error(err))
@@ -253,6 +260,11 @@ func (r *Registry) registerScorecardMatcher() {
 			r.logger.Warn("scorecard: invalid cache_ttl; using default", zap.String("value", r.configs.ScorecardCacheTTL), zap.Error(err))
 		}
 	}
+	scoreCfg.ClientConfig = &scorecard.ClientConfig{
+		APIBase:    scoreCfg.APIBase,
+		Timeout:    15 * time.Second,
+		HTTPClient: r.httpClient(15 * time.Second),
+	}
 	scoreMatcher, err := scorecard.New(scoreCfg)
 	if err != nil {
 		r.logger.Warn("scorecard matcher unavailable", zap.Error(err))
@@ -271,6 +283,7 @@ func (r *Registry) registerScorecardMatcher() {
 func (r *Registry) registerClearlyDefinedMatcher() {
 	clearlyDefinedCfg := clearlydefined.DefaultConfig()
 	clearlyDefinedCfg.Logger = r.logger
+	clearlyDefinedCfg.Client = r.httpClient(20 * time.Second)
 	clearlyDefinedChecker, err := clearlydefined.New(clearlyDefinedCfg)
 	if err != nil {
 		r.logger.Warn("ClearlyDefined license checker unavailable", zap.Error(err))
@@ -280,6 +293,20 @@ func (r *Registry) registerClearlyDefinedMatcher() {
 		}
 		r.logger.Debug("ClearlyDefined matcher configured")
 	}
+}
+
+func (r *Registry) httpClient(timeout time.Duration) *http.Client {
+	client, err := sdk.NewHTTPClient(sdk.HTTPClientConfig{
+		ProxyURL: r.configs.HTTPProxy,
+		NoProxy:  r.configs.HTTPNoProxy,
+		Timeout:  timeout,
+	})
+	if err == nil {
+		return client
+	}
+	r.logger.Warn("http client proxy configuration invalid; using environment defaults", zap.Error(err))
+	fallback, _ := sdk.NewHTTPClient(sdk.HTTPClientConfig{Timeout: timeout})
+	return fallback
 }
 
 // RegisterMatcher adds a matcher to the registry.

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
@@ -119,5 +120,18 @@ func TestBuildScanRegistryRegistersBuiltInMatchers(t *testing.T) {
 		if origin != sdk.CoreOrigin {
 			t.Fatalf("expected matcher %q to be core origin, got %q", name, origin)
 		}
+	}
+}
+
+func TestRegistryHTTPClientProviderReusesTransport(t *testing.T) {
+	builtins := NewRegistry(RegistryConfigs{HTTPProxy: "http://proxy.example:8080"}, *zap.NewNop())
+
+	first := builtins.httpClient(15 * time.Second)
+	second := builtins.httpClient(30 * time.Second)
+	if first.Transport != second.Transport {
+		t.Fatalf("registry clients do not share transport")
+	}
+	if first.Timeout != 15*time.Second || second.Timeout != 30*time.Second {
+		t.Fatalf("timeouts = %v/%v, want 15s/30s", first.Timeout, second.Timeout)
 	}
 }

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -126,8 +126,9 @@ func TestBuildScanRegistryRegistersBuiltInMatchers(t *testing.T) {
 func TestRegistryHTTPClientProviderReusesTransport(t *testing.T) {
 	builtins := NewRegistry(RegistryConfigs{HTTPProxy: "http://proxy.example:8080"}, *zap.NewNop())
 
-	first := builtins.httpClient(15 * time.Second)
-	second := builtins.httpClient(30 * time.Second)
+	provider := builtins.httpClientProvider()
+	first := provider.Client(15 * time.Second)
+	second := provider.Client(30 * time.Second)
 	if first.Transport != second.Transport {
 		t.Fatalf("registry clients do not share transport")
 	}

--- a/internal/support/config_reference.go
+++ b/internal/support/config_reference.go
@@ -219,6 +219,8 @@ func renderConfigMarkdown(fields []configField) string {
 					value = "\"\""
 				case "[]string":
 					value = "[]"
+				case "map[string]any", "map[string]map[string]any":
+					value = "{}"
 				default:
 					value = "\"\""
 				}
@@ -238,6 +240,8 @@ func configTypeString(expr ast.Expr) string {
 		return typed.Name
 	case *ast.ArrayType:
 		return "[]" + configTypeString(typed.Elt)
+	case *ast.MapType:
+		return "map[" + configTypeString(typed.Key) + "]" + configTypeString(typed.Value)
 	case *ast.StarExpr:
 		return "*" + configTypeString(typed.X)
 	case *ast.SelectorExpr:

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -52,6 +52,12 @@ type HTTPClientConfig struct {
 	Timeout       time.Duration
 }
 
+// HTTPClientProvider owns reusable HTTP transport state for one Bomly execution.
+type HTTPClientProvider struct {
+	transport      *http.Transport
+	defaultTimeout time.Duration
+}
+
 // HTTPClientConfigFromEnv returns Bomly-specific HTTP client settings from
 // environment variables. Standard HTTP_PROXY, HTTPS_PROXY, and NO_PROXY are
 // still honored by NewHTTPClient when Bomly-specific values are absent.
@@ -69,9 +75,10 @@ func HTTPClientConfigFromEnv() HTTPClientConfig {
 	}
 }
 
-// NewHTTPClient creates an outbound HTTP client using Go's default transport
-// behavior plus Bomly's proxy configuration.
-func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
+// NewHTTPClientProvider creates an HTTP client provider with a reusable
+// transport. Call Client to create timeout-specific clients that share
+// connection pools and TLS/proxy settings.
+func NewHTTPClientProvider(config HTTPClientConfig) (*HTTPClientProvider, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	proxy, err := proxyFunc(config)
 	if err != nil {
@@ -85,10 +92,50 @@ func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
 		}
 		transport.TLSClientConfig = tlsConfig
 	}
-	return &http.Client{
-		Transport: transport,
-		Timeout:   config.Timeout,
+	return &HTTPClientProvider{
+		transport:      transport,
+		defaultTimeout: config.Timeout,
 	}, nil
+}
+
+// NewHTTPClientProviderFromEnv creates a provider from Bomly HTTP environment
+// variables, with standard proxy environment variables honored as fallback.
+func NewHTTPClientProviderFromEnv() (*HTTPClientProvider, error) {
+	return NewHTTPClientProvider(HTTPClientConfigFromEnv())
+}
+
+// Client returns an HTTP client with the requested timeout. A zero timeout uses
+// the provider's configured default timeout.
+func (p *HTTPClientProvider) Client(timeout time.Duration) *http.Client {
+	if p == nil {
+		client, _ := NewHTTPClient(HTTPClientConfig{Timeout: timeout})
+		return client
+	}
+	if timeout == 0 {
+		timeout = p.defaultTimeout
+	}
+	return &http.Client{
+		Transport: p.transport,
+		Timeout:   timeout,
+	}
+}
+
+// CloseIdleConnections closes idle connections held by the provider transport.
+func (p *HTTPClientProvider) CloseIdleConnections() {
+	if p == nil || p.transport == nil {
+		return
+	}
+	p.transport.CloseIdleConnections()
+}
+
+// NewHTTPClient creates an outbound HTTP client using Go's default transport
+// behavior plus Bomly's proxy configuration.
+func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
+	provider, err := NewHTTPClientProvider(config)
+	if err != nil {
+		return nil, err
+	}
+	return provider.Client(config.Timeout), nil
 }
 
 func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), error) {

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -1,0 +1,111 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+const (
+	// EnvHTTPProxy is Bomly's explicit outbound HTTP proxy environment variable.
+	EnvHTTPProxy = "BOMLY_HTTP_PROXY"
+	// EnvHTTPNoProxy is Bomly's explicit proxy bypass list environment variable.
+	EnvHTTPNoProxy = "BOMLY_HTTP_NO_PROXY"
+	// EnvPluginConfigFile points external plugins at their per-plugin JSON config.
+	EnvPluginConfigFile = "BOMLY_PLUGIN_CONFIG_FILE"
+	// EnvPluginID identifies the managed plugin currently being executed.
+	EnvPluginID = "BOMLY_PLUGIN_ID"
+)
+
+// HTTPClientConfig configures Bomly's shared outbound HTTP client.
+type HTTPClientConfig struct {
+	ProxyURL string
+	NoProxy  string
+	Timeout  time.Duration
+}
+
+// HTTPClientConfigFromEnv returns Bomly-specific HTTP client settings from
+// environment variables. Standard HTTP_PROXY, HTTPS_PROXY, and NO_PROXY are
+// still honored by NewHTTPClient when Bomly-specific values are absent.
+func HTTPClientConfigFromEnv() HTTPClientConfig {
+	return HTTPClientConfig{
+		ProxyURL: strings.TrimSpace(os.Getenv(EnvHTTPProxy)),
+		NoProxy:  strings.TrimSpace(os.Getenv(EnvHTTPNoProxy)),
+	}
+}
+
+// NewHTTPClient creates an outbound HTTP client using Go's default transport
+// behavior plus Bomly's proxy configuration.
+func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	proxy, err := proxyFunc(config)
+	if err != nil {
+		return nil, err
+	}
+	transport.Proxy = proxy
+	return &http.Client{
+		Transport: transport,
+		Timeout:   config.Timeout,
+	}, nil
+}
+
+func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), error) {
+	proxyURL := strings.TrimSpace(config.ProxyURL)
+	noProxy := strings.TrimSpace(config.NoProxy)
+	if proxyURL == "" {
+		return http.ProxyFromEnvironment, nil
+	}
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse proxy URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("proxy URL must be absolute")
+	}
+	urlProxy := (&httpproxy.Config{
+		HTTPProxy:  proxyURL,
+		HTTPSProxy: proxyURL,
+		NoProxy:    noProxy,
+	}).ProxyFunc()
+	return func(req *http.Request) (*url.URL, error) {
+		return urlProxy(req.URL)
+	}, nil
+}
+
+// RawPluginConfigFromEnv reads the per-plugin JSON config file named by
+// BOMLY_PLUGIN_CONFIG_FILE. It returns nil when no plugin config file is set.
+func RawPluginConfigFromEnv() ([]byte, error) {
+	path := strings.TrimSpace(os.Getenv(EnvPluginConfigFile))
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin config: %w", err)
+	}
+	return data, nil
+}
+
+// DecodePluginConfigFromEnv decodes the per-plugin JSON config file into target.
+func DecodePluginConfigFromEnv(target any) error {
+	data, err := RawPluginConfigFromEnv()
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if target == nil {
+		return fmt.Errorf("plugin config target is nil")
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("decode plugin config: %w", err)
+	}
+	return nil
+}

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -1,11 +1,15 @@
 package sdk
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +21,18 @@ const (
 	EnvHTTPProxy = "BOMLY_HTTP_PROXY"
 	// EnvHTTPNoProxy is Bomly's explicit proxy bypass list environment variable.
 	EnvHTTPNoProxy = "BOMLY_HTTP_NO_PROXY"
+	// EnvHTTPProxyType is Bomly's explicit outbound proxy type.
+	EnvHTTPProxyType = "BOMLY_HTTP_PROXY_TYPE"
+	// EnvHTTPProxyHost is Bomly's explicit outbound proxy host.
+	EnvHTTPProxyHost = "BOMLY_HTTP_PROXY_HOST"
+	// EnvHTTPProxyPort is Bomly's explicit outbound proxy port.
+	EnvHTTPProxyPort = "BOMLY_HTTP_PROXY_PORT"
+	// EnvHTTPProxyUsername is Bomly's explicit outbound proxy username.
+	EnvHTTPProxyUsername = "BOMLY_HTTP_PROXY_USERNAME"
+	// EnvHTTPProxyPassword is Bomly's explicit outbound proxy password.
+	EnvHTTPProxyPassword = "BOMLY_HTTP_PROXY_PASSWORD"
+	// EnvHTTPCACertFile points to an additional PEM certificate chain for outbound HTTPS.
+	EnvHTTPCACertFile = "BOMLY_HTTP_CA_CERT_FILE"
 	// EnvPluginConfigFile points external plugins at their per-plugin JSON config.
 	EnvPluginConfigFile = "BOMLY_PLUGIN_CONFIG_FILE"
 	// EnvPluginID identifies the managed plugin currently being executed.
@@ -25,18 +41,31 @@ const (
 
 // HTTPClientConfig configures Bomly's shared outbound HTTP client.
 type HTTPClientConfig struct {
-	ProxyURL string
-	NoProxy  string
-	Timeout  time.Duration
+	ProxyURL      string
+	NoProxy       string
+	ProxyType     string
+	ProxyHost     string
+	ProxyPort     int
+	ProxyUsername string
+	ProxyPassword string
+	CACertFile    string
+	Timeout       time.Duration
 }
 
 // HTTPClientConfigFromEnv returns Bomly-specific HTTP client settings from
 // environment variables. Standard HTTP_PROXY, HTTPS_PROXY, and NO_PROXY are
 // still honored by NewHTTPClient when Bomly-specific values are absent.
 func HTTPClientConfigFromEnv() HTTPClientConfig {
+	port, _ := strconv.Atoi(strings.TrimSpace(os.Getenv(EnvHTTPProxyPort)))
 	return HTTPClientConfig{
-		ProxyURL: strings.TrimSpace(os.Getenv(EnvHTTPProxy)),
-		NoProxy:  strings.TrimSpace(os.Getenv(EnvHTTPNoProxy)),
+		ProxyURL:      strings.TrimSpace(os.Getenv(EnvHTTPProxy)),
+		NoProxy:       strings.TrimSpace(os.Getenv(EnvHTTPNoProxy)),
+		ProxyType:     strings.TrimSpace(os.Getenv(EnvHTTPProxyType)),
+		ProxyHost:     strings.TrimSpace(os.Getenv(EnvHTTPProxyHost)),
+		ProxyPort:     port,
+		ProxyUsername: strings.TrimSpace(os.Getenv(EnvHTTPProxyUsername)),
+		ProxyPassword: os.Getenv(EnvHTTPProxyPassword),
+		CACertFile:    strings.TrimSpace(os.Getenv(EnvHTTPCACertFile)),
 	}
 }
 
@@ -49,6 +78,13 @@ func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
 		return nil, err
 	}
 	transport.Proxy = proxy
+	if strings.TrimSpace(config.CACertFile) != "" {
+		tlsConfig, err := tlsConfigWithCACert(config.CACertFile)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
 	return &http.Client{
 		Transport: transport,
 		Timeout:   config.Timeout,
@@ -56,7 +92,10 @@ func NewHTTPClient(config HTTPClientConfig) (*http.Client, error) {
 }
 
 func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), error) {
-	proxyURL := strings.TrimSpace(config.ProxyURL)
+	proxyURL, err := resolvedProxyURL(config)
+	if err != nil {
+		return nil, err
+	}
 	noProxy := strings.TrimSpace(config.NoProxy)
 	if proxyURL == "" {
 		return http.ProxyFromEnvironment, nil
@@ -76,6 +115,90 @@ func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), 
 	return func(req *http.Request) (*url.URL, error) {
 		return urlProxy(req.URL)
 	}, nil
+}
+
+// EffectiveProxyURL returns the effective proxy URL after applying Bomly's URL or
+// decomposed proxy settings. It does not inspect standard proxy environment
+// variables.
+func (config HTTPClientConfig) EffectiveProxyURL() (string, error) {
+	return resolvedProxyURL(config)
+}
+
+func resolvedProxyURL(config HTTPClientConfig) (string, error) {
+	if proxyURL := strings.TrimSpace(config.ProxyURL); proxyURL != "" {
+		if err := validateProxyURL(proxyURL); err != nil {
+			return "", err
+		}
+		return proxyURL, nil
+	}
+	if strings.TrimSpace(config.ProxyHost) == "" {
+		return "", nil
+	}
+	if config.ProxyPort <= 0 || config.ProxyPort > 65535 {
+		return "", fmt.Errorf("proxy port must be between 1 and 65535")
+	}
+	scheme, err := proxyScheme(config.ProxyType)
+	if err != nil {
+		return "", err
+	}
+	parsed := &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(strings.TrimSpace(config.ProxyHost), strconv.Itoa(config.ProxyPort)),
+	}
+	username := strings.TrimSpace(config.ProxyUsername)
+	if username != "" {
+		if config.ProxyPassword != "" {
+			parsed.User = url.UserPassword(username, config.ProxyPassword)
+		} else {
+			parsed.User = url.User(username)
+		}
+	}
+	return parsed.String(), nil
+}
+
+func proxyScheme(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "http":
+		return "http", nil
+	case "https":
+		return "https", nil
+	case "socks", "socks5":
+		return "socks5", nil
+	default:
+		return "", fmt.Errorf("proxy type %q is unsupported (accepted: http, https, socks5)", value)
+	}
+}
+
+func validateProxyURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("parse proxy URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("proxy URL must be absolute")
+	}
+	if _, err := proxyScheme(parsed.Scheme); err != nil {
+		return err
+	}
+	return nil
+}
+
+func tlsConfigWithCACert(path string) (*tls.Config, error) {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return nil, fmt.Errorf("read HTTP CA certificate file: %w", err)
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if ok := pool.AppendCertsFromPEM(data); !ok {
+		return nil, fmt.Errorf("HTTP CA certificate file does not contain any PEM certificates")
+	}
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}, nil
 }
 
 // RawPluginConfigFromEnv reads the per-plugin JSON config file named by

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -1,0 +1,112 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPClientExplicitProxy(t *testing.T) {
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://proxy.example:8080",
+		Timeout:  3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	if client.Timeout != 3*time.Second {
+		t.Fatalf("Timeout = %v, want 3s", client.Timeout)
+	}
+	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
+	if proxyURL == nil || proxyURL.String() != "http://proxy.example:8080" {
+		t.Fatalf("proxy = %v, want http://proxy.example:8080", proxyURL)
+	}
+}
+
+func TestNewHTTPClientNoProxyBypass(t *testing.T) {
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://proxy.example:8080",
+		NoProxy:  ".corp.example",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	if proxyURL := proxyForRequest(t, client, "http://service.corp.example/v1"); proxyURL != nil {
+		t.Fatalf("proxy = %v, want bypass", proxyURL)
+	}
+}
+
+func TestNewHTTPClientRejectsInvalidProxy(t *testing.T) {
+	if _, err := NewHTTPClient(HTTPClientConfig{ProxyURL: "proxy.example:8080"}); err == nil {
+		t.Fatal("NewHTTPClient() error = nil, want invalid proxy error")
+	}
+}
+
+func TestHTTPClientConfigFromEnvAndStandardFallback(t *testing.T) {
+	t.Setenv(EnvHTTPProxy, "http://bomly-proxy.example:8080")
+	t.Setenv(EnvHTTPNoProxy, "internal.example")
+	cfg := HTTPClientConfigFromEnv()
+	if cfg.ProxyURL != "http://bomly-proxy.example:8080" {
+		t.Fatalf("ProxyURL = %q", cfg.ProxyURL)
+	}
+	if cfg.NoProxy != "internal.example" {
+		t.Fatalf("NoProxy = %q", cfg.NoProxy)
+	}
+
+	t.Setenv(EnvHTTPProxy, "")
+	t.Setenv(EnvHTTPNoProxy, "")
+	t.Setenv("HTTP_PROXY", "http://standard-proxy.example:8080")
+	client, err := NewHTTPClient(HTTPClientConfigFromEnv())
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
+	if proxyURL == nil || proxyURL.String() != "http://standard-proxy.example:8080" {
+		t.Fatalf("proxy = %v, want standard env proxy", proxyURL)
+	}
+}
+
+func TestDecodePluginConfigFromEnv(t *testing.T) {
+	type pluginConfig struct {
+		APIBase string `json:"api_base"`
+		Enabled bool   `json:"enabled"`
+	}
+	path := filepath.Join(t.TempDir(), "config.json")
+	data, err := json.Marshal(map[string]any{"api_base": "https://api.example.com", "enabled": true})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvPluginConfigFile, path)
+
+	var cfg pluginConfig
+	if err := DecodePluginConfigFromEnv(&cfg); err != nil {
+		t.Fatalf("DecodePluginConfigFromEnv() error = %v", err)
+	}
+	if cfg.APIBase != "https://api.example.com" || !cfg.Enabled {
+		t.Fatalf("decoded config = %#v", cfg)
+	}
+}
+
+func proxyForRequest(t *testing.T, client *http.Client, rawURL string) *url.URL {
+	t.Helper()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || transport.Proxy == nil {
+		t.Fatalf("client transport proxy unavailable")
+	}
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy func error = %v", err)
+	}
+	return proxyURL
+}

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -65,6 +65,29 @@ func TestNewHTTPClientBuildsProxyFromHostPort(t *testing.T) {
 	}
 }
 
+func TestHTTPClientProviderReusesTransportWithPerClientTimeouts(t *testing.T) {
+	provider, err := NewHTTPClientProvider(HTTPClientConfig{
+		ProxyURL: "http://proxy.example:8080",
+		Timeout:  7 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClientProvider() error = %v", err)
+	}
+	first := provider.Client(3 * time.Second)
+	second := provider.Client(5 * time.Second)
+	defaultTimeout := provider.Client(0)
+	if first.Transport != second.Transport || first.Transport != defaultTimeout.Transport {
+		t.Fatalf("provider clients do not share transport")
+	}
+	if first.Timeout != 3*time.Second || second.Timeout != 5*time.Second || defaultTimeout.Timeout != 7*time.Second {
+		t.Fatalf("timeouts = %v/%v/%v, want 3s/5s/7s", first.Timeout, second.Timeout, defaultTimeout.Timeout)
+	}
+	proxyURL := proxyForRequest(t, second, "http://service.example/v1")
+	if proxyURL == nil || proxyURL.String() != "http://proxy.example:8080" {
+		t.Fatalf("proxy = %v, want http://proxy.example:8080", proxyURL)
+	}
+}
+
 func TestNewHTTPClientRejectsHostWithoutPort(t *testing.T) {
 	if _, err := NewHTTPClient(HTTPClientConfig{ProxyHost: "proxy.example"}); err == nil {
 		t.Fatal("NewHTTPClient() error = nil, want missing port error")

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -40,15 +40,62 @@ func TestNewHTTPClientNoProxyBypass(t *testing.T) {
 	}
 }
 
+func TestNewHTTPClientBuildsProxyFromHostPort(t *testing.T) {
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyType:     "socks5",
+		ProxyHost:     "proxy.example",
+		ProxyPort:     1080,
+		ProxyUsername: "user@example.com",
+		ProxyPassword: "p@ss word",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
+	if proxyURL == nil {
+		t.Fatal("proxy = nil, want socks5 proxy")
+	}
+	if proxyURL.Scheme != "socks5" || proxyURL.Host != "proxy.example:1080" {
+		t.Fatalf("proxy = %v, want socks5://proxy.example:1080", proxyURL)
+	}
+	username := proxyURL.User.Username()
+	password, _ := proxyURL.User.Password()
+	if username != "user@example.com" || password != "p@ss word" {
+		t.Fatalf("proxy credentials = %q/%q", username, password)
+	}
+}
+
+func TestNewHTTPClientRejectsHostWithoutPort(t *testing.T) {
+	if _, err := NewHTTPClient(HTTPClientConfig{ProxyHost: "proxy.example"}); err == nil {
+		t.Fatal("NewHTTPClient() error = nil, want missing port error")
+	}
+}
+
 func TestNewHTTPClientRejectsInvalidProxy(t *testing.T) {
 	if _, err := NewHTTPClient(HTTPClientConfig{ProxyURL: "proxy.example:8080"}); err == nil {
 		t.Fatal("NewHTTPClient() error = nil, want invalid proxy error")
 	}
 }
 
+func TestNewHTTPClientRejectsInvalidCACertFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(path, []byte("not a cert"), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if _, err := NewHTTPClient(HTTPClientConfig{CACertFile: path}); err == nil {
+		t.Fatal("NewHTTPClient() error = nil, want invalid CA cert error")
+	}
+}
+
 func TestHTTPClientConfigFromEnvAndStandardFallback(t *testing.T) {
 	t.Setenv(EnvHTTPProxy, "http://bomly-proxy.example:8080")
 	t.Setenv(EnvHTTPNoProxy, "internal.example")
+	t.Setenv(EnvHTTPProxyType, "socks5")
+	t.Setenv(EnvHTTPProxyHost, "host.example")
+	t.Setenv(EnvHTTPProxyPort, "1080")
+	t.Setenv(EnvHTTPProxyUsername, "agent")
+	t.Setenv(EnvHTTPProxyPassword, "secret")
+	t.Setenv(EnvHTTPCACertFile, "/tmp/ca.pem")
 	cfg := HTTPClientConfigFromEnv()
 	if cfg.ProxyURL != "http://bomly-proxy.example:8080" {
 		t.Fatalf("ProxyURL = %q", cfg.ProxyURL)
@@ -56,9 +103,21 @@ func TestHTTPClientConfigFromEnvAndStandardFallback(t *testing.T) {
 	if cfg.NoProxy != "internal.example" {
 		t.Fatalf("NoProxy = %q", cfg.NoProxy)
 	}
+	if cfg.ProxyType != "socks5" || cfg.ProxyHost != "host.example" || cfg.ProxyPort != 1080 {
+		t.Fatalf("decomposed proxy config = %#v", cfg)
+	}
+	if cfg.ProxyUsername != "agent" || cfg.ProxyPassword != "secret" || cfg.CACertFile != "/tmp/ca.pem" {
+		t.Fatalf("proxy auth/cert config = %#v", cfg)
+	}
 
 	t.Setenv(EnvHTTPProxy, "")
 	t.Setenv(EnvHTTPNoProxy, "")
+	t.Setenv(EnvHTTPProxyType, "")
+	t.Setenv(EnvHTTPProxyHost, "")
+	t.Setenv(EnvHTTPProxyPort, "")
+	t.Setenv(EnvHTTPProxyUsername, "")
+	t.Setenv(EnvHTTPProxyPassword, "")
+	t.Setenv(EnvHTTPCACertFile, "")
 	t.Setenv("HTTP_PROXY", "http://standard-proxy.example:8080")
 	client, err := NewHTTPClient(HTTPClientConfigFromEnv())
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add public SDK helpers for proxy-aware HTTP clients, including a reusable per-execution `HTTPClientProvider` for shared transport/connection pooling with per-client timeouts.
- Add SDK helpers for per-plugin config decoding.
- Add `http_proxy`, `http_no_proxy`, `plugins`, and decomposed proxy configuration fields (`http_proxy_type`, `http_proxy_host`, `http_proxy_port`, username/password, and CA cert file).
- Support direct proxy URLs and host/port proxy definitions similar to enterprise SCA agent configuration models.
- Wire shared HTTP client providers through enrichment matchers and plugin install/release download paths.
- Forward proxy settings and per-plugin JSON config files to managed plugin subprocesses; SDK plugins can create their own process-local provider from env.
- Update plugin docs, config reference generation, and the example plugin.

## Validation

- `make generate`
- `make test`
- Pre-commit on initial commit: `go run ./internal/tools/gofmtcheck`
- Pre-commit on initial commit: `golangci-lint run`