### PR TITLE
Add experimental local-only remediation proposer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for full detail. Component ma
 | `internal/engine/diff` | Diff pipeline orchestration and audit delta classification                                        |
 | `internal/engine/explain` | Dependency path traversal (`explain` command)                                                  |
 | `internal/engine/scan` | Scan command pipeline API                                                                         |
+| `internal/engine/remediation` | Local-only experimental dependency upgrade proposals                                        |
 | `internal/matchers`    | External enrichment matchers plus shared matcher cache and enrichment helpers                     |
 | `internal/logging`     | Zap console wrapper                                                                               |
 | `internal/testutil`    | Test helpers (fake binary builder)                                                                |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ internal/output/                 Text, JSON, SARIF 2.1.0, SBOM rendering + schem
 internal/engine/diff/            Diff pipeline orchestration and audit delta classification
 internal/engine/explain/         Dependency path traversal (explain command)
 internal/engine/scan/            Scan command pipeline API
+internal/engine/remediation/     Local-only experimental dependency upgrade proposals
 internal/plugin/                 gRPC plugin system (v1 protocol)
 internal/testutil/               Test helpers (fake binary builder)
 ```
@@ -95,7 +96,7 @@ Runtime preparation is owned by `internal/engine` and is reached through CLI opt
 - `sdk` owns neutral identifiers that would otherwise create import cycles.
 - `internal/registry` owns package-manager discovery, support lookups, and built-in wiring in `builder.go`. Do not create a separate `registrybuilder` package.
 - `internal/engine` (pipeline core) may import `internal/engine/consolidation`, `internal/engine/hooks`, `internal/engine/explain`, `internal/detectors`, and `internal/registry`.
-- `internal/engine` subpackages (`consolidation`, `hooks`, `diff`, `explain`, `scan`) must not import `internal/cli`.
+- `internal/engine` subpackages (`consolidation`, `hooks`, `diff`, `explain`, `scan`, `remediation`) must not import `internal/cli`.
 - `internal/config`, `internal/selector`, `internal/progress`, `internal/cli/render`, `internal/tui` must not import `internal/cli`. They are downstream of cobra wiring; cli consumes them, not the reverse.
 - `internal/tui` may import `internal/cli/render` (for ANSI primitives, text helpers, and shared sort/format helpers used by both the TUI and the text reports).
 - `cmd/bomly/main.go` is the only file outside `internal/cli` that imports `internal/cli`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ One binary. Native detectors for the ecosystems developers use every day. Offlin
 - **Native detectors first.** Real dependency graphs (with edges) for Go, npm, pnpm, yarn, Maven, Gradle, Python, Composer, Bundler, GitHub Actions, and SBOM ingest. Syft fills the long tail for containers and rarer ecosystems.
 - **Offline-safe by default.** A scan without `--enrich` makes zero outbound HTTP calls. The only enrichment endpoints used are OSV, KEV, deps.dev, ClearlyDefined, and endoflife.date.
 - **Reachability that respects your time** (experimental). `--reachability` tells you whether your app actually calls a vulnerable symbol — Tier-1 (`govulncheck`) for Go; Tier-3 import-graph closure for npm, Python, and JVM languages. See [REACHABILITY.md](docs/REACHABILITY.md) for limitations.
+- **Local remediation guidance** (experimental). `--interactive --enrich --experimental-remediate` proposes locally evidenced semver candidates without claiming a verified manifest edit. See [REMEDIATION.md](docs/REMEDIATION.md).
 - **Stable exit codes for CI.** `0` clean, `2` policy violation, plus 1, 3, 4 for other failure classes. See [Exit codes](docs/EXIT_CODES.md).
 
 ## Highlights
@@ -88,7 +89,7 @@ Syft-backed for many more, including container images. See [docs/SUPPORT_MATRIX.
 
 Component guides:
 
-- [Detectors](docs/DETECTORS.md), [Matchers](docs/MATCHERS.md), [Auditors](docs/AUDITORS.md), [Reachability](docs/REACHABILITY.md)
+- [Detectors](docs/DETECTORS.md), [Matchers](docs/MATCHERS.md), [Auditors](docs/AUDITORS.md), [Reachability](docs/REACHABILITY.md), [Remediation](docs/REMEDIATION.md)
 - Per-ecosystem [detector guides](docs/detectors/ecosystems/) and per-matcher [reference](docs/matchers/)
 
 ## Core Commands
@@ -212,6 +213,7 @@ internal/engine/           Runtime preparation, orchestration, consolidation
 internal/engine/diff/      Diff orchestration and audit deltas
 internal/engine/explain/   Dependency path explanation
 internal/engine/scan/      Scan command pipeline API
+internal/engine/remediation/ Local-only experimental dependency upgrade proposals
 internal/detectors/        Ecosystem-specific dependency resolution
 internal/matchers/         External enrichment matchers and shared matcher cache
 internal/analyzers/        Reachability analyzers (govulncheck, jsreach, pyreach, jvmreach)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,10 @@ Bomly's YAML files use strict nested groups such as `target`, `analysis`, `polic
 
 Reachability data lives on `PackageVulnerability.Reachability` rather than only on `Finding.Reachability` because `--reachability` must be useful without `--audit`. Matchers attach the vulnerability; the analyzer enriches it; the policy auditor copies the annotation onto each emitted Finding when `--audit` runs. This keeps a single source of truth on the package graph and lets the consolidation layer's existing per-vuln merge propagate analyzer output to per-manifest entry graphs without bespoke wiring.
 
+### Decision: Remediation proposals are local-only and constraint-conservative
+
+The experimental remediation proposer (`internal/engine/remediation`) runs after the scan pipeline and reads only vulnerability records already attached to the consolidated graph. It must not call matchers, caches, HTTP clients, package managers, or subprocesses. The proposer combines locally available `FixedIn` and `FixedVersions` metadata into the minimum semver candidate that addresses every attached advisory. Because the consolidated graph does not preserve portable manifest dependency ranges, proposal constraint compatibility is always `unknown`. The TUI and MCP recommendation text require users to verify manifest constraints, re-resolve dependencies, and re-scan before treating a candidate as safe.
+
 ### Decision: Scorecard matcher reads precomputed runs, not the library
 
 The OpenSSF Scorecard matcher (`internal/matchers/scorecard`) fetches precomputed per-repo scores from `api.scorecard.dev` instead of importing `github.com/ossf/scorecard/v5` and running checks in-process. Three reasons:
@@ -190,6 +194,7 @@ Cache failures are non-fatal. The command should warn and continue rather than f
 | `internal/engine/diff` | Diff pipeline orchestration and audit delta classification                                    |
 | `internal/engine/explain` | Dependency path traversal                                                                   |
 | `internal/engine/scan` | Scan command pipeline API                                                                    |
+| `internal/engine/remediation` | Local-only experimental dependency upgrade proposals                                  |
 | `internal/output`     | Text, JSON, SARIF rendering, plus structured response payloads and schema generation            |
 | `internal/sbom`       | SPDX and CycloneDX codecs                                                                       |
 | `internal/benchmark`  | Hidden local dependency-graph benchmark, baseline comparison, scoring, and embedded presets      |

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -27,6 +27,7 @@ YAML files use the nested keys documented below. Unknown keys and the former fla
 | `analysis.enrich` | `BOMLY_ENRICH` | `bool` | - | Enrich packages with external license and vulnerability data |
 | `analysis.audit` | `BOMLY_AUDIT` | `bool` | - | Evaluate policy and create findings from package vulnerability data |
 | `analysis.reachability` | `BOMLY_REACHABILITY` | `bool` | - | Run code analysis to confirm whether vulnerabilities are reachable from application code |
+| `analysis.experimental_remediate` | `BOMLY_EXPERIMENTAL_REMEDIATE` | `bool` | - | Enable experimental local-only dependency remediation proposals in the interactive scan TUI |
 | `policy.fail_on` | `BOMLY_FAIL_ON` | `[]string` | - | Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable |
 | `policy.fail_on_scopes` | `BOMLY_FAIL_ON_SCOPES` | `[]string` | - | Dependency scopes that may produce failing findings: runtime, development, unknown |
 | `policy.allow_vulnerability_ids` | `BOMLY_ALLOW_VULNERABILITY_IDS` | `[]string` | - | Vulnerability IDs to ignore during policy evaluation |
