### PR TITLE
fix(logging): improve console logger configuration and enhance stderr handling in benchmark report

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -29,19 +29,21 @@ func NewConsole(stderr io.Writer, verbosity int, quiet bool) *zap.Logger {
 		level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 
-	config := zap.NewProductionConfig()
-	config.Encoding = "console"
-	config.Level = level
-	config.DisableCaller = true
-	config.DisableStacktrace = true
-	config.OutputPaths = nil
-	config.ErrorOutputPaths = nil
-	config.EncoderConfig.TimeKey = ""
-	config.EncoderConfig.CallerKey = ""
-	config.EncoderConfig.FunctionKey = ""
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	encoderCfg := zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "level",
+		TimeKey:        "",
+		CallerKey:      "",
+		FunctionKey:    "",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
 
-	encoder := newPrettyConsoleEncoder(config.EncoderConfig)
+	encoder := newPrettyConsoleEncoder(encoderCfg)
 	core := zapcore.NewCore(
 		encoder,
 		zapcore.AddSync(stderr),

--- a/internal/tools/benchmarkreport/main.go
+++ b/internal/tools/benchmarkreport/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -37,7 +38,7 @@ func main() {
 		string(prompt),
 	)
 	var report bytes.Buffer
-	cmd.Stdout = &report
+	cmd.Stdout = io.MultiWriter(&report, os.Stderr)
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This pull request refactors the logging configuration for console output and improves the visibility of benchmark reports by modifying output streams. The main changes streamline logger setup and ensure benchmark report output is visible in real-time.

**Logging configuration improvements:**

* Refactored the logger setup in `logger.go` to use a direct `zapcore.EncoderConfig` instead of modifying a `zap.Config`, simplifying the configuration and making the encoder setup more explicit.

**Benchmark reporting enhancements:**

* Changed the benchmark report tool to write command output to both the in-memory buffer and `os.Stderr` simultaneously, improving real-time visibility of benchmark results.
* Added the `io` package import to support the use of `io.MultiWriter` in the benchmark report tool.