### PR TITLE
Implement model standardization follow-ups

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -255,6 +255,47 @@ Required SDK hooks:
 
 Detector plugins may additionally implement `Install` when they support install-first execution.
 
+## Registry-Aware Matchers And Auditors
+
+Bomly's plugin model uses the same three-collection shape as the in-process engine:
+
+- `sdk.Dependency` nodes live in `req.Graph` and describe detected dependency instances plus relationships.
+- `sdk.Package` records live in `req.Registry`, keyed by canonical PURL.
+- `sdk.Finding` values reference registry packages by PURL instead of embedding copied package or vulnerability data.
+
+Matchers enrich the registry in place:
+
+```go
+func (m *Matcher) Match(ctx context.Context, req *sdk.MatchRequest) (*sdk.MatchResponse, error) {
+    pkg := req.Registry.Ensure("pkg:npm/lodash@4.17.15")
+    pkg.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
+    pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{ID: "GHSA-...", Source: "acme"})
+    return &sdk.MatchResponse{Registry: req.Registry, MatcherRuns: []string{"acme.matcher"}}, nil
+}
+```
+
+Auditors read `req.Graph` and `req.Registry`, then emit reference-style findings:
+
+```go
+finding := sdk.Finding{
+    ID:              "GHSA-...",
+    Kind:            sdk.FindingKindVulnerability,
+    PackageRef:      "pkg:npm/lodash@4.17.15",
+    VulnerabilityID: "GHSA-...",
+    Disposition:     sdk.FindingDispositionFail,
+}
+```
+
+Detector plugins should build dependency graphs with the SDK constructors:
+
+```go
+dep := sdk.NewDependency(sdk.Dependency{Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
+_ = graph.AddNode(dep)
+_ = graph.AddEdge(parent.ID, dep.ID)
+```
+
+See [`docs/MODELS.md`](MODELS.md) for the full model reference and migration notes.
+
 ## Supported Install Sources
 
 Current supported sources are:

--- a/examples/plugins/go-module-detector/main.go
+++ b/examples/plugins/go-module-detector/main.go
@@ -67,14 +67,13 @@ func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.Det
 	if err != nil {
 		return nil, err
 	}
-	pkg := &sdk.Dependency{
-		ID:        moduleName + "@v0.0.0",
+	pkg := sdk.NewDependency(sdk.Dependency{
 		Ecosystem: string(sdk.EcosystemGo),
 		Name:      moduleName,
 		Version:   "v0.0.0",
 		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
 		FoundBy:   pluginID,
-	}
+	})
 	graph := sdk.New()
 	if err := graph.AddNode(pkg); err != nil {
 		return nil, err

--- a/internal/analyzers/govulncheck/analyzer.go
+++ b/internal/analyzers/govulncheck/analyzer.go
@@ -16,7 +16,7 @@ const Name = "govulncheck"
 // Analyzer is a Go reachability analyzer backed by govulncheck.
 //
 // It groups Go packages in the input graph by module root, runs the
-// configured Runner once per module, and annotates each PackageVulnerability
+// configured Runner once per module, and annotates each registry vulnerability
 // on Go packages with a Reachability result.
 type Analyzer struct {
 	// Runner is the underlying govulncheck driver. Defaults to
@@ -86,7 +86,7 @@ func dependencyPURL(dep *model.Dependency) string {
 }
 
 // Analyze runs govulncheck per Go module root and writes Reachability
-// onto every Go PackageVulnerability in the graph. Errors degrade to
+// onto every Go registry vulnerability in the graph. Errors degrade to
 // Status=Unknown with a stable Reason — the engine relies on this to
 // keep the pipeline running.
 func (a Analyzer) Analyze(ctx context.Context, req model.AnalyzeRequest) (model.AnalyzeResult, error) {
@@ -354,7 +354,7 @@ func annotateAllUnknown(req model.AnalyzeRequest, reason string, now time.Time) 
 	}
 }
 
-// lookupFinding resolves a PackageVulnerability against the runner's
+// lookupFinding resolves a registry vulnerability against the runner's
 // findings via OSV id and aliases. Grype emits CVE-prefixed identifiers
 // while govulncheck emits GO/GHSA ids; this function bridges the two via
 // the alias arrays produced by the OSV envelopes.

--- a/internal/analyzers/jsreach/analyzer.go
+++ b/internal/analyzers/jsreach/analyzer.go
@@ -17,7 +17,7 @@ const Name = "jsreach"
 // Analyzer is a Tier-3 (package-level) reachability analyzer for npm
 // packages. It groups npm packages in the input graph by project root,
 // runs the configured Runner once per project, and annotates each
-// PackageVulnerability on npm packages with a Reachability result.
+// registry vulnerability on npm packages with a Reachability result.
 //
 // Tier-3 caveat: "unreachable" here means "the application source does
 // not import this package, neither directly nor indirectly through app
@@ -106,7 +106,7 @@ func vulnerabilitiesForDep(req model.AnalyzeRequest, dep *model.Dependency) []mo
 }
 
 // Analyze runs the configured Runner per discovered npm project root
