### PR TITLE
refactor: simplify pointer assignments in various components

### DIFF
--- a/internal/benchmark/summary.go
+++ b/internal/benchmark/summary.go
@@ -174,8 +174,7 @@ func compareRelationships(bomlyDoc, sourceDoc *sbom.Document) RelationshipMetric
 		}
 	}
 	if denominator := metrics.BomlyCount + metrics.SourceCount; denominator > 0 {
-		score := roundScore(100 * float64(2*metrics.Matched) / float64(denominator))
-		metrics.Score = &score
+		metrics.Score = new(roundScore(100 * float64(2*metrics.Matched) / float64(denominator)))
 	}
 	return metrics
 }
@@ -207,8 +206,7 @@ func averageScores(items []*ScoreSummary) *ScoreSummary {
 		Overall: roundScore(overallTotal / float64(len(items))),
 	}
 	if relationshipCount > 0 {
-		score := roundScore(relationshipTotal / float64(relationshipCount))
-		out.Relationship = &score
+		out.Relationship = new(roundScore(relationshipTotal / float64(relationshipCount)))
 	}
 	return out
 }

--- a/internal/cli/cmd_progress.go
+++ b/internal/cli/cmd_progress.go
@@ -76,10 +76,10 @@ func plannedSubprojectChildren(subprojects []sdk.Subproject) []progress.Child {
 			}
 		}
 		detail := string(s.Ecosystem)
-		if detail != "" {
-			label += " (" + detail + ")"
+		if detail == "" {
+			detail = "unknown ecosystem"
 		}
-		children = append(children, progress.Child{Label: label})
+		children = append(children, progress.Child{Label: label, Detail: "[" + detail + "]"})
 	}
 	return children
 }