@@ -114,6 +115,7 @@ Flat YAML keys are no longer accepted. Move each existing key to its nested repl
 | `eol_api_base` | `matchers.eol.api_base` |
 | `eol_cache_dir` | `matchers.eol.cache_dir` |
 | `eol_cache_ttl` | `matchers.eol.cache_ttl` |
+| `experimental_remediate` | `analysis.experimental_remediate` |
 | `fail_on` | `policy.fail_on` |
 | `fail_on_scopes` | `policy.fail_on_scopes` |
 | `format` | `output.format` |
@@ -174,6 +176,8 @@ Flat YAML keys are no longer accepted. Move each existing key to its nested repl
 #   audit: false
 #   Run code analysis to confirm whether vulnerabilities are reachable from application code
 #   reachability: false
+#   Enable experimental local-only dependency remediation proposals in the interactive scan TUI
+#   experimental_remediate: false
 #   Run detector-specific dependency installation before resolving graphs
 #   install_first: false
 #   Additional detector-specific install arguments

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ How Bomly thinks about your project.
 - [Matchers](MATCHERS.md) — enriching the graph with vulnerability, license, lifecycle data
 - [Auditors](AUDITORS.md) — evaluating the graph against policy
 - [Reachability](REACHABILITY.md) — narrowing findings to code your app actually calls
+- [Remediation Proposals](REMEDIATION.md) — experimental local-only upgrade candidates in the TUI
 - [Plugins](PLUGINS.md) — extending Bomly with external detectors, matchers, auditors
 - [Glossary](GLOSSARY.md) — every term, one sentence each
 

--- a/docs/REMEDIATION.md
+++ b/docs/REMEDIATION.md
@@ -1,0 +1,74 @@
+# Experimental Remediation Proposals
+
+Bomly can propose locally evidenced dependency upgrades inside the interactive vulnerabilities pane:
+
+```bash
+bomly scan --interactive --enrich --experimental-remediate
+```
+
+The feature is experimental and opt-in. It proposes candidate versions; it does not edit manifests, install dependencies, or claim that an upgrade has been verified.
+
+## TUI Controls
+
+Open the **Vulnerabilities** tab with `3`. When `--experimental-remediate` is enabled, the pane displays `f fix`. Press `f` to toggle between ordinary vulnerability details and **Proposed Upgrade Paths**.
+
+- Advisory rows show the aggregate proposal for the affected component.
+- Component-group rows show the same aggregate proposal.
+- Severity and ecosystem groups ask you to select an advisory.
+- Switching tabs resets the panel to ordinary vulnerability details.
+
+Without `--experimental-remediate`, the `f` control is hidden and the key is ignored.
+
+## Local-Only Behavior
+
+The proposer reads vulnerability records already attached to the consolidated graph. It does not call matchers, cache readers, HTTP clients, package managers, or subprocesses.
+
+`--enrich` remains required because matchers populate vulnerability metadata during the normal scan pipeline. Enrichment itself may use configured network-backed matchers. Enabling remediation does not add any later API request or retry.
+
+For each vulnerable package, Bomly:
+
+1. Collects `FixedIn` and `FixedVersions` metadata from every attached advisory.
+2. Parses the installed version and fix candidates as semver.
+3. Chooses the lowest newer fix candidate for each advisory.
+4. Chooses the highest of those advisory minima as the component candidate.
+
+If any advisory lacks usable fixed-version metadata, or if semver parsing fails, the panel reports `insufficient_local_data` without a candidate.
+
+## Verification Required
+
+Every proposal reports manifest-constraint compatibility as `unknown`. The consolidated graph does not currently retain portable declared dependency ranges, so Bomly cannot prove that a candidate satisfies the source manifest or lockfile constraints.
+
+Treat the panel as triage guidance:
+
+1. Verify the relevant manifest constraint.
+2. Update the direct dependency or dependency override as appropriate.
+3. Re-resolve the dependency tree with the package manager.
+4. Re-run `bomly scan --enrich`.
+
+Only the follow-up scan can confirm the resulting graph and vulnerability state.
+
+## Limitations
+
+- Only semver-compatible installed versions and fix metadata are supported.
+- Missing or malformed fix metadata prevents a proposal for the entire component.
+- Transitive dependencies often require upgrading a direct dependency or using an ecosystem-specific override. Bomly does not select that manifest edit automatically.
+- A proposed version is local evidence from attached advisories, not a guarantee that no other advisory affects the candidate.
+- `bomly_vuln_fix_context` remains the machine-facing MCP remediation surface. `--experimental-remediate` is a TUI-only gate.
+
+## Configuration
+
+The feature can also be enabled in YAML or through the environment:
+
+```yaml
+analysis:
+  enrich: true
+  experimental_remediate: true
+output:
+  interactive: true
+```
+
+```bash
+export BOMLY_EXPERIMENTAL_REMEDIATE=true
+```
+
+Both `--interactive` and `--enrich` are required.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -24,7 +24,8 @@ Switch with the number keys or `Tab`:
 | `3` | Vulnerabilities | Findings grouped by package |
 | `4` | Licenses | License inventory and conflicts |
 | `5` | Findings | Audit policy hits with reasons |
-| `6` | Source | Detected manifest and lockfile inventory |
+| `6` | Posture | Repository posture checks |
+| `7` | Source | Detected manifest and lockfile inventory |
 
 `Tab` cycles forward through views; `Shift+Tab` is the reverse cycle in supporting terminals.
 
@@ -69,6 +70,12 @@ Press the filter key, then pick from the popup. Press the same key again to clea
 | `g` | Group (custom grouping) |
 
 Filters compose. Search and filters compose. The current filter set is shown in the header.
+
+## Experimental Remediation
+
+Run `bomly scan --interactive --enrich --experimental-remediate` to expose `f fix` in the Vulnerabilities pane. Press `f` to toggle the selected component between normal advisory details and **Proposed Upgrade Paths**.
+
+The panel uses only vulnerability metadata already attached to the consolidated graph. It proposes a locally evidenced semver candidate, not an automated or verified manifest edit. Manifest-constraint compatibility is reported as `unknown`; re-resolve dependencies and re-scan before treating a candidate as safe. See [Remediation Proposals](REMEDIATION.md).
 
 ## Quit
 

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/bomly-dev/bomly-cli/internal/cli/opts"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
 	"github.com/bomly-dev/bomly-cli/internal/engine/explain"
+	"github.com/bomly-dev/bomly-cli/internal/engine/remediation"
 	scanengine "github.com/bomly-dev/bomly-cli/internal/engine/scan"
 	"github.com/bomly-dev/bomly-cli/internal/mcp"
 	"github.com/bomly-dev/bomly-cli/internal/output"
@@ -128,6 +128,7 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 		clone.ResolvedConfig.WarnOnly = true
 	}
 	clone.ResolvedConfig.Interactive = false
+	clone.ResolvedConfig.ExperimentalRemediate = false
 
 	applyStringOverride(&resolved.Path, o.Path)
 	applyStringOverride(&resolved.Container, o.Container)
@@ -158,6 +159,7 @@ func (a *mcpOptionsAdapter) cloneWithOverrides(o mcpOverrides) *opts.Options {
 		resolved.WarnOnly = true
 	}
 	resolved.Interactive = false
+	resolved.ExperimentalRemediate = false
 	clone.SetConfig(resolved)
 
 	return &clone
@@ -376,7 +378,11 @@ func (a *mcpOptionsAdapter) VulnFixContext(ctx context.Context, req mcp.VulnFixR
 		return mcp.VulnFixResult{}, fmt.Errorf("no vulnerabilities found for package %q; run with enrich enabled to populate vulnerability data", req.Package)
 	}
 
-	minSafeVersion := maxFixedIn(matchedVulns)
+	proposal := remediation.ProposePackage(targetPkg, matchedVulns)
+	minSafeVersion := ""
+	if proposal.Status == remediation.StatusProposed {
+		minSafeVersion = proposal.ProposedVersion
+	}
 	vulnIDs := make([]string, len(matchedVulns))
 	for i, v := range matchedVulns {
 		vulnIDs[i] = v.ID
@@ -414,28 +420,4 @@ func collectVulns(all []sdk.PackageVulnerability, vulnID string) []sdk.PackageVu
 		}
 	}
 	return nil
