### PR TITLE
Add nested YAML configuration schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ When adding a new user-visible feature (new CLI flag, new component class, new p
 ### CLI surface
 
 - Flag declared in `internal/cli/opts/flag_options.go` with override propagation in `applyFlagOverrides`.
-- Config field added to `internal/config/config.go` `Resolved` (with `doc:`/`env:`/`default:` tags) and `File` (with `yaml:` tag and matching pointer/slice shape).
+- Config field added to `internal/config/config.go` `Resolved` (with `doc:`/`env:`/`default:` tags) and the appropriate nested `File` leaf (with `yaml:`, `resolved:`, and legacy flat-key `legacy:` tags plus a pointer-backed shape).
 - Flag interactions (requires / conflicts / modifies semantics) get a check in `config.Validate` plus a unit test in `internal/config/validate_test.go`. Error messages must be actionable (`"--audit requires --enrich"`, not `"invalid combination"`).
 - If the flag drives a pipeline stage, propagate the value through `internal/cli/opts/options.go`'s `PipelineRequest` builder.
 - If the flag accepts a selector list, register an `available<Thing>Options` helper in `flag_options.go` for shell completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ When adding a new user-visible feature (new CLI flag, new component class, new p
 ### CLI surface
 
 - [ ] Flag declared in `internal/cli/opts/flag_options.go` with override propagation in `applyFlagOverrides`.
-- [ ] Config field added to `internal/config/config.go` `Resolved` (with `doc:`/`env:`/`default:` tags) and `File` (with `yaml:` tag and matching pointer/slice shape).
+- [ ] Config field added to `internal/config/config.go` `Resolved` (with `doc:`/`env:`/`default:` tags) and the appropriate nested `File` leaf (with `yaml:`, `resolved:`, and legacy flat-key `legacy:` tags plus a pointer-backed shape).
 - [ ] When the flag interacts with another flag (requires it, conflicts with it, modifies its semantics), add a check to `config.Validate` and a unit test in `internal/config/validate_test.go`. Keep validation errors actionable (`"--audit requires --enrich"`, not `"invalid combination"`).
 - [ ] If the flag drives a pipeline stage, propagate the value through `internal/cli/opts/options.go`'s `PipelineRequest` builder.
 - [ ] Shell completion: register an `available<Thing>Options` helper in `flag_options.go` if the flag accepts a selector list.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,6 +77,10 @@ Stage summary:
 
 `bomly explain` reuses the same resolution, scope filtering, consolidation, and matching stages, then performs dependency path selection in its explain orchestration before optional component audit.
 
+### Decision: YAML configuration is nested at the file boundary
+
+Bomly's YAML files use strict nested groups such as `target`, `analysis`, `policy`, `network.proxy`, and `matchers.osv`, while `config.Resolved` remains flat. Nesting keeps customer-authored files readable without spreading YAML organization through the CLI and engine. Each YAML leaf maps back to one flat runtime field, and layered files preserve explicit zero values, including empty lists. Unknown keys and the former flat YAML keys fail with migration guidance so typos cannot silently disable requested behavior.
+
 ### Decision: Reachability annotates vulnerabilities, not findings
 
 Reachability data lives on `PackageVulnerability.Reachability` rather than only on `Finding.Reachability` because `--reachability` must be useful without `--audit`. Matchers attach the vulnerability; the analyzer enriches it; the policy auditor copies the annotation onto each emitted Finding when `--audit` runs. This keeps a single source of truth on the package graph and lets the consolidation layer's existing per-vuln merge propagate analyzer output to per-manifest entry graphs without bespoke wiring.

--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -109,7 +109,7 @@ bomly:
       - .cache/bomly
 ```
 
-GitLab natively renders CycloneDX SBOMs in the dependency-scanning panel via the `reports:cyclonedx` key. To point Bomly's cache at the GitLab cache, export `XDG_CACHE_HOME` or configure `matchers.*.cacheDir` in `~/.bomly/config.yaml`.
+GitLab natively renders CycloneDX SBOMs in the dependency-scanning panel via the `reports:cyclonedx` key. To point Bomly's cache at the GitLab cache, export `XDG_CACHE_HOME` or configure matcher-specific keys such as `matchers.osv.cache_dir` in `~/.bomly/config.yaml`.
 
 ## Jenkins (declarative)
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -11,204 +11,266 @@ Bomly resolves configuration in the following order, with later sources overridi
 
 `--config <path>` adds an explicit config file to the load list before environment variables and flags are applied.
 
+YAML files use the nested keys documented below. Unknown keys and the former flat keys are rejected so configuration mistakes fail fast.
+
 ---
 
 ## General
 
 | YAML Key | Environment Variable | Type | Default | Description |
 |----------|---------------------|------|---------|-------------|
-| `path` | `BOMLY_PATH` | `string` | - | Filesystem path to scan |
-| `container` | `BOMLY_CONTAINER` | `string` | - | Container image to scan (e.g. alpine:latest) |
-| `url` | `BOMLY_URL` | `string` | - | Remote Git URL to clone and scan |
-| `ref` | `BOMLY_REF` | `string` | - | Git ref to checkout when scanning a URL |
-| `sbom` | `BOMLY_SBOM` | `bool` | - | Treat the selected filesystem target as an SBOM file |
-| `enrich` | `BOMLY_ENRICH` | `bool` | - | Enrich packages with external license and vulnerability data |
-| `audit` | `BOMLY_AUDIT` | `bool` | - | Evaluate policy and create findings from package vulnerability data |
-| `reachability` | `BOMLY_REACHABILITY` | `bool` | - | Run code analysis to confirm whether vulnerabilities are reachable from application code |
-| `fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable |
-| `fail_on_scopes` | `BOMLY_FAIL_ON_SCOPES` | `[]string` | - | Dependency scopes that may produce failing findings: runtime, development, unknown |
-| `allow_vulnerability_ids` | `BOMLY_ALLOW_VULNERABILITY_IDS` | `[]string` | - | Vulnerability IDs to ignore during policy evaluation |
-| `allow_licenses` | `BOMLY_ALLOW_LICENSES` | `[]string` | - | Allowed SPDX license identifiers or expressions |
-| `deny_licenses` | `BOMLY_DENY_LICENSES` | `[]string` | - | Denied SPDX license identifiers or expressions |
-| `license_exempt_packages` | `BOMLY_LICENSE_EXEMPT_PACKAGES` | `[]string` | - | Package URLs exempt from license policy checks |
-| `deny_packages` | `BOMLY_DENY_PACKAGES` | `[]string` | - | Package URLs to deny |
-| `deny_groups` | `BOMLY_DENY_GROUPS` | `[]string` | - | Package URL namespaces to deny |
-| `protected_packages` | `BOMLY_PROTECTED_PACKAGES` | `[]string` | - | Canonical package names to protect from typosquatting |
-| `typosquat_threshold` | `BOMLY_TYPOSQUAT_THRESHOLD` | `string` | 0.90 | Similarity threshold for typosquatting detection |
-| `typosquat_mode` | `BOMLY_TYPOSQUAT_MODE` | `string` | warn | Typosquatting policy mode: warn or fail |
-| `warn_only` | `BOMLY_WARN_ONLY` | `bool` | - | Downgrade failing findings to warnings |
-| `analyzers` | `BOMLY_ANALYZERS` | `string` | - | Reachability analyzer selectors; supports +name and -name modifiers |
-| `format` | `BOMLY_FORMAT` | `string` | - | Primary report format: text, json, markdown, or sarif |
-| `outputs` | `BOMLY_OUTPUT` | `[]string` | - | Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx |
-| `interactive` | `BOMLY_INTERACTIVE` | `bool` | - | Enable interactive TUI mode |
-| `ecosystems` | `BOMLY_ECOSYSTEMS` | `string` | - | Ecosystem selectors; supports +name and -name modifiers |
-| `detectors` | `BOMLY_DETECTORS` | `string` | - | Detector selectors; supports +name and -name modifiers |
-| `auditors` | `BOMLY_AUDITORS` | `string` | - | Auditor selectors; supports +name and -name modifiers |
-| `matchers` | `BOMLY_MATCHERS` | `string` | - | Matcher selectors; supports +name and -name modifiers |
-| `install_first` | `BOMLY_INSTALL_FIRST` | `bool` | - | Run detector-specific dependency installation before resolving graphs |
-| `install_args` | `BOMLY_INSTALL_ARGS` | `[]string` | - | Additional detector-specific install arguments |
-| `config` | `BOMLY_CONFIG` | `string` | - | Explicit YAML config file path |
-| `quiet` | `BOMLY_QUIET` | `bool` | - | Suppress all non-error output |
-| `verbosity` | `BOMLY_VERBOSE` | `int` | - | Verbosity level (0=normal, 1=verbose, 2+=debug) |
-| `http_proxy` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL used by Bomly and managed plugins |
-| `http_no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy |
-| `http_proxy_type` | `BOMLY_HTTP_PROXY_TYPE` | `string` | http | Outbound proxy type when using host/port proxy settings: http, https, or socks5 |
-| `http_proxy_host` | `BOMLY_HTTP_PROXY_HOST` | `string` | - | Outbound proxy hostname or IP address used when http_proxy is not set |
-| `http_proxy_port` | `BOMLY_HTTP_PROXY_PORT` | `int` | - | Outbound proxy port used with http_proxy_host |
-| `http_proxy_username` | `BOMLY_HTTP_PROXY_USERNAME` | `string` | - | Username for proxy authentication when using host/port proxy settings |
-| `http_proxy_password` | `BOMLY_HTTP_PROXY_PASSWORD` | `string` | - | Password for proxy authentication when using host/port proxy settings |
-| `http_ca_cert_file` | `BOMLY_HTTP_CA_CERT_FILE` | `string` | - | PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies |
+| `target.path` | `BOMLY_PATH` | `string` | - | Filesystem path to scan |
+| `target.container` | `BOMLY_CONTAINER` | `string` | - | Container image to scan (e.g. alpine:latest) |
+| `target.url` | `BOMLY_URL` | `string` | - | Remote Git URL to clone and scan |
+| `target.ref` | `BOMLY_REF` | `string` | - | Git ref to checkout when scanning a URL |
+| `target.sbom` | `BOMLY_SBOM` | `bool` | - | Treat the selected filesystem target as an SBOM file |
+| `analysis.enrich` | `BOMLY_ENRICH` | `bool` | - | Enrich packages with external license and vulnerability data |
+| `analysis.audit` | `BOMLY_AUDIT` | `bool` | - | Evaluate policy and create findings from package vulnerability data |
+| `analysis.reachability` | `BOMLY_REACHABILITY` | `bool` | - | Run code analysis to confirm whether vulnerabilities are reachable from application code |
+| `policy.fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable |
+| `policy.fail_on_scopes` | `BOMLY_FAIL_ON_SCOPES` | `[]string` | - | Dependency scopes that may produce failing findings: runtime, development, unknown |
+| `policy.allow_vulnerability_ids` | `BOMLY_ALLOW_VULNERABILITY_IDS` | `[]string` | - | Vulnerability IDs to ignore during policy evaluation |
+| `policy.allow_licenses` | `BOMLY_ALLOW_LICENSES` | `[]string` | - | Allowed SPDX license identifiers or expressions |
+| `policy.deny_licenses` | `BOMLY_DENY_LICENSES` | `[]string` | - | Denied SPDX license identifiers or expressions |
+| `policy.license_exempt_packages` | `BOMLY_LICENSE_EXEMPT_PACKAGES` | `[]string` | - | Package URLs exempt from license policy checks |
+| `policy.deny_packages` | `BOMLY_DENY_PACKAGES` | `[]string` | - | Package URLs to deny |
+| `policy.deny_groups` | `BOMLY_DENY_GROUPS` | `[]string` | - | Package URL namespaces to deny |
+| `policy.protected_packages` | `BOMLY_PROTECTED_PACKAGES` | `[]string` | - | Canonical package names to protect from typosquatting |
+| `policy.typosquat_threshold` | `BOMLY_TYPOSQUAT_THRESHOLD` | `string` | 0.90 | Similarity threshold for typosquatting detection |
+| `policy.typosquat_mode` | `BOMLY_TYPOSQUAT_MODE` | `string` | warn | Typosquatting policy mode: warn or fail |
+| `policy.warn_only` | `BOMLY_WARN_ONLY` | `bool` | - | Downgrade failing findings to warnings |
+| `components.analyzers` | `BOMLY_ANALYZERS` | `string` | - | Reachability analyzer selectors; supports +name and -name modifiers |
+| `output.format` | `BOMLY_FORMAT` | `string` | - | Primary report format: text, json, markdown, or sarif |
+| `output.outputs` | `BOMLY_OUTPUT` | `[]string` | - | Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx |
+| `output.interactive` | `BOMLY_INTERACTIVE` | `bool` | - | Enable interactive TUI mode |
+| `components.ecosystems` | `BOMLY_ECOSYSTEMS` | `string` | - | Ecosystem selectors; supports +name and -name modifiers |
+| `components.detectors` | `BOMLY_DETECTORS` | `string` | - | Detector selectors; supports +name and -name modifiers |
+| `components.auditors` | `BOMLY_AUDITORS` | `string` | - | Auditor selectors; supports +name and -name modifiers |
+| `components.matchers` | `BOMLY_MATCHERS` | `string` | - | Matcher selectors; supports +name and -name modifiers |
+| `analysis.install_first` | `BOMLY_INSTALL_FIRST` | `bool` | - | Run detector-specific dependency installation before resolving graphs |
+| `analysis.install_args` | `BOMLY_INSTALL_ARGS` | `[]string` | - | Additional detector-specific install arguments |
+| `logging.quiet` | `BOMLY_QUIET` | `bool` | - | Suppress all non-error output |
+| `logging.verbosity` | `BOMLY_VERBOSE` | `int` | - | Verbosity level (0=normal, 1=verbose, 2+=debug) |
+| `network.proxy.url` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL used by Bomly and managed plugins |
+| `network.proxy.no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy |
+| `network.proxy.type` | `BOMLY_HTTP_PROXY_TYPE` | `string` | http | Outbound proxy type when using host/port proxy settings: http, https, or socks5 |
+| `network.proxy.host` | `BOMLY_HTTP_PROXY_HOST` | `string` | - | Outbound proxy hostname or IP address used when http_proxy is not set |
+| `network.proxy.port` | `BOMLY_HTTP_PROXY_PORT` | `int` | - | Outbound proxy port used with http_proxy_host |
+| `network.proxy.username` | `BOMLY_HTTP_PROXY_USERNAME` | `string` | - | Username for proxy authentication when using host/port proxy settings |
+| `network.proxy.password` | `BOMLY_HTTP_PROXY_PASSWORD` | `string` | - | Password for proxy authentication when using host/port proxy settings |
+| `network.ca_cert_file` | `BOMLY_HTTP_CA_CERT_FILE` | `string` | - | PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies |
 | `plugins` | `-` | `map[string]map[string]any` | - | Per-plugin configuration keyed by managed plugin ID |
 
 ## OSV matcher settings
 
 | YAML Key | Environment Variable | Type | Default | Description |
 |----------|---------------------|------|---------|-------------|
-| `osv_api_base` | `BOMLY_OSV_API_BASE` | `string` | https://api.osv.dev | Base URL for the OSV vulnerability API |
-| `osv_cache_dir` | `BOMLY_OSV_CACHE_DIR` | `string` | - | Directory for the OSV response cache |
-| `osv_cache_ttl` | `BOMLY_OSV_CACHE_TTL` | `string` | 24h | TTL for cached OSV responses (e.g. 24h) |
+| `matchers.osv.api_base` | `BOMLY_OSV_API_BASE` | `string` | https://api.osv.dev | Base URL for the OSV vulnerability API |
+| `matchers.osv.cache_dir` | `BOMLY_OSV_CACHE_DIR` | `string` | - | Directory for the OSV response cache |
+| `matchers.osv.cache_ttl` | `BOMLY_OSV_CACHE_TTL` | `string` | 24h | TTL for cached OSV responses (e.g. 24h) |
 
 ## KEV enrichment settings
 
 | YAML Key | Environment Variable | Type | Default | Description |
 |----------|---------------------|------|---------|-------------|
-| `kev_cache_dir` | `BOMLY_KEV_CACHE_DIR` | `string` | - | Directory for the CISA KEV cache |
-| `kev_cache_ttl` | `BOMLY_KEV_CACHE_TTL` | `string` | 24h | TTL for cached KEV data (e.g. 24h) |
+| `matchers.osv.kev.cache_dir` | `BOMLY_KEV_CACHE_DIR` | `string` | - | Directory for the CISA KEV cache |
+| `matchers.osv.kev.cache_ttl` | `BOMLY_KEV_CACHE_TTL` | `string` | 24h | TTL for cached KEV data (e.g. 24h) |
 
 ## EOL enrichment settings
 
 | YAML Key | Environment Variable | Type | Default | Description |
 |----------|---------------------|------|---------|-------------|
-| `eol_api_base` | `BOMLY_EOL_API_BASE` | `string` | https://endoflife.date/api | Base URL for the endoflife.date API |
-| `eol_cache_dir` | `BOMLY_EOL_CACHE_DIR` | `string` | - | Directory for the EOL cache |
-| `eol_cache_ttl` | `BOMLY_EOL_CACHE_TTL` | `string` | 24h | TTL for cached EOL responses (e.g. 24h) |
+| `matchers.eol.api_base` | `BOMLY_EOL_API_BASE` | `string` | https://endoflife.date/api | Base URL for the endoflife.date API |
+| `matchers.eol.cache_dir` | `BOMLY_EOL_CACHE_DIR` | `string` | - | Directory for the EOL cache |
+| `matchers.eol.cache_ttl` | `BOMLY_EOL_CACHE_TTL` | `string` | 24h | TTL for cached EOL responses (e.g. 24h) |
 
 ## Scorecard matcher settings
 
 | YAML Key | Environment Variable | Type | Default | Description |
 |----------|---------------------|------|---------|-------------|
-| `scorecard_api_base` | `BOMLY_SCORECARD_API_BASE` | `string` | https://api.scorecard.dev | Base URL for the OpenSSF Scorecard public API |
-| `scorecard_cache_dir` | `BOMLY_SCORECARD_CACHE_DIR` | `string` | - | Directory for the Scorecard response cache |
-| `scorecard_cache_ttl` | `BOMLY_SCORECARD_CACHE_TTL` | `string` | 24h | TTL for cached Scorecard responses (e.g. 24h) |
+| `matchers.scorecard.api_base` | `BOMLY_SCORECARD_API_BASE` | `string` | https://api.scorecard.dev | Base URL for the OpenSSF Scorecard public API |
+| `matchers.scorecard.cache_dir` | `BOMLY_SCORECARD_CACHE_DIR` | `string` | - | Directory for the Scorecard response cache |
+| `matchers.scorecard.cache_ttl` | `BOMLY_SCORECARD_CACHE_TTL` | `string` | 24h | TTL for cached Scorecard responses (e.g. 24h) |
+
+## Flat YAML Migration
+
+Flat YAML keys are no longer accepted. Move each existing key to its nested replacement:
+
+| Former Flat Key | Replacement |
+|-----------------|-------------|
+| `allow_licenses` | `policy.allow_licenses` |
+| `allow_vulnerability_ids` | `policy.allow_vulnerability_ids` |
+| `analyzers` | `components.analyzers` |
+| `audit` | `analysis.audit` |
+| `auditors` | `components.auditors` |
+| `config` | `--config` |
+| `container` | `target.container` |
+| `deny_groups` | `policy.deny_groups` |
+| `deny_licenses` | `policy.deny_licenses` |
+| `deny_packages` | `policy.deny_packages` |
+| `detectors` | `components.detectors` |
+| `ecosystems` | `components.ecosystems` |
+| `enrich` | `analysis.enrich` |
+| `eol_api_base` | `matchers.eol.api_base` |
+| `eol_cache_dir` | `matchers.eol.cache_dir` |
+| `eol_cache_ttl` | `matchers.eol.cache_ttl` |
+| `fail_on` | `policy.fail_on` |
+| `fail_on_scopes` | `policy.fail_on_scopes` |
+| `format` | `output.format` |
+| `http_ca_cert_file` | `network.ca_cert_file` |
+| `http_no_proxy` | `network.proxy.no_proxy` |
+| `http_proxy` | `network.proxy.url` |
+| `http_proxy_host` | `network.proxy.host` |
+| `http_proxy_password` | `network.proxy.password` |
+| `http_proxy_port` | `network.proxy.port` |
+| `http_proxy_type` | `network.proxy.type` |
+| `http_proxy_username` | `network.proxy.username` |
+| `install_args` | `analysis.install_args` |
+| `install_first` | `analysis.install_first` |
+| `interactive` | `output.interactive` |
+| `kev_cache_dir` | `matchers.osv.kev.cache_dir` |
+| `kev_cache_ttl` | `matchers.osv.kev.cache_ttl` |
+| `license_exempt_packages` | `policy.license_exempt_packages` |
+| `matchers` | `components.matchers` |
+| `osv_api_base` | `matchers.osv.api_base` |
+| `osv_cache_dir` | `matchers.osv.cache_dir` |
+| `osv_cache_ttl` | `matchers.osv.cache_ttl` |
+| `outputs` | `output.outputs` |
+| `path` | `target.path` |
+| `protected_packages` | `policy.protected_packages` |
+| `quiet` | `logging.quiet` |
+| `reachability` | `analysis.reachability` |
+| `ref` | `target.ref` |
+| `sbom` | `target.sbom` |
+| `scorecard_api_base` | `matchers.scorecard.api_base` |
+| `scorecard_cache_dir` | `matchers.scorecard.cache_dir` |
+| `scorecard_cache_ttl` | `matchers.scorecard.cache_ttl` |
+| `typosquat_mode` | `policy.typosquat_mode` |
+| `typosquat_threshold` | `policy.typosquat_threshold` |
+| `url` | `target.url` |
+| `verbose` | `logging.verbosity` |
+| `verbosity` | `logging.verbosity` |
+| `warn_only` | `policy.warn_only` |
 
 ## Example Configuration
 
 ```yaml
 # ~/.bomly/config.yaml or .bomly/config.yaml
-
-# General
-# Filesystem path to scan
-# path: ""
-# Container image to scan (e.g. alpine:latest)
-# container: ""
-# Remote Git URL to clone and scan
-# url: ""
-# Git ref to checkout when scanning a URL
-# ref: ""
-# Treat the selected filesystem target as an SBOM file
-# sbom: false
-# Enrich packages with external license and vulnerability data
-# enrich: false
-# Evaluate policy and create findings from package vulnerability data
-# audit: false
-# Run code analysis to confirm whether vulnerabilities are reachable from application code
-# reachability: false
-# Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable
-# fail_on: []
-# Dependency scopes that may produce failing findings: runtime, development, unknown
-# fail_on_scopes: []
-# Vulnerability IDs to ignore during policy evaluation
-# allow_vulnerability_ids: []
-# Allowed SPDX license identifiers or expressions
-# allow_licenses: []
-# Denied SPDX license identifiers or expressions
-# deny_licenses: []
-# Package URLs exempt from license policy checks
-# license_exempt_packages: []
-# Package URLs to deny
-# deny_packages: []
-# Package URL namespaces to deny
-# deny_groups: []
-# Canonical package names to protect from typosquatting
-# protected_packages: []
-# Similarity threshold for typosquatting detection
-# typosquat_threshold: 0.90
-# Typosquatting policy mode: warn or fail
-# typosquat_mode: warn
-# Downgrade failing findings to warnings
-# warn_only: false
-# Reachability analyzer selectors; supports +name and -name modifiers
-# analyzers: ""
-# Primary report format: text, json, markdown, or sarif
-# format: ""
-# Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx
-# outputs: []
-# Enable interactive TUI mode
-# interactive: false
-# Ecosystem selectors; supports +name and -name modifiers
-# ecosystems: ""
-# Detector selectors; supports +name and -name modifiers
-# detectors: ""
-# Auditor selectors; supports +name and -name modifiers
-# auditors: ""
-# Matcher selectors; supports +name and -name modifiers
-# matchers: ""
-# Run detector-specific dependency installation before resolving graphs
-# install_first: false
-# Additional detector-specific install arguments
-# install_args: []
-# Explicit YAML config file path
-# config: ""
-# Suppress all non-error output
-# quiet: false
-# Verbosity level (0=normal, 1=verbose, 2+=debug)
-# verbosity: 0
-# Outbound HTTP proxy URL used by Bomly and managed plugins
-# http_proxy: ""
-# Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy
-# http_no_proxy: ""
-# Outbound proxy type when using host/port proxy settings: http, https, or socks5
-# http_proxy_type: http
-# Outbound proxy hostname or IP address used when http_proxy is not set
-# http_proxy_host: ""
-# Outbound proxy port used with http_proxy_host
-# http_proxy_port: 0
-# Username for proxy authentication when using host/port proxy settings
-# http_proxy_username: ""
-# Password for proxy authentication when using host/port proxy settings
-# http_proxy_password: ""
-# PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies
-# http_ca_cert_file: ""
+# target:
+#   Filesystem path to scan
+#   path: ""
+#   Container image to scan (e.g. alpine:latest)
+#   container: ""
+#   Remote Git URL to clone and scan
+#   url: ""
+#   Git ref to checkout when scanning a URL
+#   ref: ""
+#   Treat the selected filesystem target as an SBOM file
+#   sbom: false
+# analysis:
+#   Enrich packages with external license and vulnerability data
+#   enrich: false
+#   Evaluate policy and create findings from package vulnerability data
+#   audit: false
+#   Run code analysis to confirm whether vulnerabilities are reachable from application code
+#   reachability: false
+#   Run detector-specific dependency installation before resolving graphs
+#   install_first: false
+#   Additional detector-specific install arguments
+#   install_args: []
+# components:
+#   Ecosystem selectors; supports +name and -name modifiers
+#   ecosystems: ""
+#   Detector selectors; supports +name and -name modifiers
+#   detectors: ""
+#   Auditor selectors; supports +name and -name modifiers
+#   auditors: ""
+#   Matcher selectors; supports +name and -name modifiers
+#   matchers: ""
+#   Reachability analyzer selectors; supports +name and -name modifiers
+#   analyzers: ""
+# policy:
+#   Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable
+#   fail_on: []
+#   Dependency scopes that may produce failing findings: runtime, development, unknown
+#   fail_on_scopes: []
+#   Vulnerability IDs to ignore during policy evaluation
+#   allow_vulnerability_ids: []
+#   Allowed SPDX license identifiers or expressions
+#   allow_licenses: []
+#   Denied SPDX license identifiers or expressions
+#   deny_licenses: []
+#   Package URLs exempt from license policy checks
+#   license_exempt_packages: []
+#   Package URLs to deny
+#   deny_packages: []
+#   Package URL namespaces to deny
+#   deny_groups: []
+#   Canonical package names to protect from typosquatting
+#   protected_packages: []
+#   Similarity threshold for typosquatting detection
+#   typosquat_threshold: 0.90
+#   Typosquatting policy mode: warn or fail
+#   typosquat_mode: warn
+#   Downgrade failing findings to warnings
+#   warn_only: false
+# output:
+#   Primary report format: text, json, markdown, or sarif
+#   format: ""
+#   Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx
+#   outputs: []
+#   Enable interactive TUI mode
+#   interactive: false
+# logging:
+#   Suppress all non-error output
+#   quiet: false
+#   Verbosity level (0=normal, 1=verbose, 2+=debug)
+#   verbosity: 0
+# network:
+#   proxy:
+#     Outbound HTTP proxy URL used by Bomly and managed plugins
+#     url: ""
+#     Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy
+#     no_proxy: ""
+#     Outbound proxy type when using host/port proxy settings: http, https, or socks5
+#     type: http
+#     Outbound proxy hostname or IP address used when http_proxy is not set
+#     host: ""
+#     Outbound proxy port used with http_proxy_host
+#     port: 0
+#     Username for proxy authentication when using host/port proxy settings
+#     username: ""
+#     Password for proxy authentication when using host/port proxy settings
+#     password: ""
+#   PEM certificate chain file to trust for outbound HTTPS connections, including TLS-intercepting proxies
+#   ca_cert_file: ""
+# matchers:
+#   osv:
+#     Base URL for the OSV vulnerability API
+#     api_base: https://api.osv.dev
+#     Directory for the OSV response cache
+#     cache_dir: ""
+#     TTL for cached OSV responses (e.g. 24h)
+#     cache_ttl: 24h
+#     kev:
+#       Directory for the CISA KEV cache
+#       cache_dir: ""
+#       TTL for cached KEV data (e.g. 24h)
+#       cache_ttl: 24h
+#   eol:
+#     Base URL for the endoflife.date API
+#     api_base: https://endoflife.date/api
+#     Directory for the EOL cache
+#     cache_dir: ""
+#     TTL for cached EOL responses (e.g. 24h)
+#     cache_ttl: 24h
+#   scorecard:
+#     Base URL for the OpenSSF Scorecard public API
+#     api_base: https://api.scorecard.dev
+#     Directory for the Scorecard response cache
+#     cache_dir: ""
+#     TTL for cached Scorecard responses (e.g. 24h)
+#     cache_ttl: 24h
 # Per-plugin configuration keyed by managed plugin ID
 # plugins: {}
-
-# OSV matcher settings
-# Base URL for the OSV vulnerability API
-# osv_api_base: https://api.osv.dev
-# Directory for the OSV response cache
-# osv_cache_dir: ""
-# TTL for cached OSV responses (e.g. 24h)
-# osv_cache_ttl: 24h
-
-# KEV enrichment settings
-# Directory for the CISA KEV cache
-# kev_cache_dir: ""
-# TTL for cached KEV data (e.g. 24h)
-# kev_cache_ttl: 24h
-
-# EOL enrichment settings
-# Base URL for the endoflife.date API
-# eol_api_base: https://endoflife.date/api
-# Directory for the EOL cache
-# eol_cache_dir: ""
-# TTL for cached EOL responses (e.g. 24h)
-# eol_cache_ttl: 24h
-
-# Scorecard matcher settings
-# Base URL for the OpenSSF Scorecard public API
-# scorecard_api_base: https://api.scorecard.dev
-# Directory for the Scorecard response cache
-# scorecard_cache_dir: ""
-# TTL for cached Scorecard responses (e.g. 24h)
-# scorecard_cache_ttl: 24h
 ```

--- a/docs/MATCHERS.md
+++ b/docs/MATCHERS.md
@@ -80,7 +80,7 @@ rm -rf ~/.bomly/cache    # Unix/macOS
 Remove-Item -Recurse $env:USERPROFILE\.bomly\cache  # PowerShell
 ```
 
-Override the cache location per matcher in `~/.bomly/config.yaml`; see [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md). Cache failures are **always non-fatal** — Bomly logs a warning and continues.
+Override cache locations with matcher-specific keys such as `matchers.osv.cache_dir`, `matchers.eol.cache_dir`, and `matchers.scorecard.cache_dir`; see [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md). Cache failures are **always non-fatal** — Bomly logs a warning and continues.
 
 ## Failure semantics
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -34,20 +34,24 @@ Bomly passes the active plugin API version, the explicit `BOMLY_CONFIG` path whe
 Proxy settings can be configured with a direct proxy URL:
 
 ```yaml
-http_proxy: http://proxy.example:8080
-http_no_proxy: localhost,127.0.0.1,.corp.example
+network:
+  proxy:
+    url: http://proxy.example:8080
+    no_proxy: localhost,127.0.0.1,.corp.example
 ```
 
 For environments that manage proxy details separately, Bomly also accepts decomposed proxy settings:
 
 ```yaml
-http_proxy_type: http # http, https, or socks5
-http_proxy_host: proxy.example
-http_proxy_port: 8080
-http_proxy_username: my-user
-http_proxy_password: my-password
-http_no_proxy: localhost,127.0.0.1,.corp.example
-http_ca_cert_file: /path/to/proxy-ca-chain.pem
+network:
+  proxy:
+    type: http # http, https, or socks5
+    host: proxy.example
+    port: 8080
+    username: my-user
+    password: my-password
+    no_proxy: localhost,127.0.0.1,.corp.example
+  ca_cert_file: /path/to/proxy-ca-chain.pem
 ```
 
 Equivalent environment variables are `BOMLY_HTTP_PROXY`, `BOMLY_HTTP_NO_PROXY`, `BOMLY_HTTP_PROXY_TYPE`, `BOMLY_HTTP_PROXY_HOST`, `BOMLY_HTTP_PROXY_PORT`, `BOMLY_HTTP_PROXY_USERNAME`, `BOMLY_HTTP_PROXY_PASSWORD`, and `BOMLY_HTTP_CA_CERT_FILE`. When Bomly proxy fields are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values to plugin subprocesses using the standard proxy environment variable names.

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -319,22 +319,30 @@ func TestCommandContextInitialize_LoadsConfigHierarchy(t *testing.T) {
 		t.Fatalf("mkdir home config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(tempHome, ".bomly", "config.yaml"), map[string]any{
-		"ecosystems": "npm",
-		"detectors":  "syft-detector",
-		"verbose":    true,
+		"components": map[string]any{
+			"ecosystems": "npm",
+			"detectors":  "syft-detector",
+		},
+		"logging": map[string]any{
+			"verbosity": 1,
+		},
 	})
 
 	if err := os.MkdirAll(filepath.Join(projectDir, ".bomly"), 0o755); err != nil {
 		t.Fatalf("mkdir project config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(projectDir, ".bomly", "config.yaml"), map[string]any{
-		"ecosystems": "go",
-		"detectors":  "go-detector",
+		"components": map[string]any{
+			"ecosystems": "go",
+			"detectors":  "go-detector",
+		},
 	})
 
 	explicitConfig := filepath.Join(t.TempDir(), "bomly.yaml")
 	writeConfigFile(t, explicitConfig, map[string]any{
-		"detectors": "maven-detector",
+		"components": map[string]any{
+			"detectors": "maven-detector",
+		},
 	})
 
 	options := &Options{
@@ -392,28 +400,56 @@ func TestCommandContextInitialize_AppliesConfigPrecedence(t *testing.T) {
 		t.Fatalf("mkdir home config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(tempHome, ".bomly", "config.yaml"), map[string]any{
-		"detectors":     "syft-detector",
-		"fail_on":       "low",
-		"format":        "text",
-		"osv_cache_ttl": "1h",
+		"components": map[string]any{
+			"detectors": "syft-detector",
+		},
+		"policy": map[string]any{
+			"fail_on": "low",
+		},
+		"output": map[string]any{
+			"format": "text",
+		},
+		"matchers": map[string]any{
+			"osv": map[string]any{
+				"cache_ttl": "1h",
+			},
+		},
 	})
 
 	if err := os.MkdirAll(filepath.Join(projectDir, ".bomly"), 0o755); err != nil {
 		t.Fatalf("mkdir project config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(projectDir, ".bomly", "config.yaml"), map[string]any{
-		"detectors":     "go-detector",
-		"fail_on":       "medium",
-		"format":        "json",
-		"matchers":      "osv",
-		"osv_cache_ttl": "2h",
+		"components": map[string]any{
+			"detectors": "go-detector",
+			"matchers":  "osv",
+		},
+		"policy": map[string]any{
+			"fail_on": "medium",
+		},
+		"output": map[string]any{
+			"format": "json",
+		},
+		"matchers": map[string]any{
+			"osv": map[string]any{
+				"cache_ttl": "2h",
+			},
+		},
 	})
 
 	explicitConfig := filepath.Join(t.TempDir(), "bomly.yaml")
 	writeConfigFile(t, explicitConfig, map[string]any{
-		"auditors":      "policy-auditor",
-		"fail_on":       "high",
-		"osv_cache_ttl": "4h",
+		"components": map[string]any{
+			"auditors": "policy-auditor",
+		},
+		"policy": map[string]any{
+			"fail_on": "high",
+		},
+		"matchers": map[string]any{
+			"osv": map[string]any{
+				"cache_ttl": "4h",
+			},
+		},
 	})
 
 	options := &Options{}
@@ -517,7 +553,9 @@ func TestCommandContextInitialize_LoadsQuietFromConfig(t *testing.T) {
 		t.Fatalf("mkdir home config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(tempHome, ".bomly", "config.yaml"), map[string]any{
-		"quiet": true,
+		"logging": map[string]any{
+			"quiet": true,
+		},
 	})
 
 	options := &Options{}
@@ -562,7 +600,9 @@ func TestCommandContextInitialize_ProjectConfigUsesSelectedPath(t *testing.T) {
 		t.Fatalf("mkdir project config dir: %v", err)
 	}
 	writeConfigFile(t, filepath.Join(projectDir, ".bomly", "config.yaml"), map[string]any{
-		"ecosystems": "go",
+		"components": map[string]any{
+			"ecosystems": "go",
+		},
 	})
 
 	options := &Options{ResolvedConfig: config.Resolved{Path: projectDir}}

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -1787,7 +1787,9 @@ func TestRoot_StartupLogsDoNotExposeHTTPAndPluginSecrets(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
-http_proxy: http://agent:super-secret@proxy.example:8080
+network:
+  proxy:
+    url: http://agent:super-secret@proxy.example:8080
 plugins:
   acme.matcher:
     token: plugin-secret

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,8 @@
 // Package config defines Bomly's resolved CLI configuration shape.
 //
-// The Resolved struct is the canonical declaration of every CLI flag, env
-// var, and YAML config key. Tag conventions:
+// The Resolved struct is the canonical declaration of every runtime config
+// value and environment override. The nested File structs declare YAML paths.
+// Resolved tag conventions:
 //
 //   - `doc:"..."`     — human-readable description (rendered in docs/CONFIG_REFERENCE.md)
 //   - `env:"..."`     — environment variable that sets the field
@@ -83,72 +84,127 @@ type Resolved struct {
 	ScorecardCacheTTL string `doc:"TTL for cached Scorecard responses (e.g. 24h)" env:"BOMLY_SCORECARD_CACHE_TTL" default:"24h"`
 }
 
-// File is the YAML-deserialized shape of a Bomly config file. The
-// pointer-to-primitive fields let cli code distinguish "field absent" from
-// "field set to zero value" when merging multiple config sources. The
-// configref generator parses this struct's yaml tags to map each Resolved
-// field to its corresponding YAML key in the reference docs.
+// File is the nested YAML-deserialized shape of a Bomly config file. Leaf
+// fields use pointers so merging can distinguish "field absent" from
+// "field explicitly set to its zero value". The resolved tags map YAML leaves
+// back to the flat runtime configuration, while legacy tags drive migration
+// errors and generated documentation for the former flat YAML keys.
 type File struct {
-	Path                  *string                   `yaml:"path,omitempty"`
-	Container             *string                   `yaml:"container,omitempty"`
-	URL                   *string                   `yaml:"url,omitempty"`
-	Ref                   *string                   `yaml:"ref,omitempty"`
-	SBOM                  *bool                     `yaml:"sbom,omitempty"`
-	Enrich                *bool                     `yaml:"enrich,omitempty"`
-	Audit                 *bool                     `yaml:"audit,omitempty"`
-	Reachability          *bool                     `yaml:"reachability,omitempty"`
-	FailOn                FailOnList                `yaml:"fail_on,omitempty"`
-	FailOnScopes          []string                  `yaml:"fail_on_scopes,omitempty"`
-	AllowVulnerabilityIDs []string                  `yaml:"allow_vulnerability_ids,omitempty"`
-	AllowLicenses         []string                  `yaml:"allow_licenses,omitempty"`
-	DenyLicenses          []string                  `yaml:"deny_licenses,omitempty"`
-	LicenseExemptPackages []string                  `yaml:"license_exempt_packages,omitempty"`
-	DenyPackages          []string                  `yaml:"deny_packages,omitempty"`
-	DenyGroups            []string                  `yaml:"deny_groups,omitempty"`
-	ProtectedPackages     []string                  `yaml:"protected_packages,omitempty"`
-	TyposquatThreshold    *string                   `yaml:"typosquat_threshold,omitempty"`
-	TyposquatMode         *string                   `yaml:"typosquat_mode,omitempty"`
-	WarnOnly              *bool                     `yaml:"warn_only,omitempty"`
-	Analyzers             *string                   `yaml:"analyzers,omitempty"`
-	Format                *string                   `yaml:"format,omitempty"`
-	Outputs               []string                  `yaml:"outputs,omitempty"`
-	Interactive           *bool                     `yaml:"interactive,omitempty"`
-	Ecosystems            *string                   `yaml:"ecosystems,omitempty"`
-	Detectors             *string                   `yaml:"detectors,omitempty"`
-	Auditors              *string                   `yaml:"auditors,omitempty"`
-	Matchers              *string                   `yaml:"matchers,omitempty"`
-	InstallFirst          *bool                     `yaml:"install_first,omitempty"`
-	InstallArgs           []string                  `yaml:"install_args,omitempty"`
-	Config                *string                   `yaml:"config,omitempty"`
-	Quiet                 *bool                     `yaml:"quiet,omitempty"`
-	Verbosity             *int                      `yaml:"verbosity,omitempty"`
-	Verbose               *bool                     `yaml:"verbose,omitempty"`
-	HTTPProxy             *string                   `yaml:"http_proxy,omitempty"`
-	HTTPNoProxy           *string                   `yaml:"http_no_proxy,omitempty"`
-	HTTPProxyType         *string                   `yaml:"http_proxy_type,omitempty"`
-	HTTPProxyHost         *string                   `yaml:"http_proxy_host,omitempty"`
-	HTTPProxyPort         *int                      `yaml:"http_proxy_port,omitempty"`
-	HTTPProxyUsername     *string                   `yaml:"http_proxy_username,omitempty"`
-	HTTPProxyPassword     *string                   `yaml:"http_proxy_password,omitempty"`
-	HTTPCACertFile        *string                   `yaml:"http_ca_cert_file,omitempty"`
-	Plugins               map[string]map[string]any `yaml:"plugins,omitempty"`
+	Target     TargetFile                `yaml:"target,omitempty"`
+	Analysis   AnalysisFile              `yaml:"analysis,omitempty"`
+	Components ComponentsFile            `yaml:"components,omitempty"`
+	Policy     PolicyFile                `yaml:"policy,omitempty"`
+	Output     OutputFile                `yaml:"output,omitempty"`
+	Logging    LoggingFile               `yaml:"logging,omitempty"`
+	Network    NetworkFile               `yaml:"network,omitempty"`
+	Matchers   MatchersFile              `yaml:"matchers,omitempty"`
+	Plugins    map[string]map[string]any `yaml:"plugins,omitempty" resolved:"Plugins"`
+}
 
-	// OSV matcher settings
-	OsvAPIBase  *string `yaml:"osv_api_base,omitempty"`
-	OsvCacheDir *string `yaml:"osv_cache_dir,omitempty"`
-	OsvCacheTTL *string `yaml:"osv_cache_ttl,omitempty"`
+// TargetFile configures the execution target selected for a scan.
+type TargetFile struct {
+	Path      *string `yaml:"path,omitempty" resolved:"Path" legacy:"path"`
+	Container *string `yaml:"container,omitempty" resolved:"Container" legacy:"container"`
+	URL       *string `yaml:"url,omitempty" resolved:"URL" legacy:"url"`
+	Ref       *string `yaml:"ref,omitempty" resolved:"Ref" legacy:"ref"`
+	SBOM      *bool   `yaml:"sbom,omitempty" resolved:"SBOM" legacy:"sbom"`
+}
 
-	// KEV enrichment settings
-	KEVCacheDir *string `yaml:"kev_cache_dir,omitempty"`
-	KEVCacheTTL *string `yaml:"kev_cache_ttl,omitempty"`
+// AnalysisFile configures optional analysis behavior and dependency preparation.
+type AnalysisFile struct {
+	Enrich       *bool     `yaml:"enrich,omitempty" resolved:"Enrich" legacy:"enrich"`
+	Audit        *bool     `yaml:"audit,omitempty" resolved:"Audit" legacy:"audit"`
+	Reachability *bool     `yaml:"reachability,omitempty" resolved:"Reachability" legacy:"reachability"`
+	InstallFirst *bool     `yaml:"install_first,omitempty" resolved:"InstallFirst" legacy:"install_first"`
+	InstallArgs  *[]string `yaml:"install_args,omitempty" resolved:"InstallArgs" legacy:"install_args"`
+}
 
-	// EOL enrichment settings
-	EOLAPIBase  *string `yaml:"eol_api_base,omitempty"`
-	EOLCacheDir *string `yaml:"eol_cache_dir,omitempty"`
-	EOLCacheTTL *string `yaml:"eol_cache_ttl,omitempty"`
+// ComponentsFile configures component selection.
+type ComponentsFile struct {
+	Ecosystems *string `yaml:"ecosystems,omitempty" resolved:"Ecosystems" legacy:"ecosystems"`
+	Detectors  *string `yaml:"detectors,omitempty" resolved:"Detectors" legacy:"detectors"`
+	Auditors   *string `yaml:"auditors,omitempty" resolved:"Auditors" legacy:"auditors"`
+	Matchers   *string `yaml:"matchers,omitempty" resolved:"Matchers" legacy:"matchers"`
+	Analyzers  *string `yaml:"analyzers,omitempty" resolved:"Analyzers" legacy:"analyzers"`
+}
 
-	// Scorecard matcher settings
-	ScorecardAPIBase  *string `yaml:"scorecard_api_base,omitempty"`
-	ScorecardCacheDir *string `yaml:"scorecard_cache_dir,omitempty"`
-	ScorecardCacheTTL *string `yaml:"scorecard_cache_ttl,omitempty"`
+// PolicyFile configures audit policy evaluation.
+type PolicyFile struct {
+	FailOn                *FailOnList `yaml:"fail_on,omitempty" resolved:"FailOn" legacy:"fail_on"`
+	FailOnScopes          *[]string   `yaml:"fail_on_scopes,omitempty" resolved:"FailOnScopes" legacy:"fail_on_scopes"`
+	AllowVulnerabilityIDs *[]string   `yaml:"allow_vulnerability_ids,omitempty" resolved:"AllowVulnerabilityIDs" legacy:"allow_vulnerability_ids"`
+	AllowLicenses         *[]string   `yaml:"allow_licenses,omitempty" resolved:"AllowLicenses" legacy:"allow_licenses"`
+	DenyLicenses          *[]string   `yaml:"deny_licenses,omitempty" resolved:"DenyLicenses" legacy:"deny_licenses"`
+	LicenseExemptPackages *[]string   `yaml:"license_exempt_packages,omitempty" resolved:"LicenseExemptPackages" legacy:"license_exempt_packages"`
+	DenyPackages          *[]string   `yaml:"deny_packages,omitempty" resolved:"DenyPackages" legacy:"deny_packages"`
+	DenyGroups            *[]string   `yaml:"deny_groups,omitempty" resolved:"DenyGroups" legacy:"deny_groups"`
+	ProtectedPackages     *[]string   `yaml:"protected_packages,omitempty" resolved:"ProtectedPackages" legacy:"protected_packages"`
+	TyposquatThreshold    *string     `yaml:"typosquat_threshold,omitempty" resolved:"TyposquatThreshold" legacy:"typosquat_threshold"`
+	TyposquatMode         *string     `yaml:"typosquat_mode,omitempty" resolved:"TyposquatMode" legacy:"typosquat_mode"`
+	WarnOnly              *bool       `yaml:"warn_only,omitempty" resolved:"WarnOnly" legacy:"warn_only"`
+}
+
+// OutputFile configures report rendering.
+type OutputFile struct {
+	Format      *string   `yaml:"format,omitempty" resolved:"Format" legacy:"format"`
+	Outputs     *[]string `yaml:"outputs,omitempty" resolved:"Outputs" legacy:"outputs"`
+	Interactive *bool     `yaml:"interactive,omitempty" resolved:"Interactive" legacy:"interactive"`
+}
+
+// LoggingFile configures CLI logging.
+type LoggingFile struct {
+	Quiet     *bool `yaml:"quiet,omitempty" resolved:"Quiet" legacy:"quiet"`
+	Verbosity *int  `yaml:"verbosity,omitempty" resolved:"Verbosity" legacy:"verbosity"`
+}
+
+// NetworkFile configures outbound network behavior.
+type NetworkFile struct {
+	Proxy      ProxyFile `yaml:"proxy,omitempty"`
+	CACertFile *string   `yaml:"ca_cert_file,omitempty" resolved:"HTTPCACertFile" legacy:"http_ca_cert_file"`
+}
+
+// ProxyFile configures the explicit outbound proxy.
+type ProxyFile struct {
+	URL      *string `yaml:"url,omitempty" resolved:"HTTPProxy" legacy:"http_proxy"`
+	NoProxy  *string `yaml:"no_proxy,omitempty" resolved:"HTTPNoProxy" legacy:"http_no_proxy"`
+	Type     *string `yaml:"type,omitempty" resolved:"HTTPProxyType" legacy:"http_proxy_type"`
+	Host     *string `yaml:"host,omitempty" resolved:"HTTPProxyHost" legacy:"http_proxy_host"`
+	Port     *int    `yaml:"port,omitempty" resolved:"HTTPProxyPort" legacy:"http_proxy_port"`
+	Username *string `yaml:"username,omitempty" resolved:"HTTPProxyUsername" legacy:"http_proxy_username"`
+	Password *string `yaml:"password,omitempty" resolved:"HTTPProxyPassword" legacy:"http_proxy_password"`
+}
+
+// MatchersFile configures built-in enrichment matchers.
+type MatchersFile struct {
+	OSV       OSVMatcherFile       `yaml:"osv,omitempty"`
+	EOL       EOLMatcherFile       `yaml:"eol,omitempty"`
+	Scorecard ScorecardMatcherFile `yaml:"scorecard,omitempty"`
+}
+
+// OSVMatcherFile configures OSV vulnerability enrichment.
+type OSVMatcherFile struct {
+	APIBase  *string `yaml:"api_base,omitempty" resolved:"OsvAPIBase" legacy:"osv_api_base"`
+	CacheDir *string `yaml:"cache_dir,omitempty" resolved:"OsvCacheDir" legacy:"osv_cache_dir"`
+	CacheTTL *string `yaml:"cache_ttl,omitempty" resolved:"OsvCacheTTL" legacy:"osv_cache_ttl"`
+	KEV      KEVFile `yaml:"kev,omitempty"`
+}
+
+// KEVFile configures CISA Known Exploited Vulnerabilities enrichment.
+type KEVFile struct {
+	CacheDir *string `yaml:"cache_dir,omitempty" resolved:"KEVCacheDir" legacy:"kev_cache_dir"`
+	CacheTTL *string `yaml:"cache_ttl,omitempty" resolved:"KEVCacheTTL" legacy:"kev_cache_ttl"`
+}
+
+// EOLMatcherFile configures endoflife.date enrichment.
+type EOLMatcherFile struct {
+	APIBase  *string `yaml:"api_base,omitempty" resolved:"EOLAPIBase" legacy:"eol_api_base"`
+	CacheDir *string `yaml:"cache_dir,omitempty" resolved:"EOLCacheDir" legacy:"eol_cache_dir"`
+	CacheTTL *string `yaml:"cache_ttl,omitempty" resolved:"EOLCacheTTL" legacy:"eol_cache_ttl"`
+}
+
+// ScorecardMatcherFile configures OpenSSF Scorecard enrichment.
+type ScorecardMatcherFile struct {
+	APIBase  *string `yaml:"api_base,omitempty" resolved:"ScorecardAPIBase" legacy:"scorecard_api_base"`
+	CacheDir *string `yaml:"cache_dir,omitempty" resolved:"ScorecardCacheDir" legacy:"scorecard_cache_dir"`
+	CacheTTL *string `yaml:"cache_ttl,omitempty" resolved:"ScorecardCacheTTL" legacy:"scorecard_cache_ttl"`
 }

--- a/internal/config/failon.go
+++ b/internal/config/failon.go
@@ -7,9 +7,9 @@ import (
 )
 
 // FailOnList is the YAML shape for fail_on values. It accepts either a
-// single scalar string ("fail_on: low") for backward compatibility with
+// single scalar string ("policy.fail_on: low") for backward compatibility with
 // the historical single-value form, or a sequence of strings
-// ("fail_on: [low, reachable]") for the new repeatable form. Both shapes
+// ("policy.fail_on: [low, reachable]") for the repeatable form. Both shapes
 // normalize to []string.
 type FailOnList []string
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -30,8 +32,8 @@ func UserConfigPath() (string, error) {
 }
 
 // LoadFile reads and parses a YAML config file at path. Returns nil with no
-// error when the file does not exist or path is empty. Relative path/config
-// fields inside the file are resolved relative to the file's directory.
+// error when the file does not exist or path is empty. Relative path fields
+// inside the file are resolved relative to the file's directory.
 func LoadFile(path string) (*File, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, nil
@@ -44,7 +46,12 @@ func LoadFile(path string) (*File, error) {
 		return nil, err
 	}
 	var cfg File
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := rejectLegacyFlatKeys(data); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("parse YAML: %w", err)
 	}
 	normalizeFilePaths(&cfg, filepath.Dir(path))
@@ -52,7 +59,7 @@ func LoadFile(path string) (*File, error) {
 }
 
 func normalizeFilePaths(cfg *File, baseDir string) {
-	for _, target := range []*string{cfg.Path, cfg.Config, cfg.HTTPCACertFile} {
+	for _, target := range []*string{cfg.Target.Path, cfg.Network.CACertFile} {
 		if target == nil || strings.TrimSpace(*target) == "" || filepath.IsAbs(*target) {
 			continue
 		}
@@ -60,60 +67,12 @@ func normalizeFilePaths(cfg *File, baseDir string) {
 	}
 }
 
-// ApplyFileConfig merges non-nil src fields into dst. File fields are pointers;
-// nil means the user did not set the field, so dst is left unchanged.
+// ApplyFileConfig merges explicitly set src leaves into dst.
 func ApplyFileConfig(dst *Resolved, src File) {
 	if dst == nil {
 		return
 	}
-	dstVal := reflect.ValueOf(dst).Elem()
-	srcVal := reflect.ValueOf(src)
-	t := srcVal.Type()
-	for i := 0; i < t.NumField(); i++ {
-		sf := srcVal.Field(i)
-		if sf.Kind() != reflect.Pointer || sf.IsNil() {
-			continue
-		}
-		df := dstVal.FieldByName(t.Field(i).Name)
-		if df.IsValid() && df.CanSet() {
-			df.Set(sf.Elem())
-		}
-	}
-	// InstallArgs is a slice (not a pointer) — replace when provided.
-	if len(src.InstallArgs) > 0 {
-		dst.InstallArgs = append([]string(nil), src.InstallArgs...)
-	}
-	// FailOn is a custom-unmarshaled slice (FailOnList) — replace when set.
-	if len(src.FailOn) > 0 {
-		dst.FailOn = append([]string(nil), src.FailOn...)
-	}
-	if len(src.FailOnScopes) > 0 {
-		dst.FailOnScopes = append([]string(nil), src.FailOnScopes...)
-	}
-	if len(src.AllowVulnerabilityIDs) > 0 {
-		dst.AllowVulnerabilityIDs = append([]string(nil), src.AllowVulnerabilityIDs...)
-	}
-	if len(src.AllowLicenses) > 0 {
-		dst.AllowLicenses = append([]string(nil), src.AllowLicenses...)
-	}
-	if len(src.DenyLicenses) > 0 {
-		dst.DenyLicenses = append([]string(nil), src.DenyLicenses...)
-	}
-	if len(src.LicenseExemptPackages) > 0 {
-		dst.LicenseExemptPackages = append([]string(nil), src.LicenseExemptPackages...)
-	}
-	if len(src.DenyPackages) > 0 {
-		dst.DenyPackages = append([]string(nil), src.DenyPackages...)
-	}
-	if len(src.DenyGroups) > 0 {
-		dst.DenyGroups = append([]string(nil), src.DenyGroups...)
-	}
-	if len(src.ProtectedPackages) > 0 {
-		dst.ProtectedPackages = append([]string(nil), src.ProtectedPackages...)
-	}
-	if len(src.Outputs) > 0 {
-		dst.Outputs = append([]string(nil), src.Outputs...)
-	}
+	applyFileLeaves(reflect.ValueOf(dst).Elem(), reflect.ValueOf(src))
 	if len(src.Plugins) > 0 {
 		if dst.Plugins == nil {
 			dst.Plugins = make(map[string]map[string]any, len(src.Plugins))
@@ -126,10 +85,150 @@ func ApplyFileConfig(dst *Resolved, src File) {
 			dst.Plugins[trimmedID] = clonePluginConfig(pluginConfig)
 		}
 	}
-	// Verbose is a legacy shorthand; map it to Verbosity=1 if not already set.
-	if src.Verbose != nil && *src.Verbose && dst.Verbosity == 0 {
-		dst.Verbosity = 1
+}
+
+func applyFileLeaves(dst reflect.Value, src reflect.Value) {
+	srcType := src.Type()
+	for i := 0; i < src.NumField(); i++ {
+		fieldType := srcType.Field(i)
+		srcField := src.Field(i)
+		resolvedName := fieldType.Tag.Get("resolved")
+		if resolvedName != "" {
+			if srcField.Kind() == reflect.Pointer && !srcField.IsNil() {
+				setResolvedField(dst.FieldByName(resolvedName), srcField.Elem())
+			}
+			continue
+		}
+		if srcField.Kind() == reflect.Struct {
+			applyFileLeaves(dst, srcField)
+		}
 	}
+}
+
+func setResolvedField(dst reflect.Value, src reflect.Value) {
+	if !dst.IsValid() || !dst.CanSet() {
+		return
+	}
+	if src.Type().ConvertibleTo(dst.Type()) {
+		src = src.Convert(dst.Type())
+	}
+	if src.Kind() == reflect.Slice {
+		clone := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+		reflect.Copy(clone, src)
+		src = clone
+	}
+	if src.Type().AssignableTo(dst.Type()) {
+		dst.Set(src)
+	}
+}
+
+func rejectLegacyFlatKeys(data []byte) error {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return err
+	}
+	if len(document.Content) == 0 {
+		return nil
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	legacyPaths := LegacyMigrationPaths()
+	canonicalRoots := canonicalRootKeys()
+	for idx := 0; idx+1 < len(root.Content); idx += 2 {
+		keyNode := root.Content[idx]
+		valueNode := root.Content[idx+1]
+		key := strings.TrimSpace(keyNode.Value)
+		if key == "config" {
+			return fmt.Errorf("config file key %q is no longer supported; use --config to select an explicit file", key)
+		}
+		nestedPath, ok := legacyPaths[key]
+		if !ok {
+			continue
+		}
+		if _, isCanonicalRoot := canonicalRoots[key]; isCanonicalRoot && valueNode.Kind == yaml.MappingNode {
+			continue
+		}
+		return fmt.Errorf("flat config key %q is no longer supported; use %q", key, nestedPath)
+	}
+	return nil
+}
+
+// LegacyMigrationPaths returns former flat YAML keys and their replacements.
+func LegacyMigrationPaths() map[string]string {
+	paths := make(map[string]string)
+	collectLegacyConfigPaths(reflect.TypeOf(File{}), "", paths)
+	paths["config"] = "--config"
+	paths["verbose"] = "logging.verbosity"
+	return paths
+}
+
+// YAMLPathsByResolvedField returns nested YAML paths keyed by flat runtime field.
+func YAMLPathsByResolvedField() map[string]string {
+	paths := make(map[string]string)
+	collectResolvedConfigPaths(reflect.TypeOf(File{}), "", paths)
+	return paths
+}
+
+func collectLegacyConfigPaths(t reflect.Type, prefix string, paths map[string]string) {
+	for idx := 0; idx < t.NumField(); idx++ {
+		field := t.Field(idx)
+		key := yamlTagName(field.Tag.Get("yaml"))
+		if key == "" || key == "-" {
+			continue
+		}
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		if legacy := field.Tag.Get("legacy"); legacy != "" {
+			paths[legacy] = path
+		}
+		if field.Type.Kind() == reflect.Struct {
+			collectLegacyConfigPaths(field.Type, path, paths)
+		}
+	}
+}
+
+func collectResolvedConfigPaths(t reflect.Type, prefix string, paths map[string]string) {
+	for idx := 0; idx < t.NumField(); idx++ {
+		field := t.Field(idx)
+		key := yamlTagName(field.Tag.Get("yaml"))
+		if key == "" || key == "-" {
+			continue
+		}
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		if resolved := field.Tag.Get("resolved"); resolved != "" {
+			paths[resolved] = path
+		}
+		if field.Type.Kind() == reflect.Struct {
+			collectResolvedConfigPaths(field.Type, path, paths)
+		}
+	}
+}
+
+func canonicalRootKeys() map[string]struct{} {
+	keys := make(map[string]struct{})
+	fileType := reflect.TypeOf(File{})
+	for idx := 0; idx < fileType.NumField(); idx++ {
+		key := yamlTagName(fileType.Field(idx).Tag.Get("yaml"))
+		if key != "" && key != "-" {
+			keys[key] = struct{}{}
+		}
+	}
+	return keys
+}
+
+func yamlTagName(tag string) string {
+	if idx := strings.Index(tag, ","); idx >= 0 {
+		tag = tag[:idx]
+	}
+	return tag
 }
 
 // ApplyEnvOverrides reads the environment variables named in Resolved's env

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,20 +3,23 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestLoadFileAndEnvProxyPrecedence(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte(`
-http_proxy: http://file-proxy.example:8080
-http_no_proxy: file.internal
-http_proxy_type: socks5
-http_proxy_host: split-proxy.example
-http_proxy_port: 1080
-http_proxy_username: agent
-http_proxy_password: secret
-http_ca_cert_file: certs/proxy-ca.pem
+network:
+  proxy:
+    url: http://file-proxy.example:8080
+    no_proxy: file.internal
+    type: socks5
+    host: split-proxy.example
+    port: 1080
+    username: agent
+    password: secret
+  ca_cert_file: certs/proxy-ca.pem
 plugins:
   acme.matcher:
     api_base: https://api.file.example
@@ -66,6 +69,169 @@ plugins:
 	}
 	if got := resolved.Plugins["acme.matcher"]["batch_size"]; got != float64(10) {
 		t.Fatalf("plugin batch_size = %#v", got)
+	}
+}
+
+func TestLoadFileNestedConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+target:
+  path: fixture
+  container: alpine:3.20
+  url: https://example.com/acme/repo.git
+  ref: main
+  sbom: true
+analysis:
+  enrich: true
+  audit: true
+  reachability: true
+  install_first: true
+  install_args: [--offline]
+components:
+  ecosystems: go,npm
+  detectors: gomod
+  auditors: policy
+  matchers: osv
+  analyzers: govulncheck
+policy:
+  fail_on: [high, reachable]
+  fail_on_scopes: [runtime]
+  allow_vulnerability_ids: [CVE-2026-0001]
+  allow_licenses: [MIT]
+  deny_licenses: [GPL-3.0]
+  license_exempt_packages: [pkg:golang/example.com/exempt@v1.0.0]
+  deny_packages: [pkg:golang/example.com/denied@v1.0.0]
+  deny_groups: [example.com/private]
+  protected_packages: [github.com/acme/core]
+  typosquat_threshold: "0.95"
+  typosquat_mode: fail
+  warn_only: true
+output:
+  format: json
+  outputs: [spdx=sbom.json]
+  interactive: true
+logging:
+  quiet: true
+  verbosity: 2
+matchers:
+  osv:
+    api_base: https://osv.example
+    cache_dir: cache/osv
+    cache_ttl: 1h
+    kev:
+      cache_dir: cache/kev
+      cache_ttl: 2h
+  eol:
+    api_base: https://eol.example
+    cache_dir: cache/eol
+    cache_ttl: 3h
+  scorecard:
+    api_base: https://scorecard.example
+    cache_dir: cache/scorecard
+    cache_ttl: 4h
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fileCfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	var resolved Resolved
+	ApplyFileConfig(&resolved, *fileCfg)
+
+	if want := filepath.Join(filepath.Dir(path), "fixture"); resolved.Path != want {
+		t.Fatalf("Path = %q, want %q", resolved.Path, want)
+	}
+	if resolved.Container != "alpine:3.20" || resolved.URL == "" || resolved.Ref != "main" || !resolved.SBOM {
+		t.Fatalf("target config = %#v", resolved)
+	}
+	if !resolved.Enrich || !resolved.Audit || !resolved.Reachability || !resolved.InstallFirst {
+		t.Fatalf("analysis config = %#v", resolved)
+	}
+	if len(resolved.InstallArgs) != 1 || resolved.InstallArgs[0] != "--offline" {
+		t.Fatalf("InstallArgs = %#v", resolved.InstallArgs)
+	}
+	if resolved.Ecosystems != "go,npm" || resolved.Detectors != "gomod" || resolved.Auditors != "policy" || resolved.Matchers != "osv" || resolved.Analyzers != "govulncheck" {
+		t.Fatalf("component config = %#v", resolved)
+	}
+	if len(resolved.FailOn) != 2 || len(resolved.FailOnScopes) != 1 || len(resolved.AllowVulnerabilityIDs) != 1 || len(resolved.AllowLicenses) != 1 || len(resolved.DenyLicenses) != 1 || len(resolved.LicenseExemptPackages) != 1 || len(resolved.DenyPackages) != 1 || len(resolved.DenyGroups) != 1 || len(resolved.ProtectedPackages) != 1 {
+		t.Fatalf("policy config = %#v", resolved)
+	}
+	if resolved.TyposquatThreshold != "0.95" || resolved.TyposquatMode != "fail" || !resolved.WarnOnly {
+		t.Fatalf("typosquat config = %#v", resolved)
+	}
+	if resolved.Format != "json" || len(resolved.Outputs) != 1 || !resolved.Interactive || !resolved.Quiet || resolved.Verbosity != 2 {
+		t.Fatalf("output/logging config = %#v", resolved)
+	}
+	if resolved.OsvAPIBase != "https://osv.example" || resolved.OsvCacheTTL != "1h" || resolved.KEVCacheTTL != "2h" || resolved.EOLAPIBase != "https://eol.example" || resolved.EOLCacheTTL != "3h" || resolved.ScorecardAPIBase != "https://scorecard.example" || resolved.ScorecardCacheTTL != "4h" {
+		t.Fatalf("matcher config = %#v", resolved)
+	}
+}
+
+func TestApplyFileConfigClearsInheritedLists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+analysis:
+  enrich: false
+  install_args: []
+policy:
+  fail_on: []
+  allow_licenses: []
+output:
+  interactive: false
+  outputs: []
+logging:
+  verbosity: 0
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fileCfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	resolved := Resolved{
+		Enrich:        true,
+		InstallArgs:   []string{"--offline"},
+		FailOn:        []string{"high"},
+		AllowLicenses: []string{"MIT"},
+		Interactive:   true,
+		Outputs:       []string{"spdx=sbom.json"},
+		Verbosity:     2,
+	}
+	ApplyFileConfig(&resolved, *fileCfg)
+	if resolved.Enrich || resolved.Interactive || resolved.Verbosity != 0 {
+		t.Fatalf("expected explicit zero values to override inherited values, got %#v", resolved)
+	}
+	if len(resolved.InstallArgs) != 0 || len(resolved.FailOn) != 0 || len(resolved.AllowLicenses) != 0 || len(resolved.Outputs) != 0 {
+		t.Fatalf("expected explicit empty lists to clear inherited values, got %#v", resolved)
+	}
+}
+
+func TestLoadFileRejectsLegacyAndUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "flat key", yaml: "http_proxy: http://proxy.example:8080\n", want: `use "network.proxy.url"`},
+		{name: "flat matcher selector", yaml: "matchers: osv\n", want: `use "components.matchers"`},
+		{name: "config key", yaml: "config: other.yaml\n", want: "use --config"},
+		{name: "verbose shorthand", yaml: "verbose: true\n", want: `use "logging.verbosity"`},
+		{name: "unknown root", yaml: "unknown: true\n", want: "field unknown not found"},
+		{name: "unknown nested", yaml: "network:\n  proxy:\n    unknown: true\n", want: "field unknown not found"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := LoadFile(path)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadFile() error = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -299,7 +299,7 @@ rm -rf ~/.bomly/cache    # Unix/macOS
 Remove-Item -Recurse $env:USERPROFILE\.bomly\cache  # PowerShell
 `+"```"+`
 
-Override the cache location per matcher in `+"`~/.bomly/config.yaml`"+`; see [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md). Cache failures are **always non-fatal** — Bomly logs a warning and continues.
+Override cache locations with matcher-specific keys such as `+"`matchers.osv.cache_dir`"+`, `+"`matchers.eol.cache_dir`"+`, and `+"`matchers.scorecard.cache_dir`"+`; see [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md). Cache failures are **always non-fatal** — Bomly logs a warning and continues.
 
 ## Failure semantics
 

--- a/internal/support/config_reference.go
+++ b/internal/support/config_reference.go
@@ -7,7 +7,10 @@ import (
 	"go/token"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
+
+	"github.com/bomly-dev/bomly-cli/internal/config"
 )
 
 type configField struct {
@@ -48,37 +51,7 @@ func parseConfigFields(configPath string) ([]configField, error) {
 		return nil, fmt.Errorf("parse %s: %w", configPath, err)
 	}
 
-	fileConfigYAML := map[string]string{}
-	for _, decl := range f.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok || genDecl.Tok != token.TYPE {
-			continue
-		}
-		for _, spec := range genDecl.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok || ts.Name.Name != "File" {
-				continue
-			}
-			st, ok := ts.Type.(*ast.StructType)
-			if !ok {
-				continue
-			}
-			for _, field := range st.Fields.List {
-				if len(field.Names) == 0 || field.Tag == nil {
-					continue
-				}
-				tag := strings.Trim(field.Tag.Value, "`")
-				structTag := reflect.StructTag(tag)
-				yamlKey := structTag.Get("yaml")
-				if i := strings.Index(yamlKey, ","); i >= 0 {
-					yamlKey = yamlKey[:i]
-				}
-				if yamlKey != "" && yamlKey != "-" {
-					fileConfigYAML[field.Names[0].Name] = yamlKey
-				}
-			}
-		}
-	}
+	fileConfigYAML := config.YAMLPathsByResolvedField()
 
 	var fields []configField
 	currentSection := "General"
@@ -137,7 +110,7 @@ func parseConfigFields(configPath string) ([]configField, error) {
 
 				yamlKey := fileConfigYAML[name]
 				if yamlKey == "" {
-					yamlKey = toSnakeCase(name)
+					continue
 				}
 
 				fields = append(fields, configField{
@@ -165,6 +138,7 @@ func renderConfigMarkdown(fields []configField) string {
 	builder.WriteString("3. `BOMLY_*` environment variables\n")
 	builder.WriteString("4. CLI flags\n\n")
 	builder.WriteString("`--config <path>` adds an explicit config file to the load list before environment variables and flags are applied.\n\n")
+	builder.WriteString("YAML files use the nested keys documented below. Unknown keys and the former flat keys are rejected so configuration mistakes fail fast.\n\n")
 	builder.WriteString("---\n\n")
 
 	type sectionGroup struct {
@@ -202,36 +176,101 @@ func renderConfigMarkdown(fields []configField) string {
 		builder.WriteString("\n")
 	}
 
+	builder.WriteString("## Flat YAML Migration\n\n")
+	builder.WriteString("Flat YAML keys are no longer accepted. Move each existing key to its nested replacement:\n\n")
+	builder.WriteString("| Former Flat Key | Replacement |\n")
+	builder.WriteString("|-----------------|-------------|\n")
+	migrations := config.LegacyMigrationPaths()
+	legacyKeys := make([]string, 0, len(migrations))
+	for key := range migrations {
+		legacyKeys = append(legacyKeys, key)
+	}
+	sort.Strings(legacyKeys)
+	for _, key := range legacyKeys {
+		fmt.Fprintf(&builder, "| `%s` | `%s` |\n", key, migrations[key])
+	}
+	builder.WriteString("\n")
+
 	builder.WriteString("## Example Configuration\n\n")
 	builder.WriteString("```yaml\n")
 	builder.WriteString("# ~/.bomly/config.yaml or .bomly/config.yaml\n")
-	for _, section := range sections {
-		builder.WriteString("\n# " + section.name + "\n")
-		for _, field := range section.fields {
-			value := field.DefaultVal
-			if value == "" {
-				switch field.GoType {
-				case "bool":
-					value = "false"
-				case "int":
-					value = "0"
-				case "string":
-					value = "\"\""
-				case "[]string":
-					value = "[]"
-				case "map[string]any", "map[string]map[string]any":
-					value = "{}"
-				default:
-					value = "\"\""
-				}
-			}
-			fmt.Fprintf(&builder, "# %s\n", field.Doc)
-			fmt.Fprintf(&builder, "# %s: %s\n", field.YAMLKey, value)
-		}
-	}
+	writeNestedConfigExample(&builder, fields)
 	builder.WriteString("```\n")
 
 	return builder.String()
+}
+
+func writeNestedConfigExample(builder *strings.Builder, fields []configField) {
+	fieldsByPath := make(map[string]configField, len(fields))
+	for _, field := range fields {
+		fieldsByPath[field.YAMLKey] = field
+	}
+	writeNestedConfigType(builder, reflect.TypeOf(config.File{}), "", 0, fieldsByPath)
+}
+
+func writeNestedConfigType(builder *strings.Builder, t reflect.Type, prefix string, depth int, fields map[string]configField) {
+	for idx := 0; idx < t.NumField(); idx++ {
+		structField := t.Field(idx)
+		key := yamlTagName(structField.Tag.Get("yaml"))
+		if key == "" || key == "-" {
+			continue
+		}
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		if structField.Type.Kind() == reflect.Struct {
+			if !hasConfigPath(fields, path+".") {
+				continue
+			}
+			fmt.Fprintf(builder, "# %s%s:\n", strings.Repeat("  ", depth), key)
+			writeNestedConfigType(builder, structField.Type, path, depth+1, fields)
+			continue
+		}
+		field, ok := fields[path]
+		if !ok {
+			continue
+		}
+		indent := strings.Repeat("  ", depth)
+		fmt.Fprintf(builder, "# %s%s\n", indent, field.Doc)
+		fmt.Fprintf(builder, "# %s%s: %s\n", indent, key, exampleConfigValue(field))
+	}
+}
+
+func hasConfigPath(fields map[string]configField, prefix string) bool {
+	for path := range fields {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func exampleConfigValue(field configField) string {
+	if field.DefaultVal != "" {
+		return field.DefaultVal
+	}
+	switch field.GoType {
+	case "bool":
+		return "false"
+	case "int":
+		return "0"
+	case "string":
+		return "\"\""
+	case "[]string":
+		return "[]"
+	case "map[string]any", "map[string]map[string]any":
+		return "{}"
+	default:
+		return "\"\""
+	}
+}
+
+func yamlTagName(tag string) string {
+	if idx := strings.Index(tag, ","); idx >= 0 {
+		tag = tag[:idx]
+	}
+	return tag
 }
 
 func configTypeString(expr ast.Expr) string {
@@ -249,19 +288,4 @@ func configTypeString(expr ast.Expr) string {
 	default:
 		return "any"
 	}
-}
-
-func toSnakeCase(value string) string {
-	var result strings.Builder
-	for idx, character := range value {
-		if character >= 'A' && character <= 'Z' {
-			if idx > 0 {
-				result.WriteByte('_')
-			}
-			result.WriteByte(byte(character + 32))
-			continue
-		}
-		result.WriteRune(character)
-	}
-	return result.String()
 }

--- a/internal/support/generate_test.go
+++ b/internal/support/generate_test.go
@@ -18,11 +18,17 @@ func TestGenerateConfigReference(t *testing.T) {
 	if fieldCount == 0 {
 		t.Fatal("expected generated config fields")
 	}
-	if !strings.Contains(markdown, "| `format` | `BOMLY_FORMAT` | `string` |") {
+	if !strings.Contains(markdown, "| `output.format` | `BOMLY_FORMAT` | `string` |") {
 		t.Fatalf("generated config reference missing format field:\n%s", markdown)
 	}
 	if !strings.Contains(markdown, "## OSV matcher settings") {
 		t.Fatalf("generated config reference missing section heading:\n%s", markdown)
+	}
+	if !strings.Contains(markdown, "| `http_proxy` | `network.proxy.url` |") {
+		t.Fatalf("generated config reference missing flat-key migration:\n%s", markdown)
+	}
+	if !strings.Contains(markdown, "# network:\n#   proxy:") || !strings.Contains(markdown, "#     url:") {
+		t.Fatalf("generated config reference missing nested example:\n%s", markdown)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the flat YAML config file format with strict nested groups such as `target`, `analysis`, `policy`, `network.proxy`, and matcher-specific sections
- keep the resolved runtime config, CLI flags, environment variables, MCP interfaces, and plugin protocol unchanged
- place `install_first` and `install_args` together under `analysis`

## Behavior changes
- map nested YAML leaves back to the existing flat runtime fields through schema metadata
- recursively merge layered config files, including explicit `false`, `0`, and `[]` overrides
- reject unknown YAML keys and former flat keys with actionable migration hints
- remove YAML support for `config` and the legacy `verbose` shorthand while keeping `--config` selection

## Documentation
- regenerate the configuration reference with dotted paths, a nested example, and a flat-key migration table
- update proxy, matcher-cache, architecture, and contributor guidance

## Follow-up fix
- merge current `main` and migrate its startup secret-redaction fixture from flat `http_proxy` to nested `network.proxy.url`

## Validation
- `make generate`
- `go test -count=1 ./...`
- `make build`
- `make fmt-check`
- `git diff --check`