### PR TITLE
Fix empty SARIF rules array

### DIFF
--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -148,7 +148,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, toolName, toolVersion strin
 	}
 	// Deduplicate rules by finding ID.
 	seen := map[string]bool{}
-	var rules []sarifRule
+	rules := make([]sarifRule, 0, len(findings))
 	for _, f := range findings {
 		if seen[f.ID] {
 			continue

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -112,6 +112,35 @@ func TestWriteSARIF_RuleDeduplication(t *testing.T) {
 	}
 }
 
+func TestWriteSARIF_EmptyFindingsEncodeArrayFields(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, nil, "bomly", "0.1.0"); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	run := doc["runs"].([]any)[0].(map[string]any)
+	driver := run["tool"].(map[string]any)["driver"].(map[string]any)
+	rules, ok := driver["rules"].([]any)
+	if !ok {
+		t.Fatalf("tool.driver.rules has type %T, want array; output:\n%s", driver["rules"], buf.String())
+	}
+	if len(rules) != 0 {
+		t.Fatalf("rules = %d, want 0", len(rules))
+	}
+	results, ok := run["results"].([]any)
+	if !ok {
+		t.Fatalf("results has type %T, want array; output:\n%s", run["results"], buf.String())
+	}
+	if len(results) != 0 {
+		t.Fatalf("results = %d, want 0", len(results))
+	}
+}
+
 func TestSeverityToSARIFLevel(t *testing.T) {
 	tests := []struct {
 		sev   string


### PR DESCRIPTION
## Summary

- Ensure SARIF output encodes `runs[0].tool.driver.rules` as an empty array when there are no findings.
- Add a regression test for empty SARIF reports so `rules` and `results` remain array-typed.

## Root Cause

The SARIF renderer initialized `rules` as a nil slice. When an audit produced no findings, Go encoded that field as JSON `null`, which GitHub Code Scanning rejects because SARIF requires `tool.driver.rules` to be an array.

## Validation

- `go test ./internal/output`
- `make generate`
- `make test`

`make generate` completed without leaving generated docs changed.