### PR TITLE
feat: reinforce plugin security model with runtime warnings and docs overhaul

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -27,6 +27,8 @@ Installed external plugins are disabled by default. They do not participate in s
 
 Enabled plugins are loaded during runtime preparation in local and CI workflows. Treat `bomly plugin enable` as the trust decision for running that external binary.
 
+When enabled, a plugin binary runs as a native OS subprocess with the same user-level privileges as the bomly process. It can read and write files, make network connections, and execute system calls within those privileges.
+
 ## Configuration And Proxy Support
 
 Bomly passes the active plugin API version, the explicit `BOMLY_CONFIG` path when one was provided, proxy settings, and the enabled plugin's own config to managed plugin subprocesses.
@@ -275,15 +277,37 @@ For GitHub Release installs, Bomly resolves the release metadata, selects the as
 
 ## Security Model
 
-Bomly validates plugin manifests before execution and rejects unsafe archive paths.
+External plugins are native OS subprocesses. They are not sandboxed, not containerized, and not restricted by Bomly in any way beyond the operating system's standard user-level privilege boundary. When a plugin runs, it inherits the full privileges of the user invoking bomly: it can read and write files, open network connections, spawn child processes, and access environment variables.
 
-Important constraints:
+**What Bomly validates before executing a plugin:**
 
-- direct URL installs require `--checksum` unless you explicitly bypass it
-- runtime metadata must match manifest identity, version, kind, and API version
-- plugin metadata is treated as untrusted input
-- enabled state is host-owned and stored in Bomly's installed plugin database
-- plugin execution uses context cancellation
-- repository-declared plugins are not executed automatically
+- Manifest schema and required fields (ID, version, kind, runtime, API version)
+- Plugin API version compatibility with the running core version
+- Entrypoint binary exists at the recorded path
+- SHA256 checksum matches the installed record, when a checksum was recorded
+- Runtime-reported metadata matches the manifest identity, version, kind, and API version
 
-Managed plugins are isolated by process boundary, but they are still external binaries. Treat install and execution as a trust decision.
+**What Bomly cannot enforce:**
+
+- Restricting the plugin's filesystem or network access
+- Preventing the plugin from reading environment variables or credentials on the host
+- Preventing the plugin from spawning additional child processes
+- Guaranteeing that the installed binary matches the declared source if no checksum was recorded
+
+**Installation mode risk:**
+
+| Source | Integrity guarantee |
+|--------|---------------------|
+| Local archive (`bomly plugin install ./plugin.tar.gz --checksum sha256:...`) | Strongest: checksum ties the installed binary to the declared archive |
+| GitHub Release (`github:owner/repo@tag`) | SHA256SUMS asset verified automatically when present |
+| Direct URL with `--checksum` | Checksum ties the download to the declared identity |
+| Direct URL with `--insecure-skip-checksum` | None: the downloaded binary may differ from the declared source |
+| Local binary with `--dev` | None: appropriate only for binaries you built locally |
+
+**Recommended practices:**
+
+- Always supply `--checksum` for direct URL installs.
+- Run `bomly plugin verify <id>` before enabling any plugin installed from an external source.
+- Treat `bomly plugin enable` as the explicit trust decision for granting execution privileges. Do not enable plugins you did not build or obtain from a source you control.
+- Prefer `github:owner/repo@tag` installs — they resolve the asset for your current OS and architecture and verify against the published SHA256SUMS automatically.
+- Repository-declared plugins are never executed automatically. Bomly requires an explicit `bomly plugin enable` on the host before any external plugin participates in a scan.

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -238,7 +238,18 @@ func newPluginInstallCmd() *cobra.Command {
 				nonEmptyString(result.ResolvedSource, args[0]),
 				nonEmptyString(result.Installed.Checksum, "not recorded"),
 			)
