### PR TITLE
Add parity between format and output flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,10 @@ Runtime preparation is owned by `internal/engine`: build the filtered registry o
 
 ## Code Conventions
 
+### Shared Types
+
+- Use canonical shared types directly instead of creating local type aliases or re-exported constants just to rename them. For example, if `internal/output.Format` owns CLI output formats, downstream packages should store and compare `output.Format` / `output.FormatJSON` directly rather than introducing `render.OutputFormat` aliases.
+
 ### Errors
 
 ```go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ Detector chains are explicit in `internal/registry/support.go` and `internal/reg
 
 ## Code Conventions
 
+**Shared types**: Use canonical shared types directly instead of creating local type aliases or re-exported constants just to rename them. For example, if `internal/output.Format` owns CLI output formats, downstream packages should store and compare `output.Format` / `output.FormatJSON` directly rather than introducing `render.OutputFormat` aliases.
+
 **Errors** — always wrap with context:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ One binary. Native detectors for the ecosystems developers use every day. Offlin
 ## Highlights
 
 - Scan local trees, SBOMs (SPDX 2.3, CycloneDX 1.6), Git repositories, container images.
-- Write SBOMs in either format alongside any report: `-o spdx=…  -o cyclonedx=…`.
+- Write SBOMs in either format as the primary output or alongside any report: `--format spdx`, `-o cyclonedx=…`.
 - Enrich with OSV, KEV, deps.dev, ClearlyDefined, endoflife.date via `--enrich`.
 - Audit with `--audit --fail-on <severity>`; SARIF emitted with `--format sarif`.
 - Explain transitive paths with `bomly explain <package>`.
@@ -32,6 +32,9 @@ bomly scan
 
 # Write SBOMs in two formats
 bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json
+
+# Write one SBOM to stdout
+bomly scan --format spdx
 
 # Enrich packages with external vulnerability and license data
 bomly scan --enrich
@@ -145,8 +148,8 @@ bomly diff --sbom --base ./old.spdx.json --head ./new.spdx.json
 | Human-readable report | `bomly scan` |
 | Structured JSON | `bomly scan --json` |
 | SARIF 2.1.0 | `bomly scan --audit --format sarif` |
-| SPDX 2.3 JSON | `bomly scan -o spdx=sbom.spdx.json` |
-| CycloneDX JSON | `bomly scan -o cyclonedx=sbom.cdx.json` |
+| SPDX 2.3 JSON | `bomly scan --format spdx` or `bomly scan -o spdx=sbom.spdx.json` |
+| CycloneDX JSON | `bomly scan --format cyclonedx` or `bomly scan -o cyclonedx=sbom.cdx.json` |
 
 Full details: [Output formats](docs/OUTPUT_FORMATS.md), [SBOM formats](docs/SBOM.md), [Exit codes](docs/EXIT_CODES.md).
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -40,8 +40,8 @@ YAML files use the nested keys documented below. Unknown keys and the former fla
 | `policy.typosquat_mode` | `BOMLY_TYPOSQUAT_MODE` | `string` | warn | Typosquatting policy mode: warn or fail |
 | `policy.warn_only` | `BOMLY_WARN_ONLY` | `bool` | - | Downgrade failing findings to warnings |
 | `components.analyzers` | `BOMLY_ANALYZERS` | `string` | - | Reachability analyzer selectors; supports +name and -name modifiers |
-| `output.format` | `BOMLY_FORMAT` | `string` | - | Primary report format: text, json, markdown, or sarif |
-| `output.outputs` | `BOMLY_OUTPUT` | `[]string` | - | Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx |
+| `output.format` | `BOMLY_FORMAT` | `string` | - | Primary output format: text, json, markdown, sarif, spdx, or cyclonedx. SBOM formats are scan-only |
+| `output.outputs` | `BOMLY_OUTPUT` | `[]string` | - | Additional output target(s) as <format> or <format>=<path>. Repeatable; supports text, json, markdown, sarif, spdx, and cyclonedx |
 | `output.interactive` | `BOMLY_INTERACTIVE` | `bool` | - | Enable interactive TUI mode |
 | `components.ecosystems` | `BOMLY_ECOSYSTEMS` | `string` | - | Ecosystem selectors; supports +name and -name modifiers |
 | `components.detectors` | `BOMLY_DETECTORS` | `string` | - | Detector selectors; supports +name and -name modifiers |
@@ -215,9 +215,9 @@ Flat YAML keys are no longer accepted. Move each existing key to its nested repl
 #   Downgrade failing findings to warnings
 #   warn_only: false
 # output:
-#   Primary report format: text, json, markdown, or sarif
+#   Primary output format: text, json, markdown, sarif, spdx, or cyclonedx. SBOM formats are scan-only
 #   format: ""
-#   Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx
+#   Additional output target(s) as <format> or <format>=<path>. Repeatable; supports text, json, markdown, sarif, spdx, and cyclonedx
 #   outputs: []
 #   Enable interactive TUI mode
 #   interactive: false

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -1,8 +1,8 @@
 # Output Formats
 
-Bomly writes one of four reporting formats and any number of SBOM artifacts in the same run.
+Bomly writes one primary stdout output and any number of additional outputs in the same run.
 
-## Reporting format: `--format`
+## Primary output: `--format`
 
 Use `--json` as a shortcut for `--format json` when you want structured output quickly.
 
@@ -12,6 +12,8 @@ Use `--json` as a shortcut for `--format json` when you want structured output q
 | `json` | Automation | Pipelines, custom dashboards, anything consumed by code |
 | `markdown` | Reviews | Job summaries, PR comments, and other Markdown surfaces |
 | `sarif` | Audit-only | CI security panes, GitHub Security tab, IDE problem markers |
+| `spdx` | Scan only | SPDX 2.3 JSON SBOMs |
+| `cyclonedx` | Scan only | CycloneDX 1.6 JSON SBOMs |
 
 Flag:
 
