### PR TITLE
Redact proxy and plugin config secrets

### DIFF
--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -1771,6 +1771,62 @@ func TestRoot_StartupLogsResolvedOptionsWhenVerbose(t *testing.T) {
 	}
 }
 
+func TestRoot_StartupLogsDoNotExposeHTTPAndPluginSecrets(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	configDir := filepath.Join(projectDir, ".bomly")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
+http_proxy: http://agent:super-secret@proxy.example:8080
+plugins:
+  acme.matcher:
+    token: plugin-secret
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	setFakeNPMOnPath(t, `{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": {
+      "version": "18.2.0"
+    }
+  }
+}`)
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"scan", "--path", projectDir, "--ecosystems", "npm", "--format", "json", "-vv"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+
+	logText := stderr.String()
+	for _, leaked := range []string{"super-secret", "plugin-secret", "agent:"} {
+		if strings.Contains(logText, leaked) {
+			t.Fatalf("startup logs leaked %q:\n%s", leaked, logText)
+		}
+	}
+}
+
 func TestRoot_ScanCommand_TreeFormatRejected(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -251,9 +252,9 @@ func validateProxyURL(value string) error {
 	if value == "" {
 		return nil
 	}
-	parsed, err := url.Parse(value)
+	parsed, err := parseProxyURL(value)
 	if err != nil {
-		return fmt.Errorf("invalid http_proxy URL: %w", err)
+		return err
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return fmt.Errorf("invalid http_proxy URL: must be absolute")
@@ -264,6 +265,22 @@ func validateProxyURL(value string) error {
 		return fmt.Errorf("unsupported http_proxy scheme %q (accepted: http, https, socks5)", parsed.Scheme)
 	}
 	return nil
+}
+
+func parseProxyURL(value string) (*url.URL, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid http_proxy URL: %w", redactURLParseError(err))
+	}
+	return parsed, nil
+}
+
+func redactURLParseError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return urlErr.Err
+	}
+	return err
 }
 
 func validateProxyFields(cfg Resolved) error {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -64,6 +64,22 @@ func TestValidateRejectsInvalidHTTPProxy(t *testing.T) {
 	}
 }
 
+func TestValidateRedactsCredentialsInInvalidHTTPProxy(t *testing.T) {
+	err := Validate(Resolved{HTTPProxy: "http://agent:super-secret%zz@proxy.example:8080"})
+	if err == nil {
+		t.Fatal("Validate returned nil for invalid proxy URL")
+	}
+	if strings.Contains(err.Error(), "super-secret") {
+		t.Fatalf("error leaked proxy password: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "agent:") {
+		t.Fatalf("error leaked proxy userinfo: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "invalid http_proxy URL") {
+		t.Fatalf("error = %q, want invalid http_proxy URL", err.Error())
+	}
+}
+
 func TestValidateRejectsInvalidHTTPProxyFields(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/plugin/env_test.go
+++ b/internal/plugin/env_test.go
@@ -92,6 +92,36 @@ func TestPluginEnvForwardsStandardProxyEnvWhenBomlyProxyUnset(t *testing.T) {
 	}
 }
 
+func TestPluginEnvOnlyWritesSelectedPluginConfig(t *testing.T) {
+	env, cleanup, err := pluginEnv(LaunchOptions{
+		PluginConfigs: map[string]map[string]any{
+			"acme.matcher": {"token": "selected-secret"},
+			"other.plugin": {"token": "other-secret"},
+		},
+	}, "acme.matcher")
+	if err != nil {
+		t.Fatalf("pluginEnv() error = %v", err)
+	}
+	defer cleanup()
+
+	values := envMap(env)
+	configPath := values[sdk.EnvPluginConfigFile]
+	if configPath == "" {
+		t.Fatal("missing plugin config file env")
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read plugin config: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "selected-secret") {
+		t.Fatalf("selected plugin config missing: %s", text)
+	}
+	if strings.Contains(text, "other-secret") || strings.Contains(text, "other.plugin") {
+		t.Fatalf("unrelated plugin config leaked: %s", text)
+	}
+}
+
 func envMap(env []string) map[string]string {
 	out := make(map[string]string, len(env))
 	for _, item := range env {

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -147,9 +148,9 @@ func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), 
 	if proxyURL == "" {
 		return http.ProxyFromEnvironment, nil
 	}
-	parsed, err := url.Parse(proxyURL)
+	parsed, err := parseProxyURL(proxyURL)
 	if err != nil {
-		return nil, fmt.Errorf("parse proxy URL: %w", err)
+		return nil, err
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return nil, fmt.Errorf("proxy URL must be absolute")
@@ -217,9 +218,9 @@ func proxyScheme(value string) (string, error) {
 }
 
 func validateProxyURL(value string) error {
-	parsed, err := url.Parse(value)
+	parsed, err := parseProxyURL(value)
 	if err != nil {
-		return fmt.Errorf("parse proxy URL: %w", err)
+		return err
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return fmt.Errorf("proxy URL must be absolute")
@@ -228,6 +229,22 @@ func validateProxyURL(value string) error {
 		return err
 	}
 	return nil
+}
+
+func parseProxyURL(value string) (*url.URL, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("parse proxy URL: %w", redactURLParseError(err))
+	}
+	return parsed, nil
+}
+
+func redactURLParseError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return urlErr.Err
+	}
+	return err
 }
 
 func tlsConfigWithCACert(path string) (*tls.Config, error) {

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -97,6 +98,19 @@ func TestNewHTTPClientRejectsHostWithoutPort(t *testing.T) {
 func TestNewHTTPClientRejectsInvalidProxy(t *testing.T) {
 	if _, err := NewHTTPClient(HTTPClientConfig{ProxyURL: "proxy.example:8080"}); err == nil {
 		t.Fatal("NewHTTPClient() error = nil, want invalid proxy error")
+	}
+}
+
+func TestNewHTTPClientRedactsCredentialsInInvalidProxy(t *testing.T) {
+	_, err := NewHTTPClient(HTTPClientConfig{ProxyURL: "http://agent:super-secret%zz@proxy.example:8080"})
+	if err == nil {
+		t.Fatal("NewHTTPClient() error = nil, want invalid proxy error")
+	}
+	if strings.Contains(err.Error(), "super-secret") {
+		t.Fatalf("error leaked proxy password: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "agent:") {
+		t.Fatalf("error leaked proxy userinfo: %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Sanitize malformed proxy URL parse errors so proxy userinfo cannot be echoed through CLI errors or zap error fields.
- Add focused regressions for SDK/config proxy validation, verbose startup logging, and per-plugin config isolation.
- Confirm generated docs remain stable after running the required generator.

## Root Cause

The new shared HTTP proxy path accepted proxy URLs that may contain credentials. When `net/url.Parse` failed on a malformed URL, the wrapped parse error could include the original URL, including userinfo. Plugin config handoff was already scoped to the selected plugin, but did not have a regression proving sibling plugin secrets are not written into the launched plugin's config file.

## Validation

- `make generate`
- `make test`