-// and writes Reachability onto every npm PackageVulnerability in the
+// and writes Reachability onto every npm registry vulnerability in the
 // graph. Errors degrade to Status=Unknown with a stable Reason — the
 // engine relies on this to keep the pipeline running.
 func (a Analyzer) Analyze(ctx context.Context, req model.AnalyzeRequest) (model.AnalyzeResult, error) {

--- a/internal/analyzers/jsreach/runner.go
+++ b/internal/analyzers/jsreach/runner.go
@@ -1,7 +1,7 @@
 // Package jsreach implements a Tier-3 (package-level) reachability
 // analyzer for npm packages. It walks application source files reachable
 // from package.json entry points, builds a static import graph, and
-// reports each npm PackageVulnerability as Reachable / Unreachable /
+// reports each npm registry vulnerability as Reachable / Unreachable /
 // Unknown depending on whether the affected package's bare specifier
 // appears in the import set.
 //

--- a/internal/analyzers/jvmreach/analyzer.go
+++ b/internal/analyzers/jvmreach/analyzer.go
@@ -17,7 +17,7 @@ const Name = "jvmreach"
 // Analyzer is a Tier-3 (package-level) reachability analyzer for
 // JVM-ecosystem packages. It groups Maven artifacts in the input
 // graph by project root, runs the configured Runner once per
-// project, and annotates each PackageVulnerability on JVM packages
+// project, and annotates each registry vulnerability on JVM packages
 // with a Reachability result.
 //
 // Tier-3 caveat: "unreachable" means "the application source does

--- a/internal/analyzers/jvmreach/runner.go
+++ b/internal/analyzers/jvmreach/runner.go
@@ -4,7 +4,7 @@
 // reachable .java / .kt / .kts / .scala / .groovy file for top-of-file
 // import statements, maps the imported FQN prefixes to Maven artifact
 // coordinates (`groupId:artifactId`), and reports each
-// PackageVulnerability as Reachable / Unreachable / Unknown depending
+// registry vulnerability as Reachable / Unreachable / Unknown depending
 // on whether the artifact appears in the import set (expanded
 // transitively through the dep graph).
 //

--- a/internal/analyzers/pyreach/analyzer.go
+++ b/internal/analyzers/pyreach/analyzer.go
@@ -16,7 +16,7 @@ const Name = "pyreach"
 // Analyzer is a Tier-3 (package-level) reachability analyzer for
 // Python packages. It groups Python packages in the input graph by
 // project root, runs the configured Runner once per project, and
-// annotates each PackageVulnerability on Python packages with a
+// annotates each registry vulnerability on Python packages with a
 // Reachability result.
 //
 // Tier-3 caveat: "unreachable" here means "the application source
@@ -114,7 +114,7 @@ func vulnerabilitiesForDependency(req model.AnalyzeRequest, dep *model.Dependenc
 }
 
 // Analyze runs the configured Runner per discovered Python project
-// root and writes Reachability onto every Python PackageVulnerability
+// root and writes Reachability onto every Python registry vulnerability
 // in the graph. Errors degrade to Status=Unknown with a stable Reason
 // — the engine relies on this to keep the pipeline running.
 func (a Analyzer) Analyze(ctx context.Context, req model.AnalyzeRequest) (model.AnalyzeResult, error) {

--- a/internal/analyzers/pyreach/runner.go
+++ b/internal/analyzers/pyreach/runner.go
@@ -3,7 +3,7 @@
 // rooted at a Python project (pyproject.toml / setup.py / requirements.txt
 // / Pipfile / poetry.lock / pdm.lock / uv.lock), scans every reachable
 // .py file for top-level import statements, maps the imported module
-// names to PyPI distribution names, and reports each PackageVulnerability
+// names to PyPI distribution names, and reports each registry vulnerability
 // as Reachable / Unreachable / Unknown depending on whether the
 // distribution appears in the import set (expanded transitively through
 // the dep graph).

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -159,6 +159,8 @@ func newDiffCmd() *cobra.Command {
 			}
 
 			reportOptions := reportOptionsFromPipelineResults(current.Reachability, diffResult.Base, diffResult.Head)
+			reportOptions.BaseRegistry = diffResult.Base.Registry
+			reportOptions.HeadRegistry = diffResult.Head.Registry
 			payload := output.BuildDiffResponse(projectIdentifier, compBase, compHead, diffResult.Base.Consolidated, diffResult.Head.Consolidated, auditPayload, started, reportOptions)
 			markdownRenderer := func(w io.Writer) error {
 				return render.DiffMarkdown(w, payload)
@@ -193,7 +195,7 @@ func newDiffCmd() *cobra.Command {
 			}
 			if current.Interactive {
 				prog.Stop()
-				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewDiff(payload, diffResult.Base.Consolidated, diffResult.Head.Consolidated).WithEnrichEnabled(current.Enrich)))
+				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewDiff(payload, diffResult.Base.Consolidated, diffResult.Head.Consolidated).WithRegistry(diffResult.Base.Registry, diffResult.Head.Registry).WithEnrichEnabled(current.Enrich)))
 			}
 
 			prog.Success("Resolved Graph")

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -317,6 +317,10 @@ func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (o
 		return output.DiffResponse{}, err
 	}
 