@@ -21,11 +23,13 @@ bomly scan --json
 bomly explain lodash --format markdown
 bomly diff --base main --head HEAD --format markdown
 bomly scan --audit --format sarif
+bomly scan --format spdx
 ```
 
 Constraints:
 
 - `--format sarif` requires `--audit`. SARIF is a findings format; without an auditor there are no findings.
+- `--format spdx` and `--format cyclonedx` are supported by `scan` only.
 - `--interactive` forces `--format text`. Combining it with `--json` or another non-text reporting format is rejected with exit 4.
 
 ## `text` — human-readable
@@ -82,10 +86,11 @@ GitHub Code Scanning, Azure DevOps, and most IDE extensions ingest SARIF directl
 
 ## Additional output: `-o`
 
-Independent of `--format`. You can write review reports and SBOM artifacts alongside the primary output:
+`-o` uses the same format names as `--format`, plus an optional file path. Use `<format>=<path>` to write to a file, or just `<format>` to write that additional output to stdout.
 
 ```bash
 bomly scan --json \
+  -o text=summary.txt \
   -o markdown=summary.md \
   -o sarif=bomly.sarif \
   -o spdx=sbom.spdx.json \
@@ -96,12 +101,14 @@ Supported targets:
 
 | `-o` value | Format |
 | --- | --- |
+| `text` | Human-readable terminal report |
+| `json` | Structured Bomly JSON report |
 | `markdown` | GitHub-flavored Markdown report |
 | `sarif` | SARIF 2.1.0 report; requires `--audit` |
 | `spdx` | SPDX 2.3 JSON |
 | `cyclonedx` | CycloneDX 1.6 JSON |
 
-`spdx` and `cyclonedx` are supported by `scan`. `markdown` and `sarif` are supported by report-producing commands. See [SBOM formats](SBOM.md) for the SBOM comparison and writing rules.
+`spdx` and `cyclonedx` are supported by `scan`. Report formats (`text`, `json`, `markdown`, `sarif`) are supported by report-producing commands. See [SBOM formats](SBOM.md) for the SBOM comparison and writing rules.
 
 ## Combining outputs
 

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -25,9 +25,12 @@ In practice: pick **SPDX** when a regulator or customer asks for it; pick **Cycl
 
 ## Writing an SBOM
 
-Use `-o <format>[=<path>]`. The format alone writes to stdout; `format=path` writes to a file:
+Use `--format <format>` for the primary stdout output, or `-o <format>[=<path>]` when you want an SBOM alongside another output. The format alone writes to stdout; `format=path` writes to a file:
 
 ```bash
+# One format to stdout
+bomly scan --format spdx
+
 # One format to a file
 bomly scan -o spdx=sbom.spdx.json
 
@@ -44,6 +47,7 @@ Constraints:
 
 - At most one `-o` may omit `=<path>`. Two stdout outputs would collide.
 - `-o spdx=` (empty path) is an error.
+- `--format spdx`, `--format cyclonedx`, `-o spdx`, and `-o cyclonedx` are supported by `scan` only.
 - Paths are resolved relative to the current working directory.
 
 ## Ingesting an SBOM
@@ -89,7 +93,7 @@ Reachability annotations and Bomly-specific metadata are emitted in the JSON out
 To convert between formats, run a scan and emit both in one pass:
 
 ```bash
