### PR TITLE
Add conditional interactive reachability filter

### DIFF
--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -146,7 +146,7 @@ func newScanCmd() *cobra.Command {
 
 			if commandCtx.ResolvedConfig.Interactive {
 				prog.Stop()
-				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewScan(payload.Project, consolidated, selectedGraph, findings).WithEnrichEnabled(commandCtx.ResolvedConfig.Enrich)))
+				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewScan(payload.Project, consolidated, selectedGraph, findings).WithEnrichEnabled(commandCtx.ResolvedConfig.Enrich).WithReachabilityEnabled(commandCtx.ResolvedConfig.Reachability)))
 			}
 
 			writer, closeWriter, err := commandCtx.Writer(streams.reportWriter())

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -36,6 +36,20 @@ func (m *scanModel) WithEnrichEnabled(enabled bool) *scanModel {
 	return m
 }
 
+// WithReachabilityEnabled records whether the scan requested reachability
+// analysis so the conditional interactive filter is only exposed for an
+// explicitly enabled scan.
+func (m *scanModel) WithReachabilityEnabled(enabled bool) *scanModel {
+	if m == nil {
+		return nil
+	}
+	m.reachabilityEnabled = enabled
+	if m.shellModel != nil {
+		m.Rebuild()
+	}
+	return m
+}
+
 func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, consolidated sdk.ConsolidatedGraph, graphValue *sdk.Graph, findings []sdk.Finding, explainQuery string) *scanModel {
 	manifests := manifestRows(consolidated)
 	manifestByID := make(map[string]listPackageRow, len(manifests))
@@ -315,6 +329,36 @@ func (m *scanModel) CycleEcosystemFilter() {
 	m.rebuildListPreserveSelection()
 }
 
+func (m *scanModel) CycleReachabilityFilter() {
+	if !m.reachabilityFilterAvailable() {
+		return
+	}
+	switch m.currentScanView() {
+	case interactiveScanViewPackages, interactiveScanViewVulns:
+	default:
+		return
+	}
+	m.reachabilityFilter = nextFilterValue(m.reachabilityFilter, []string{"", string(sdk.ReachabilityReachable), string(sdk.ReachabilityUnreachable)})
+	m.rebuildListPreserveSelection()
+}
+
+func (m *scanModel) reachabilityFilterAvailable() bool {
+	if m == nil || !m.reachabilityEnabled || m.graphValue == nil {
+		return false
+	}
+	for _, pkg := range m.graphValue.Packages() {
+		if pkg == nil {
+			continue
+		}
+		for _, vulnerability := range pkg.Vulnerabilities {
+			if vulnerability.Reachability != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (m *scanModel) componentEcosystemValues() []string {
 	if m == nil || m.graphValue == nil {
 		return nil
@@ -467,7 +511,12 @@ func (m *scanModel) scanFooterLines(width int) []string {
 }
 
 func (m *scanModel) componentControlsLine() string {
-	return keyHint("/", "search") + " " + keyHint("r", "relationship") + " " + keyHint("s", "scope") + " " + keyHint("v", "severity") + " " + keyHint("e", "ecosystem") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all")
+	parts := []string{keyHint("/", "search"), keyHint("r", "relationship"), keyHint("s", "scope"), keyHint("v", "severity"), keyHint("e", "ecosystem")}
+	if m.reachabilityFilterAvailable() {
+		parts = append(parts, keyHint("a", "reachability"))
+	}
+	parts = append(parts, keyHint("]", "expand all"), keyHint("[", "collapse all"))
+	return strings.Join(parts, " ")
 }
 
 func (m *scanModel) componentStateLine(extra string) string {
@@ -476,6 +525,9 @@ func (m *scanModel) componentStateLine(extra string) string {
 		render.Style(" | Scope: ", render.Dim) + render.Style(valueOrDefault(m.scopeFilter, "All"), render.BgYellow, render.Bold) +
 		render.Style(" | Severity: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold) +
 		render.Style(" | Ecosystem: ", render.Dim) + render.Style(valueOrDefault(m.ecosystemFilter, "All"), render.BgYellow, render.Bold)
+	if m.reachabilityFilterAvailable() {
+		state += render.Style(" | Reachability: ", render.Dim) + render.Style(titleCase(valueOrDefault(m.reachabilityFilter, "All")), render.BgYellow, render.Bold)
+	}
 	if strings.TrimSpace(extra) != "" {
 		state += render.Style(" | ", render.Dim) + extra
 	}
@@ -692,6 +744,16 @@ func (m *scanModel) filterComponentRows(rows []listPackageRow, maxSevByID map[st
 		}
 		rows = kept
 	}
+	if m.reachabilityFilter != "" {
+		kept := rows[:0]
+		for _, row := range rows {
+			pkg, _ := m.graphValue.Package(row.id)
+			if packageMatchesReachabilityFilter(pkg, m.reachabilityFilter) {
+				kept = append(kept, row)
+			}
+		}
+		rows = kept
+	}
 	if m.severityFilter == "" {
 		return rows
 	}
@@ -702,6 +764,31 @@ func (m *scanModel) filterComponentRows(rows []listPackageRow, maxSevByID map[st
 		}
 	}
 	return kept
+}
+
+func packageMatchesReachabilityFilter(pkg *sdk.Package, filter string) bool {
+	if filter == "" {
+		return true
+	}
+	if pkg == nil || len(pkg.Vulnerabilities) == 0 {
+		return false
+	}
+	switch filter {
+	case string(sdk.ReachabilityReachable):
+		for _, vulnerability := range pkg.Vulnerabilities {
+			if vulnerability.Reachability != nil && vulnerability.Reachability.Status == sdk.ReachabilityReachable {
+				return true
+			}
+		}
+	case string(sdk.ReachabilityUnreachable):
+		for _, vulnerability := range pkg.Vulnerabilities {
+			if vulnerability.Reachability == nil || vulnerability.Reachability.Status != sdk.ReachabilityUnreachable {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func componentCountRows(graphValue *sdk.Graph, rootID string) []listPackageRow {
@@ -893,14 +980,18 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 func (m *scanModel) buildVulnsListModel() *listModel {
 	all := packageVulnerabilityRows(m.graphValue)
 
-	// Apply severity filter.
+	// Apply severity and reachability filters.
 	filtered := all
-	if m.severityFilter != "" {
+	if m.severityFilter != "" || m.reachabilityFilter != "" {
 		filtered = make([]packageVulnerabilityRow, 0, len(all))
 		for _, row := range all {
-			if strings.EqualFold(row.vulnerability.Severity, m.severityFilter) {
-				filtered = append(filtered, row)
+			if m.severityFilter != "" && !strings.EqualFold(row.vulnerability.Severity, m.severityFilter) {
+				continue
 			}
+			if m.reachabilityFilter != "" && (row.vulnerability.Reachability == nil || string(row.vulnerability.Reachability.Status) != m.reachabilityFilter) {
+				continue
+			}
+			filtered = append(filtered, row)
 		}
 	}
 
@@ -1043,13 +1134,22 @@ func vulnerabilityPackageName(row packageVulnerabilityRow) string {
 }
 
 func (m *scanModel) vulnerabilityControlsLine() string {
-	return keyHint("/", "search") + " " + keyHint("g", "group") + " " + keyHint("v", "severity") + " " + keyHint("]", "expand all") + " " + keyHint("[", "collapse all")
+	parts := []string{keyHint("/", "search"), keyHint("g", "group"), keyHint("v", "severity")}
+	if m.reachabilityFilterAvailable() {
+		parts = append(parts, keyHint("a", "reachability"))
+	}
+	parts = append(parts, keyHint("]", "expand all"), keyHint("[", "collapse all"))
+	return strings.Join(parts, " ")
 }
 
 func (m *scanModel) vulnerabilityStateLine(showing, total int) string {
-	return render.Style("Filter: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold) +
+	state := render.Style("Filter: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold) +
 		render.Style(" | Group: ", render.Dim) + render.Style(valueOrDefault(m.vulnerabilityGroup, "component"), render.BgYellow, render.Bold) +
 		render.Style(" | Showing: ", render.Dim) + fmt.Sprintf("%d/%d", showing, total)
+	if m.reachabilityFilterAvailable() {
+		state += render.Style(" | Reachability: ", render.Dim) + render.Style(titleCase(valueOrDefault(m.reachabilityFilter, "All")), render.BgYellow, render.Bold)
+	}
+	return state
 }
 
 func vulnerabilitySummaryLines(vulnerabilities []packageVulnerabilityRow) []string {

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -759,7 +759,7 @@ func (m *scanModel) filterComponentRows(rows []listPackageRow, maxSevByID map[st
 	}
 	kept := rows[:0]
 	for _, row := range rows {
-		if strings.EqualFold(maxSevByID[row.id], m.severityFilter) {
+		if packageMatchesSeverityFilter(maxSevByID[row.id], m.severityFilter) {
 			kept = append(kept, row)
 		}
 	}
@@ -789,6 +789,44 @@ func packageMatchesReachabilityFilter(pkg *sdk.Package, filter string) bool {
 		return true
 	}
 	return false
+}
+
+func packageMatchesSeverityFilter(maxSeverity, filter string) bool {
+	switch strings.ToLower(strings.TrimSpace(filter)) {
+	case "":
+		return true
+	case "any":
+		return strings.TrimSpace(maxSeverity) != ""
+	case "none":
+		return strings.TrimSpace(maxSeverity) == ""
+	default:
+		return strings.EqualFold(maxSeverity, filter)
+	}
+}
+
+func vulnerabilityMatchesSeverityFilter(vulnerability sdk.PackageVulnerability, filter string) bool {
+	switch strings.ToLower(strings.TrimSpace(filter)) {
+	case "", "any":
+		return true
+	case "none":
+		return false
+	default:
+		return strings.EqualFold(vulnerability.Severity, filter)
+	}
+}
+
+func vulnerabilityReachabilityBadge(vulnerability sdk.PackageVulnerability) (badge, bool) {
+	if vulnerability.Reachability == nil {
+		return badge{}, false
+	}
+	switch vulnerability.Reachability.Status {
+	case sdk.ReachabilityReachable:
+		return badge{label: string(sdk.ReachabilityReachable), kind: "reachability-reachable"}, true
+	case sdk.ReachabilityUnreachable:
+		return badge{label: string(sdk.ReachabilityUnreachable), kind: "reachability-unreachable"}, true
+	default:
+		return badge{}, false
+	}
 }
 
 func componentCountRows(graphValue *sdk.Graph, rootID string) []listPackageRow {
@@ -856,7 +894,7 @@ func (m *scanModel) buildOverviewListModel() *listModel {
 		{
 			title:    "Vulnerabilities by Severity",
 			subtitle: "distribution",
-			details:  distributionDetails("Vulnerability Severity", severityDistribution(vulnerabilities)),
+			details:  severityDistributionDetails("Vulnerability Severity", vulnerabilities, m.reachabilityEnabled),
 		},
 		{
 			title:    "Components by Ecosystem",
@@ -916,10 +954,10 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 			fmt.Sprintf("%d manifests", len(m.manifests)),
 		), summaryWidth, cardHeight, render.Cyan),
 		boxView("Vulnerabilities", summaryCountCardLines(stats.vulnerabilities, "Vulnerabilities", summaryWidth-2, render.Red,
-			severityCardLine(vulnerabilities, "critical"),
-			severityCardLine(vulnerabilities, "high"),
-			severityCardLine(vulnerabilities, "medium"),
-			severityCardLine(vulnerabilities, "low"),
+			severityCardLine(vulnerabilities, "critical", m.reachabilityEnabled),
+			severityCardLine(vulnerabilities, "high", m.reachabilityEnabled),
+			severityCardLine(vulnerabilities, "medium", m.reachabilityEnabled),
+			severityCardLine(vulnerabilities, "low", m.reachabilityEnabled),
 		), summaryWidth, cardHeight, render.Red),
 		boxView("Licenses", summaryCountCardLines(stats.licenses, "Unique Licenses", summaryWidth-2, render.Yellow,
 			fmt.Sprintf("%d unknown", unknownLicenseCount(m.graphValue)),
@@ -969,7 +1007,7 @@ func (m *scanModel) overviewDashboardView(width, height int) string {
 	}
 	rightContent := stackBoxes(
 		boxView("License Distribution", coloredDistributionLines(groupedLicenseCounts(m.graphValue, 10), stats.components, 10, rightWidth-2), rightWidth, rightA, render.Yellow),
-		boxView("Vulnerability Severity", severityDistributionLines(vulnerabilities, rightWidth-2), rightWidth, rightB, render.Red),
+		boxView("Vulnerability Severity", severityDistributionLines(vulnerabilities, rightWidth-2, m.reachabilityEnabled), rightWidth, rightB, render.Red),
 		boxView(fmt.Sprintf("Top Vulnerable Components (%d)", vulnerableComponentTotal(m.graphValue)), topVulnerableTableLines(topVuln, rightWidth-2), rightWidth, rightC, render.Red),
 	)
 	lines = append(lines, joinColumns(leftContent, rightContent, leftWidth, rightWidth)...)
@@ -985,7 +1023,7 @@ func (m *scanModel) buildVulnsListModel() *listModel {
 	if m.severityFilter != "" || m.reachabilityFilter != "" {
 		filtered = make([]packageVulnerabilityRow, 0, len(all))
 		for _, row := range all {
-			if m.severityFilter != "" && !strings.EqualFold(row.vulnerability.Severity, m.severityFilter) {
+			if !vulnerabilityMatchesSeverityFilter(row.vulnerability, m.severityFilter) {
 				continue
 			}
 			if m.reachabilityFilter != "" && (row.vulnerability.Reachability == nil || string(row.vulnerability.Reachability.Status) != m.reachabilityFilter) {
@@ -1071,6 +1109,11 @@ func (m *scanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow
 			badges := []badge{}
 			if group != "severity" {
 				badges = append(badges, badge{label: vulnerability.vulnerability.Severity, kind: "severity-" + strings.ToLower(vulnerability.vulnerability.Severity)})
+			}
+			if m.reachabilityEnabled {
+				if reachabilityBadge, ok := vulnerabilityReachabilityBadge(vulnerability.vulnerability); ok {
+					badges = append(badges, reachabilityBadge)
+				}
 			}
 			items = append(items, listItem{
 				title:   title,
@@ -2602,6 +2645,38 @@ func severityDistribution(vulnerabilities []packageVulnerabilityRow) map[string]
 	return counts
 }
 
+func reachableSeverityDistribution(vulnerabilities []packageVulnerabilityRow) map[string]int {
+	counts := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+	for _, row := range vulnerabilities {
+		if row.vulnerability.Reachability == nil || row.vulnerability.Reachability.Status != sdk.ReachabilityReachable {
+			continue
+		}
+		severity := strings.ToLower(strings.TrimSpace(row.vulnerability.Severity))
+		if _, ok := counts[severity]; !ok {
+			severity = "unknown"
+		}
+		counts[severity]++
+	}
+	return counts
+}
+
+func severityDistributionDetails(title string, vulnerabilities []packageVulnerabilityRow, includeReachability bool) []string {
+	counts := severityDistribution(vulnerabilities)
+	reachableCounts := reachableSeverityDistribution(vulnerabilities)
+	lines := []string{render.Style(title, render.Bold, render.Cyan)}
+	for _, severity := range sortedCountKeys(counts) {
+		value := fmt.Sprintf("%d", counts[severity])
+		if includeReachability {
+			value += fmt.Sprintf(" (%d reachable)", reachableCounts[severity])
+		}
+		lines = append(lines, render.Style("  "+severity+": ", render.Dim)+value+" "+barLine(counts[severity], maxCount(counts)))
+	}
+	if len(lines) == 1 {
+		lines = append(lines, render.Style("  (none)", render.Dim))
+	}
+	return lines
+}
+
 func distributionDetails(title string, counts map[string]int) []string {
 	lines := []string{render.Style(title, render.Bold, render.Cyan)}
 	for _, key := range sortedCountKeys(counts) {
@@ -2653,14 +2728,20 @@ func summaryCountCardLines(count int, unit string, width int, color string, extr
 	return append(lines, extra...)
 }
 
-func severityCardLine(vulnerabilities []packageVulnerabilityRow, severity string) string {
+func severityCardLine(vulnerabilities []packageVulnerabilityRow, severity string, includeReachability bool) string {
 	counts := severityDistribution(vulnerabilities)
+	reachableCounts := reachableSeverityDistribution(vulnerabilities)
 	label := titleCase(severity)
-	return severityColor(severity, fmt.Sprintf("%d %s", counts[severity], label))
+	value := fmt.Sprintf("%d %s", counts[severity], label)
+	if includeReachability {
+		value += fmt.Sprintf(" (%d reachable)", reachableCounts[severity])
+	}
+	return severityColor(severity, value)
 }
 
-func severityDistributionLines(vulnerabilities []packageVulnerabilityRow, width int) []string {
+func severityDistributionLines(vulnerabilities []packageVulnerabilityRow, width int, includeReachability bool) []string {
 	counts := severityDistribution(vulnerabilities)
+	reachableCounts := reachableSeverityDistribution(vulnerabilities)
 	total := 0
 	for _, severity := range []string{"critical", "high", "medium", "low", "unknown"} {
 		total += counts[severity]
@@ -2669,6 +2750,9 @@ func severityDistributionLines(vulnerabilities []packageVulnerabilityRow, width 
 	lines := make([]string, 0, 5)
 	for _, severity := range []string{"critical", "high", "medium", "low", "unknown"} {
 		label := titleCase(severity)
+		if includeReachability {
+			label += fmt.Sprintf(" (%d reachable)", reachableCounts[severity])
+		}
 		lines = append(lines, distributionLine(label, counts[severity], total, max, severityColorCode(severity), width))
 	}
 	return lines

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -34,6 +34,10 @@ type filterModel interface {
 	CycleEcosystemFilter()
 }
 
+type reachabilityFilterModel interface {
+	CycleReachabilityFilter()
+}
+
 type tabbedModel interface {
 	CycleView()
 }
@@ -204,12 +208,14 @@ type scanModel struct {
 	mode                  scanMode
 	findings              []sdk.Finding
 	enrichEnabled         bool
+	reachabilityEnabled   bool
 	currentManifestID     string
 	allowManifestExit     bool
 	relationshipFilter    string
 	scopeFilter           string
 	severityFilter        string
 	ecosystemFilter       string
+	reachabilityFilter    string
 	explainQuery          string
 	sourceExpanded        map[string]bool
 	componentExpanded     map[string]bool
@@ -322,6 +328,10 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "s":
 			if filterModel, ok := m.inner.(filterModel); ok {
 				filterModel.CycleScopeFilter()
+			}
+		case "a":
+			if filterModel, ok := m.inner.(reachabilityFilterModel); ok {
+				filterModel.CycleReachabilityFilter()
 			}
 		case "g":
 			if groupModel, ok := m.inner.(groupModel); ok {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1057,6 +1057,66 @@ func TestScanInteractiveModel_ReachabilityFilterUnavailableIsHiddenAndNoOp(t *te
 	}
 }
 
+func TestScanInteractiveModel_OverviewShowsReachableSeverityCountsWhenEnabled(t *testing.T) {
+	enabled := newScanReachabilityFilterModel(t, true)
+	plain := render.StripANSI(enabled.View(240, 48))
+	if !strings.Contains(plain, "6 High (2 reachable)") {
+		t.Fatalf("expected overview vulnerability severity count to include reachable count, got:\n%s", plain)
+	}
+
+	disabled := newScanReachabilityFilterModel(t, false)
+	plain = render.StripANSI(disabled.View(240, 48))
+	if strings.Contains(plain, "reachable)") {
+		t.Fatalf("expected overview reachable counts to stay hidden when disabled, got:\n%s", plain)
+	}
+}
+
+func TestScanInteractiveModel_VulnerabilityRowsShowReachabilityBadgesWhenEnabled(t *testing.T) {
+	model := newScanReachabilityFilterModel(t, true)
+	model.SelectView(3)
+	assertInteractiveItemBadges(t, model, "CVE-REACHABLE", []string{"reachable"})
+	assertInteractiveItemBadges(t, model, "CVE-UNREACHABLE", []string{"unreachable"})
+	assertInteractiveItemBadges(t, model, "CVE-UNKNOWN", nil)
+	assertInteractiveItemBadges(t, model, "CVE-NIL", nil)
+
+	disabled := newScanReachabilityFilterModel(t, false)
+	disabled.SelectView(3)
+	assertInteractiveItemBadges(t, disabled, "CVE-REACHABLE", nil)
+}
+
+func TestScanInteractiveModel_SeverityFilterIncludesAnyAndNone(t *testing.T) {
+	if got := nextSeverityFilter(""); got != "any" {
+		t.Fatalf("nextSeverityFilter(all) = %q, want any", got)
+	}
+	if got := nextSeverityFilter("any"); got != "none" {
+		t.Fatalf("nextSeverityFilter(any) = %q, want none", got)
+	}
+
+	model := newScanReachabilityFilterModel(t, true)
+	model.SelectView(2)
+	model.CycleSeverityFilter()
+	if model.severityFilter != "any" {
+		t.Fatalf("expected first severity cycle to select any, got %q", model.severityFilter)
+	}
+	assertInteractiveListTitles(t, model, []string{"reachable-lib@1.0.0", "unreachable-lib@1.0.0", "mixed-lib@1.0.0", "unknown-lib@1.0.0", "nil-lib@1.0.0"}, []string{"demo-app@1.0.0"})
+
+	model.CycleSeverityFilter()
+	if model.severityFilter != "none" {
+		t.Fatalf("expected second severity cycle to select none, got %q", model.severityFilter)
+	}
+	assertInteractiveListTitles(t, model, []string{"demo-app@1.0.0"}, []string{"reachable-lib@1.0.0", "unreachable-lib@1.0.0", "mixed-lib@1.0.0", "unknown-lib@1.0.0", "nil-lib@1.0.0"})
+
+	model.SelectView(3)
+	model.severityFilter = "any"
+	model.rebuildListPreserveSelection()
+	assertInteractiveListTitles(t, model, []string{"CVE-REACHABLE", "CVE-UNREACHABLE", "CVE-MIXED-REACHABLE", "CVE-MIXED-UNREACHABLE", "CVE-UNKNOWN", "CVE-NIL"}, nil)
+	model.severityFilter = "none"
+	model.rebuildListPreserveSelection()
+	if len(model.List().items) != 0 {
+		t.Fatalf("expected none severity filter to hide every vulnerability row, got %#v", model.List().items)
+	}
+}
+
 func newScanReachabilityFilterModel(t *testing.T, enabled bool) *scanModel {
 	t.Helper()
 	vulnerability := func(id string, reachability *sdk.Reachability) sdk.PackageVulnerability {
@@ -1144,6 +1204,26 @@ func assertInteractiveListTitles(t *testing.T, model *scanModel, contains, exclu
 			t.Fatalf("expected interactive list titles to exclude %q, got:\n%s", excluded, joined)
 		}
 	}
+}
+
+func assertInteractiveItemBadges(t *testing.T, model *scanModel, title string, expectedReachability []string) {
+	t.Helper()
+	for _, item := range model.List().items {
+		if item.title != title {
+			continue
+		}
+		var actual []string
+		for _, itemBadge := range item.badges {
+			if strings.HasPrefix(itemBadge.kind, "reachability-") {
+				actual = append(actual, itemBadge.label)
+			}
+		}
+		if strings.Join(actual, ",") != strings.Join(expectedReachability, ",") {
+			t.Fatalf("reachability badges for %q = %#v, want %#v", title, actual, expectedReachability)
+		}
+		return
+	}
+	t.Fatalf("expected interactive list item %q", title)
 }
 
 func TestScanInteractiveModel_ExplainTopBarUsesQuery(t *testing.T) {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -981,6 +981,172 @@ func TestScanInteractiveModel_VulnerabilityFilterEmptyStateDistinguishesNoMatche
 	}
 }
 
+func TestScanInteractiveModel_ReachabilityFilterCyclesFromKeyboard(t *testing.T) {
+	model := newScanReachabilityFilterModel(t, true)
+	model.SelectView(2)
+	wrapper := &teaModel{inner: model, width: 180, height: 40}
+
+	components := render.StripANSI(model.View(180, 40))
+	if !strings.Contains(components, "a reachability") || !strings.Contains(components, "Reachability: All") {
+		t.Fatalf("expected enabled components view to expose reachability controls, got:\n%s", components)
+	}
+
+	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	wrapper = updated.(*teaModel)
+	if model.reachabilityFilter != string(sdk.ReachabilityReachable) {
+		t.Fatalf("expected first a key to select reachable filter, got %q", model.reachabilityFilter)
+	}
+	assertInteractiveListTitles(t, model, []string{"reachable-lib@1.0.0", "mixed-lib@1.0.0"}, []string{"unreachable-lib@1.0.0", "unknown-lib@1.0.0", "nil-lib@1.0.0"})
+	if plain := render.StripANSI(wrapper.View()); !strings.Contains(plain, "Reachability: Reachable") {
+		t.Fatalf("expected reachable state line, got:\n%s", plain)
+	}
+
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	wrapper = updated.(*teaModel)
+	if model.reachabilityFilter != string(sdk.ReachabilityUnreachable) {
+		t.Fatalf("expected second a key to select unreachable filter, got %q", model.reachabilityFilter)
+	}
+	assertInteractiveListTitles(t, model, []string{"unreachable-lib@1.0.0"}, []string{"reachable-lib@1.0.0", "mixed-lib@1.0.0", "unknown-lib@1.0.0", "nil-lib@1.0.0"})
+
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	wrapper = updated.(*teaModel)
+	if model.reachabilityFilter != "" {
+		t.Fatalf("expected third a key to restore all filter, got %q", model.reachabilityFilter)
+	}
+
+	model.SelectView(3)
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	wrapper = updated.(*teaModel)
+	assertInteractiveListTitles(t, model, []string{"CVE-REACHABLE", "CVE-MIXED-REACHABLE"}, []string{"CVE-UNREACHABLE", "CVE-MIXED-UNREACHABLE", "CVE-UNKNOWN", "CVE-NIL"})
+	if plain := render.StripANSI(wrapper.View()); !strings.Contains(plain, "Reachability: Reachable") {
+		t.Fatalf("expected vulnerability state line to show reachable filter, got:\n%s", plain)
+	}
+
+	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	wrapper = updated.(*teaModel)
+	assertInteractiveListTitles(t, model, []string{"CVE-UNREACHABLE", "CVE-MIXED-UNREACHABLE"}, []string{"CVE-REACHABLE", "CVE-MIXED-REACHABLE", "CVE-UNKNOWN", "CVE-NIL"})
+}
+
+func TestScanInteractiveModel_ReachabilityFilterUnavailableIsHiddenAndNoOp(t *testing.T) {
+	model := newScanReachabilityFilterModel(t, false)
+	model.SelectView(2)
+	wrapper := &teaModel{inner: model, width: 180, height: 40}
+	plain := render.StripANSI(wrapper.View())
+	if strings.Contains(plain, "a reachability") || strings.Contains(plain, "Reachability:") {
+		t.Fatalf("expected disabled reachability filter to stay hidden, got:\n%s", plain)
+	}
+	if _, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}); model.reachabilityFilter != "" {
+		t.Fatalf("expected a key to be ignored while reachability is disabled, got %q", model.reachabilityFilter)
+	}
+
+	noData := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, sdk.ConsolidatedGraph{}, sdk.New(), nil).WithReachabilityEnabled(true)
+	noData.SelectView(3)
+	plain = render.StripANSI(noData.View(180, 40))
+	if strings.Contains(plain, "a reachability") || strings.Contains(plain, "Reachability:") {
+		t.Fatalf("expected filter to stay hidden without reachability annotations, got:\n%s", plain)
+	}
+	noData.CycleReachabilityFilter()
+	if noData.reachabilityFilter != "" {
+		t.Fatalf("expected cycle to be ignored without annotations, got %q", noData.reachabilityFilter)
+	}
+
+	model = newScanReachabilityFilterModel(t, true)
+	model.SelectView(1)
+	model.CycleReachabilityFilter()
+	if model.reachabilityFilter != "" {
+		t.Fatalf("expected cycle to be ignored outside components and vulnerabilities, got %q", model.reachabilityFilter)
+	}
+}
+
+func newScanReachabilityFilterModel(t *testing.T, enabled bool) *scanModel {
+	t.Helper()
+	vulnerability := func(id string, reachability *sdk.Reachability) sdk.PackageVulnerability {
+		return sdk.PackageVulnerability{ID: id, Severity: "high", Reachability: reachability}
+	}
+	root := sdk.NewPackage(sdk.Package{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	reachable := sdk.NewPackage(sdk.Package{
+		Name:            "reachable-lib",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		Vulnerabilities: []sdk.PackageVulnerability{vulnerability("CVE-REACHABLE", &sdk.Reachability{Status: sdk.ReachabilityReachable})},
+	})
+	unreachable := sdk.NewPackage(sdk.Package{
+		Name:            "unreachable-lib",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		Vulnerabilities: []sdk.PackageVulnerability{vulnerability("CVE-UNREACHABLE", &sdk.Reachability{Status: sdk.ReachabilityUnreachable})},
+	})
+	mixed := sdk.NewPackage(sdk.Package{
+		Name:      "mixed-lib",
+		Version:   "1.0.0",
+		Ecosystem: "npm",
+		Vulnerabilities: []sdk.PackageVulnerability{
+			vulnerability("CVE-MIXED-REACHABLE", &sdk.Reachability{Status: sdk.ReachabilityReachable}),
+			vulnerability("CVE-MIXED-UNREACHABLE", &sdk.Reachability{Status: sdk.ReachabilityUnreachable}),
+		},
+	})
+	unknown := sdk.NewPackage(sdk.Package{
+		Name:            "unknown-lib",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		Vulnerabilities: []sdk.PackageVulnerability{vulnerability("CVE-UNKNOWN", &sdk.Reachability{Status: sdk.ReachabilityUnknown})},
+	})
+	nilReachability := sdk.NewPackage(sdk.Package{
+		Name:            "nil-lib",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		Vulnerabilities: []sdk.PackageVulnerability{vulnerability("CVE-NIL", nil)},
+	})
+	g := sdk.New()
+	for _, pkg := range []*sdk.Package{root, reachable, unreachable, mixed, unknown, nilReachability} {
+		if err := g.AddPackage(pkg); err != nil {
+			t.Fatalf("add package: %v", err)
+		}
+	}
+	for _, pkg := range []*sdk.Package{reachable, unreachable, mixed, unknown, nilReachability} {
+		if err := g.AddDependency(root.ID, pkg.ID); err != nil {
+			t.Fatalf("add dependency: %v", err)
+		}
+	}
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo-app"},
+			RelativePath:            ".",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	return NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil).WithEnrichEnabled(true).WithReachabilityEnabled(enabled)
+}
+
+func assertInteractiveListTitles(t *testing.T, model *scanModel, contains, excludes []string) {
+	t.Helper()
+	titles := make([]string, 0, len(model.List().items))
+	titleSet := make(map[string]struct{}, len(model.List().items))
+	for _, item := range model.List().items {
+		titles = append(titles, item.title)
+		titleSet[item.title] = struct{}{}
+	}
+	joined := strings.Join(titles, "\n")
+	for _, want := range contains {
+		if _, ok := titleSet[want]; !ok {
+			t.Fatalf("expected interactive list titles to contain %q, got:\n%s", want, joined)
+		}
+	}
+	for _, excluded := range excludes {
+		if _, ok := titleSet[excluded]; ok {
+			t.Fatalf("expected interactive list titles to exclude %q, got:\n%s", excluded, joined)
+		}
+	}
+}
+
 func TestScanInteractiveModel_ExplainTopBarUsesQuery(t *testing.T) {
 	model := NewExplain(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, "react", sdk.ConsolidatedGraph{}, sdk.New(), nil)
 	plain := render.StripANSI(model.View(100, 26))

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1022,8 +1022,7 @@ func TestScanInteractiveModel_ReachabilityFilterCyclesFromKeyboard(t *testing.T)
 		t.Fatalf("expected vulnerability state line to show reachable filter, got:\n%s", plain)
 	}
 
-	updated, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	wrapper = updated.(*teaModel)
+	_, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	assertInteractiveListTitles(t, model, []string{"CVE-UNREACHABLE", "CVE-MIXED-UNREACHABLE"}, []string{"CVE-REACHABLE", "CVE-MIXED-REACHABLE", "CVE-UNKNOWN", "CVE-NIL"})
 }
 

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -215,6 +215,10 @@ func badgeView(badge badge) string {
 		return render.Style(label, render.BgYellow, render.Bold)
 	case "severity-low":
 		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
+	case "reachability-reachable":
+		return render.Style(label, render.BgRed, render.White, render.Bold)
+	case "reachability-unreachable":
+		return render.Style(label, render.BgBlue, render.White, render.Bold)
 	case "repeated":
 		return render.Style(label, render.BgBlue, render.White)
 	default:
@@ -302,7 +306,7 @@ func nextScopeFilter(current string) string {
 }
 
 func nextSeverityFilter(current string) string {
-	values := []string{"", "critical", "high", "medium", "low"}
+	values := []string{"", "any", "none", "critical", "high", "medium", "low"}
 	return nextFilterValue(current, values)
 }
 


### PR DESCRIPTION
## Summary
- add an `a` key cycle in the scan TUI for `All -> Reachable -> Unreachable -> All`
- expose the reachability filter only when analysis was explicitly enabled and populated annotations are present
- show `REACHABLE` / `UNREACHABLE` badges on vulnerability rows when applicable
- include reachable counts beside each overview severity total when reachability is enabled
- extend the scan severity cycle with `Any` and `None` selectors

## Behavior
Components are classified conservatively: any reachable vulnerability makes a component reachable, while the unreachable view includes a component only when every attached vulnerability is explicitly unreachable. Unknown, not-applicable, nil, and mixed non-reachable states are excluded from narrowed component views.

The new severity selectors make component triage more useful: `Any` keeps packages with at least one enriched vulnerability and `None` keeps packages without vulnerabilities. On the Vulnerabilities tab, `Any` keeps all rows and `None` produces an empty result.

## Validation
- `go test ./internal/tui`
- `make fmt-check`
- `make lint`
- `make test`
- `git diff --check`