+	reportOptions := reportOptionsFromPipelineResults(o.GetConfig().Reachability, diffResult.Base, diffResult.Head)
+	reportOptions.BaseRegistry = diffResult.Base.Registry
+	reportOptions.HeadRegistry = diffResult.Head.Registry
+
 	return output.BuildDiffResponse(
 		projectIdentifier,
 		req.Base,
@@ -325,7 +329,7 @@ func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (o
 		diffResult.Head.Consolidated,
 		diffAuditOutput(diffResult.Audit, diffResult.Base.Registry, diffResult.Head.Registry),
 		started,
-		reportOptionsFromPipelineResults(o.GetConfig().Reachability, diffResult.Base, diffResult.Head),
+		reportOptions,
 	), nil
 }
 

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -326,7 +326,7 @@ func sarifLocationsForFinding(f sdk.Finding, _ *sdk.Package, fallbackURI string)
 	}
 }
 
-// sarifPropertiesFromVulnerability converts a registry Vulnerability into
+// sarifPropertiesFromVulnerability converts a registry vulnerability into
 // the SARIF properties bag. Reachability-related fields are omitted unless
 // includeReachability is true.
 func sarifPropertiesFromVulnerability(v *sdk.Vulnerability, includeReachability bool) sarifProperties {

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -24,6 +24,8 @@ type ReportOptions struct {
 	ReachabilityEnabled bool
 	AnalyzerRuns        []string
 	AnalyzerStats       map[string]sdk.ReachabilityStats
+	BaseRegistry        *sdk.PackageRegistry
+	HeadRegistry        *sdk.PackageRegistry
 }
 
 // ProjectDescriptor describes the project being analyzed.

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -314,7 +314,8 @@ func BuildExplainResponse(project ProjectDescriptor, query string, targets []Exp
 
 // BuildDiffResponse constructs the structured diff payload from consolidated manifest selections.
 func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, headConsolidated sdk.ConsolidatedGraph, audit *DiffAudit, started time.Time, options ...ReportOptions) DiffResponse {
-	results, summary := diffResultsFromConsolidated(baseConsolidated, headConsolidated)
+	reportOptions := firstReportOptions(options)
+	results, summary := diffResultsFromConsolidated(baseConsolidated, headConsolidated, reportOptions.BaseRegistry, reportOptions.HeadRegistry)
 	response := DiffResponse{
 		SchemaVersion: SchemaVersion,
 		Command:       "diff",
@@ -331,7 +332,7 @@ func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, h
 		Audit:      audit,
 		Metadata:   Metadata{DurationMS: time.Since(started).Milliseconds()},
 	}
-	return response.WithReportOptions(firstReportOptions(options))
+	return response.WithReportOptions(reportOptions)
 }
 
 // WithReportOptions annotates a DiffResponse with optional report data and
@@ -524,7 +525,7 @@ type diffManifestRef struct {
 	PackageManager string
 }
 
-func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.ConsolidatedGraph) (DiffResults, DiffSummary) {
+func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.ConsolidatedGraph, baseRegistry, headRegistry *sdk.PackageRegistry) (DiffResults, DiffSummary) {
 	baseByKey := manifestSnapshotsByConsolidated(baseConsolidated)
 	headByKey := manifestSnapshotsByConsolidated(headConsolidated)
 	keys := make([]string, 0, len(baseByKey)+len(headByKey))
@@ -560,7 +561,7 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 				Subproject:     headManifest.Manifest.Subproject,
 				Ecosystem:      headManifest.Manifest.Ecosystem,
 				PackageManager: headManifest.Manifest.PackageManager,
-				Added:          diffPackageChangesFromPackages(headManifest.Graph.Nodes()),
+				Added:          diffPackageChangesFromPackages(headManifest.Graph.Nodes(), headRegistry),
 			}
 			results.Manifests = append(results.Manifests, result)
 			summary.AddedManifestCount++
@@ -574,7 +575,7 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 				Subproject:     baseManifest.Manifest.Subproject,
 				Ecosystem:      baseManifest.Manifest.Ecosystem,
 				PackageManager: baseManifest.Manifest.PackageManager,
-				Removed:        diffPackageChangesFromPackages(baseManifest.Graph.Nodes()),
+				Removed:        diffPackageChangesFromPackages(baseManifest.Graph.Nodes(), baseRegistry),
 			}
 			results.Manifests = append(results.Manifests, result)
 			summary.RemovedManifestCount++
@@ -597,9 +598,9 @@ func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.Consolid
 				Subproject:     headManifest.Manifest.Subproject,
 				Ecosystem:      headManifest.Manifest.Ecosystem,
 				PackageManager: headManifest.Manifest.PackageManager,
-				Added:          diffPackageChangesFromPackages(manifestDiff.Added),
-				Removed:        diffPackageChangesFromPackages(manifestDiff.Removed),
-				Changed:        diffChangedPackagesFromDiff(manifestDiff.Updated),
+				Added:          diffPackageChangesFromPackages(manifestDiff.Added, headRegistry),
+				Removed:        diffPackageChangesFromPackages(manifestDiff.Removed, baseRegistry),
+				Changed:        diffChangedPackagesFromDiff(manifestDiff.Updated, baseRegistry, headRegistry),
 			}
 			if len(result.Added) == 0 && len(result.Removed) == 0 && len(result.Changed) == 0 {
 				summary.UnchangedManifestCount++
@@ -983,21 +984,21 @@ func isSBOMPseudoPackage(pkg *sdk.Dependency, rootIDs map[string]struct{}) bool 
 	return false
 }
 
