### PR TITLE
test: parallelize smoke leaf cases

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -59,6 +59,14 @@ Regenerate smoke goldens only after confirming the behavior change is expected:
 make smoke ARGS="-update"
 ```
 
+Smoke leaf cases run in parallel within each `go test` invocation. Go's default
+`-parallel` setting is used unless you override it through `ARGS`:
+
+```bash
+make smoke ARGS="-parallel 4"
+make smoke ARGS="-update -parallel 4"
+```
+
 The URL-backed scan cases are defined in the embedded `internal/benchmark/testdata/scan_targets.json` manifest. Each target has:
 
 - `name`: stable test and artifact identity

--- a/test/smoke/audit_test.go
+++ b/test/smoke/audit_test.go
@@ -107,7 +107,8 @@ func TestAuditScan(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -147,7 +148,8 @@ func TestContainerAuditScan(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			stdout, stderr, code := runBomlyWithEnv(t, auditEnv, tc.args...)
 			if code != 0 {
 				t.Fatalf("bomly exited %d\nstderr:\n%s", code, stderr)
@@ -184,7 +186,8 @@ func TestAuditDiffAndExplain(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}

--- a/test/smoke/container_test.go
+++ b/test/smoke/container_test.go
@@ -33,7 +33,8 @@ func TestContainerScan(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			stdout, stderr, code := runBomly(t, tc.args...)
 			if code != 0 {
 				t.Fatalf("bomly exited %d\nstderr:\n%s", code, stderr)
@@ -66,7 +67,8 @@ func TestContainerDiff(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			stdout, stderr, code := runBomly(t, tc.args...)
 			if code != 0 {
 				t.Fatalf("bomly exited %d\nstderr:\n%s", code, stderr)
@@ -99,7 +101,8 @@ func TestContainerExplain(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			stdout, stderr, code := runBomly(t, tc.args...)
 			if code != 0 {
 				t.Fatalf("bomly exited %d\nstderr:\n%s", code, stderr)

--- a/test/smoke/helpers_test.go
+++ b/test/smoke/helpers_test.go
@@ -14,10 +14,25 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
 var update = flag.Bool("update", false, "update golden files")
+
+var (
+	goldenWritesMu sync.Mutex
+	goldenWrites   = map[string]string{}
+)
+
+// parallelSubtest runs a leaf smoke case under Go's -parallel scheduler.
+func parallelSubtest(t *testing.T, name string, run func(t *testing.T)) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		run(t)
+	})
+}
 
 // runBomly executes the built CLI binary with the given arguments and returns
 // stdout, stderr, and exit code. It does not fail the test on non-zero exit.
@@ -31,8 +46,13 @@ func runBomly(t *testing.T, args ...string) (stdout, stderr string, exitCode int
 // inherited and env entries are appended (overriding duplicates).
 func runBomlyWithEnv(t *testing.T, env []string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runBomlyBinaryWithEnv(t, bomlyBin, env, args...)
+}
 
-	cmd := exec.Command(bomlyBin, args...)
+func runBomlyBinaryWithEnv(t *testing.T, bin string, env []string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmd := exec.Command(bin, args...)
 	cmd.Env = append(os.Environ(), env...)
 
 	// Isolate plugin/config discovery to a throwaway home directory so the
@@ -539,10 +559,11 @@ func assertGolden(t *testing.T, name string, got []byte) {
 	gp := goldenPath(name)
 
 	if *update {
+		claimGoldenWrite(t, gp)
 		if err := os.MkdirAll(filepath.Dir(gp), 0o755); err != nil {
 			t.Fatalf("create golden dir: %v", err)
 		}
-		if err := os.WriteFile(gp, got, 0o644); err != nil {
+		if err := writeFileAtomic(gp, got, 0o644); err != nil {
 			t.Fatalf("write golden file: %v", err)
 		}
 		t.Logf("updated golden file %s", gp)
@@ -562,6 +583,66 @@ func assertGolden(t *testing.T, name string, got []byte) {
 		t.Errorf("output does not match golden file %s\n\n--- want ---\n%s\n--- got ---\n%s\n\n--- diff (first divergence) ---\n%s",
 			gp, string(want), string(got), firstDiff(want, got))
 	}
+}
+
+func claimGoldenWrite(t *testing.T, path string) {
+	t.Helper()
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("resolve golden path %s: %v", path, err)
+	}
+
+	goldenWritesMu.Lock()
+	defer goldenWritesMu.Unlock()
+
+	if owner, ok := goldenWrites[abs]; ok {
+		t.Fatalf("golden file %s is already claimed by %s; duplicate smoke golden names cannot run safely in update mode", path, owner)
+	}
+	goldenWrites[abs] = t.Name()
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		if runtime.GOOS == "windows" {
+			if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+				return fmt.Errorf("remove existing file after rename failed: %w", removeErr)
+			}
+			if retryErr := os.Rename(tmpPath, path); retryErr != nil {
+				return fmt.Errorf("replace target after removing existing file: %w", retryErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("replace target: %w", err)
+	}
+	return nil
 }
 
 func normalizeLineEndings(b []byte) []byte {

--- a/test/smoke/lite_test.go
+++ b/test/smoke/lite_test.go
@@ -8,18 +8,23 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
 // bomlyLiteBin is the path to the lite binary, built once per test run.
 // It is set lazily by buildLiteBinary.
 var bomlyLiteBin string
+var bomlyLiteMu sync.Mutex
 
 // buildLiteBinary builds the lite binary (external Syft/Grype mode) once and
 // caches the path. Safe to call from multiple tests — only the first call
 // builds.
 func buildLiteBinary(t *testing.T) string {
 	t.Helper()
+	bomlyLiteMu.Lock()
+	defer bomlyLiteMu.Unlock()
+
 	if bomlyLiteBin != "" {
 		return bomlyLiteBin
 	}
@@ -56,10 +61,7 @@ func runBomlyLite(t *testing.T, args ...string) (stdout, stderr string, exitCode
 func runBomlyLiteWithEnv(t *testing.T, env []string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
 	bin := buildLiteBinary(t)
-	origBin := bomlyBin
-	bomlyBin = bin
-	defer func() { bomlyBin = origBin }()
-	return runBomlyWithEnv(t, env, args...)
+	return runBomlyBinaryWithEnv(t, bin, env, args...)
 }
 
 // ---------------------------------------------------------------------------
@@ -88,7 +90,8 @@ func TestLiteScan(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -125,7 +128,8 @@ func TestLiteDiff(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -162,7 +166,8 @@ func TestLiteExplain(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -186,6 +191,8 @@ func TestLiteExplain(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLiteVersion(t *testing.T) {
+	t.Parallel()
+
 	stdout, stderr, code := runBomlyLite(t, "version")
 	if code != 0 {
 		t.Fatalf("bomly-lite version exited %d\nstderr:\n%s", code, stderr)

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -18,7 +18,7 @@ import (
 func TestPluginWorkflows(t *testing.T) {
 	requireTool(t, "go")
 
-	t.Run("dev-install-scan", func(t *testing.T) {
+	parallelSubtest(t, "dev-install-scan", func(t *testing.T) {
 		binaryPath, manifest := buildExamplePlugin(t)
 		projectDir := createExamplePluginProject(t)
 		env := pluginWorkflowEnv(t)
@@ -66,7 +66,7 @@ func TestPluginWorkflows(t *testing.T) {
 		assertGolden(t, "plugin-scan-dev", normalizeJSON(t, []byte(scanStdout)))
 	})
 
-	t.Run("archive-install-scan", func(t *testing.T) {
+	parallelSubtest(t, "archive-install-scan", func(t *testing.T) {
 		binaryPath, manifest := buildExamplePlugin(t)
 		archivePath := packageExamplePluginArchive(t, binaryPath)
 		projectDir := createExamplePluginProject(t)

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -203,7 +203,8 @@ func TestScan(t *testing.T) {
 	}...)
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -249,7 +250,8 @@ func TestDiff(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}
@@ -286,7 +288,8 @@ func TestExplain(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		parallelSubtest(t, tc.name, func(t *testing.T) {
 			for _, tool := range tc.tools {
 				requireTool(t, tool)
 			}


### PR DESCRIPTION
## Summary

- Run independent smoke-test leaf cases under Go's `-parallel` scheduler within a single `make smoke` invocation.
- Add safer update-mode golden writes with duplicate golden-path detection and atomic replacement.
- Make lite smoke runs concurrency-safe by avoiding global `bomlyBin` mutation, and document `-parallel` tuning through existing `ARGS` usage.

## Validation

- `go test -tags "smoke" ./test/smoke/ -run 'TestScan/(scan-sbom-spdx|scan-sbom-cyclonedx)|TestDiff/diff-sbom|TestLiteScan/(lite-scan-sbom-spdx|lite-scan-sbom-cyclonedx)' -count=1 -parallel 4 -timeout 15m`
- Same subset with `-update -parallel 4`; no golden files changed
- `make smoke ARGS="-run 'TestPluginWorkflows' -parallel 2"`
- `make test`
- `git diff --check`

Draft until CI has had a chance to run the GitHub-side smoke slices.