-bomly scan --sbom --path ./in.spdx.json -o cyclonedx=out.cdx.json
+bomly scan --sbom --path ./in.spdx.json --format cyclonedx > out.cdx.json
 ```
 
 Bomly does not advertise a one-shot `convert` command — the scan pipeline is the conversion path.

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -80,6 +80,9 @@ func newDiffCmd() *cobra.Command {
 			if err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
+			if err := validatePrimaryReportFormat(outputFormat); err != nil {
+				return exit.InvalidInputError("%v", err)
+			}
 			if outputFormat == output.FormatSARIF && !current.Audit {
 				return exit.InvalidInputError("--format sarif requires --audit")
 			}
@@ -90,7 +93,7 @@ func newDiffCmd() *cobra.Command {
 			if err := validateReportOutputs(outputSpecs); err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
-			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !current.Audit {
+			if hasOutputFormat(outputSpecs, output.FormatSARIF) && !current.Audit {
 				return exit.InvalidInputError("-o sarif requires --audit")
 			}
 			if current.Interactive && len(outputSpecs) > 0 {
@@ -165,23 +168,21 @@ func newDiffCmd() *cobra.Command {
 			markdownRenderer := func(w io.Writer) error {
 				return render.DiffMarkdown(w, payload)
 			}
+			textRenderer := func(w io.Writer) error {
+				return render.Diff(w, payload)
+			}
+			reportRenderers := output.Renderers{
+				Markdown: markdownRenderer,
+				Text:     textRenderer,
+			}
 			sarifRenderer := func(w io.Writer) error {
 				return output.WriteSARIF(w, diffResult.Findings, diffResult.Head.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Reachability})
 			}
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
 				for _, spec := range outputSpecs {
-					switch spec.Format {
-					case render.OutputFormatMarkdown:
-						if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
-							return err
-						}
-					case render.OutputFormatSARIF:
-						if err := writeRenderedOutput(streams.reportWriter(), spec, sarifRenderer); err != nil {
-							return err
-						}
-					default:
-						return exit.InvalidInputError("output format %q is only supported by scan", spec.Label)
+					if err := writeReportOutput(streams.reportWriter(), spec, payload, reportRenderers, sarifRenderer); err != nil {
+						return err
 					}
 				}
 			}
@@ -202,12 +203,7 @@ func newDiffCmd() *cobra.Command {
 			if outputFormat == output.FormatMarkdown || outputFormat == output.FormatText {
 				prog.SeparateReport()
 			}
-			err = output.Write(streams.reportWriter(), outputFormat, payload, output.Renderers{
-				Markdown: markdownRenderer,
-				Text: func(w io.Writer) error {
-					return render.Diff(w, payload)
-				},
-			})
+			err = output.Write(streams.reportWriter(), outputFormat, payload, reportRenderers)
 			if err == nil && current.Audit && diffResult.Audit != nil {
 				if failing := output.FailingFindingCount(diffResult.Audit.Introduced); failing > 0 {
 					return exit.PolicyViolationFindings(failing)

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -161,7 +161,7 @@ func TestRenderDiffMarkdownRendersScopedPolicyPayloadDirectly(t *testing.T) {
 
 func TestWriteRenderedOutputCreatesParentDirectory(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "summary.md")
-	if err := writeRenderedOutput(bytes.NewBuffer(nil), render.OutputSpec{Format: render.OutputFormatMarkdown, Label: "markdown", Path: path}, func(w io.Writer) error {
+	if err := writeRenderedOutput(bytes.NewBuffer(nil), render.OutputSpec{Format: output.FormatMarkdown, Label: "markdown", Path: path}, func(w io.Writer) error {
 		_, err := w.Write([]byte("# Summary\n"))
 		return err
 	}); err != nil {

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -43,6 +43,13 @@ func newExplainCmd() *cobra.Command {
 				}
 				restoreStdout()
 			}()
+			requestedFormat, err := options.OutputFormat()
+			if err != nil {
+				return exit.InvalidInputError("%v", err)
+			}
+			if err := validatePrimaryReportFormat(requestedFormat); err != nil {
+				return exit.InvalidInputError("%v", err)
+			}
 
 			// Two-phase pre-pipeline setup: resolve execution target (only
 			// when non-local) and index subprojects. Each gets its own
@@ -62,7 +69,7 @@ func newExplainCmd() *cobra.Command {
 			if err := validateReportOutputs(outputSpecs); err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
-			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !context.ResolvedConfig.Audit {
+			if hasOutputFormat(outputSpecs, output.FormatSARIF) && !context.ResolvedConfig.Audit {
 				return exit.InvalidInputError("-o sarif requires --audit")
 			}
 			if context.ResolvedConfig.Interactive && len(outputSpecs) > 0 {
@@ -109,6 +116,26 @@ func newExplainCmd() *cobra.Command {
 			markdownRenderer := func(w io.Writer) error {
 				return render.ExplainMarkdown(w, payload)
 			}
+			textRenderer := func(w io.Writer) error {
+				for i, target := range payload.Targets {
+					if i > 0 {
+						if _, err := fmt.Fprintln(w); err != nil {
+							return err
+						}
+					}
+					if err := render.Explain(w, target, payload.Metadata.ReachabilityEnabled); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+			reportRenderers := output.Renderers{
+				Markdown: markdownRenderer,
+				Text:     textRenderer,
+			}
+			sarifRenderer := func(w io.Writer) error {
+				return output.WriteSARIF(w, explainResult.Findings, explainResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: context.ResolvedConfig.Reachability})
+			}
 			if context.ResolvedConfig.Interactive {
 				prog.Stop()
 				return exit.InteractiveResult(tui.Run(cmd.InOrStdin(), streams.interactiveWriter(), tui.NewExplain(payload.Project, args[0], explainResult.FocusedConsolidated, explainResult.FocusedGraph, explainResult.Findings).WithRegistry(explainResult.Registry).WithEnrichEnabled(context.ResolvedConfig.Enrich)))
@@ -116,19 +143,8 @@ func newExplainCmd() *cobra.Command {
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
 				for _, spec := range outputSpecs {
-					switch spec.Format {
-					case render.OutputFormatMarkdown:
-						if err := writeRenderedOutput(streams.reportWriter(), spec, markdownRenderer); err != nil {
-							return err
-						}
-					case render.OutputFormatSARIF:
-						if err := writeRenderedOutput(streams.reportWriter(), spec, func(w io.Writer) error {
-							return output.WriteSARIF(w, explainResult.Findings, explainResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: context.ResolvedConfig.Reachability})
-						}); err != nil {
-							return err
-						}
-					default:
-						return exit.InvalidInputError("output format %q is only supported by scan", spec.Label)
+					if err := writeReportOutput(streams.reportWriter(), spec, payload, reportRenderers, sarifRenderer); err != nil {
+						return err
 					}
 				}
 			}
@@ -138,7 +154,7 @@ func newExplainCmd() *cobra.Command {
 			}
 			if context.Format == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return output.WriteSARIF(streams.reportWriter(), explainResult.Findings, explainResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: context.ResolvedConfig.Reachability})
+				return sarifRenderer(streams.reportWriter())
 			}
 
 			writer, closeWriter, err := context.Writer(streams.reportWriter())
@@ -151,22 +167,7 @@ func newExplainCmd() *cobra.Command {
 				prog.SeparateReport()
 			}
 
-			err = output.Write(writer, context.Format, payload, output.Renderers{
-				Markdown: markdownRenderer,
-				Text: func(w io.Writer) error {
-					for i, target := range payload.Targets {
-						if i > 0 {
-							if _, err := fmt.Fprintln(w); err != nil {
-								return err
-							}
-						}
-						if err := render.Explain(w, target, payload.Metadata.ReachabilityEnabled); err != nil {
-							return err
-						}
-					}
-					return nil
-				},
-			})
+			err = output.Write(writer, context.Format, payload, reportRenderers)
 			if err == nil && context.ResolvedConfig.Audit {
 				if failing := output.FailingFindingCount(explainResult.Findings); failing > 0 {
 					return exit.PolicyViolationFindings(failing)

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -95,9 +95,9 @@ func bindSelectorFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
 }
 
 func bindExecutionFlags(flags *pflag.FlagSet, cfg *config.Resolved) {
-	flags.StringVarP(&cfg.Format, "format", "f", "", "Output format: text, json, markdown, sarif")
+	flags.StringVarP(&cfg.Format, "format", "f", "", "Output format: text, json, markdown, sarif, spdx, cyclonedx (SBOM formats are scan-only)")
 	BindJSONFormatFlag(flags, &cfg.Format, "Shortcut for --format json")
-	flags.StringArrayVarP(&cfg.Outputs, "output", "o", nil, "Additional output target as <format> or <format>=<path>; repeat for multiple outputs")
+	flags.StringArrayVarP(&cfg.Outputs, "output", "o", nil, "Additional output target as <format> or <format>=<path>; repeat for multiple outputs. Supports text, json, markdown, sarif, spdx, cyclonedx")
 	flags.BoolVar(&cfg.Interactive, "interactive", false, "Open an interactive terminal UI")
 	flags.BoolVar(&cfg.InstallFirst, "install-first", false, "Run detector-specific dependency installation before resolving graphs")
 	flags.StringArrayVar(&cfg.InstallArgs, "install-arg", nil, "Additional detector-specific install argument; may be repeated")

--- a/internal/cli/output_artifacts.go
+++ b/internal/cli/output_artifacts.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/output"
 )
 
 func parseOutputSpecs(values []string) ([]render.OutputSpec, error) {
@@ -24,7 +25,7 @@ func hasStdoutOutput(specs []render.OutputSpec) bool {
 	return false
 }
 
-func hasOutputFormat(specs []render.OutputSpec, format render.OutputFormat) bool {
+func hasOutputFormat(specs []render.OutputSpec, format output.Format) bool {
 	for _, spec := range specs {
 		if spec.Format == format {
 			return true
@@ -47,7 +48,7 @@ func allOutputsAreSBOM(specs []render.OutputSpec) bool {
 
 func validateMarkdownOnlyOutputs(specs []render.OutputSpec) error {
 	for _, spec := range specs {
-		if spec.Format != render.OutputFormatMarkdown {
+		if spec.Format != output.FormatMarkdown {
 			return fmt.Errorf("output format %q is only supported by scan", spec.Label)
 		}
 	}
@@ -57,12 +58,35 @@ func validateMarkdownOnlyOutputs(specs []render.OutputSpec) error {
 func validateReportOutputs(specs []render.OutputSpec) error {
 	for _, spec := range specs {
 		switch spec.Format {
-		case render.OutputFormatMarkdown, render.OutputFormatSARIF:
+		case output.FormatText, output.FormatJSON, output.FormatMarkdown, output.FormatSARIF:
 		default:
 			return fmt.Errorf("output format %q is only supported by scan", spec.Label)
 		}
 	}
 	return nil
+}
+
+func validatePrimaryReportFormat(format output.Format) error {
+	if format.IsSBOM() {
+		return fmt.Errorf("--format %s is only supported by scan", format)
+	}
+	return nil
+}
+
+func writeReportOutput(stdout io.Writer, spec render.OutputSpec, payload any, renderers output.Renderers, sarifRenderer func(io.Writer) error) error {
+	switch spec.Format {
+	case output.FormatJSON, output.FormatMarkdown, output.FormatText:
+		return writeRenderedOutput(stdout, spec, func(w io.Writer) error {
+			return output.Write(w, spec.Format, payload, renderers)
+		})
+	case output.FormatSARIF:
+		if sarifRenderer == nil {
+			return fmt.Errorf("sarif output is not implemented")
+		}
+		return writeRenderedOutput(stdout, spec, sarifRenderer)
+	default:
+		return fmt.Errorf("output format %q is only supported by scan", spec.Label)
+	}
 }
 
 func writeRenderedOutput(stdout io.Writer, spec render.OutputSpec, renderer func(io.Writer) error) error {

--- a/internal/cli/render/sbom.go
+++ b/internal/cli/render/sbom.go
@@ -7,23 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/internal/sbom"
-)
-
-// OutputFormat identifies one additional output target.
-type OutputFormat string
-
-const (
-	OutputFormatMarkdown  OutputFormat = "markdown"
-	OutputFormatSARIF     OutputFormat = "sarif"
-	OutputFormatSPDX      OutputFormat = "spdx"
-	OutputFormatCycloneDX OutputFormat = "cyclonedx"
 )
 
 // OutputSpec describes one parsed -o argument: an output format and the
 // destination path (empty path means stdout).
 type OutputSpec struct {
-	Format OutputFormat
+	Format output.Format
 	Target sbom.Target
 	Label  string
 	Path   string
@@ -31,22 +22,28 @@ type OutputSpec struct {
 
 // IsSBOM reports whether this output is a standard SBOM artifact.
 func (s OutputSpec) IsSBOM() bool {
-	return s.Format == OutputFormatSPDX || s.Format == OutputFormatCycloneDX
+	return s.Format.IsSBOM()
 }
 
 // ParseOutputFormat normalizes a user-supplied output format string.
-func ParseOutputFormat(value string) (OutputFormat, sbom.Target, string, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "markdown", "md":
-		return OutputFormatMarkdown, "", "markdown", nil
-	case "sarif":
-		return OutputFormatSARIF, "", "sarif", nil
-	case "spdx", "spdx-json":
-		return OutputFormatSPDX, sbom.TargetSPDX23JSON, "spdx", nil
-	case "cyclonedx", "cyclonedx-json":
-		return OutputFormatCycloneDX, sbom.TargetCycloneDX16JSON, "cyclonedx", nil
-	default:
+func ParseOutputFormat(value string) (output.Format, sbom.Target, string, error) {
+	format, err := output.ParseFormat(value)
+	if err != nil {
 		return "", "", "", fmt.Errorf("unsupported output format %q", value)
+	}
+	target, _ := SBOMTarget(format)
+	return format, target, string(format), nil
+}
+
+// SBOMTarget returns the SBOM encoder target for an SBOM output format.
+func SBOMTarget(format output.Format) (sbom.Target, bool) {
+	switch format {
+	case output.FormatSPDX:
+		return sbom.TargetSPDX23JSON, true
+	case output.FormatCycloneDX:
+		return sbom.TargetCycloneDX16JSON, true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/cli/render/sbom_test.go
+++ b/internal/cli/render/sbom_test.go
@@ -1,0 +1,84 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/internal/sbom"
+)
+
+func TestParseOutputFormatAcceptsSharedFormatsAndAliases(t *testing.T) {
+	tests := []struct {
+		value      string
+		wantFormat output.Format
+		wantTarget sbom.Target
+		wantLabel  string
+	}{
+		{value: "text", wantFormat: output.FormatText, wantLabel: "text"},
+		{value: "json", wantFormat: output.FormatJSON, wantLabel: "json"},
+		{value: "markdown", wantFormat: output.FormatMarkdown, wantLabel: "markdown"},
+		{value: "md", wantFormat: output.FormatMarkdown, wantLabel: "markdown"},
+		{value: "sarif", wantFormat: output.FormatSARIF, wantLabel: "sarif"},
+		{value: "spdx", wantFormat: output.FormatSPDX, wantTarget: sbom.TargetSPDX23JSON, wantLabel: "spdx"},
+		{value: "spdx-json", wantFormat: output.FormatSPDX, wantTarget: sbom.TargetSPDX23JSON, wantLabel: "spdx"},
+		{value: "cyclonedx", wantFormat: output.FormatCycloneDX, wantTarget: sbom.TargetCycloneDX16JSON, wantLabel: "cyclonedx"},
+		{value: "cyclonedx-json", wantFormat: output.FormatCycloneDX, wantTarget: sbom.TargetCycloneDX16JSON, wantLabel: "cyclonedx"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			format, target, label, err := ParseOutputFormat(tc.value)
+			if err != nil {
+				t.Fatalf("ParseOutputFormat(%q) error = %v", tc.value, err)
+			}
+			if format != tc.wantFormat {
+				t.Fatalf("format = %q, want %q", format, tc.wantFormat)
+			}
+			if target != tc.wantTarget {
+				t.Fatalf("target = %q, want %q", target, tc.wantTarget)
+			}
+			if label != tc.wantLabel {
+				t.Fatalf("label = %q, want %q", label, tc.wantLabel)
+			}
+		})
+	}
+}
+
+func TestParseOutputSpecsParsesReportAndSBOMTargets(t *testing.T) {
+	specs, err := ParseOutputSpecs([]string{
+		"text=report.txt",
+		"json=report.json",
+		"md=summary.md",
+		"sarif=bomly.sarif",
+		"spdx=sbom.spdx.json",
+		"cyclonedx=sbom.cdx.json",
+	})
+	if err != nil {
+		t.Fatalf("ParseOutputSpecs() error = %v", err)
+	}
+	if len(specs) != 6 {
+		t.Fatalf("expected 6 specs, got %#v", specs)
+	}
+	if specs[0].Format != output.FormatText || specs[0].Path != "report.txt" {
+		t.Fatalf("unexpected text spec: %#v", specs[0])
+	}
+	if specs[1].Format != output.FormatJSON || specs[1].Path != "report.json" {
+		t.Fatalf("unexpected json spec: %#v", specs[1])
+	}
+	if specs[2].Format != output.FormatMarkdown || specs[2].Label != "markdown" {
+		t.Fatalf("unexpected markdown spec: %#v", specs[2])
+	}
+	if specs[4].Target != sbom.TargetSPDX23JSON || !specs[4].IsSBOM() {
+		t.Fatalf("unexpected spdx spec: %#v", specs[4])
+	}
+	if specs[5].Target != sbom.TargetCycloneDX16JSON || !specs[5].IsSBOM() {
+		t.Fatalf("unexpected cyclonedx spec: %#v", specs[5])
+	}
+}
+
+func TestParseOutputSpecsRejectsMultipleStdoutTargets(t *testing.T) {
+	_, err := ParseOutputSpecs([]string{"json", "spdx"})
+	if err == nil {
+		t.Fatal("expected multiple stdout outputs to be rejected")
+	}
+}

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -633,6 +633,49 @@ func TestRoot_DiffCommand_JSONOutputWithMarkdownOutputFile(t *testing.T) {
 	}
 }
 
+func TestRoot_DiffCommand_TextOutputWithJSONOutputFile(t *testing.T) {
+	requireGit(t)
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	setDynamicFakeNPMOnPath(t)
+	repoDir, baseSHA, headSHA := createGitNPMRepoHistory(t)
+	reportPath := filepath.Join(t.TempDir(), "reports", "diff.json")
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"diff", "--path", repoDir, "--ecosystems", "npm", "--base", baseSHA, "--head", headSHA, "--format", "text", "-o", "json=" + reportPath})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Dependency diff") {
+		t.Fatalf("expected primary text diff output, got:\n%s", stdout.String())
+	}
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read JSON report: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal JSON report: %v\n%s", err, data)
+	}
+	if got := payload["command"]; got != "diff" {
+		t.Fatalf("expected diff command in JSON report, got %#v", got)
+	}
+}
+
 func TestRoot_ScanCommand_MarkdownOutput(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
@@ -743,6 +786,75 @@ func TestRoot_ScanCommand_JSONOutputWithMarkdownOutputFile(t *testing.T) {
 	}
 	if !strings.Contains(string(summary), "# Bomly Scan Summary") || !strings.Contains(string(summary), "react@18.2.0") {
 		t.Fatalf("unexpected Markdown summary:\n%s", summary)
+	}
+}
+
+func TestRoot_ScanCommand_MarkdownOutputWithJSONAndTextOutputFiles(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	setFakeNPMOnPath(t, `{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": {
+      "version": "18.2.0"
+    }
+  }
+}`)
+	reportDir := t.TempDir()
+	jsonPath := filepath.Join(reportDir, "scan.json")
+	textPath := filepath.Join(reportDir, "scan.txt")
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"scan", "--path", projectDir, "--ecosystems", "npm", "--format", "markdown", "-o", "json=" + jsonPath, "-o", "text=" + textPath})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "# Bomly Scan Summary") {
+		t.Fatalf("expected primary Markdown output, got:\n%s", stdout.String())
+	}
+
+	jsonData, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read JSON report: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(jsonData, &payload); err != nil {
+		t.Fatalf("unmarshal JSON report: %v\n%s", err, jsonData)
+	}
+	if got := payload["command"]; got != "scan" {
+		t.Fatalf("expected scan command in JSON report, got %#v", got)
+	}
+
+	textData, err := os.ReadFile(textPath)
+	if err != nil {
+		t.Fatalf("read text report: %v", err)
+	}
+	if !strings.Contains(string(textData), "Dependency report for demo-app") || !strings.Contains(string(textData), "react") {
+		t.Fatalf("unexpected text report:\n%s", textData)
 	}
 }
 
@@ -1215,6 +1327,71 @@ func TestRoot_WhyCommand_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestRoot_WhyCommand_TextOutputWithJSONOutputFile(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	setFakeNPMOnPath(t, `{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": {
+      "version": "18.2.0",
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0"
+        }
+      }
+    }
+  }
+}`)
+	reportPath := filepath.Join(t.TempDir(), "reports", "explain.json")
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"explain", "loose-envify", "--path", projectDir, "--ecosystems", "npm", "--format", "text", "-o", "json=" + reportPath})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "loose-envify") {
+		t.Fatalf("expected primary text explain output, got:\n%s", stdout.String())
+	}
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read JSON report: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal JSON report: %v\n%s", err, data)
+	}
+	if got := payload["command"]; got != "explain" {
+		t.Fatalf("expected explain command in JSON report, got %#v", got)
+	}
+}
+
 func TestRoot_WhyCommand_MarkdownOutput(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
@@ -1482,6 +1659,87 @@ func TestRoot_ScanCommand_SBOMJSONOutput(t *testing.T) {
 	packages, ok := payload["packages"].([]any)
 	if !ok || len(packages) < 2 {
 		t.Fatalf("expected SPDX packages, got %#v", payload["packages"])
+	}
+}
+
+func TestRoot_ScanCommand_PrimarySBOMFormats(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		assertDoc func(*testing.T, map[string]any)
+	}{
+		{
+			name:   "spdx",
+			format: "spdx",
+			assertDoc: func(t *testing.T, payload map[string]any) {
+				t.Helper()
+				if got := payload["spdxVersion"]; got == nil {
+					t.Fatalf("expected SPDX document, got %#v", payload)
+				}
+			},
+		},
+		{
+			name:   "cyclonedx",
+			format: "cyclonedx",
+			assertDoc: func(t *testing.T, payload map[string]any) {
+				t.Helper()
+				if got := payload["bomFormat"]; got != "CycloneDX" {
+					t.Fatalf("expected CycloneDX document, got %#v", payload)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempHome := t.TempDir()
+			t.Setenv("HOME", tempHome)
+			if runtime.GOOS == "windows" {
+				t.Setenv("USERPROFILE", tempHome)
+			}
+
+			projectDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}
+`), 0o644); err != nil {
+				t.Fatalf("write package.json: %v", err)
+			}
+			setFakeNPMOnPath(t, `{
+  "name": "demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": {
+      "version": "18.2.0"
+    }
+  }
+}`)
+
+			root, err := newRootCmd("0.9.0-test")
+			if err != nil {
+				t.Fatalf("newRootCmd() error = %v", err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs([]string{"scan", "--path", projectDir, "--ecosystems", "npm", "--format", tc.format})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal output: %v\n%s", err, stdout.String())
+			}
+			tc.assertDoc(t, payload)
+		})
 	}
 }
 