-func diffPackageChangesFromPackages(packages []*sdk.Dependency) []DiffPackageChange {
+func diffPackageChangesFromPackages(packages []*sdk.Dependency, registry *sdk.PackageRegistry) []DiffPackageChange {
 	changes := make([]DiffPackageChange, 0, len(packages))
 	for _, pkg := range packages {
-		changes = append(changes, DiffPackageChange{Package: PackageFromGraphPackage(pkg)})
+		changes = append(changes, DiffPackageChange{Package: PackageFromDependencyAndRegistry(pkg, registry)})
 	}
 	sort.Slice(changes, func(i, j int) bool { return changes[i].Package.ID < changes[j].Package.ID })
 	return changes
 }
 
-func diffChangedPackagesFromDiff(changes []sdk.VersionChange) []DiffChangedPackage {
+func diffChangedPackagesFromDiff(changes []sdk.VersionChange, baseRegistry, headRegistry *sdk.PackageRegistry) []DiffChangedPackage {
 	out := make([]DiffChangedPackage, 0, len(changes))
 	for _, change := range changes {
 		out = append(out, DiffChangedPackage{
-			After:  PackageFromGraphPackage(change.After),
-			Before: PackageFromGraphPackage(change.Before),
+			After:  PackageFromDependencyAndRegistry(change.After, headRegistry),
+			Before: PackageFromDependencyAndRegistry(change.Before, baseRegistry),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].After.ID < out[j].After.ID })

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -375,13 +375,89 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 	}
 }
 
+func TestBuildDiffResponseEnrichesPackageDeltasFromRegistries(t *testing.T) {
+	baseGraph := sdk.New()
+	headGraph := sdk.New()
+	baseApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
+	baseLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.14", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "lodash", Version: "4.17.14", PURL: "pkg:npm/lodash@4.17.14"})
+	baseRemoved := sdk.NewDependencyWithID("pkg:npm/removed@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "removed", Version: "1.0.0", PURL: "pkg:npm/removed@1.0.0"})
+	headApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
+	headLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.15", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
+	headAdded := sdk.NewDependencyWithID("pkg:npm/added@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "added", Version: "1.0.0", PURL: "pkg:npm/added@1.0.0"})
+	for _, pkg := range []*sdk.Dependency{baseApp, baseLodash, baseRemoved} {
+		if err := baseGraph.AddNode(pkg); err != nil {
+			t.Fatalf("base AddNode(%q): %v", pkg.ID, err)
+		}
+	}
+	if err := baseGraph.AddEdge(baseApp.ID, baseLodash.ID); err != nil {
+		t.Fatalf("base AddEdge(lodash): %v", err)
+	}
+	if err := baseGraph.AddEdge(baseApp.ID, baseRemoved.ID); err != nil {
+		t.Fatalf("base AddEdge(removed): %v", err)
+	}
+	for _, pkg := range []*sdk.Dependency{headApp, headLodash, headAdded} {
+		if err := headGraph.AddNode(pkg); err != nil {
+			t.Fatalf("head AddNode(%q): %v", pkg.ID, err)
+		}
+	}
+	if err := headGraph.AddEdge(headApp.ID, headLodash.ID); err != nil {
+		t.Fatalf("head AddEdge(lodash): %v", err)
+	}
+	if err := headGraph.AddEdge(headApp.ID, headAdded.ID); err != nil {
+		t.Fatalf("head AddEdge(added): %v", err)
+	}
+
+	baseConsolidated, err := consolidation.ConsolidateGraphs(singleManifestDiffResults(baseGraph))
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(base) error = %v", err)
+	}
+	headConsolidated, err := consolidation.ConsolidateGraphs(singleManifestDiffResults(headGraph))
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs(head) error = %v", err)
+	}
+	baseRegistry := sdk.NewPackageRegistry()
+	baseRegistry.Ensure(baseLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-base", Source: "osv", ParsedSeverity: "high"}}
+	baseRegistry.Ensure(baseRemoved.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "BSD-2-Clause"}}
+	headRegistry := sdk.NewPackageRegistry()
+	headRegistry.Ensure(headLodash.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
+	headRegistry.Ensure(headLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-head", Source: "osv", ParsedSeverity: "medium"}}
+	headRegistry.Ensure(headAdded.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "Apache-2.0"}}
+
+	response := output.BuildDiffResponse("/tmp/demo", "base", "head", baseConsolidated, headConsolidated, nil, time.Now().Add(-time.Second), output.ReportOptions{
+		BaseRegistry: baseRegistry,
+		HeadRegistry: headRegistry,
+	})
+	changed := response.Results.Dependencies.Changed[0]
+	if got := len(changed.Before.Vulnerabilities); got != 1 || changed.Before.Vulnerabilities[0].ID != "GHSA-base" {
+		t.Fatalf("expected base registry vulnerability on changed before package, got %#v", changed.Before.Vulnerabilities)
+	}
+	if got := len(changed.After.Vulnerabilities); got != 1 || changed.After.Vulnerabilities[0].ID != "GHSA-head" {
+		t.Fatalf("expected head registry vulnerability on changed after package, got %#v", changed.After.Vulnerabilities)
+	}
+	if got := len(changed.After.Licenses); got != 1 || changed.After.Licenses[0].SPDXExpression != "MIT" {
+		t.Fatalf("expected head registry license on changed after package, got %#v", changed.After.Licenses)
+	}
+	if got := len(response.Results.Dependencies.Added[0].Package.Licenses); got != 1 || response.Results.Dependencies.Added[0].Package.Licenses[0].SPDXExpression != "Apache-2.0" {
+		t.Fatalf("expected head registry license on added package, got %#v", response.Results.Dependencies.Added[0].Package.Licenses)
+	}
+	if got := len(response.Results.Dependencies.Removed[0].Package.Licenses); got != 1 || response.Results.Dependencies.Removed[0].Package.Licenses[0].SPDXExpression != "BSD-2-Clause" {
+		t.Fatalf("expected base registry license on removed package, got %#v", response.Results.Dependencies.Removed[0].Package.Licenses)
+	}
+	if len(response.Results.Vulnerabilities.Added) != 1 || response.Results.Vulnerabilities.Added[0].Vulnerability.ID != "GHSA-head" {
+		t.Fatalf("expected one head-side vulnerability delta, got %#v", response.Results.Vulnerabilities)
+	}
+	if len(response.Results.Vulnerabilities.Removed) != 1 || response.Results.Vulnerabilities.Removed[0].Vulnerability.ID != "GHSA-base" {
+		t.Fatalf("expected one base-side vulnerability delta, got %#v", response.Results.Vulnerabilities)
+	}
+	if len(response.Results.Licenses.Changed) != 1 || response.Results.Licenses.Changed[0].After[0].SPDXExpression != "MIT" {
+		t.Fatalf("expected registry-backed license delta, got %#v", response.Results.Licenses)
+	}
+}
+
 func TestBuildDiffResponseGatesReachability(t *testing.T) {
-	// Reachability on Diff result vulnerabilities is sourced from registry
-	// packages keyed by PURL. The diff result aggregator currently builds
-	// vulnerability change records from graph dependencies only; plumbing
-	// the registry through it is tracked separately. Until then this test
-	// only exercises the audit-finding reachability gating path, which is
-	// the primary surface SARIF consumers rely on.
+	// Audit findings carry reachability resolved through registry packages
+	// keyed by PURL. This test keeps that gating behavior pinned alongside
+	// the package-delta registry coverage above.
 	baseGraph := newViewTestGraph(t)
 	headGraph := newViewTestGraph(t)
 	pkg := sdk.NewDependencyRef("newpkg", "1.0.0")
@@ -751,6 +827,21 @@ func sbomDiffResults(graph *sdk.Graph, location, manifestPath string) []sdk.Dete
 		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
 			Graph:    graph,
 			Manifest: sdk.ManifestMetadata{Path: manifestPath, Kind: "spdx"},
+		}}},
+	}}
+}
+
+func singleManifestDiffResults(graph *sdk.Graph) []sdk.DetectionResult {
+	return []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			RelativePath:            ".",
+			PrimaryDetector:         "npm-detector",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		Graphs: &sdk.GraphContainer{Entries: []sdk.GraphEntry{{
+			Graph:    graph,
+			Manifest: sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"},
 		}}},
 	}}
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -262,6 +262,56 @@ func TestPrepareLoadsAndRunsExternalDetector(t *testing.T) {
 	}
 }
 