-}
-
-// maxFixedIn returns the highest FixedIn version across the given vulnerabilities.
-// Uses semver comparison when parseable; falls back to the last non-empty string.
-func maxFixedIn(vulns []sdk.PackageVulnerability) string {
-	var maxV *semver.Version
-	var maxStr string
-	for _, v := range vulns {
-		if v.FixedIn == "" {
-			continue
-		}
-		parsed, err := semver.NewVersion(v.FixedIn)
-		if err != nil {
-			if maxStr == "" {
-				maxStr = v.FixedIn
-			}
-			continue
-		}
-		if maxV == nil || parsed.GreaterThan(maxV) {
-			maxV = parsed
-			maxStr = v.FixedIn
-		}
-	}
-	return maxStr
 }

--- a/internal/cli/mcp_cmd_test.go
+++ b/internal/cli/mcp_cmd_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/cli/opts"
+	"github.com/bomly-dev/bomly-cli/internal/config"
+)
 
 func TestApplyStringOverride(t *testing.T) {
 	value := "original"
@@ -12,5 +17,22 @@ func TestApplyStringOverride(t *testing.T) {
 	applyStringOverride(&value, "updated")
 	if value != "updated" {
 		t.Fatalf("expected updated value, got %q", value)
+	}
+}
+
+func TestCloneWithOverridesClearsTUIOnlyRemediationGate(t *testing.T) {
+	adapter := &mcpOptionsAdapter{options: &opts.Options{
+		ResolvedConfig: config.Resolved{
+			Interactive:           true,
+			ExperimentalRemediate: true,
+		},
+	}}
+
+	cloned := adapter.cloneWithOverrides(mcpOverrides{})
+	if cloned.ResolvedConfig.Interactive || cloned.ResolvedConfig.ExperimentalRemediate {
+		t.Fatalf("MCP clone retained TUI-only options: %#v", cloned.ResolvedConfig)
+	}
+	if resolved := cloned.GetConfig(); resolved.Interactive || resolved.ExperimentalRemediate {
+		t.Fatalf("MCP resolved config retained TUI-only options: %#v", resolved)
 	}
 }

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -16,10 +16,11 @@ import (
 type FlagGroup string
 
 const (
-	FlagGroupTarget    FlagGroup = "target"
-	FlagGroupAnalysis  FlagGroup = "analysis"
-	FlagGroupSelectors FlagGroup = "selectors"
-	FlagGroupExecution FlagGroup = "execution"
+	FlagGroupTarget                  FlagGroup = "target"
+	FlagGroupAnalysis                FlagGroup = "analysis"
+	FlagGroupSelectors               FlagGroup = "selectors"
+	FlagGroupExecution               FlagGroup = "execution"
+	FlagGroupExperimentalRemediation FlagGroup = "experimental-remediation"
 )
 
 func bindFlagOptions(cmd *cobra.Command, cfg *config.Resolved) error {
@@ -54,6 +55,8 @@ func BindCommandFlagGroups(cmd *cobra.Command, cfg *config.Resolved, groups ...F
 			}
 		case FlagGroupExecution:
 			bindExecutionFlags(cmd.Flags(), cfg)
+		case FlagGroupExperimentalRemediation:
+			bindExperimentalRemediationFlags(cmd.Flags(), cfg)
 		}
 	}
 
@@ -103,6 +106,10 @@ func bindExecutionFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 	flags.StringArrayVar(&cfg.InstallArgs, "install-arg", nil, "Additional detector-specific install argument; may be repeated")
 }
 