@@ -1872,6 +2130,111 @@ func TestRoot_ScanCommand_TreeFormatRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `parse format: unsupported format "tree"`) {
 		t.Fatalf("expected tree format error, got %v", err)
+	}
+}
+
+func TestRoot_ReportCommandsRejectPrimarySBOMFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "diff spdx",
+			args: []string{"diff", "--base", "base", "--head", "head", "--format", "spdx"},
+			want: "--format spdx is only supported by scan",
+		},
+		{
+			name: "explain cyclonedx",
+			args: []string{"explain", "react", "--format", "cyclonedx"},
+			want: "--format cyclonedx is only supported by scan",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempHome := t.TempDir()
+			t.Setenv("HOME", tempHome)
+			if runtime.GOOS == "windows" {
+				t.Setenv("USERPROFILE", tempHome)
+			}
+
+			root, err := newRootCmd("0.9.0-test")
+			if err != nil {
+				t.Fatalf("newRootCmd() error = %v", err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tc.args)
+
+			err = normalizeExecuteError(root.Execute())
+			if err == nil {
+				t.Fatal("expected scan-only format error")
+			}
+			if exit.Code(err) != ExitCodeInvalidInput {
+				t.Fatalf("expected invalid input exit code, got %d (err=%v)", exit.Code(err), err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to contain %q, got %v", tc.want, err)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no stdout output, got %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRoot_DiffCommand_SARIFRequiresAudit(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "primary format",
+			args: []string{"diff", "--base", "base", "--head", "head", "--format", "sarif"},
+			want: "--format sarif requires --audit",
+		},
+		{
+			name: "additional output",
+			args: []string{"diff", "--base", "base", "--head", "head", "-o", "sarif=bomly.sarif"},
+			want: "-o sarif requires --audit",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempHome := t.TempDir()
+			t.Setenv("HOME", tempHome)
+			if runtime.GOOS == "windows" {
+				t.Setenv("USERPROFILE", tempHome)
+			}
+
+			root, err := newRootCmd("0.9.0-test")
+			if err != nil {
+				t.Fatalf("newRootCmd() error = %v", err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tc.args)
+
+			err = normalizeExecuteError(root.Execute())
+			if err == nil {
+				t.Fatal("expected SARIF audit requirement error")
+			}
+			if exit.Code(err) != ExitCodeInvalidInput {
+				t.Fatalf("expected invalid input exit code, got %d (err=%v)", exit.Code(err), err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to contain %q, got %v", tc.want, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -69,7 +69,7 @@ func newScanCmd() *cobra.Command {
 			if err != nil {
 				return exit.InvalidInputError("%v", err)
 			}
-			if hasOutputFormat(outputSpecs, render.OutputFormatSARIF) && !commandCtx.ResolvedConfig.Audit {
+			if hasOutputFormat(outputSpecs, output.FormatSARIF) && !commandCtx.ResolvedConfig.Audit {
 				return exit.InvalidInputError("-o sarif requires --audit")
 			}
 			if current.Interactive && hasStdoutOutput(outputSpecs) {
@@ -104,6 +104,26 @@ func newScanCmd() *cobra.Command {
 			markdownRenderer := func(w io.Writer) error {
 				return render.ScanMarkdown(w, payload)
 			}
+			textRenderer := func(w io.Writer) error {
+				if len(resolved) == 1 {
+					if _, err := fmt.Fprintf(w, "Dependency report for %s\n\n", render.ScanGraphDisplayName(selectedGraph, payload.Project.Name)); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(w, "Dependency report for %d subprojects\n\n", len(resolved)); err != nil {
+						return err
+					}
+				}
+				_, err := io.WriteString(w, render.Scan(payload.Manifests, selectedGraph, pipeResult.Registry, findings, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Reachability))
+				return err
+			}
+			reportRenderers := output.Renderers{
+				Markdown: markdownRenderer,
+				Text:     textRenderer,
+			}
+			sarifRenderer := func(w io.Writer) error {
+				return output.WriteSARIF(w, findings, pipeResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: commandCtx.ResolvedConfig.Reachability})
+			}
 
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
@@ -119,18 +139,10 @@ func newScanCmd() *cobra.Command {
 						if err := render.WriteOutputDocument(stdout, spec, rawDocument); err != nil {
 							return err
 						}
-					case spec.Format == render.OutputFormatMarkdown:
-						if err := writeRenderedOutput(stdout, spec, markdownRenderer); err != nil {
-							return err
-						}
-					case spec.Format == render.OutputFormatSARIF:
-						if err := writeRenderedOutput(stdout, spec, func(w io.Writer) error {
-							return output.WriteSARIF(w, findings, pipeResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: commandCtx.ResolvedConfig.Reachability})
-						}); err != nil {
-							return err
-						}
 					default:
-						return exit.InvalidInputError("output format %q is not supported by scan", spec.Label)
+						if err := writeReportOutput(stdout, spec, payload, reportRenderers, sarifRenderer); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -139,9 +151,25 @@ func newScanCmd() *cobra.Command {
 				return scanPolicyExit(commandCtx.ResolvedConfig.Audit, findings)
 			}
 
+			if graphOutputFormat.IsSBOM() {
+				target, ok := render.SBOMTarget(graphOutputFormat)
+				if !ok {
+					return exit.InvalidInputError("output format %q is not supported by scan", graphOutputFormat)
+				}
+				rawDocument, err := sbom.MarshalDepGraphJSON(selectedGraph, target, sbom.BuildOptions{ToolNames: sbomToolNames(resolved)}, sbom.EncodeOptions{Pretty: true})
+				if err != nil {
+					return fmt.Errorf("marshal %s sbom: %w", graphOutputFormat, err)
+				}
+				prog.Success("Wrote output")
+				if err := render.WriteOutputDocument(streams.reportWriter(), render.OutputSpec{Format: graphOutputFormat, Label: string(graphOutputFormat)}, rawDocument); err != nil {
+					return err
+				}
+				return scanPolicyExit(commandCtx.ResolvedConfig.Audit, findings)
+			}
+
 			if graphOutputFormat == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return output.WriteSARIF(streams.reportWriter(), findings, pipeResult.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: commandCtx.ResolvedConfig.Reachability})
+				return sarifRenderer(streams.reportWriter())
 			}
 
 			if commandCtx.ResolvedConfig.Interactive {
@@ -160,22 +188,7 @@ func newScanCmd() *cobra.Command {
 				prog.SeparateReport()
 			}
 
-			err = output.Write(writer, commandCtx.Format, payload, output.Renderers{
-				Markdown: markdownRenderer,
-				Text: func(w io.Writer) error {
-					if len(resolved) == 1 {
-						if _, err := fmt.Fprintf(w, "Dependency report for %s\n\n", render.ScanGraphDisplayName(selectedGraph, payload.Project.Name)); err != nil {
-							return err
-						}
-					} else {
-						if _, err := fmt.Fprintf(w, "Dependency report for %d subprojects\n\n", len(resolved)); err != nil {
-							return err
-						}
-					}
-					_, err := io.WriteString(w, render.Scan(payload.Manifests, selectedGraph, pipeResult.Registry, findings, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Reachability))
-					return err
-				},
-			})
+			err = output.Write(writer, commandCtx.Format, payload, reportRenderers)
 			if err == nil && commandCtx.ResolvedConfig.Audit {
 				if failing := output.FailingFindingCount(findings); failing > 0 {
 					return exit.PolicyViolationFindings(failing)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,8 @@ type Resolved struct {
 	TyposquatMode         string   `doc:"Typosquatting policy mode: warn or fail" env:"BOMLY_TYPOSQUAT_MODE" default:"warn"`
 	WarnOnly              bool     `doc:"Downgrade failing findings to warnings" env:"BOMLY_WARN_ONLY"`
 	Analyzers             string   `doc:"Reachability analyzer selectors; supports +name and -name modifiers" env:"BOMLY_ANALYZERS"`
-	Format                string   `doc:"Primary report format: text, json, markdown, or sarif" env:"BOMLY_FORMAT"`
-	Outputs               []string `doc:"Additional output target(s) as <format> or <format>=<path>. Repeatable; formats include markdown, spdx, and cyclonedx" env:"BOMLY_OUTPUT"`
+	Format                string   `doc:"Primary output format: text, json, markdown, sarif, spdx, or cyclonedx. SBOM formats are scan-only" env:"BOMLY_FORMAT"`
+	Outputs               []string `doc:"Additional output target(s) as <format> or <format>=<path>. Repeatable; supports text, json, markdown, sarif, spdx, and cyclonedx" env:"BOMLY_OUTPUT"`
 	Interactive           bool     `doc:"Enable interactive TUI mode" env:"BOMLY_INTERACTIVE"`
 	Ecosystems            string   `doc:"Ecosystem selectors; supports +name and -name modifiers" env:"BOMLY_ECOSYSTEMS"`
 	Detectors             string   `doc:"Detector selectors; supports +name and -name modifiers" env:"BOMLY_DETECTORS"`

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Format identifies a supported output format.
@@ -18,7 +19,16 @@ const (
 	FormatText Format = "text"
 	// FormatSARIF renders SARIF 2.1.0 output for vulnerability findings.
 	FormatSARIF Format = "sarif"
+	// FormatSPDX renders an SPDX 2.3 JSON SBOM.
+	FormatSPDX Format = "spdx"
+	// FormatCycloneDX renders a CycloneDX 1.6 JSON SBOM.
+	FormatCycloneDX Format = "cyclonedx"
 )
+
+// IsSBOM reports whether the format is a standard SBOM artifact.
+func (f Format) IsSBOM() bool {
+	return f == FormatSPDX || f == FormatCycloneDX
+}
 
 // Renderers provides alternative renderers for human-readable formats.
 type Renderers struct {
@@ -28,9 +38,19 @@ type Renderers struct {
 
 // ParseFormat validates a format value.
 func ParseFormat(value string) (Format, error) {
-	switch Format(value) {
-	case FormatJSON, FormatMarkdown, FormatText, FormatSARIF:
-		return Format(value), nil
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(FormatJSON):
+		return FormatJSON, nil
+	case string(FormatMarkdown), "md":
+		return FormatMarkdown, nil
+	case string(FormatText):
+		return FormatText, nil
+	case string(FormatSARIF):
+		return FormatSARIF, nil
+	case string(FormatSPDX), "spdx-json":
+		return FormatSPDX, nil
+	case string(FormatCycloneDX), "cyclonedx-json":
+		return FormatCycloneDX, nil
 	default:
 		return "", fmt.Errorf("unsupported format %q", value)
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -38,12 +38,32 @@ func TestPackageFromGraphPackageIncludesStructuredLicenses(t *testing.T) {
 	}
 }
 
-func TestParseFormatAcceptsMarkdown(t *testing.T) {
-	format, err := ParseFormat("markdown")
-	if err != nil {
-		t.Fatalf("ParseFormat(markdown) error = %v", err)
+func TestParseFormatAcceptsSharedFormatsAndAliases(t *testing.T) {
+	tests := []struct {
+		value string
+		want  Format
+	}{
+		{value: "text", want: FormatText},
+		{value: "json", want: FormatJSON},
+		{value: "markdown", want: FormatMarkdown},
+		{value: "md", want: FormatMarkdown},
+		{value: "sarif", want: FormatSARIF},
+		{value: "spdx", want: FormatSPDX},
+		{value: "spdx-json", want: FormatSPDX},
+		{value: "cyclonedx", want: FormatCycloneDX},
+		{value: "cyclonedx-json", want: FormatCycloneDX},
+		{value: " JSON ", want: FormatJSON},
 	}
-	if format != FormatMarkdown {
-		t.Fatalf("ParseFormat(markdown) = %q, want %q", format, FormatMarkdown)
+
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			format, err := ParseFormat(tc.value)
+			if err != nil {
+				t.Fatalf("ParseFormat(%q) error = %v", tc.value, err)
+			}
+			if format != tc.want {
+				t.Fatalf("ParseFormat(%q) = %q, want %q", tc.value, format, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR brings `--format` and `-o/--output` into parity.

- Uses one shared format parser for primary output and additional outputs.
- Supports `text`, `json`, `markdown`/`md`, `sarif`, `spdx`/`spdx-json`, and `cyclonedx`/`cyclonedx-json` consistently.
- Allows `bomly scan --format spdx` and `bomly scan --format cyclonedx` as primary stdout SBOM outputs.
- Expands `-o` so report formats like `json=report.json` and `text=report.txt` work alongside existing Markdown, SARIF, SPDX, and CycloneDX outputs.
- Keeps SBOM formats scan-only for `diff` and `explain` with clear errors.
- Updates CLI help, generated config docs, README, and output/SBOM docs.

## Why

Before this change, `--format` and `-o` were backed by separate parsers and accepted different values. That made the UX harder to explain: users could write SBOMs with `-o`, but not as the primary `--format`, and could request JSON with `--format`, but not as an additional `-o` artifact.

This makes the model simpler: `--format` selects the primary stdout output, and `-o` selects the same kind of output plus optional file writing.

## Validation

- `gofmt`
- Targeted output and CLI parity tests
- `make generate`
- `make test`
- `git diff --check`