+func TestExternalMatcherReceivesAndReturnsRegistry(t *testing.T) {
+	root := t.TempDir()
+	binaryPath := filepath.Join(t.TempDir(), executableName("bomly-plugin-matcher"))
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeMatcherPluginSource("acme.matcher.registry")); err != nil {
+		t.Fatalf("build fake matcher plugin: %v", err)
+	}
+	if _, err := managedplugin.Install(context.Background(), root, binaryPath, managedplugin.InstallOptions{DevBinary: true}); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if _, err := managedplugin.Enable(root, "acme.matcher.registry"); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	reg := engine.NewRegistry(engine.RegistryConfigs{}, *zap.NewNop())
+	if err := managedplugin.RegisterRuntimePlugins(context.Background(), reg, root); err != nil {
+		t.Fatalf("RegisterRuntimePlugins() error = %v", err)
+	}
+	matchers := reg.Matchers(sdk.MatchRequest{
+		Mode:          sdk.TargetModeFullGraph,
+		MatcherFilter: sdk.MatcherFilter{Include: []string{"acme.matcher.registry"}},
+	})
+	if len(matchers) != 1 {
+		t.Fatalf("expected one external matcher, got %d", len(matchers))
+	}
+
+	const purl = "pkg:npm/react@18.2.0"
+	registry := sdk.NewPackageRegistry()
+	registry.Ensure(purl).Name = "react"
+	result, err := matchers[0].Match(context.Background(), sdk.MatchRequest{
+		Mode:     sdk.TargetModeFullGraph,
+		Registry: registry,
+	})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if result.Registry == nil {
+		t.Fatal("expected external matcher to return registry")
+	}
+	pkg, ok := result.Registry.Get(purl)
+	if !ok {
+		t.Fatalf("expected matched package %q", purl)
+	}
+	if len(pkg.Licenses) != 1 || pkg.Licenses[0].SPDXExpression != "MIT" {
+		t.Fatalf("expected registry enrichment from external matcher, got %#v", pkg.Licenses)
+	}
+	if len(result.MatcherRuns) != 1 || result.MatcherRuns[0] != "acme.matcher.registry" {
+		t.Fatalf("expected matcher run marker, got %#v", result.MatcherRuns)
+	}
+}
+
 func fakeDetectorPluginSource(id string) string {
 	return `package main
 
@@ -335,6 +385,65 @@ func (d *detector) Detect(ctx context.Context, req *schemav1.DetectRequest) (*sc
 
 func main() {
 	schemav1.ServeDetector(&detector{})
+}
+`
+}
+
+func fakeMatcherPluginSource(id string) string {
+	return `package main
+
+import (
+	"context"
+	"fmt"
+	schemav1 "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+type matcher struct{}
+
+func (m *matcher) Metadata(ctx context.Context) (*schemav1.PluginMetadata, error) {
+	return &schemav1.PluginMetadata{
+		ID:               "` + id + `",
+		Name:             "Fake Matcher",
+		Version:          "1.0.0",
+		Kind:             schemav1.PluginKindMatcher,
+		PluginAPIVersion: schemav1.PluginAPIVersion,
+	}, nil
+}
+
+func (m *matcher) Descriptor(ctx context.Context) (*schemav1.MatcherDescriptor, error) {
+	return &schemav1.MatcherDescriptor{
+		Name:           "` + id + `",
+		Enabled:        true,
+		Origin:         schemav1.ExternalOrigin,
+		SupportedModes: []schemav1.TargetMode{schemav1.TargetModeFullGraph, schemav1.TargetModeComponent},
+	}, nil
+}
+
+func (m *matcher) Ready(context.Context, *schemav1.MatchRequest) (*schemav1.ReadyResponse, error) {
+	return &schemav1.ReadyResponse{Ready: true}, nil
+}
+
+func (m *matcher) Applicable(context.Context, *schemav1.MatchRequest) (*schemav1.ApplicableResponse, error) {
+	return &schemav1.ApplicableResponse{Applicable: true}, nil
+}
+
+func (m *matcher) Match(ctx context.Context, req *schemav1.MatchRequest) (*schemav1.MatchResponse, error) {
+	if req.Registry == nil {
+		return nil, fmt.Errorf("registry is nil")
+	}
+	pkg, ok := req.Registry.Get("pkg:npm/react@18.2.0")
+	if !ok || pkg == nil {
+		return nil, fmt.Errorf("expected registry package")
+	}
+	pkg.Licenses = []schemav1.PackageLicense{{SPDXExpression: "MIT"}}
+	return &schemav1.MatchResponse{
+		Registry:    req.Registry,
+		MatcherRuns: []string{"` + id + `"},
+	}, nil
+}
+
+func main() {
+	schemav1.ServeMatcher(&matcher{})
 }
 `
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -184,9 +184,13 @@ func (m externalMatcher) Match(ctx context.Context, req sdk.MatchRequest) (sdk.M
 		return sdk.MatchResult{}, fmt.Errorf("run external matcher %s: %w", m.info.ID, err)
 	}
 	if resp == nil {
-		return sdk.MatchResult{}, nil
+		return sdk.MatchResult{Registry: req.Registry}, nil
 	}
-	return *resp, nil
+	result := *resp
+	if result.Registry == nil {
+		result.Registry = req.Registry
+	}
+	return result, nil
 }
 
 func newExternalMatcher(info PluginInfo, ctx context.Context) sdk.Matcher {

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -47,6 +47,9 @@ type diffModel struct {
 	baseGraph sdk.ConsolidatedGraph
 	headGraph sdk.ConsolidatedGraph
 
+	baseRegistry *sdk.PackageRegistry
+	headRegistry *sdk.PackageRegistry
+
 	enrichEnabled bool
 
 	componentsGroup        componentsGroup
@@ -109,6 +112,18 @@ func NewDiff(payload output.DiffResponse, baseGraph, headGraph sdk.ConsolidatedG
 			return m.diffFooterSummary(), m.diffLegend()
 		},
 	})