+func bindExperimentalRemediationFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
+	flags.BoolVar(&cfg.ExperimentalRemediate, "experimental-remediate", false, "[Experimental] Propose local-only dependency upgrade paths in the interactive vulnerabilities pane (requires --interactive and --enrich)")
+}
+
 // BindJSONFormatFlag binds --json as a no-argument shortcut for setting format to json.
 func BindJSONFormatFlag(flags *pflag.FlagSet, format *string, usage string) {
 	if flags == nil {
@@ -148,6 +155,9 @@ func applyFlagOverrides(dst *config.Resolved, flags config.Resolved, cmd *cobra.
 	}
 	if flagChanged(cmd, "reachability") {
 		dst.Reachability = flags.Reachability
+	}
+	if flagChanged(cmd, "experimental-remediate") {
+		dst.ExperimentalRemediate = flags.ExperimentalRemediate
 	}
 	if flagChanged(cmd, "fail-on") {
 		dst.FailOn = append([]string(nil), flags.FailOn...)

--- a/internal/cli/opts/flag_options_test.go
+++ b/internal/cli/opts/flag_options_test.go
@@ -99,3 +99,20 @@ func TestApplyFlagOverridesJSONShortcut(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyFlagOverridesExperimentalRemediate(t *testing.T) {
+	options := &Options{}
+	root := newTestRootCommand(t)
+	if err := BindCommandFlagGroups(root, &options.ResolvedConfig, FlagGroupExperimentalRemediation); err != nil {
+		t.Fatalf("BindCommandFlagGroups() error = %v", err)
+	}
+	if err := root.ParseFlags([]string{"--experimental-remediate"}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	var dst config.Resolved
+	applyFlagOverrides(&dst, options.ResolvedConfig, root)
+	if !dst.ExperimentalRemediate {
+		t.Fatal("expected changed --experimental-remediate flag to override config")
+	}
+}

--- a/internal/cli/root_cmd.go
+++ b/internal/cli/root_cmd.go
@@ -95,6 +95,7 @@ func newRootCmd(version string) (*cobra.Command, error) {
 		opts.FlagGroupAnalysis,
 		opts.FlagGroupSelectors,
 		opts.FlagGroupExecution,
+		opts.FlagGroupExperimentalRemediation,
 	); err != nil {
 		return nil, err
 	}
@@ -177,6 +178,7 @@ func logResolvedOptions(cmd *cobra.Command) {
 		zap.Bool("audit", resolved.Audit),
 		zap.Strings("fail_on", resolved.FailOn),
 		zap.Bool("reachability", resolved.Reachability),
+		zap.Bool("experimental_remediate", resolved.ExperimentalRemediate),
 		zap.String("analyzers", resolved.Analyzers),
 		zap.String("format", resolved.Format),
 		zap.Bool("interactive", resolved.Interactive),

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -347,7 +347,7 @@ func TestRootHelp_IncludesAvailableOptionValuesSection(t *testing.T) {
 	if strings.Contains(helpText, "Explore available detectors, matchers, and auditors with `bomly plugin list`.") {
 		t.Fatalf("expected root help output to omit selector guidance, got:\n%s", helpText)
 	}
-	for _, nonGlobal := range []string{"--enrich", "--audit", "--reachability", "--ecosystems", "--detectors"} {
+	for _, nonGlobal := range []string{"--enrich", "--audit", "--reachability", "--experimental-remediate", "--ecosystems", "--detectors"} {
 		if strings.Contains(helpText, nonGlobal) {
 			t.Fatalf("expected root help output to omit non-global flag %q, got:\n%s", nonGlobal, helpText)
 		}
@@ -402,6 +402,7 @@ func TestRootHelp_CommandExamplesRender(t *testing.T) {
 				"bomly scan -o spdx=bomly.spdx.json",
 				"bomly scan --url https://github.com/bomly-dev/bomly-cli --ref main --json",
 				"bomly scan --container alpine:3.20",
+				"--experimental-remediate",
 				"Explore available detectors, matchers, and auditors with `bomly plugin list`.",
 			},
 			notInText: []string{"Exit Codes:"},
@@ -410,13 +411,13 @@ func TestRootHelp_CommandExamplesRender(t *testing.T) {
 			name:      "diff",
 			args:      []string{"diff", "--help"},
 			examples:  []string{"Examples:", "bomly diff --sbom --base ./before.cdx.json --head ./after.cdx.json --json"},
-			notInText: []string{"Exit Codes:"},
+			notInText: []string{"Exit Codes:", "--experimental-remediate"},
 		},
 		{
 			name:      "explain",
 			args:      []string{"explain", "--help"},
 			examples:  []string{"Examples:", "bomly explain pkg:npm/react", "bomly explain github.com/spf13/cobra --path . --json"},
-			notInText: []string{"Exit Codes:"},
+			notInText: []string{"Exit Codes:", "--experimental-remediate"},
 		},
 		{
 			name:      "plugin",

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -9,12 +9,14 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/cli/exit"
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
+	"github.com/bomly-dev/bomly-cli/internal/engine/remediation"
 	scanengine "github.com/bomly-dev/bomly-cli/internal/engine/scan"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/internal/sbom"
 	"github.com/bomly-dev/bomly-cli/internal/tui"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 func newScanCmd() *cobra.Command {
@@ -93,6 +95,24 @@ func newScanCmd() *cobra.Command {
 
 			consolidated := pipeResult.Consolidated
 			selectedGraph := pipeResult.Graph
+			remediationResult := remediation.Result{}
+			if commandCtx.ResolvedConfig.ExperimentalRemediate {
+				remediationResult = remediation.Evaluate(selectedGraph)
+				logger.Info("remediation: evaluated local upgrade proposals",
+					zap.Int("vulnerable_packages", len(remediationResult.Proposals)),
+					zap.Int("proposed", remediationResult.ProposedCount()),
+					zap.Int("unavailable", remediationResult.UnavailableCount()),
+				)
+				for _, proposal := range remediationResult.Proposals {
+					if proposal.Status == remediation.StatusProposed {
+						continue
+					}
+					logger.Debug("remediation: proposal unavailable",
+						zap.String("package_id", proposal.PackageID),
+						zap.String("reason", proposal.Reason),
+					)
+				}
+			}
 
 			var findings []sdk.Finding
 			if commandCtx.ResolvedConfig.Audit {
@@ -146,7 +166,13 @@ func newScanCmd() *cobra.Command {
 
 			if commandCtx.ResolvedConfig.Interactive {
 				prog.Stop()
-				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewScan(payload.Project, consolidated, selectedGraph, findings).WithEnrichEnabled(commandCtx.ResolvedConfig.Enrich).WithReachabilityEnabled(commandCtx.ResolvedConfig.Reachability)))
+				model := tui.NewScan(payload.Project, consolidated, selectedGraph, findings).
+					WithEnrichEnabled(commandCtx.ResolvedConfig.Enrich).
+					WithReachabilityEnabled(commandCtx.ResolvedConfig.Reachability)
+				if commandCtx.ResolvedConfig.ExperimentalRemediate {
+					model.WithRemediationProposals(remediationResult)
+				}
+				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), model))
 			}
 
 			writer, closeWriter, err := commandCtx.Writer(streams.reportWriter())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Resolved struct {
 	Enrich                bool     `doc:"Enrich packages with external license and vulnerability data" env:"BOMLY_ENRICH"`
 	Audit                 bool     `doc:"Evaluate policy and create findings from package vulnerability data" env:"BOMLY_AUDIT"`
 	Reachability          bool     `doc:"Run code analysis to confirm whether vulnerabilities are reachable from application code" env:"BOMLY_REACHABILITY"`
+	ExperimentalRemediate bool     `doc:"Enable experimental local-only dependency remediation proposals in the interactive scan TUI" env:"BOMLY_EXPERIMENTAL_REMEDIATE"`
 	FailOn                []string `doc:"Constraint(s) for which findings should be created. Repeatable; AND-ed. Severity: any|low|medium|high|critical. Reachability: reachable. Exploitability: exploitable" env:"BOMLY_FAIL_ON"`
 	FailOnScopes          []string `doc:"Dependency scopes that may produce failing findings: runtime, development, unknown" env:"BOMLY_FAIL_ON_SCOPES"`
 	AllowVulnerabilityIDs []string `doc:"Vulnerability IDs to ignore during policy evaluation" env:"BOMLY_ALLOW_VULNERABILITY_IDS"`
@@ -112,11 +113,12 @@ type TargetFile struct {
 
 // AnalysisFile configures optional analysis behavior and dependency preparation.
 type AnalysisFile struct {
-	Enrich       *bool     `yaml:"enrich,omitempty" resolved:"Enrich" legacy:"enrich"`
-	Audit        *bool     `yaml:"audit,omitempty" resolved:"Audit" legacy:"audit"`
-	Reachability *bool     `yaml:"reachability,omitempty" resolved:"Reachability" legacy:"reachability"`
-	InstallFirst *bool     `yaml:"install_first,omitempty" resolved:"InstallFirst" legacy:"install_first"`
-	InstallArgs  *[]string `yaml:"install_args,omitempty" resolved:"InstallArgs" legacy:"install_args"`
+	Enrich                *bool     `yaml:"enrich,omitempty" resolved:"Enrich" legacy:"enrich"`
+	Audit                 *bool     `yaml:"audit,omitempty" resolved:"Audit" legacy:"audit"`
+	Reachability          *bool     `yaml:"reachability,omitempty" resolved:"Reachability" legacy:"reachability"`
+	ExperimentalRemediate *bool     `yaml:"experimental_remediate,omitempty" resolved:"ExperimentalRemediate" legacy:"experimental_remediate"`
+	InstallFirst          *bool     `yaml:"install_first,omitempty" resolved:"InstallFirst" legacy:"install_first"`
+	InstallArgs           *[]string `yaml:"install_args,omitempty" resolved:"InstallArgs" legacy:"install_args"`
 }
 
 // ComponentsFile configures component selection.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -317,6 +317,12 @@ func Validate(cfg Resolved) error {
 	if cfg.Reachability && !cfg.Enrich {
 		return fmt.Errorf("--reachability requires --enrich")
 	}
+	if cfg.ExperimentalRemediate && !cfg.Interactive {
+		return fmt.Errorf("--experimental-remediate requires --interactive")
+	}
+	if cfg.ExperimentalRemediate && !cfg.Enrich {
+		return fmt.Errorf("--experimental-remediate requires --enrich")
+	}
 	if len(cfg.AllowLicenses) > 0 && len(cfg.DenyLicenses) > 0 {
 		return fmt.Errorf("--allow-license cannot be combined with --deny-license")
 	}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -85,6 +85,7 @@ analysis:
   enrich: true
   audit: true
   reachability: true
+  experimental_remediate: true
   install_first: true
   install_args: [--offline]
 components:
@@ -146,7 +147,7 @@ matchers:
 	if resolved.Container != "alpine:3.20" || resolved.URL == "" || resolved.Ref != "main" || !resolved.SBOM {
 		t.Fatalf("target config = %#v", resolved)
 	}
-	if !resolved.Enrich || !resolved.Audit || !resolved.Reachability || !resolved.InstallFirst {
+	if !resolved.Enrich || !resolved.Audit || !resolved.Reachability || !resolved.ExperimentalRemediate || !resolved.InstallFirst {
 		t.Fatalf("analysis config = %#v", resolved)
 	}
 	if len(resolved.InstallArgs) != 1 || resolved.InstallArgs[0] != "--offline" {
@@ -174,6 +175,7 @@ func TestApplyFileConfigClearsInheritedLists(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`
 analysis:
   enrich: false
+  experimental_remediate: false
   install_args: []
 policy:
   fail_on: []
@@ -191,20 +193,30 @@ logging:
 		t.Fatalf("LoadFile() error = %v", err)
 	}
 	resolved := Resolved{
-		Enrich:        true,
-		InstallArgs:   []string{"--offline"},
-		FailOn:        []string{"high"},
-		AllowLicenses: []string{"MIT"},
-		Interactive:   true,
-		Outputs:       []string{"spdx=sbom.json"},
-		Verbosity:     2,
+		Enrich:                true,
+		ExperimentalRemediate: true,
+		InstallArgs:           []string{"--offline"},
+		FailOn:                []string{"high"},
+		AllowLicenses:         []string{"MIT"},
+		Interactive:           true,
+		Outputs:               []string{"spdx=sbom.json"},
+		Verbosity:             2,
 	}
 	ApplyFileConfig(&resolved, *fileCfg)
-	if resolved.Enrich || resolved.Interactive || resolved.Verbosity != 0 {
+	if resolved.Enrich || resolved.ExperimentalRemediate || resolved.Interactive || resolved.Verbosity != 0 {
 		t.Fatalf("expected explicit zero values to override inherited values, got %#v", resolved)
 	}
 	if len(resolved.InstallArgs) != 0 || len(resolved.FailOn) != 0 || len(resolved.AllowLicenses) != 0 || len(resolved.Outputs) != 0 {
 		t.Fatalf("expected explicit empty lists to clear inherited values, got %#v", resolved)
+	}
+}
+
+func TestApplyEnvOverridesExperimentalRemediate(t *testing.T) {
+	t.Setenv("BOMLY_EXPERIMENTAL_REMEDIATE", "true")
+	var resolved Resolved
+	ApplyEnvOverrides(&resolved)
+	if !resolved.ExperimentalRemediate {
+		t.Fatal("expected BOMLY_EXPERIMENTAL_REMEDIATE to enable experimental remediation")
 	}
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -25,6 +25,33 @@ func TestValidateRejectsReachabilityWithoutEnrich(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsExperimentalRemediationWithoutInteractiveAndEnrich(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Resolved
+		want string
+	}{
+		{
+			name: "interactive required",
+			cfg:  Resolved{ExperimentalRemediate: true, Enrich: true},
+			want: "--experimental-remediate requires --interactive",
+		},
+		{
+			name: "enrich required",
+			cfg:  Resolved{ExperimentalRemediate: true, Interactive: true},
+			want: "--experimental-remediate requires --enrich",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateAcceptsAuditAndReachabilityWithEnrich(t *testing.T) {
 	cases := []struct {
 		name string
@@ -33,6 +60,7 @@ func TestValidateAcceptsAuditAndReachabilityWithEnrich(t *testing.T) {
 		{"audit + enrich", Resolved{Enrich: true, Audit: true}},
 		{"reachability + enrich", Resolved{Enrich: true, Reachability: true}},
 		{"all three", Resolved{Enrich: true, Audit: true, Reachability: true}},
+		{"experimental remediation", Resolved{Enrich: true, Interactive: true, ExperimentalRemediate: true}},
 		{"enrich alone", Resolved{Enrich: true}},
 		{"none of the three", Resolved{}},
 	}

--- a/internal/engine/remediation/remediation.go
+++ b/internal/engine/remediation/remediation.go
@@ -1,0 +1,210 @@
+// Package remediation proposes locally evidenced dependency upgrades for
+// packages with attached vulnerability data.
+package remediation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// Status describes whether a package has enough local data for a proposal.
+type Status string
+
+const (
+	// StatusProposed means a locally evidenced upgrade candidate is available.
+	StatusProposed Status = "proposed"
+	// StatusInsufficientLocalData means local vulnerability metadata could not
+	// support a conservative proposal.
+	StatusInsufficientLocalData Status = "insufficient_local_data"
+)
+
+// ConstraintCompatibility describes whether a proposal satisfies the
+// dependency constraint declared by the package manager manifest.
+type ConstraintCompatibility string
+
+const (
+	// ConstraintCompatibilityUnknown is used because the consolidated graph
+	// does not retain portable package-manager dependency constraints.
+	ConstraintCompatibilityUnknown ConstraintCompatibility = "unknown"
+)
+
+// Proposal describes the minimum locally evidenced upgrade candidate for one
+// vulnerable package.
+type Proposal struct {
+	PackageID               string
+	PackageName             string
+	CurrentVersion          string
+	ProposedVersion         string
+	VulnerabilityIDs        []string
+	Status                  Status
+	ConstraintCompatibility ConstraintCompatibility
+	Reason                  string
+}
+
+// Result contains deterministic package remediation proposals.
+type Result struct {
+	Proposals   []Proposal
+	ByPackageID map[string]Proposal
+}
+
+// ProposalForPackageID returns the proposal for packageID when one exists.
+func (r Result) ProposalForPackageID(packageID string) (Proposal, bool) {
+	proposal, ok := r.ByPackageID[packageID]
+	return proposal, ok
+}
+
+// ProposedCount returns the number of packages with locally evidenced
+// remediation candidates.
+func (r Result) ProposedCount() int {
+	count := 0
+	for _, proposal := range r.Proposals {
+		if proposal.Status == StatusProposed {
+			count++
+		}
+	}
+	return count
+}
+
+// UnavailableCount returns the number of vulnerable packages without enough
+// local data for a remediation candidate.
+func (r Result) UnavailableCount() int {
+	return len(r.Proposals) - r.ProposedCount()
+}
+
+// Evaluate returns one deterministic proposal for each vulnerable package in
+// graph. It uses only vulnerability metadata already attached to the graph.
+func Evaluate(graph *sdk.Graph) Result {
+	result := Result{ByPackageID: make(map[string]Proposal)}
+	if graph == nil {
+		return result
+	}
+	for _, pkg := range graph.Packages() {
+		if pkg == nil || len(pkg.Vulnerabilities) == 0 {
+			continue
+		}
+		proposal := ProposePackage(pkg, pkg.Vulnerabilities)
+		result.Proposals = append(result.Proposals, proposal)
+		result.ByPackageID[proposal.PackageID] = proposal
+	}
+	sort.Slice(result.Proposals, func(i, j int) bool {
+		return result.Proposals[i].PackageID < result.Proposals[j].PackageID
+	})
+	return result
+}
+
+// ProposePackage returns a conservative proposal for pkg based on
+// vulnerabilities already attached by local graph enrichment.
+func ProposePackage(pkg *sdk.Package, vulnerabilities []sdk.PackageVulnerability) Proposal {
+	proposal := Proposal{
+		Status:                  StatusInsufficientLocalData,
+		ConstraintCompatibility: ConstraintCompatibilityUnknown,
+	}
+	if pkg == nil {
+		proposal.Reason = "package is nil"
+		return proposal
+	}
+	proposal.PackageID = pkg.ID
+	proposal.PackageName = pkg.DisplayName()
+	proposal.CurrentVersion = pkg.Version
+	proposal.VulnerabilityIDs = vulnerabilityIDs(vulnerabilities)
+	if len(vulnerabilities) == 0 {
+		proposal.Reason = "package has no locally attached vulnerabilities"
+		return proposal
+	}
+
+	current, err := semver.NewVersion(strings.TrimSpace(pkg.Version))
+	if err != nil {
+		proposal.Reason = fmt.Sprintf("installed version %q is not semver-compatible", pkg.Version)
+		return proposal
+	}
+
+	var packageMinimum *semver.Version
+	var packageMinimumRaw string
+	for _, vulnerability := range sortedVulnerabilities(vulnerabilities) {
+		minimum, raw, reason := minimumFixedVersionAfter(current, vulnerability)
+		if reason != "" {
+			proposal.Reason = reason
+			return proposal
+		}
+		if packageMinimum == nil || minimum.GreaterThan(packageMinimum) {
+			packageMinimum = minimum
+			packageMinimumRaw = raw
+		}
+	}
+	if packageMinimum == nil {
+		proposal.Reason = "no locally attached fixed version is available"
+		return proposal
+	}
+
+	proposal.Status = StatusProposed
+	proposal.ProposedVersion = packageMinimumRaw
+	return proposal
+}
+
+func minimumFixedVersionAfter(current *semver.Version, vulnerability sdk.PackageVulnerability) (*semver.Version, string, string) {
+	candidates := append([]string{vulnerability.FixedIn}, vulnerability.FixedVersions...)
+	candidates = uniqueNonEmptyStrings(candidates)
+	if len(candidates) == 0 {
+		return nil, "", fmt.Sprintf("vulnerability %q has no locally attached fixed version", vulnerability.ID)
+	}
+
+	var minimum *semver.Version
+	var minimumRaw string
+	for _, raw := range candidates {
+		parsed, err := semver.NewVersion(raw)
+		if err != nil {
+			return nil, "", fmt.Sprintf("vulnerability %q fixed version %q is not semver-compatible", vulnerability.ID, raw)
+		}
+		if !parsed.GreaterThan(current) {
+			continue
+		}
+		if minimum == nil || parsed.LessThan(minimum) {
+			minimum = parsed
+			minimumRaw = raw
+		}
+	}
+	if minimum == nil {
+		return nil, "", fmt.Sprintf("vulnerability %q has no locally attached fixed version newer than installed version %q", vulnerability.ID, current.Original())
+	}
+	return minimum, minimumRaw, ""
+}
+
+func vulnerabilityIDs(vulnerabilities []sdk.PackageVulnerability) []string {
+	ids := make([]string, 0, len(vulnerabilities))
+	for _, vulnerability := range vulnerabilities {
+		if id := strings.TrimSpace(vulnerability.ID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return uniqueNonEmptyStrings(ids)
+}
+
+func sortedVulnerabilities(vulnerabilities []sdk.PackageVulnerability) []sdk.PackageVulnerability {
+	out := append([]sdk.PackageVulnerability(nil), vulnerabilities...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/engine/remediation/remediation_test.go
+++ b/internal/engine/remediation/remediation_test.go
@@ -1,0 +1,124 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestEvaluateReturnsDeterministicPackageProposals(t *testing.T) {
+	graph := sdk.New()
+	for _, pkg := range []*sdk.Package{
+		sdk.NewPackage(sdk.Package{
+			Name:    "zeta",
+			Version: "1.0.0",
+			Vulnerabilities: []sdk.PackageVulnerability{{
+				ID:            "CVE-Z",
+				FixedVersions: []string{"1.2.0", "1.1.0"},
+			}},
+		}),
+		sdk.NewPackage(sdk.Package{Name: "root", Version: "1.0.0"}),
+		sdk.NewPackage(sdk.Package{
+			Name:    "alpha",
+			Version: "2.0.0",
+			Vulnerabilities: []sdk.PackageVulnerability{{
+				ID:      "CVE-A",
+				FixedIn: "2.0.1",
+			}},
+		}),
+	} {
+		if err := graph.AddPackage(pkg); err != nil {
+			t.Fatalf("AddPackage() error = %v", err)
+		}
+	}
+
+	result := Evaluate(graph)
+	if len(result.Proposals) != 2 {
+		t.Fatalf("len(Proposals) = %d, want 2", len(result.Proposals))
+	}
+	if result.Proposals[0].PackageName != "alpha" || result.Proposals[1].PackageName != "zeta" {
+		t.Fatalf("proposal order = %#v, want alpha then zeta", result.Proposals)
+	}
+	if got := result.Proposals[1].ProposedVersion; got != "1.1.0" {
+		t.Fatalf("zeta ProposedVersion = %q, want 1.1.0", got)
+	}
+	if result.ProposedCount() != 2 || result.UnavailableCount() != 0 {
+		t.Fatalf("counts = proposed %d unavailable %d", result.ProposedCount(), result.UnavailableCount())
+	}
+}
+
+func TestProposePackageAggregatesMinimumAcrossVulnerabilities(t *testing.T) {
+	pkg := sdk.NewPackage(sdk.Package{Name: "lodash", Version: "4.17.19"})
+	proposal := ProposePackage(pkg, []sdk.PackageVulnerability{
+		{ID: "CVE-B", FixedIn: "4.17.21"},
+		{ID: "CVE-A", FixedVersions: []string{"4.17.20", "4.17.22"}},
+	})
+	if proposal.Status != StatusProposed {
+		t.Fatalf("Status = %q, want proposed: %s", proposal.Status, proposal.Reason)
+	}
+	if proposal.ProposedVersion != "4.17.21" {
+		t.Fatalf("ProposedVersion = %q, want 4.17.21", proposal.ProposedVersion)
+	}
+	if got := strings.Join(proposal.VulnerabilityIDs, ","); got != "CVE-A,CVE-B" {
+		t.Fatalf("VulnerabilityIDs = %q, want sorted IDs", got)
+	}
+	if proposal.ConstraintCompatibility != ConstraintCompatibilityUnknown {
+		t.Fatalf("ConstraintCompatibility = %q, want unknown", proposal.ConstraintCompatibility)
+	}
+}
+
+func TestProposePackageRejectsIncompleteOrInvalidEvidence(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         string
+		vulnerabilities []sdk.PackageVulnerability
+		wantReason      string
+	}{
+		{
+			name:            "missing fixed version",
+			version:         "1.0.0",
+			vulnerabilities: []sdk.PackageVulnerability{{ID: "CVE-MISSING"}},
+			wantReason:      "no locally attached fixed version",
+		},
+		{
+			name:            "invalid installed version",
+			version:         "latest",
+			vulnerabilities: []sdk.PackageVulnerability{{ID: "CVE-INSTALLED", FixedIn: "1.0.1"}},
+			wantReason:      "installed version",
+		},
+		{
+			name:            "invalid fixed version",
+			version:         "1.0.0",
+			vulnerabilities: []sdk.PackageVulnerability{{ID: "CVE-FIXED", FixedVersions: []string{"1.0.1", "next"}}},
+			wantReason:      "not semver-compatible",
+		},
+		{
+			name:            "older fixed version",
+			version:         "2.0.0",
+			vulnerabilities: []sdk.PackageVulnerability{{ID: "CVE-OLDER", FixedIn: "1.9.9"}},
+			wantReason:      "newer than installed version",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			proposal := ProposePackage(sdk.NewPackage(sdk.Package{Name: "demo", Version: tc.version}), tc.vulnerabilities)
+			if proposal.Status != StatusInsufficientLocalData {
+				t.Fatalf("Status = %q, want insufficient_local_data", proposal.Status)
+			}
+			if proposal.ProposedVersion != "" {
+				t.Fatalf("ProposedVersion = %q, want empty", proposal.ProposedVersion)
+			}
+			if !strings.Contains(proposal.Reason, tc.wantReason) {
+				t.Fatalf("Reason = %q, want substring %q", proposal.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestEvaluateNilGraph(t *testing.T) {
+	result := Evaluate(nil)
+	if len(result.Proposals) != 0 || len(result.ByPackageID) != 0 {
+		t.Fatalf("Evaluate(nil) = %#v, want empty result", result)
+	}
+}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -391,6 +391,9 @@ func TestBuildRecommendationText_Direct(t *testing.T) {
 	if rec == "" {
 		t.Error("expected non-empty recommendation")
 	}
+	if !strings.Contains(rec, "Verify manifest constraints") || !strings.Contains(rec, "re-scan") {
+		t.Errorf("recommendation should disclose verification requirements, got: %s", rec)
+	}
 }
 
 func TestBuildRecommendationText_MultipleVulns(t *testing.T) {
@@ -419,5 +422,8 @@ func TestBuildRecommendationText_NoTargets(t *testing.T) {
 	rec := mcp.BuildRecommendationText(dep, []string{"CVE-2024-1234"}, "4.17.21", nil)
 	if rec == "" {
 		t.Error("expected non-empty fallback recommendation")
+	}
+	if !strings.Contains(rec, "Verify manifest constraints") || !strings.Contains(rec, "re-scan") {
+		t.Errorf("fallback recommendation should disclose verification requirements, got: %s", rec)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -206,6 +206,7 @@ func BuildRecommendationText(
 			msg += ". No fixed version is available at this time"
 		}
 		msg += ". No manifest file could be identified for automated remediation."
+		msg += " Verify manifest constraints, re-resolve dependencies, and re-scan before treating any candidate as safe."
 		return msg
 	}
 
@@ -214,7 +215,8 @@ func BuildRecommendationText(
 		return "Upgrade `" + t.TargetPackage + "` from " + t.CurrentVersion +
 			" to " + t.RecommendedVersion +
 			" in " + t.ManifestPath +
-			" to fix " + vulnLabel + " affecting " + dependency.Name + "@" + dependency.Version + "."
+			" to address " + vulnLabel + " affecting " + dependency.Name + "@" + dependency.Version +
+			". Verify manifest constraints, re-resolve dependencies, and re-scan before treating this candidate as safe."
 	}
 	suffix := ""
 	if minSafeVersion != "" {
@@ -224,5 +226,5 @@ func BuildRecommendationText(
 		"` is a transitive dependency introduced via `" + t.TargetPackage + "@" + t.CurrentVersion + "`" +
 		" in " + t.ManifestPath + "." +
 		" Look for a newer version of `" + t.TargetPackage + "` that depends on a patched version of `" + dependency.Name + "`" +
-		suffix + "."
+		suffix + ". Verify manifest constraints, re-resolve dependencies, and re-scan before treating any candidate as safe."
 }

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/engine/remediation"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
@@ -44,6 +45,20 @@ func (m *scanModel) WithReachabilityEnabled(enabled bool) *scanModel {
 		return nil
 	}
 	m.reachabilityEnabled = enabled
+	if m.shellModel != nil {
+		m.Rebuild()
+	}
+	return m
+}
+
+// WithRemediationProposals enables the experimental vulnerability remediation
+// layout with proposals computed from locally attached vulnerability metadata.
+func (m *scanModel) WithRemediationProposals(proposals remediation.Result) *scanModel {
+	if m == nil {
+		return nil
+	}
+	m.remediationEnabled = true
+	m.remediationProposals = proposals
 	if m.shellModel != nil {
 		m.Rebuild()
 	}
@@ -106,6 +121,36 @@ func (m *scanModel) currentScanView() scanView {
 		return interactiveScanViewOverview
 	}
 	return scanView(m.ActiveTabID())
+}
+
+// CycleView advances to the next tab and clears the vulnerability remediation
+// layout so it cannot leak into a different details pane.
+func (m *scanModel) CycleView() {
+	if m == nil || m.shellModel == nil {
+		return
+	}
+	m.remediationDetails = false
+	m.shellModel.CycleView()
+}
+
+// SelectView jumps to the requested tab and clears the vulnerability
+// remediation layout.
+func (m *scanModel) SelectView(index int) {
+	if m == nil || m.shellModel == nil {
+		return
+	}
+	m.remediationDetails = false
+	m.shellModel.SelectView(index)
+}
+
+// ToggleRemediationDetails switches the vulnerability pane between advisory
+// details and experimental local-only remediation proposals.
+func (m *scanModel) ToggleRemediationDetails() {
+	if m == nil || !m.remediationEnabled || m.currentScanView() != interactiveScanViewVulns {
+		return
+	}
+	m.remediationDetails = !m.remediationDetails
+	m.rebuildListPreserveSelection()
 }
 
 // View overrides shellModel.View so the Overview tab can render its custom
@@ -1050,6 +1095,14 @@ func (m *scanModel) buildVulnsListModel() *listModel {
 			emptyState = "No enriched vulnerabilities found. Run with --enrich to populate vulnerability data."
 		}
 	}
+	detailTitle := "Vulnerability Details"
+	if m.remediationDetails {
+		detailTitle = "Proposed Upgrade Paths"
+	}
+	filterHelp := "Use / to search; Enter focuses details; Esc clears search; v cycles severity filter; g groups vulnerabilities; 1-7 switch tabs"
+	if m.remediationEnabled {
+		filterHelp += "; f toggles proposed upgrade paths"
+	}
 
 	return &listModel{
 		title:       fmt.Sprintf("%s: %s", m.titlePrefix, m.project.Name),
@@ -1057,13 +1110,13 @@ func (m *scanModel) buildVulnsListModel() *listModel {
 		controls:    []string{m.vulnerabilityControlsLine(), m.vulnerabilityStateLine(len(filtered), len(all))},
 		listTitle:   fmt.Sprintf("Vulnerabilities (%d)", len(filtered)),
 		listHeader:  "Vulnerability ID / Group",
-		detailTitle: "Vulnerability Details",
+		detailTitle: detailTitle,
 		topPanels: []listPanel{
 			{title: "Severity Summary", lines: vulnerabilitySummaryLines(all), color: render.Red, weight: 1},
 			{title: "Top Affected", lines: topAffectedLines(all, 5, 140), color: render.Green, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
-		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; v cycles severity filter; g groups vulnerabilities; 1-7 switch tabs",
+		filterHelp:     filterHelp,
 		emptyState:     emptyState,
 		items:          items,
 	}
@@ -1091,7 +1144,7 @@ func (m *scanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow
 		items = append(items, listItem{
 			title:    fmt.Sprintf("%s (%d)", key, len(groupVulnerabilities)),
 			subtitle: "group",
-			details:  vulnerabilityGroupDetails(key, group, groupVulnerabilities),
+			details:  m.vulnerabilityGroupDetails(key, group, groupVulnerabilities),
 			key:      groupKey,
 			canOpen:  true,
 			expanded: expanded,
@@ -1118,7 +1171,7 @@ func (m *scanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow
 			items = append(items, listItem{
 				title:   title,
 				badges:  badges,
-				details: vulnerabilityDetails(vulnerability),
+				details: m.vulnerabilityDetails(vulnerability),
 				tree:    treePrefix(nil, idx == len(groupVulnerabilities)-1, 1),
 				depth:   1,
 			})
@@ -1180,6 +1233,9 @@ func (m *scanModel) vulnerabilityControlsLine() string {
 	parts := []string{keyHint("/", "search"), keyHint("g", "group"), keyHint("v", "severity")}
 	if m.reachabilityFilterAvailable() {
 		parts = append(parts, keyHint("a", "reachability"))
+	}
+	if m.remediationEnabled {
+		parts = append(parts, keyHint("f", "fix"))
 	}
 	parts = append(parts, keyHint("]", "expand all"), keyHint("[", "collapse all"))
 	return strings.Join(parts, " ")
@@ -1258,6 +1314,77 @@ func vulnerabilityGroupDetails(key, group string, vulnerabilities []packageVulne
 	for _, vulnerability := range vulnerabilities {
 		lines = append(lines, render.Style("  - ", render.Dim)+vulnerability.vulnerability.ID+" "+valueOrDash(vulnerability.vulnerability.Title))
 	}
+	return lines
+}
+
+func (m *scanModel) vulnerabilityGroupDetails(key, group string, vulnerabilities []packageVulnerabilityRow) []string {
+	if !m.remediationDetails {
+		return vulnerabilityGroupDetails(key, group, vulnerabilities)
+	}
+	if group != "component" || len(vulnerabilities) == 0 || vulnerabilities[0].pkg == nil {
+		return remediationSelectionPrompt()
+	}
+	return m.remediationDetailsForPackage(vulnerabilities[0].pkg.ID)
+}
+
+func (m *scanModel) vulnerabilityDetails(row packageVulnerabilityRow) []string {
+	if !m.remediationDetails {
+		return vulnerabilityDetails(row)
+	}
+	if row.pkg == nil {
+		return remediationSelectionPrompt()
+	}
+	return m.remediationDetailsForPackage(row.pkg.ID)
+}
+
+func remediationSelectionPrompt() []string {
+	return []string{
+		render.Style("Proposed Upgrade Paths", render.Bold, render.Cyan),
+		"",
+		render.Style("  Select an advisory or a component group to view a local-only upgrade proposal.", render.Dim),
+	}
+}
+
+func (m *scanModel) remediationDetailsForPackage(packageID string) []string {
+	proposal, ok := m.remediationProposals.ProposalForPackageID(packageID)
+	if !ok {
+		proposal = remediation.Proposal{
+			PackageID:               packageID,
+			Status:                  remediation.StatusInsufficientLocalData,
+			ConstraintCompatibility: remediation.ConstraintCompatibilityUnknown,
+			Reason:                  "no locally attached remediation proposal is available for this component",
+		}
+	}
+	lines := []string{
+		render.Style("Proposed Upgrade Paths", render.Bold, render.Cyan),
+		"",
+		render.Style("Component", render.Bold, render.Magenta),
+		render.Style("  Package: ", render.Dim) + valueOrDash(proposal.PackageName),
+		render.Style("  Package ID: ", render.Dim) + valueOrDash(proposal.PackageID),
+		render.Style("  Installed version: ", render.Dim) + valueOrDash(proposal.CurrentVersion),
+		render.Style("  Status: ", render.Dim) + string(proposal.Status),
+		render.Style("  Candidate version: ", render.Dim) + valueOrDash(proposal.ProposedVersion),
+		render.Style("  Constraint compatibility: ", render.Dim) + string(proposal.ConstraintCompatibility),
+		"",
+		render.Style("Local-only Evidence", render.Bold, render.Magenta),
+		render.Style("  Based only on FixedIn / FixedVersions metadata already attached to the consolidated graph.", render.Dim),
+	}
+	if proposal.Reason != "" {
+		lines = append(lines, render.Style("  Unavailable reason: ", render.Dim)+proposal.Reason)
+	}
+	lines = append(lines, "", render.Style(fmt.Sprintf("Vulnerabilities (%d)", len(proposal.VulnerabilityIDs)), render.Bold, render.Magenta))
+	if len(proposal.VulnerabilityIDs) == 0 {
+		lines = append(lines, render.Style("  (none)", render.Dim))
+	} else {
+		for _, vulnerabilityID := range proposal.VulnerabilityIDs {
+			lines = append(lines, render.Style("  - ", render.Dim)+vulnerabilityID)
+		}
+	}
+	lines = append(lines,
+		"",
+		render.Style("Verification Required", render.Bold, render.Magenta),
+		render.Style("  Verify manifest constraints, re-resolve dependencies, and re-scan before treating this candidate as safe.", render.Dim),
+	)
 	return lines
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/engine/remediation"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	tea "github.com/charmbracelet/bubbletea"
@@ -36,6 +37,10 @@ type filterModel interface {
 
 type reachabilityFilterModel interface {
 	CycleReachabilityFilter()
+}
+
+type remediationModel interface {
+	ToggleRemediationDetails()
 }
 
 type tabbedModel interface {
@@ -209,6 +214,9 @@ type scanModel struct {
 	findings              []sdk.Finding
 	enrichEnabled         bool
 	reachabilityEnabled   bool
+	remediationEnabled    bool
+	remediationDetails    bool
+	remediationProposals  remediation.Result
 	currentManifestID     string
 	allowManifestExit     bool
 	relationshipFilter    string
@@ -332,6 +340,10 @@ func (m *teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "a":
 			if filterModel, ok := m.inner.(reachabilityFilterModel); ok {
 				filterModel.CycleReachabilityFilter()
+			}
+		case "f":
+			if remediationModel, ok := m.inner.(remediationModel); ok {
+				remediationModel.ToggleRemediationDetails()
 			}
 		case "g":
 			if groupModel, ok := m.inner.(groupModel); ok {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	"github.com/bomly-dev/bomly-cli/internal/engine/consolidation"
+	"github.com/bomly-dev/bomly-cli/internal/engine/remediation"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	tea "github.com/charmbracelet/bubbletea"
@@ -979,6 +980,108 @@ func TestScanInteractiveModel_VulnerabilityFilterEmptyStateDistinguishesNoMatche
 	if !strings.Contains(plain, "No enriched vulnerabilities found. Run with --enrich to populate vulnerability data.") {
 		t.Fatalf("expected no-enrich empty state, got:\n%s", plain)
 	}
+}
+
+func TestScanInteractiveModel_RemediationIsHiddenAndNoOpUnlessEnabled(t *testing.T) {
+	model := newScanRemediationModel(t, false, []sdk.PackageVulnerability{{
+		ID:      "CVE-ONE",
+		FixedIn: "1.1.0",
+	}})
+	model.SelectView(3)
+	wrapper := &teaModel{inner: model, width: 180, height: 40}
+	if plain := render.StripANSI(wrapper.View()); strings.Contains(plain, "f fix") {
+		t.Fatalf("expected remediation control to stay hidden, got:\n%s", plain)
+	}
+
+	_, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if model.remediationDetails {
+		t.Fatal("expected f key to be ignored when remediation is disabled")
+	}
+}
+
+func TestScanInteractiveModel_RemediationToggleShowsAggregateComponentProposal(t *testing.T) {
+	model := newScanRemediationModel(t, true, []sdk.PackageVulnerability{
+		{ID: "CVE-ONE", FixedIn: "1.1.0"},
+		{ID: "CVE-TWO", FixedVersions: []string{"1.3.0", "1.2.0"}},
+	})
+	model.SelectView(3)
+	wrapper := &teaModel{inner: model, width: 180, height: 40}
+	if plain := render.StripANSI(wrapper.View()); !strings.Contains(plain, "f fix") {
+		t.Fatalf("expected enabled remediation control, got:\n%s", plain)
+	}
+
+	_, _ = wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if !model.remediationDetails {
+		t.Fatal("expected f key to toggle remediation details")
+	}
+	assertRemediationDetails(t, model, "Candidate version: 1.2.0", "Constraint compatibility: unknown", "Verify manifest constraints")
+
+	model.Move(1)
+	assertRemediationDetails(t, model, "Candidate version: 1.2.0")
+
+	model.SelectView(2)
+	model.SelectView(3)
+	if model.remediationDetails {
+		t.Fatal("expected tab switch to clear remediation details")
+	}
+	if details := selectedInteractiveDetails(model); strings.Contains(details, "Proposed Upgrade Paths") {
+		t.Fatalf("expected vulnerability details after tab switch, got:\n%s", details)
+	}
+}
+
+func TestScanInteractiveModel_RemediationShowsUnavailableAndGroupedPrompt(t *testing.T) {
+	model := newScanRemediationModel(t, true, []sdk.PackageVulnerability{{ID: "CVE-NO-FIX"}})
+	model.SelectView(3)
+	model.ToggleRemediationDetails()
+	assertRemediationDetails(t, model, "Status: insufficient_local_data", "Unavailable reason:")
+
+	model.ToggleRemediationDetails()
+	model.vulnerabilityGroup = "severity"
+	model.rebuildListPreserveSelection()
+	model.ToggleRemediationDetails()
+	assertRemediationDetails(t, model, "Select an advisory or a component group")
+}
+
+func newScanRemediationModel(t *testing.T, enabled bool, vulnerabilities []sdk.PackageVulnerability) *scanModel {
+	t.Helper()
+	graphValue := sdk.New()
+	root := sdk.NewPackage(sdk.Package{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	dependency := sdk.NewPackage(sdk.Package{
+		Name:            "lodash",
+		Version:         "1.0.0",
+		Ecosystem:       "npm",
+		Vulnerabilities: vulnerabilities,
+	})
+	for _, pkg := range []*sdk.Package{root, dependency} {
+		if err := graphValue.AddPackage(pkg); err != nil {
+			t.Fatalf("add package: %v", err)
+		}
+	}
+	if err := graphValue.AddDependency(root.ID, dependency.ID); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, sdk.ConsolidatedGraph{}, graphValue, nil).WithEnrichEnabled(true)
+	if enabled {
+		model.WithRemediationProposals(remediation.Evaluate(graphValue))
+	}
+	return model
+}
+
+func assertRemediationDetails(t *testing.T, model *scanModel, expected ...string) {
+	t.Helper()
+	details := selectedInteractiveDetails(model)
+	for _, value := range expected {
+		if !strings.Contains(details, value) {
+			t.Fatalf("expected remediation details to contain %q, got:\n%s", value, details)
+		}
+	}
+}
+
+func selectedInteractiveDetails(model *scanModel) string {
+	if model == nil || model.List() == nil || len(model.List().items) == 0 {
+		return ""
+	}
+	return render.StripANSI(strings.Join(model.List().items[model.List().selected].details, "\n"))
 }
 
 func TestScanInteractiveModel_ReachabilityFilterCyclesFromKeyboard(t *testing.T) {


### PR DESCRIPTION
## Summary

Add an opt-in dependency remediation proposer for interactive vulnerability triage:

```bash
bomly scan --interactive --enrich --experimental-remediate
```

The vulnerabilities pane exposes `f fix` only when the experimental gate is enabled and renders a **Proposed Upgrade Paths** layout for the selected component.

## What Changed

- Add scan-only `--experimental-remediate`, `analysis.experimental_remediate`, and `BOMLY_EXPERIMENTAL_REMEDIATE` support.
- Require both `--interactive` and `--enrich` with actionable validation errors.
- Add `internal/engine/remediation`, a pure consolidated-graph evaluator that derives deterministic aggregate semver candidates from attached `FixedIn` and `FixedVersions` metadata.
- Report `insufficient_local_data` when any advisory lacks usable fixed-version metadata or semver parsing fails.
- Add gated TUI `f fix` handling, selected-component aggregation, unavailable states, grouped-row guidance, and tab-switch reset behavior.
- Reuse the remediation evaluator in `bomly_vuln_fix_context` so CLI and MCP candidate selection stay aligned.
- Update MCP recommendation text to require manifest verification, dependency re-resolution, and a follow-up scan.
- Add public remediation documentation, architecture notes, contributor maps, and regenerated config reference output.

## Safety Boundary

The remediation evaluator reads only vulnerability metadata already attached to the consolidated graph. It does not call matchers, cache readers, HTTP clients, package managers, or subprocesses.

The consolidated graph does not retain portable declared dependency ranges, so constraint compatibility is deliberately reported as `unknown`. The proposal is triage guidance, not a verified manifest edit.

## Validation

- `make generate`
- `make fmt-check`
- `make test`
- `make build`
- `git diff --check`

Smoke goldens were not updated because this feature is TUI-only and does not alter smoke output.