### PR TITLE
Improve TUI tree expansion defaults

### DIFF
--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -68,7 +68,7 @@ type diffModel struct {
 	findingGroup    string
 	findingExpanded map[string]bool
 
-	postureGroup    string // "repository" (default) or "check"
+	postureGroup    string // "check" (default) or "repository"
 	postureExpanded map[string]bool
 
 	sourceSide         diffSourceSide
@@ -85,17 +85,17 @@ func NewDiff(payload output.DiffResponse, baseGraph, headGraph sdk.ConsolidatedG
 		headGraph:          headGraph,
 		componentsGroup:    componentsGroupStatus,
 		componentsExpanded: map[string]bool{},
-		vulnGroup:          "status",
+		vulnGroup:          "severity",
 		vulnExpanded:       map[string]bool{},
 		licenseGroup:       "license",
 		licenseExpanded:    map[string]bool{},
 		findingGroup:       "status",
 		findingExpanded:    map[string]bool{},
-		postureGroup:       "repository",
+		postureGroup:       "check",
 		postureExpanded:    map[string]bool{},
 		sourceSide:         diffSourceBase,
-		sourceBaseExpanded: map[string]bool{"root": true, "manifests": true},
-		sourceHeadExpanded: map[string]bool{"root": true, "manifests": true},
+		sourceBaseExpanded: map[string]bool{"root": true},
+		sourceHeadExpanded: map[string]bool{"root": true},
 	}
 	m.shellModel = newShell(ShellSpec{
 		TopBar: m.topBarLine,
@@ -151,7 +151,7 @@ func (m *diffModel) CycleGroup() {
 	case "findings":
 		m.findingGroup = nextFindingGroup(m.findingGroup)
 	case "posture":
-		m.postureGroup = cycleString(m.postureGroup, []string{"repository", "check"})
+		m.postureGroup = cycleString(m.postureGroup, []string{"check", "repository"})
 	case "source":
 		if m.sourceSide == diffSourceBase {
 			m.sourceSide = diffSourceHead
@@ -323,11 +323,8 @@ func (m *diffModel) setAllExpansion(expanded bool) {
 	if list == nil {
 		return
 	}
-	for _, item := range list.items {
-		if !item.canOpen || item.key == "" {
-			continue
-		}
-		expansion[item.key] = expanded
+	if !setVisibleExpansionLayer(list, expansion, expanded) {
+		return
 	}
 	m.rebuildPreserveSelection()
 }

--- a/internal/tui/focus_test.go
+++ b/internal/tui/focus_test.go
@@ -200,13 +200,9 @@ func TestPostureGrouping_ByCheckRendersFailingFirst(t *testing.T) {
 	model := NewScan(output.ProjectDescriptor{Name: "demo", Path: "/tmp/demo"}, consolidated, graphValue, nil).WithRegistry(registry).WithEnrichEnabled(true)
 	model.SelectView(6)
 
-	// Cycle the group via `g`.
 	wrapper := &teaModel{inner: model, width: 200, height: 60}
-	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
-	wrapper = updated.(*teaModel)
-
 	plain := render.StripANSI(wrapper.View())
-	// Header should show "Checks (N)" once grouped by check.
+	// Header should show "Checks (N)" in the default check-grouped view.
 	if !strings.Contains(plain, "Checks (2)") {
 		t.Errorf("expected Checks (2) header in check-grouped view; got:\n%s", plain)
 	}
@@ -247,7 +243,6 @@ func TestPostureDiffGrouping_ByCheckRegressionsFirst(t *testing.T) {
 	}
 	model := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 	model.SelectView(6)
-	model.CycleGroup()
 
 	wrapper := &teaModel{inner: model, width: 200, height: 60}
 	plain := render.StripANSI(wrapper.View())

--- a/internal/tui/posture_diff.go
+++ b/internal/tui/posture_diff.go
@@ -774,7 +774,7 @@ func postureDiffCheckGroupRowDetails(group postureDiffCheckGroup, r postureDiffC
 // buildPostureTab is the diffModel's TabSpec.Build for the Posture tab.
 // Layout mirrors the other diff tabs: top summary panels, single main
 // list, secondary details pane. The `g` key cycles the grouping axis
-// between "repository" (default) and "check".
+// between "check" (default) and "repository".
 func (m *diffModel) buildPostureTab() *listModel {
 	rows := postureDiffRowsFromPayload(m.payload.Results.Dependencies)
 	repoWidth := 24
@@ -787,7 +787,7 @@ func (m *diffModel) buildPostureTab() *listModel {
 		repoWidth = 56
 	}
 
-	group := valueOrDefault(m.postureGroup, "repository")
+	group := valueOrDefault(m.postureGroup, "check")
 	var items []listItem
 	var listTitle, listHeader string
 	switch group {

--- a/internal/tui/posture_test.go
+++ b/internal/tui/posture_test.go
@@ -67,7 +67,7 @@ func TestPostureTab_ScanRendersList(t *testing.T) {
 	plain := render.StripANSI(model.View(160, 40))
 	for _, want := range []string{
 		"Posture",
-		"Repositories (1)",
+		"Checks (2)",
 		"github.com/example/lib",
 		"3.5/10",
 		"Repository Posture", // details pane title
@@ -207,11 +207,17 @@ func TestPostureTab_DiffRendersList(t *testing.T) {
 		Results: output.DiffResults{
 			Dependencies: output.DiffDependencyResults{
 				Changed: []output.DiffChangedPackage{{
-					Before: output.PackageRef{Name: "shared", Scorecard: newTestScorecardTUI("github.com/shared/repo", 5.0)},
-					After:  output.PackageRef{Name: "shared", Scorecard: newTestScorecardTUI("github.com/shared/repo", 8.0)},
+					Before: output.PackageRef{Name: "shared", Scorecard: newTestScorecardTUI("github.com/shared/repo", 5.0,
+						sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 4},
+					)},
+					After: output.PackageRef{Name: "shared", Scorecard: newTestScorecardTUI("github.com/shared/repo", 8.0,
+						sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 7},
+					)},
 				}},
 				Added: []output.DiffPackageChange{{
-					Package: output.PackageRef{Name: "new", Scorecard: newTestScorecardTUI("github.com/new/repo", 6.0)},
+					Package: output.PackageRef{Name: "new", Scorecard: newTestScorecardTUI("github.com/new/repo", 6.0,
+						sdk.PackageScorecardCheck{Name: "Code-Review", Score: 6},
+					)},
 				}},
 			},
 		},
@@ -222,7 +228,7 @@ func TestPostureTab_DiffRendersList(t *testing.T) {
 	plain := render.StripANSI(model.View(160, 40))
 	for _, want := range []string{
 		"Posture",
-		"Repositories (2)",
+		"Checks (2)",
 		"github.com/shared/repo",
 		"github.com/new/repo",
 		"Posture Delta",

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -85,13 +85,13 @@ func newScanNavigator(titlePrefix string, project output.ProjectDescriptor, cons
 		explainQuery:          strings.TrimSpace(explainQuery),
 		sourceExpanded:        map[string]bool{"root": true},
 		componentExpanded:     map[string]bool{},
-		vulnerabilityGroup:    "component",
+		vulnerabilityGroup:    "severity",
 		vulnerabilityExpanded: map[string]bool{},
 		licenseGroup:          "license",
 		licenseExpanded:       map[string]bool{},
 		findingGroup:          "type",
 		findingExpanded:       map[string]bool{},
-		postureGroup:          "repository",
+		postureGroup:          "check",
 		postureExpanded:       map[string]bool{},
 	}
 	if len(manifests) == 1 {
@@ -239,51 +239,32 @@ func (m *scanModel) setAllTreeNodes(expanded bool) {
 	if m == nil || m.List() == nil {
 		return
 	}
-	for _, item := range m.List().items {
-		if !item.canOpen || item.key == "" {
-			continue
-		}
-		switch m.currentScanView() {
-		case interactiveScanViewPackages:
-			m.componentExpanded[item.key] = expanded
-		case interactiveScanViewVulns:
-			m.vulnerabilityExpanded[item.key] = expanded
-		case interactiveScanViewLicenses:
-			m.licenseExpanded[item.key] = expanded
-		case interactiveScanViewFindings:
-			m.findingExpanded[item.key] = expanded
-		case interactiveScanViewPosture:
-			m.postureExpanded[item.key] = expanded
-		case interactiveScanViewSource:
-			m.sourceExpanded[item.key] = expanded
-		}
-	}
-	if m.currentScanView() == interactiveScanViewPackages {
-		m.componentExpanded["project"] = expanded
-		for _, manifest := range m.manifests {
-			m.componentExpanded["manifest:"+manifest.id] = expanded
-		}
-		if m.graphValue != nil {
-			for _, pkg := range m.graphValue.Nodes() {
-				if pkg != nil {
-					m.componentExpanded[pkg.ID] = expanded
-				}
-			}
-		}
-	}
-	if m.currentScanView() == interactiveScanViewSource {
-		for _, key := range []string{"root", "target", "manifests", "packages", "relationships"} {
-			m.sourceExpanded[key] = expanded
-		}
-		if m.graphValue != nil {
-			for _, pkg := range m.graphValue.Nodes() {
-				if pkg != nil {
-					m.sourceExpanded["package:"+pkg.ID] = expanded
-				}
-			}
-		}
+	if !setVisibleExpansionLayer(m.List(), m.currentTreeExpansionMap(), expanded) {
+		return
 	}
 	m.rebuildListPreserveSelection()
+}
+
+func (m *scanModel) currentTreeExpansionMap() map[string]bool {
+	if m == nil {
+		return nil
+	}
+	switch m.currentScanView() {
+	case interactiveScanViewPackages:
+		return m.componentExpanded
+	case interactiveScanViewVulns:
+		return m.vulnerabilityExpanded
+	case interactiveScanViewLicenses:
+		return m.licenseExpanded
+	case interactiveScanViewFindings:
+		return m.findingExpanded
+	case interactiveScanViewPosture:
+		return m.postureExpanded
+	case interactiveScanViewSource:
+		return m.sourceExpanded
+	default:
+		return nil
+	}
 }
 
 func (m *scanModel) CycleGroup() {
@@ -292,13 +273,13 @@ func (m *scanModel) CycleGroup() {
 	}
 	switch m.currentScanView() {
 	case interactiveScanViewVulns:
-		m.vulnerabilityGroup = nextFilterValue(m.vulnerabilityGroup, []string{"component", "severity", "ecosystem"})
+		m.vulnerabilityGroup = nextFilterValue(m.vulnerabilityGroup, []string{"severity", "component", "ecosystem"})
 	case interactiveScanViewLicenses:
 		m.licenseGroup = nextFilterValue(m.licenseGroup, []string{"license", "category", "recognition"})
 	case interactiveScanViewFindings:
 		m.findingGroup = nextFilterValue(m.findingGroup, []string{"type", "severity", "component", "ecosystem"})
 	case interactiveScanViewPosture:
-		m.postureGroup = nextFilterValue(m.postureGroup, []string{"repository", "check"})
+		m.postureGroup = nextFilterValue(m.postureGroup, []string{"check", "repository"})
 	default:
 		return
 	}
@@ -613,7 +594,7 @@ func (m *scanModel) buildComponentsTreeListModel() *listModel {
 		for idx, manifest := range m.manifests {
 			manifestLast := idx == len(m.manifests)-1
 			manifestKey := "manifest:" + manifest.id
-			manifestExpanded := expandedValue(m.componentExpanded, manifestKey, true)
+			manifestExpanded := expandedValue(m.componentExpanded, manifestKey, false)
 			manifestTree := "├─ "
 			if manifestLast {
 				manifestTree = "└─ "
@@ -639,7 +620,7 @@ func (m *scanModel) buildComponentsTreeListModel() *listModel {
 					badges = append([]badge{{label: sev, kind: "severity-" + strings.ToLower(sev)}}, badges...)
 				}
 				deps, _ := m.graphValue.DirectDependencies(row.id)
-				expanded := expandedValue(m.componentExpanded, row.id, row.relationship == "root")
+				expanded := expandedValue(m.componentExpanded, row.id, false)
 				if row.repeated {
 					deps = nil
 					expanded = false
@@ -1090,7 +1071,7 @@ func (m *scanModel) buildVulnsListModel() *listModel {
 func (m *scanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow) []listItem {
 	group := strings.TrimSpace(m.vulnerabilityGroup)
 	if group == "" {
-		group = "component"
+		group = "severity"
 	}
 	groups := make(map[string][]packageVulnerabilityRow)
 	for _, vulnerability := range vulnerabilities {
@@ -1101,10 +1082,7 @@ func (m *scanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow
 	items := make([]listItem, 0, len(vulnerabilities)+len(keys))
 	for _, key := range keys {
 		groupKey := group + ":" + key
-		expanded, ok := m.vulnerabilityExpanded[groupKey]
-		if !ok {
-			expanded = true
-		}
+		expanded := expandedValue(m.vulnerabilityExpanded, groupKey, true)
 		groupVulnerabilities := groups[key]
 		items = append(items, listItem{
 			title:    fmt.Sprintf("%s (%d)", key, len(groupVulnerabilities)),
@@ -1205,7 +1183,7 @@ func (m *scanModel) vulnerabilityControlsLine() string {
 
 func (m *scanModel) vulnerabilityStateLine(showing, total int) string {
 	state := render.Style("Filter: ", render.Dim) + render.Style(valueOrDefault(m.severityFilter, "All"), render.BgYellow, render.Bold) +
-		render.Style(" | Group: ", render.Dim) + render.Style(valueOrDefault(m.vulnerabilityGroup, "component"), render.BgYellow, render.Bold) +
+		render.Style(" | Group: ", render.Dim) + render.Style(valueOrDefault(m.vulnerabilityGroup, "severity"), render.BgYellow, render.Bold) +
 		render.Style(" | Showing: ", render.Dim) + fmt.Sprintf("%d/%d", showing, total)
 	if m.reachabilityFilterAvailable() {
 		state += render.Style(" | Reachability: ", render.Dim) + render.Style(titleCase(valueOrDefault(m.reachabilityFilter, "All")), render.BgYellow, render.Bold)
@@ -1552,7 +1530,7 @@ func (m *scanModel) buildFindingsListModel() *listModel {
 // list lines up one row per source repository (worst-scoring first), and
 // the details pane shows the full Scorecard breakdown plus the packages
 // that resolved to the selected repo. The `g` key cycles between two
-// grouping axes: "repository" (default) and "check".
+// grouping axes: "check" (default) and "repository".
 func (m *scanModel) buildPostureListModel() *listModel {
 	rows := postureRowsFromGraph(m.graphValue, m.registry)
 	repoWidth := 40
@@ -1572,7 +1550,7 @@ func (m *scanModel) buildPostureListModel() *listModel {
 		}
 	}
 
-	group := valueOrDefault(m.postureGroup, "repository")
+	group := valueOrDefault(m.postureGroup, "check")
 	var items []listItem
 	var listTitle, listHeader string
 	switch group {
@@ -1861,7 +1839,7 @@ func (m *scanModel) sourceExplorerItems() []listItem {
 		if section.last {
 			tree = "└─ "
 		}
-		expanded := expandedValue(m.sourceExpanded, section.key, section.key == "target")
+		expanded := expandedValue(m.sourceExpanded, section.key, false)
 		items = append(items, sourceNode(section.title, section.key, tree, 1, true, expanded))
 		if !expanded {
 			continue
@@ -2455,13 +2433,7 @@ func (m *scanModel) componentTreeRows(rootID string) []listPackageRow {
 		}
 		rows = append(rows, row)
 
-		expanded := m.componentExpanded[pkg.ID]
-		if depth == 0 {
-			expanded = true
-			if _, ok := m.componentExpanded[pkg.ID]; ok {
-				expanded = m.componentExpanded[pkg.ID]
-			}
-		}
+		expanded := expandedValue(m.componentExpanded, pkg.ID, false)
 		if !expanded {
 			return
 		}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -149,6 +149,46 @@ type listPanel struct {
 
 const interactiveCommonNavigationHelp = "Up/Down or j/k move; Enter focus details (Up/Down scroll, Esc back); Home/End jump; q quits"
 
+func setVisibleExpansionLayer(list *listModel, expansion map[string]bool, expanded bool) bool {
+	if list == nil || expansion == nil {
+		return false
+	}
+	visible := list.visibleItemIndices()
+	if len(visible) == 0 {
+		return false
+	}
+	targetDepth := -1
+	for _, index := range visible {
+		item := list.items[index]
+		if !item.canOpen || item.key == "" || item.expanded == expanded {
+			continue
+		}
+		if targetDepth < 0 {
+			targetDepth = item.depth
+			continue
+		}
+		if expanded && item.depth < targetDepth {
+			targetDepth = item.depth
+		}
+		if !expanded && item.depth > targetDepth {
+			targetDepth = item.depth
+		}
+	}
+	if targetDepth < 0 {
+		return false
+	}
+	changed := false
+	for _, index := range visible {
+		item := list.items[index]
+		if !item.canOpen || item.key == "" || item.depth != targetDepth || item.expanded == expanded {
+			continue
+		}
+		expansion[item.key] = expanded
+		changed = true
+	}
+	return changed
+}
+
 type listPackageRow struct {
 	id               string
 	rootID           string
@@ -226,7 +266,7 @@ type scanModel struct {
 	licenseExpanded       map[string]bool
 	findingGroup          string
 	findingExpanded       map[string]bool
-	postureGroup          string // "repository" (default) or "check"
+	postureGroup          string // "check" (default) or "repository"
 	postureExpanded       map[string]bool
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -89,6 +89,7 @@ func TestInteractiveListModel_ViewIncludesDetails(t *testing.T) {
 	}
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 	model.Move(3)
 	view := model.View(90, 26)
 
@@ -270,6 +271,7 @@ func TestScanInteractiveModel_MultiManifestNavigation(t *testing.T) {
 	wrapper := &teaModel{inner: model, width: 100, height: 20}
 	updated, _ := wrapper.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")})
 	wrapper = updated.(*teaModel)
+	expandTreeLayers(model, 2)
 	plain = render.StripANSI(wrapper.View())
 	if !strings.Contains(plain, "multi (2 manifests)") || !strings.Contains(plain, "zod@3.23.0") {
 		t.Fatalf("expected unified component tree, got:\n%s", plain)
@@ -660,6 +662,7 @@ func TestScanInteractiveModel_FiltersAndScopeBadges(t *testing.T) {
 	}
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 
 	plain := render.StripANSI(model.View(100, 30))
 	if !strings.Contains(plain, "react@18.2.0") || !strings.Contains(plain, "vitest@2.0.0") {
@@ -718,6 +721,7 @@ func TestScanInteractiveModel_EcosystemFilterUpdatesComponents(t *testing.T) {
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
 	model.SelectView(2)
 	model.ecosystemFilter = "npm"
+	expandTreeLayers(model, 2)
 	model.rebuildListPreserveSelection()
 
 	plain := render.StripANSI(model.View(110, 32))
@@ -833,6 +837,7 @@ func TestScanInteractiveModel_UsesEnrichedVulnerabilitiesWithoutFindings(t *test
 	}
 
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 	model.Move(3)
 	components := render.StripANSI(model.View(110, 32))
 	if !strings.Contains(components, "react@18.2.0") || !strings.Contains(components, "HIGH") {
@@ -978,6 +983,7 @@ func TestScanInteractiveModel_VulnerabilityFilterEmptyStateDistinguishesNoMatche
 func TestScanInteractiveModel_ReachabilityFilterCyclesFromKeyboard(t *testing.T) {
 	model := newScanReachabilityFilterModel(t, true)
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 	wrapper := &teaModel{inner: model, width: 180, height: 40}
 
 	components := render.StripANSI(model.View(180, 40))
@@ -1088,6 +1094,7 @@ func TestScanInteractiveModel_SeverityFilterIncludesAnyAndNone(t *testing.T) {
 
 	model := newScanReachabilityFilterModel(t, true)
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 	model.CycleSeverityFilter()
 	if model.severityFilter != "any" {
 		t.Fatalf("expected first severity cycle to select any, got %q", model.severityFilter)
@@ -1169,28 +1176,41 @@ func newScanReachabilityFilterModel(t *testing.T, enabled bool) *scanModel {
 func assertInteractiveListTitles(t *testing.T, model *scanModel, contains, excludes []string) {
 	t.Helper()
 	titles := make([]string, 0, len(model.List().items))
-	titleSet := make(map[string]struct{}, len(model.List().items))
 	for _, item := range model.List().items {
 		titles = append(titles, item.title)
-		titleSet[item.title] = struct{}{}
 	}
 	joined := strings.Join(titles, "\n")
 	for _, want := range contains {
-		if _, ok := titleSet[want]; !ok {
+		if !listTitlesContain(titles, want) {
 			t.Fatalf("expected interactive list titles to contain %q, got:\n%s", want, joined)
 		}
 	}
 	for _, excluded := range excludes {
-		if _, ok := titleSet[excluded]; ok {
+		if listTitlesContain(titles, excluded) {
 			t.Fatalf("expected interactive list titles to exclude %q, got:\n%s", excluded, joined)
 		}
 	}
 }
 
+func expandTreeLayers(model treeControlModel, layers int) {
+	for i := 0; i < layers; i++ {
+		model.ExpandAll()
+	}
+}
+
+func listTitlesContain(titles []string, want string) bool {
+	for _, title := range titles {
+		if title == want || strings.HasPrefix(title, want+"  ") {
+			return true
+		}
+	}
+	return false
+}
+
 func assertInteractiveItemBadges(t *testing.T, model *scanModel, title string, expectedReachability []string) {
 	t.Helper()
 	for _, item := range model.List().items {
-		if item.title != title {
+		if item.title != title && !strings.HasPrefix(item.title, title+"  ") {
 			continue
 		}
 		var actual []string
@@ -1280,6 +1300,7 @@ func TestScanInteractiveModel_ComponentTreeExpandsSelectedNode(t *testing.T) {
 
 	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
 	model.SelectView(2)
+	expandTreeLayers(model, 2)
 	plain := render.StripANSI(model.View(100, 24))
 	if !strings.Contains(plain, "react@18.2.0") {
 		t.Fatalf("expected direct dependency in component tree, got:\n%s", plain)
@@ -1296,6 +1317,77 @@ func TestScanInteractiveModel_ComponentTreeExpandsSelectedNode(t *testing.T) {
 	}
 	if !strings.Contains(plain, "└─") && !strings.Contains(plain, "├─") {
 		t.Fatalf("expected component tree to use box-drawing connectors, got:\n%s", plain)
+	}
+}
+
+func TestScanInteractiveModel_ComponentExpandCollapseAllProgressesByLayer(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewDependencyRef("demo-app", "1.0.0")
+	direct := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0"})
+	transitive := sdk.NewDependency(sdk.Dependency{Name: "loose-envify", Version: "1.4.0"})
+	for _, pkg := range []*sdk.Dependency{root, direct, transitive} {
+		if err := g.AddNode(pkg); err != nil {
+			t.Fatalf("add package: %v", err)
+		}
+	}
+	if err := g.AddEdge(root.ID, direct.ID); err != nil {
+		t.Fatalf("add root dependency: %v", err)
+	}
+	if err := g.AddEdge(direct.ID, transitive.ID); err != nil {
+		t.Fatalf("add transitive dependency: %v", err)
+	}
+
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo-app"},
+			RelativePath:            ".",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "package-lock.json", Kind: "package-lock.json"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, consolidated, graphValue, nil)
+	model.SelectView(2)
+	assertViewContains(t, model, []string{"package-lock.json"}, []string{"demo-app@1.0.0", "react@18.2.0", "loose-envify@1.4.0"})
+
+	model.ExpandAll()
+	assertViewContains(t, model, []string{"demo-app@1.0.0"}, []string{"react@18.2.0", "loose-envify@1.4.0"})
+
+	model.ExpandAll()
+	assertViewContains(t, model, []string{"react@18.2.0"}, []string{"loose-envify@1.4.0"})
+
+	model.ExpandAll()
+	assertViewContains(t, model, []string{"loose-envify@1.4.0"}, nil)
+
+	model.CollapseAll()
+	assertViewContains(t, model, []string{"react@18.2.0"}, []string{"loose-envify@1.4.0"})
+
+	model.CollapseAll()
+	assertViewContains(t, model, []string{"demo-app@1.0.0"}, []string{"react@18.2.0"})
+
+	model.CollapseAll()
+	assertViewContains(t, model, []string{"package-lock.json"}, []string{"demo-app@1.0.0"})
+}
+
+func assertViewContains(t *testing.T, model *scanModel, contains, excludes []string) {
+	t.Helper()
+	plain := render.StripANSI(model.View(120, 30))
+	for _, want := range contains {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected view to contain %q, got:\n%s", want, plain)
+		}
+	}
+	for _, excluded := range excludes {
+		if strings.Contains(plain, excluded) {
+			t.Fatalf("expected view to exclude %q, got:\n%s", excluded, plain)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Apply progressive expand/collapse behavior across scan, explain, and diff TUI trees.
- Default tree rendering to one visible level so deeper nodes open layer by layer.
- Default vulnerability grouping to severity and posture grouping to check.
- Update and extend TUI tests for the new defaults and layered tree controls.

## Validation

- `go test ./internal/tui`
- `make test`