+	return m
+}
+
+// WithRegistry attaches the base/head package registries so source-tree package
+// details can show matcher and analyzer enrichment by PURL.
+func (m *diffModel) WithRegistry(base, head *sdk.PackageRegistry) *diffModel {
+	if m == nil {
+		return nil
+	}
+	m.baseRegistry = base
+	m.headRegistry = head
+	m.Rebuild()
 	return m
 }
 
@@ -2949,8 +2964,8 @@ func (m *diffModel) buildSourceTab() *listModel {
 	// Build BOTH sides' items up front — the focused side's items also
 	// power list-level state (visibleItemIndices, expand, search) by
 	// living in the listModel.items slice.
-	baseItems := diffSourceItems(m.baseGraph, m.sourceBaseExpanded, "base")
-	headItems := diffSourceItems(m.headGraph, m.sourceHeadExpanded, "head")
+	baseItems := diffSourceItems(m.baseGraph, m.baseRegistry, m.sourceBaseExpanded, "base")
+	headItems := diffSourceItems(m.headGraph, m.headRegistry, m.sourceHeadExpanded, "head")
 	focusedItems := baseItems
 	if focused == diffSourceHead {
 		focusedItems = headItems
@@ -3060,7 +3075,7 @@ func sourceItemPlain(it listItem) string {
 	return it.tree + marker + it.title
 }
 
-func diffSourceItems(consolidated sdk.ConsolidatedGraph, expanded map[string]bool, sidePrefix string) []listItem {
+func diffSourceItems(consolidated sdk.ConsolidatedGraph, registry *sdk.PackageRegistry, expanded map[string]bool, sidePrefix string) []listItem {
 	items := []listItem{sourceNode(fmt.Sprintf("%s: {}", sidePrefix), "root", "", 0, true, expandedValue(expanded, "root", true))}
 	if !expandedValue(expanded, "root", true) {
 		return items
@@ -3141,7 +3156,7 @@ func diffSourceItems(consolidated sdk.ConsolidatedGraph, expanded map[string]boo
 				} else {
 					childPrefix += "│  "
 				}
-				items = append(items, sourceLeafItems(packageRawLines(pkg, nil), childPrefix)...)
+				items = append(items, sourceLeafItems(packageRawLines(pkg, registry), childPrefix)...)
 			}
 			if truncated {
 				items = append(items, sourceNode(fmt.Sprintf("(showing 200 of %d packages)", len(pkgs)), "", prefix+"└─ ", 2, false, false))

--- a/sdk/analyzer.go
+++ b/sdk/analyzer.go
@@ -48,7 +48,7 @@ type AnalyzeRequest struct {
 	Mode            TargetMode       `json:"mode,omitempty"`
 	Query           PackageQuery     `json:"query"`
 	Graph           *Graph           `json:"graph,omitempty"`
-	Registry        *PackageRegistry `json:"-"`
+	Registry        *PackageRegistry `json:"registry,omitempty"`
 	Target          *Dependency      `json:"target,omitempty"`
 	AnalyzerFilter  AnalyzerFilter   `json:"analyzerFilter"`
 	Stderr          io.Writer        `json:"-"`
@@ -64,7 +64,7 @@ type ReachabilityStats struct {
 
 // AnalyzeResult contains the registry after analyzer enrichment.
 type AnalyzeResult struct {
-	Registry      *PackageRegistry             `json:"-"`
+	Registry      *PackageRegistry             `json:"registry,omitempty"`
 	AnalyzerRuns  []string                     `json:"analyzerRuns,omitempty"`
 	AnalyzerStats map[string]ReachabilityStats `json:"analyzerStats,omitempty"`
 }

--- a/sdk/auditor.go
+++ b/sdk/auditor.go
@@ -33,7 +33,7 @@ type AuditRequest struct {
 	Query           PackageQuery     `json:"query"`
 	Graph           *Graph           `json:"graph,omitempty"`
 	BaselineGraph   *Graph           `json:"baselineGraph,omitempty"`
-	Registry        *PackageRegistry `json:"-"`
+	Registry        *PackageRegistry `json:"registry,omitempty"`
 	Target          *Dependency      `json:"target,omitempty"`
 	AuditorFilter   AuditorFilter    `json:"auditorFilter"`
 	Stderr          io.Writer        `json:"-"`

--- a/sdk/json.go
+++ b/sdk/json.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 )
 
 type graphJSON struct {
@@ -57,6 +58,51 @@ func (g *Graph) UnmarshalJSON(data []byte) error {
 		}
 	}
 	*g = *out
+	return nil
+}
+
+// MarshalJSON encodes a package registry as a stable PURL-keyed object for
+// plugin transport.
+func (r *PackageRegistry) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return []byte("null"), nil
+	}
+	payload := make(map[string]*Package, r.Len())
+	for _, pkg := range r.All() {
+		if pkg == nil || pkg.PURL == "" {
+			continue
+		}
+		payload[pkg.PURL] = pkg.Clone()
+	}
+	return json.Marshal(payload)
+}
+
+// UnmarshalJSON decodes a PURL-keyed package registry from plugin transport.
+func (r *PackageRegistry) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*r = *NewPackageRegistry()
+		return nil
+	}
+	payload := map[string]*Package{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+	out := NewPackageRegistry()
+	purls := make([]string, 0, len(payload))
+	for purl := range payload {
+		purls = append(purls, purl)
+	}
+	sort.Strings(purls)
+	for _, purl := range purls {
+		pkg := payload[purl]
+		if pkg == nil {
+			pkg = &Package{}
+		}
+		clone := pkg.Clone()
+		clone.PURL = purl
+		out.Add(clone)
+	}
+	*r = *out
 	return nil
 }
 

--- a/sdk/json_test.go
+++ b/sdk/json_test.go
@@ -39,3 +39,85 @@ func TestGraphJSONRoundTrip(t *testing.T) {
 		t.Fatalf("decoded dependencies = %#v, want %q", deps, dep.ID)
 	}
 }
+
+func TestPackageRegistryJSONRoundTrip(t *testing.T) {
+	registry := NewPackageRegistry()
+	pkg := registry.Ensure("pkg:npm/react@18.2.0")
+	pkg.Name = "react"
+	pkg.Version = "18.2.0"
+	pkg.Licenses = []PackageLicense{{SPDXExpression: "MIT"}}
+	pkg.Vulnerabilities = []Vulnerability{{ID: "GHSA-1", Source: "osv", ParsedSeverity: "high"}}
+
+	data, err := json.Marshal(registry)
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+
+	var decoded PackageRegistry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal(): %v", err)
+	}
+	decodedPkg, ok := decoded.Get("pkg:npm/react@18.2.0")
+	if !ok {
+		t.Fatalf("decoded registry missing package: %s", data)
+	}
+	if decodedPkg.Name != "react" || decodedPkg.Version != "18.2.0" {
+		t.Fatalf("decoded package identity = %#v", decodedPkg)
+	}
+	if len(decodedPkg.Licenses) != 1 || decodedPkg.Licenses[0].SPDXExpression != "MIT" {
+		t.Fatalf("decoded licenses = %#v", decodedPkg.Licenses)
+	}
+	if len(decodedPkg.Vulnerabilities) != 1 || decodedPkg.Vulnerabilities[0].ID != "GHSA-1" {
+		t.Fatalf("decoded vulnerabilities = %#v", decodedPkg.Vulnerabilities)
+	}
+}
+
+func TestPluginRequestResponseRegistryJSON(t *testing.T) {
+	registry := NewPackageRegistry()
+	registry.Ensure("pkg:npm/lodash@4.17.15").Vulnerabilities = []Vulnerability{{ID: "GHSA-lodash", Source: "osv"}}
+
+	matchData, err := json.Marshal(MatchRequest{Registry: registry})
+	if err != nil {
+		t.Fatalf("marshal match request: %v", err)
+	}
+	var matchReq MatchRequest
+	if err := json.Unmarshal(matchData, &matchReq); err != nil {
+		t.Fatalf("unmarshal match request: %v", err)
+	}
+	if matchReq.Registry == nil {
+		t.Fatal("match request registry was not decoded")
+	}
+	if pkg, ok := matchReq.Registry.Get("pkg:npm/lodash@4.17.15"); !ok || len(pkg.Vulnerabilities) != 1 {
+		t.Fatalf("match request registry package = %#v, ok=%v", pkg, ok)
+	}
+
+	resultData, err := json.Marshal(MatchResult{Registry: registry, MatcherRuns: []string{"test-matcher"}})
+	if err != nil {
+		t.Fatalf("marshal match result: %v", err)
+	}
+	var matchResult MatchResult
+	if err := json.Unmarshal(resultData, &matchResult); err != nil {
+		t.Fatalf("unmarshal match result: %v", err)
+	}
+	if matchResult.Registry == nil {
+		t.Fatal("match result registry was not decoded")
+	}
+	if pkg, ok := matchResult.Registry.Get("pkg:npm/lodash@4.17.15"); !ok || len(pkg.Vulnerabilities) != 1 {
+		t.Fatalf("match result registry package = %#v, ok=%v", pkg, ok)
+	}
+
+	auditData, err := json.Marshal(AuditRequest{Registry: registry})
+	if err != nil {
+		t.Fatalf("marshal audit request: %v", err)
+	}
+	var auditReq AuditRequest
+	if err := json.Unmarshal(auditData, &auditReq); err != nil {
+		t.Fatalf("unmarshal audit request: %v", err)
+	}
+	if auditReq.Registry == nil {
+		t.Fatal("audit request registry was not decoded")
+	}
+	if pkg, ok := auditReq.Registry.Get("pkg:npm/lodash@4.17.15"); !ok || len(pkg.Vulnerabilities) != 1 {
+		t.Fatalf("audit request registry package = %#v, ok=%v", pkg, ok)
+	}
+}

--- a/sdk/matcher.go
+++ b/sdk/matcher.go
@@ -45,7 +45,7 @@ type MatchRequest struct {
 	Mode            TargetMode       `json:"mode,omitempty"`
 	Query           PackageQuery     `json:"query"`
 	Graph           *Graph           `json:"graph,omitempty"`
-	Registry        *PackageRegistry `json:"-"`
+	Registry        *PackageRegistry `json:"registry,omitempty"`
 	Target          *Dependency      `json:"target,omitempty"`
 	MatcherFilter   MatcherFilter    `json:"matcherFilter"`
 	Stderr          io.Writer        `json:"-"`
@@ -53,7 +53,7 @@ type MatchRequest struct {
 
 // MatchResult contains the package registry after matcher enrichment.
 type MatchResult struct {
-	Registry    *PackageRegistry `json:"-"`
+	Registry    *PackageRegistry `json:"registry,omitempty"`
 	MatcherRuns []string         `json:"matcherRuns,omitempty"`
 }
 

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -23,7 +23,7 @@ const (
 	// PluginKindAuditor evaluates findings and risk.
 	PluginKindAuditor PluginKind = "auditor"
 	// PluginKindAnalyzer runs code analysis (e.g. reachability) over the
-	// matched graph and annotates PackageVulnerability entries.
+	// matched graph and annotates registry vulnerability entries.
 	PluginKindAnalyzer PluginKind = "analyzer"
 )
 


### PR DESCRIPTION
## Summary

- Make `bomly diff` package result payloads registry-aware, so dependency/license/vulnerability result sections can show matcher and analyzer enrichment from the correct base/head side.
- Wire base/head registries into the diff TUI source view and MCP diff response path.
- Expose `sdk.PackageRegistry` on the existing plugin JSON-over-gRPC transport and preserve incoming registries for external matcher responses that omit one.
- Update plugin author docs and the example Go module detector for the current Dependency/Package/Finding model.

## Root Cause

Audit diff output already resolved findings through base/head registries, but package-diff results were still projected from consolidated graphs only. External plugin matcher/auditor/analyzer payloads also kept registry fields out of JSON, leaving external plugins on an incomplete view of the post-refactor model.

## Validation

- `go test ./internal/output ./internal/tui ./sdk ./internal/plugin`
- `make test`
- `go run ./cmd/bomly diff --url https://github.com/bomly-dev/example-javascript-npm --base v0.9.0 --head v1.0.0 --enrich --audit --json` now shows the changed lodash package in `results.dependencies.changed[0].after` with 6 vulnerabilities and 1 license, matching audit-enriched package data. The command still exits with a policy violation, as expected.