-			return err
+			if err != nil {
+				return err
+			}
+			if devBinary {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"Warning: installed in development mode — no checksum was recorded. Only enable plugins you built or fully trust.\n")
+			}
+			if insecureSkipChecksum {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"Warning: checksum verification was skipped. Verify this plugin's integrity before enabling it.\n")
+			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&devBinary, "dev", false, "Install a local development plugin binary instead of an archive")
@@ -269,7 +280,30 @@ func newPluginUninstallCmd() *cobra.Command {
 }
 
 func newPluginEnableCmd() *cobra.Command {
-	return togglePluginStateCmd("enable", "Enable an installed external plugin", managedplugin.Enable, "enabled")
+	return &cobra.Command{
+		Use:   "enable <id>",
+		Short: "Enable an installed external plugin",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options, err := commandOptions(cmd)
+			if err != nil {
+				return err
+			}
+			pluginRecord, err := managedplugin.Enable("", strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			current := options.GetConfig()
+			streams := newCommandStreams(cmd, current.Quiet, current.Verbosity)
+			if _, err := fmt.Fprintf(streams.reportWriter(), "enabled %s@%s\n", pluginRecord.ID, pluginRecord.Version); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"Warning: %s@%s will run as a native subprocess with full OS execution privileges during scans. Only enable plugins from sources you trust.\n",
+				pluginRecord.ID, pluginRecord.Version)
+			return nil
+		},
+	}
 }
 
 func newPluginDisableCmd() *cobra.Command {
@@ -319,6 +353,11 @@ func newPluginVerifyCmd() *cobra.Command {
 			result, err := managedplugin.Verify(options.PluginLaunchContext(cmd.Context()), "", strings.TrimSpace(args[0]))
 			if err != nil {
 				return err
+			}
+			if result.Installed != nil && result.Installed.Checksum == "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"Warning: no checksum is recorded for %s@%s — this plugin was installed without integrity verification. Treat it as untrusted.\n",
+					result.ID, result.Version)
 			}
 			if jsonOutput {
 				return writeJSON(streams.reportWriter(), result)


### PR DESCRIPTION
## Summary

Clearly documents and reinforces the security boundary of Bomly's plugin architecture, emphasizing that plugin installation and enablement represent explicit host-level trust decisions.

## Changes

### `internal/cli/plugin_cmd.go`

**`bomly plugin install`** — adds two independent warnings to stderr after a successful install, each gated on the flag that created the risk:
- `--dev`: *"installed in development mode — no checksum was recorded. Only enable plugins you built or fully trust."*
- `--insecure-skip-checksum`: *"checksum verification was skipped. Verify this plugin's integrity before enabling it."*

**`bomly plugin enable`** — expanded from a shared `togglePluginStateCmd` delegation to a standalone function that emits a privilege warning after the success line:
- *"\<id\>@\<version\> will run as a native subprocess with full OS execution privileges during scans. Only enable plugins from sources you trust."*

**`bomly plugin verify`** — before the `--json` branch, checks whether no checksum was recorded for the installed plugin and emits:
- *"no checksum is recorded for \<id\>@\<version\> — this plugin was installed without integrity verification. Treat it as untrusted."*

All three warnings use `cmd.ErrOrStderr()` directly (bypassing `commandStreams.notificationWriter()`), so they always appear on stderr even when `--quiet` is set.

### `docs/PLUGINS.md`

**Runtime Policy** — appended an explicit sentence stating that enabled plugins run as native OS subprocesses with the same user-level privileges as the bomly process.

**Security Model** — full rewrite replacing the brief bullet list with:
1. Lead paragraph: native OS subprocess execution model — not sandboxed, not containerized
2. What Bomly validates (manifest schema, API version, entrypoint, checksum when recorded, runtime metadata match)
3. What Bomly cannot enforce (filesystem/network restriction, env var reads, child process spawning)
4. Installation mode risk table (5 rows from strongest to no guarantee)
5. Recommended practices (checksum for URL installs, verify before enable, prefer `github:` sources)

## Testing

- `make test` — all packages pass (exit 0)
- `go test ./internal/cli/...` — passes (exit 0)
- No schema changes, no new exported types, no new test files required