--- a/internal/cli/exit/errors.go
+++ b/internal/cli/exit/errors.go
@@ -33,8 +33,7 @@ func Code(err error) int {
 	if err == nil {
 		return exitCodeSuccess
 	}
-	var coded *exitError
-	if errors.As(err, &coded) {
+	if coded, ok := errors.AsType[*exitError](err); ok {
 		return coded.code
 	}
 	return exitCodeExecutionError

--- a/internal/cli/opts/filters.go
+++ b/internal/cli/opts/filters.go
@@ -256,8 +256,7 @@ func resolveSelector(raw string, defaults []string, catalog catalog, implicitAll
 	if err == nil {
 		return include, exclude, nil
 	}
-	var unknown *unknownSelectorError
-	if errors.As(err, &unknown) {
+	if unknown, ok := errors.AsType[*unknownSelectorError](err); ok {
 		return nil, nil, exit.InvalidInputError(
 			"unknown %s selector(s): %s\navailable %ss: %s\nrun `bomly scan --help` for full selector details",
 			unknown.Kind,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -375,8 +375,7 @@ func parseProxyURL(value string) (*url.URL, error) {
 }
 
 func redactURLParseError(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) && urlErr.Err != nil {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok && urlErr.Err != nil {
 		return urlErr.Err
 	}
 	return err

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -135,15 +135,13 @@ func TestEngineAudit_ReturnsPartialResultsWhenAnAuditorFails(t *testing.T) {
 
 func TestEngineAudit_SkipsNotReadyOrNotApplicableAuditors(t *testing.T) {
 	registry := newTestRegistry()
-	notReady := false
-	notApplicable := false
 	registry.registerAuditor(fakeAuditor{
 		descriptor: AuditorDescriptor{Name: "not-ready", Enabled: true, SupportedEcosystems: []Ecosystem{EcosystemNPM}, SupportedManagers: []PackageManager{PackageManagerNPM}},
-		ready:      &notReady,
+		ready:      new(false),
 	})
 	registry.registerAuditor(fakeAuditor{
 		descriptor: AuditorDescriptor{Name: "not-applicable", Enabled: true, SupportedEcosystems: []Ecosystem{EcosystemNPM}, SupportedManagers: []PackageManager{PackageManagerNPM}},
-		applicable: &notApplicable,
+		applicable: new(false),
 	})
 	registry.registerAuditor(fakeAuditor{
 		descriptor: AuditorDescriptor{Name: "usable", Enabled: true, SupportedEcosystems: []Ecosystem{EcosystemNPM}, SupportedManagers: []PackageManager{PackageManagerNPM}},

--- a/internal/matchers/eol/matcher.go
+++ b/internal/matchers/eol/matcher.go
@@ -206,8 +206,7 @@ func (d *dateOrBool) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if trimmed == "true" || trimmed == "false" {
-		value := trimmed == "true"
-		d.Bool = &value
+		d.Bool = new(trimmed == "true")
 		d.Date = ""
 		return nil
 	}

--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -378,8 +378,7 @@ func (a *Matcher) fetchVulnDetails(ids []string, stats *auditStats) map[string]*
 				if stats != nil {
 					stats.detailCacheHits++
 				}
-				v := found
-				result[id] = &v
+				result[id] = new(found)
 				continue
 			}
 		}

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -357,8 +357,7 @@ func sarifPropertiesFromVulnerability(v *sdk.Vulnerability, includeReachability 
 		props.Analyzer = r.Analyzer
 		props.ReachabilityConfidence = string(r.Confidence)
 		if r.Hops != nil {
-			hops := *r.Hops
-			props.ReachabilityHops = &hops
+			props.ReachabilityHops = new(*r.Hops)
 		}
 		props.DynamicImportsDetected = r.DynamicImportsDetected
 	}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -537,8 +537,7 @@ func findInstalled(root, id string) (*InstalledPlugin, error) {
 	}
 	for _, plugin := range db.Plugins {
 		if plugin.ID == id {
-			copyValue := plugin
-			return &copyValue, nil
+			return new(plugin), nil
 		}
 	}
 	return nil, fmt.Errorf("plugin %q is not installed", id)
@@ -669,10 +668,9 @@ func LoadInstalledPlugins(root string) ([]PluginInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		record := item
 		infos = append(infos, PluginInfo{
 			Manifest:   manifest,
-			Installed:  &record,
+			Installed:  new(item),
 			Enabled:    item.Enabled,
 			Entrypoint: filepath.Join(item.Path, entry),
 			SourceType: "external",
@@ -721,10 +719,9 @@ func LoadRuntimePlugins(root string) ([]PluginInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		record := item
 		out = append(out, PluginInfo{
 			Manifest:   manifest,
-			Installed:  &record,
+			Installed:  new(item),
 			Enabled:    item.Enabled,
 			Entrypoint: filepath.Join(item.Path, entry),
 			SourceType: "external",

--- a/internal/tools/gofmtcheck/main.go
+++ b/internal/tools/gofmtcheck/main.go
@@ -43,8 +43,7 @@ func trackedGoFiles() ([]string, error) {
 	cmd := exec.Command("git", "ls-files", "*.go")
 	output, err := cmd.Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
 		}
 		return nil, err

--- a/sdk/dependency.go
+++ b/sdk/dependency.go
@@ -201,8 +201,7 @@ func (d *Dependency) Clone() *Dependency {
 		for i, loc := range d.Locations {
 			clone.Locations[i] = loc
 			if loc.Position != nil {
-				pos := *loc.Position
-				clone.Locations[i].Position = &pos
+				clone.Locations[i].Position = new(*loc.Position)
 			}
 		}
 	}

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -240,8 +240,7 @@ func parseProxyURL(value string) (*url.URL, error) {
 }
 
 func redactURLParseError(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) && urlErr.Err != nil {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok && urlErr.Err != nil {
 		return urlErr.Err
 	}
 	return err

--- a/sdk/package.go
+++ b/sdk/package.go
@@ -43,8 +43,7 @@ func (e *PackageEOL) Clone() *PackageEOL {
 	if e == nil {
 		return nil
 	}
-	clone := *e
-	return &clone
+	return new(*e)
 }
 
 // Package describes one matching artifact: the PURL-keyed, deduplicated record

--- a/sdk/reachability_test.go
+++ b/sdk/reachability_test.go
@@ -11,14 +11,14 @@ func TestDeriveConfidence(t *testing.T) {
 	}{
 		{"nil hops -> unknown", nil, false, ConfidenceUnknown},
 		{"nil hops with dynamic still unknown", nil, true, ConfidenceUnknown},
-		{"hops=0 -> high", intPtr(0), false, ConfidenceHigh},
-		{"hops=1 -> medium", intPtr(1), false, ConfidenceMedium},
-		{"hops=3 -> medium", intPtr(3), false, ConfidenceMedium},
-		{"hops=4 -> low", intPtr(4), false, ConfidenceLow},
-		{"hops=10 -> low", intPtr(10), false, ConfidenceLow},
-		{"dynamic forces low for direct", intPtr(0), true, ConfidenceLow},
-		{"dynamic forces low for medium chain", intPtr(2), true, ConfidenceLow},
-		{"dynamic forces low for long chain", intPtr(8), true, ConfidenceLow},
+		{"hops=0 -> high", new(0), false, ConfidenceHigh},
+		{"hops=1 -> medium", new(1), false, ConfidenceMedium},
+		{"hops=3 -> medium", new(3), false, ConfidenceMedium},
+		{"hops=4 -> low", new(4), false, ConfidenceLow},
+		{"hops=10 -> low", new(10), false, ConfidenceLow},
+		{"dynamic forces low for direct", new(0), true, ConfidenceLow},
+		{"dynamic forces low for medium chain", new(2), true, ConfidenceLow},
+		{"dynamic forces low for long chain", new(8), true, ConfidenceLow},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -30,10 +30,9 @@ func TestDeriveConfidence(t *testing.T) {
 }
 
 func TestReachabilityCloneDeepCopiesHops(t *testing.T) {
-	five := 5
 	src := &Reachability{
 		Status:                 ReachabilityReachable,
-		Hops:                   &five,
+		Hops:                   new(5),
 		Confidence:             ConfidenceMedium,
 		DynamicImportsDetected: true,
 	}

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -111,8 +111,7 @@ type AffectedSymbol struct {
 func (s AffectedSymbol) Clone() AffectedSymbol {
 	clone := s
 	if s.Definition != nil {
-		def := *s.Definition
-		clone.Definition = &def
+		clone.Definition = new(*s.Definition)
 	}
 	return clone
 }
@@ -225,8 +224,7 @@ func (r *Reachability) Clone() *Reachability {
 		}
 	}
 	if r.Hops != nil {
-		hops := *r.Hops
-		clone.Hops = &hops
+		clone.Hops = new(*r.Hops)
 	}
 	return &clone
 }


### PR DESCRIPTION
This pull request applies a consistent pattern of using `new(T)` for pointer allocation and initialization throughout the codebase, replacing previous patterns that created a value and then took its address. It also updates error handling to use `errors.AsType` for type assertions. Additionally, there are minor improvements to test code, output formatting, and code clarity.

### Pointer allocation and initialization

* Replaced manual value assignment and address-taking with `new(T)` for pointer initialization in many places, such as cloning methods, metrics calculations, and test cases (e.g., `sdk/vulnerability.go`, `sdk/dependency.go`, `internal/benchmark/summary.go`, `internal/plugin/types.go`, `internal/matchers/eol/matcher.go`, `internal/matchers/osv/matcher.go`, `sdk/package.go`, `sdk/reachability_test.go`). [[1]](diffhunk://#diff-394526c78f33c0dee32bd788148c280d986d20193db7a9eb9cb41e5b365bf8d5L114-R114) [[2]](diffhunk://#diff-394526c78f33c0dee32bd788148c280d986d20193db7a9eb9cb41e5b365bf8d5L228-R227) [[3]](diffhunk://#diff-3b8ced6d7e23db61e00e98d72bea7850e54bf638af794b8784a3ec972959bb3cL204-R204) [[4]](diffhunk://#diff-28aa0f98951f707220c10e4c6ead2e4660d0329586cee09e20cb270b079d026fL177-R177) [[5]](diffhunk://#diff-28aa0f98951f707220c10e4c6ead2e4660d0329586cee09e20cb270b079d026fL210-R209) [[6]](diffhunk://#diff-d5939cd40c9a064a1db8a4e9e2d401065d44513282729fa7543b9d025d5ee358L540-R540) [[7]](diffhunk://#diff-d5939cd40c9a064a1db8a4e9e2d401065d44513282729fa7543b9d025d5ee358L672-R673) [[8]](diffhunk://#diff-d5939cd40c9a064a1db8a4e9e2d401065d44513282729fa7543b9d025d5ee358L724-R724) [[9]](diffhunk://#diff-313242b28cca8d7755fd98163e7fa95643b72eac4d234cb29b154ef2143568f8L209-R209) [[10]](diffhunk://#diff-42d48205f7ef333d11312f681a325361d83d02820db6ab2291e291d98ee68896L381-R381) [[11]](diffhunk://#diff-1284a80616e84d91dd9e487266cda7673ddaa1e70672061c394a0e1f486099b2L46-R46) [[12]](diffhunk://#diff-0b42560e7cde045b02e2752378aa3128bc8af1d0071c2a76725888b0d8bbb987L14-R21) [[13]](diffhunk://#diff-0b42560e7cde045b02e2752378aa3128bc8af1d0071c2a76725888b0d8bbb987L33-R35)

### Error handling improvements

* Updated error type assertions to use `errors.AsType` for clarity and consistency (e.g., `internal/cli/exit/errors.go`, `internal/cli/opts/filters.go`, `internal/tools/gofmtcheck/main.go`, `sdk/http.go`, `internal/config/load.go`). [[1]](diffhunk://#diff-ffb5d7036c97cdf06e1f03e2f72d07d8f1ed3390cd5c0f29f2a06b257185e542L36-R36) [[2]](diffhunk://#diff-446baa5fdec965bc5d32eb0a133d04fd82010e138cb1a376d40ce55a34a15725L259-R259) [[3]](diffhunk://#diff-f053e4e8008eb81498259008f994c384dcaa40a565d5bbbddf57d4af7d31762aL46-R46) [[4]](diffhunk://#diff-e3cec428c9a54d579fb2cbed7c01742ebd7d9a940039ddc0d9cd7b43d2eb4426L243-R243) [[5]](diffhunk://#diff-8444bfa4415d597e85ba47f294904015a6a49089e5ed5f7e613c0410b749f7f5L378-R378)

### Test and output improvements

* Updated test code to use the new pointer allocation pattern for test case setup and improved how test auditors are registered (e.g., `sdk/reachability_test.go`, `internal/engine/engine_test.go`). [[1]](diffhunk://#diff-0b42560e7cde045b02e2752378aa3128bc8af1d0071c2a76725888b0d8bbb987L14-R21) [[2]](diffhunk://#diff-0b42560e7cde045b02e2752378aa3128bc8af1d0071c2a76725888b0d8bbb987L33-R35) [[3]](diffhunk://#diff-68a5dbfc71b25f4c298179ebbd49912018d91ac489cf81c991ea1ea3790fce17L138-R144)
* Improved detail formatting for subproject labels in progress output, now including ecosystem information or "unknown ecosystem" if not available (`internal/cli/cmd_progress.go`).

### SARIF and reachability output

* Updated SARIF property assignment to use the new pointer allocation pattern for reachability hops (`internal/output/sarif.go`).

These changes improve code consistency, readability, and safety across the codebase.