### PR TITLE
Refresh managed plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ Install, enable, and verify external plugins before they can participate in scan
 
 ```bash
 # Install a published plugin from GitHub Releases
-bomly plugin install github:acme/bomly-plugin-example@v1.2.0
-bomly plugin enable acme.detector.example
+bomly plugin install github:security-team/bomly-plugin-gomod@v1.2.0
+bomly plugin enable security-team.detector.gomod
 
 # Verify it
-bomly plugin verify acme.detector.example
+bomly plugin verify security-team.detector.gomod
 
 # Run it explicitly during a scan
-bomly scan --path ./my-go-project --detectors acme.detector.example --json
+bomly scan --path ./my-go-project --detectors security-team.detector.gomod --json
 ```
 
 Detector plugins declare package-manager support and evidence patterns through their detector contract. Bomly uses those patterns during runtime preparation so external detectors can participate in subproject discovery alongside built-ins.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [docs/CONFIG_REFERENCE.md](docs/CONFIG_REFERENCE.md) for the generated refer
 
 Bomly supports managed external plugins for detectors, matchers, and auditors.
 
-The common workflow is:
+Install, enable, and verify external plugins before they can participate in scans:
 
 ```bash
 # Install a published plugin from GitHub Releases
@@ -186,7 +186,7 @@ bomly scan --path ./my-go-project --detectors acme.detector.example --json
 
 Detector plugins declare package-manager support and evidence patterns through their detector contract. Bomly uses those patterns during runtime preparation so external detectors can participate in subproject discovery alongside built-ins.
 
-The full getting-started guide lives in [docs/PLUGINS.md](docs/PLUGINS.md), and the working example plugin lives in [examples/plugins/go-module-detector](examples/plugins/go-module-detector).
+The plugin hub lives in [docs/PLUGINS.md](docs/PLUGINS.md). Implementation guides are available for [detectors](docs/plugins/how-to-implement-detector.md), [matchers](docs/plugins/how-to-implement-matcher.md), and [auditors](docs/plugins/how-to-implement-auditor.md). The working example plugin lives in [examples/plugins/go-module-detector](examples/plugins/go-module-detector).
 
 ## Architecture
 

--- a/docs/DETECTORS.md
+++ b/docs/DETECTORS.md
@@ -50,7 +50,7 @@ bomly scan --detectors go-detector
 bomly scan --detectors -syft-detector
 
 # Add an external plugin detector
-bomly scan --detectors +acme.detector.example
+bomly scan --detectors +security-team.detector.gomod
 ```
 
 Pass the bare detector name to filter to only that detector, `+name` to add it on top of defaults, or `-name` to remove it.

--- a/docs/MATCHERS.md
+++ b/docs/MATCHERS.md
@@ -37,7 +37,7 @@ bomly scan --enrich --matchers osv
 bomly scan --enrich --matchers -depsdev-license-checker,-clearlydefined-license-checker
 
 # Add an external plugin matcher
-bomly scan --enrich --matchers +acme.matcher.example
+bomly scan --enrich --matchers +security-team.matcher.vulnfeed
 ```
 
 ## Network endpoints

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,68 +1,170 @@
 # Managed Plugins
 
-Bomly supports managed external plugins for detectors, matchers, and auditors.
+Bomly plugins let you extend scans without changing the Bomly binary. Today, managed external plugins can add:
 
-This document covers the current workflow for building, installing, verifying, and running them.
+- **detectors** that turn project files into dependency graphs
+- **matchers** that enrich packages with vulnerabilities, licenses, lifecycle data, or other package metadata
+- **auditors** that turn graph and registry data into findings or risk scores
 
-## What Managed Plugins Are
+External analyzer plugins are not supported yet. `bomly plugin list --analyzers` can show built-in reachability analyzers, but the external plugin runtime currently serves only detectors, matchers, and auditors through `sdk.ServeDetector`, `sdk.ServeMatcher`, and `sdk.ServeAuditor`.
 
-Managed plugins are Go binaries that use the Bomly plugin SDK and run in a separate process through HashiCorp `go-plugin`.
+## Start Here
 
-The SDK contract is also the source of truth for built-in detectors, matchers, and auditors. Built-ins run in-process and skip installation, enable/disable state, and verification, but they use the same metadata and execution contract as external plugins.
+Use this page when you want to install, trust, configure, package, or troubleshoot a managed plugin.
+
+Use the implementation guides when you are writing one:
+
+- [How To Implement A Detector Plugin](plugins/how-to-implement-detector.md)
+- [How To Implement A Matcher Plugin](plugins/how-to-implement-matcher.md)
+- [How To Implement An Auditor Plugin](plugins/how-to-implement-auditor.md)
+
+The repository also includes a working detector example at [`examples/plugins/go-module-detector`](../examples/plugins/go-module-detector).
+
+## How Plugins Run
+
+Managed plugins are Go binaries that use Bomly's public `sdk` package. Bomly starts each enabled external plugin as a separate native OS subprocess through HashiCorp `go-plugin` in gRPC mode.
 
 Bomly owns:
 
-- installation
-- manifest validation
-- checksum enforcement for direct URL installs
-- plugin store layout
-- enable and disable state
-- runtime loading during scan preparation
+- installing plugin packages
+- validating `bomly-plugin.json`
+- checking recorded checksums
+- storing plugins under `~/.bomly/plugins`
+- enabling and disabling plugins
+- loading enabled plugins during scan runtime preparation
 
 Plugins do not get install hooks, post-install scripts, or automatic execution from repository checkouts.
 
-## Runtime Policy
+## Trust And Enablement
 
-Installed external plugins are disabled by default. They do not participate in scans until you enable them with `bomly plugin enable <id>`.
+Installed external plugins are disabled by default. They do not participate in scans until you enable them:
 
-Enabled plugins are loaded during runtime preparation in local and CI workflows. Treat `bomly plugin enable` as the trust decision for running that external binary.
+```bash
+bomly plugin enable <plugin-id>
+```
 
-When enabled, a plugin binary runs as a native OS subprocess with the same user-level privileges as the bomly process. It can read and write files, make network connections, and execute system calls within those privileges.
+Treat `bomly plugin enable` as the trust decision. When enabled, a plugin runs with the same user-level privileges as the Bomly process. It can read and write files, make network connections, spawn child processes, and access environment variables available to that user.
+
+Repository-declared plugins are never executed automatically. The host must explicitly install and enable the plugin before it can run.
+
+## Try The Example Plugin
+
+Build the example detector from the repository root:
+
+```bash
+go build -o ./bin/bomly-example-gomod-detector ./examples/plugins/go-module-detector
+```
+
+On Windows, Go writes `./bin/bomly-example-gomod-detector.exe`. `bomly plugin install --dev` accepts either the extensionless path or the explicit `.exe` path.
+
+Install and enable it for local development:
+
+```bash
+bomly plugin install ./bin/bomly-example-gomod-detector --dev
+bomly plugin enable bomly.example.gomod-detector
+```
+
+Check that Bomly can see it:
+
+```bash
+bomly plugin list --external
+bomly plugin info bomly.example.gomod-detector
+```
+
+Run verification and readiness checks:
+
+```bash
+bomly plugin verify bomly.example.gomod-detector
+bomly plugin test bomly.example.gomod-detector
+bomly plugin doctor bomly.example.gomod-detector
+```
+
+Select it explicitly during a scan:
+
+```bash
+bomly scan \
+  --path ./my-go-project \
+  --detectors bomly.example.gomod-detector \
+  --json
+```
+
+Disable or uninstall it later:
+
+```bash
+bomly plugin disable bomly.example.gomod-detector
+bomly plugin uninstall bomly.example.gomod-detector
+```
+
+## Common Commands
+
+List plugins:
+
+```bash
+bomly plugin list
+bomly plugin list --external
+bomly plugin list --detectors
+bomly plugin list --matchers --json
+bomly plugin list --auditors
+```
+
+Show one plugin:
+
+```bash
+bomly plugin info <plugin-id>
+bomly plugin info <plugin-id> --json
+```
+
+Install a plugin:
+
+```bash
+bomly plugin install ./dist/bomly-plugin-example.tar.gz
+bomly plugin install ./bin/bomly-example-gomod-detector --dev
+bomly plugin install https://example.com/bomly-plugin-example.tar.gz --checksum sha256:...
+bomly plugin install github:acme/bomly-plugin-example@v1.2.0
+```
+
+Check a plugin:
+
+```bash
+bomly plugin verify <plugin-id> # manifest, checksum, binary, runtime metadata
+bomly plugin test <plugin-id>   # runtime readiness
+bomly plugin doctor <plugin-id> # verify + test
+```
+
+Enable, disable, or remove a plugin:
+
+```bash
+bomly plugin enable <plugin-id>
+bomly plugin disable <plugin-id>
+bomly plugin uninstall <plugin-id>
+```
+
+## Select Plugins During A Scan
+
+Plugin selectors use the same `+/-` grammar as built-in components:
+
+```bash
+# Use only this detector.
+bomly scan --detectors acme.detector.example
+
+# Add an external matcher to the default matcher set.
+bomly scan --enrich --matchers +acme.matcher.example
+
+# Use one auditor explicitly.
+bomly scan --audit --auditors acme.auditor.example
+```
+
+Detector plugins can participate in subproject discovery. Their manifest records `detectorDescriptor.packageManagerSupport`, and each support entry names a package manager plus evidence patterns such as `go.mod`. Bomly uses those patterns during runtime preparation so external detectors can join the same scan-planning flow as built-ins.
 
 ## Configuration And Proxy Support
 
 Bomly passes the active plugin API version, the explicit `BOMLY_CONFIG` path when one was provided, proxy settings, and the enabled plugin's own config to managed plugin subprocesses.
 
-Proxy settings can be configured with a direct proxy URL:
-
-```yaml
-network:
-  proxy:
-    url: http://proxy.example:8080
-    no_proxy: localhost,127.0.0.1,.corp.example
-```
-
-For environments that manage proxy details separately, Bomly also accepts decomposed proxy settings:
-
-```yaml
-network:
-  proxy:
-    type: http # http, https, or socks5
-    host: proxy.example
-    port: 8080
-    username: my-user
-    password: my-password
-    no_proxy: localhost,127.0.0.1,.corp.example
-  ca_cert_file: /path/to/proxy-ca-chain.pem
-```
-
-Equivalent environment variables are `BOMLY_HTTP_PROXY`, `BOMLY_HTTP_NO_PROXY`, `BOMLY_HTTP_PROXY_TYPE`, `BOMLY_HTTP_PROXY_HOST`, `BOMLY_HTTP_PROXY_PORT`, `BOMLY_HTTP_PROXY_USERNAME`, `BOMLY_HTTP_PROXY_PASSWORD`, and `BOMLY_HTTP_CA_CERT_FILE`. When Bomly proxy fields are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values to plugin subprocesses using the standard proxy environment variable names.
-
 Per-plugin configuration lives under `plugins.<plugin-id>`:
 
 ```yaml
 plugins:
-  acme.matcher:
+  acme.matcher.example:
     api_base: https://api.example.com
 ```
 
@@ -79,7 +181,34 @@ if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
 }
 ```
 
-Plugins that make outbound HTTP calls should create one process-local provider with `sdk.NewHTTPClientProviderFromEnv()` and reuse it for timeout-specific clients. This keeps proxy settings consistent while preserving Go's HTTP connection pooling:
+Proxy settings can be configured with a direct proxy URL:
+
+```yaml
+network:
+  proxy:
+    url: http://proxy.example:8080
+    no_proxy: localhost,127.0.0.1,.corp.example
+```
+
+Bomly also accepts decomposed proxy settings:
+
+```yaml
+network:
+  proxy:
+    type: http # http, https, or socks5
+    host: proxy.example
+    port: 8080
+    username: my-user
+    password: my-password
+    no_proxy: localhost,127.0.0.1,.corp.example
+  ca_cert_file: /path/to/proxy-ca-chain.pem
+```
+
+Equivalent environment variables are `BOMLY_HTTP_PROXY`, `BOMLY_HTTP_NO_PROXY`, `BOMLY_HTTP_PROXY_TYPE`, `BOMLY_HTTP_PROXY_HOST`, `BOMLY_HTTP_PROXY_PORT`, `BOMLY_HTTP_PROXY_USERNAME`, `BOMLY_HTTP_PROXY_PASSWORD`, and `BOMLY_HTTP_CA_CERT_FILE`.
+
+When Bomly proxy fields are not set, Bomly's SDK HTTP client still honors standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For compatibility with non-SDK plugin code, Bomly also forwards the effective proxy values using the standard proxy environment variable names.
+
+Plugins that make outbound HTTP calls should create one process-local provider with `sdk.NewHTTPClientProviderFromEnv()` and reuse it for timeout-specific clients:
 
 ```go
 provider, err := sdk.NewHTTPClientProviderFromEnv()
@@ -89,11 +218,9 @@ if err != nil {
 client := provider.Client(20 * time.Second)
 ```
 
-## Plugin Layout
+## Package Layout
 
-External plugin packages include a `bomly-plugin.json` manifest and a platform entrypoint binary.
-
-Typical layout:
+An external plugin package includes a `bomly-plugin.json` manifest and one or more platform entrypoint binaries:
 
 ```text
 bomly-plugin.json
@@ -113,187 +240,7 @@ Installed plugins are stored under:
       <version>/
 ```
 
-## Discovery Patterns
-
-Detector plugin manifests declare package-manager support inside `detectorDescriptor.packageManagerSupport`. Each support entry names a package manager and can include evidence patterns such as `go.mod`; Bomly derives ecosystem and manager planning data from those entries.
-
-Bomly uses those patterns during runtime preparation:
-
-- matching files can create or augment the normal package-manager subproject plan
-- pattern-driven support can still plan a standalone detector subproject when it does not map to a built-in package-manager pattern
-
-That keeps external detectors inside the same scan-planning flow as built-ins instead of dispatching them ad hoc from CLI commands.
-
-## Getting Started
-
-The repo includes a working example detector plugin at:
-
-[`examples/plugins/go-module-detector`](../examples/plugins/go-module-detector)
-
-Build it from the repository root:
-
-```bash
-go build -o ./bin/bomly-example-gomod-detector ./examples/plugins/go-module-detector
-```
-
-On Windows, the built file is `./bin/bomly-example-gomod-detector.exe`. `bomly plugin install --dev` accepts either the extensionless path or the explicit `.exe` path.
-
-Install it in development mode:
-
-```bash
-bomly plugin install ./bin/bomly-example-gomod-detector --dev
-bomly plugin enable bomly.example.gomod-detector
-```
-
-List installed plugins:
-
-```bash
-bomly plugin list --external --json
-```
-
-Verify the installation:
-
-```bash
-bomly plugin verify bomly.example.gomod-detector
-```
-
-Test runtime readiness (without running verify):
-
-```bash
-bomly plugin test bomly.example.gomod-detector
-```
-
-Run a full health check (verify + test):
-
-```bash
-bomly plugin doctor bomly.example.gomod-detector
-```
-
-Run a scan with the plugin selected explicitly:
-
-```bash
-bomly scan \
-  --path ./my-go-project \
-  --detectors bomly.example.gomod-detector \
-  --json
-```
-
-Disable or uninstall it later:
-
-```bash
-bomly plugin disable bomly.example.gomod-detector
-bomly plugin uninstall bomly.example.gomod-detector
-```
-
-## Authoring Model
-
-Plugin authors import:
-
-```text
-github.com/bomly-dev/bomly-cli/sdk
-```
-
-Minimal detector example:
-
-```go
-package main
-
-import (
-    "context"
-
-    "github.com/bomly-dev/bomly-cli/sdk"
-)
-
-type Detector struct{}
-
-func (d *Detector) Metadata(ctx context.Context) (*sdk.PluginMetadata, error) {
-    return &sdk.PluginMetadata{
-        ID:               "acme.detector.example",
-        Name:             "Acme Example Detector",
-        Version:          "1.0.0",
-        Kind:             sdk.PluginKindDetector,
-        PluginAPIVersion: sdk.PluginAPIVersion,
-    }, nil
-}
-
-func (d *Detector) Descriptor(ctx context.Context) (*sdk.DetectorDescriptor, error) {
-    return &sdk.DetectorDescriptor{
-        Name:           "acme.detector.example",
-        Enabled:        true,
-        Origin:         sdk.ExternalOrigin,
-        Capabilities:   []string{"dependency-detection"},
-    }, nil
-}
-
-func (d *Detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
-    return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGoMod, "go.mod")}, nil
-}
-
-func (d *Detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
-    return &sdk.ReadyResponse{Ready: true}, nil
-}
-
-func (d *Detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
-    return &sdk.ApplicableResponse{Applicable: true}, nil
-}
-
-func (d *Detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
-    return &sdk.DetectResponse{}, nil
-}
-
-func main() {
-    sdk.ServeDetector(&Detector{})
-}
-```
-
-Required SDK hooks:
-
-- detectors must implement `Descriptor`, `PackageManagerSupport`, `Ready`, `Applicable`, and `Detect`
-- matchers must implement `Descriptor`, `Ready`, `Applicable`, and `Match`
-- auditors must implement `Descriptor`, `Ready`, `Applicable`, and `Audit`
-
-Detector plugins may additionally implement `Install` when they support install-first execution.
-
-## Registry-Aware Matchers And Auditors
-
-Bomly's plugin model uses the same three-collection shape as the in-process engine:
-
-- `sdk.Dependency` nodes live in `req.Graph` and describe detected dependency instances plus relationships.
-- `sdk.Package` records live in `req.Registry`, keyed by canonical PURL.
-- `sdk.Finding` values reference registry packages by PURL instead of embedding copied package or vulnerability data.
-
-Matchers enrich the registry in place:
-
-```go
-func (m *Matcher) Match(ctx context.Context, req *sdk.MatchRequest) (*sdk.MatchResponse, error) {
-    pkg := req.Registry.Ensure("pkg:npm/lodash@4.17.15")
-    pkg.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
-    pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{ID: "GHSA-...", Source: "acme"})
-    return &sdk.MatchResponse{Registry: req.Registry, MatcherRuns: []string{"acme.matcher"}}, nil
-}
-```
-
-Auditors read `req.Graph` and `req.Registry`, then emit reference-style findings:
-
-```go
-finding := sdk.Finding{
-    ID:              "GHSA-...",
-    Kind:            sdk.FindingKindVulnerability,
-    PackageRef:      "pkg:npm/lodash@4.17.15",
-    VulnerabilityID: "GHSA-...",
-    Disposition:     sdk.FindingDispositionFail,
-}
-```
-
-Detector plugins should build dependency graphs with the SDK constructors:
-
-```go
-dep := sdk.NewDependency(sdk.Dependency{Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
-_ = graph.AddNode(dep)
-_ = graph.AddEdge(parent.ID, dep.ID)
-```
-
-See [`docs/MODELS.md`](MODELS.md) for the full model reference and migration notes.
+The manifest identity must match the runtime metadata returned by the plugin binary. A detector manifest must also include package-manager support so Bomly can plan when the detector should run.
 
 ## Supported Install Sources
 
@@ -304,24 +251,15 @@ Current supported sources are:
 - direct URL with checksum
 - GitHub Release via `github:owner/repo@tag`
 
-Examples:
-
-```bash
-bomly plugin install ./dist/bomly-plugin-example.tar.gz
-bomly plugin install ./bin/bomly-example-gomod-detector --dev
-bomly plugin install https://example.com/bomly-plugin-example.tar.gz --checksum sha256:...
-bomly plugin install github:acme/bomly-plugin-example@v1.2.0
-```
-
-For GitHub Release installs, Bomly resolves the release metadata, selects the asset matching the current OS and architecture, and uses a `SHA256SUMS` asset when present to verify the archive automatically.
+For GitHub Release installs, Bomly resolves release metadata, selects the asset matching the current OS and architecture, and uses a `SHA256SUMS` asset when present to verify the archive automatically.
 
 ## Security Model
 
-External plugins are native OS subprocesses. They are not sandboxed, not containerized, and not restricted by Bomly in any way beyond the operating system's standard user-level privilege boundary. When a plugin runs, it inherits the full privileges of the user invoking bomly: it can read and write files, open network connections, spawn child processes, and access environment variables.
+External plugins are native OS subprocesses. They are not sandboxed, not containerized, and not restricted by Bomly beyond the operating system's standard user-level privilege boundary.
 
 **What Bomly validates before executing a plugin:**
 
-- Manifest schema and required fields (ID, version, kind, runtime, API version)
+- Manifest schema and required fields: ID, version, kind, runtime, API version
 - Plugin API version compatibility with the running core version
 - Entrypoint binary exists at the recorded path
 - SHA256 checksum matches the installed record, when a checksum was recorded
@@ -337,9 +275,9 @@ External plugins are native OS subprocesses. They are not sandboxed, not contain
 **Installation mode risk:**
 
 | Source | Integrity guarantee |
-|--------|---------------------|
-| Local archive (`bomly plugin install ./plugin.tar.gz --checksum sha256:...`) | Strongest: checksum ties the installed binary to the declared archive |
-| GitHub Release (`github:owner/repo@tag`) | SHA256SUMS asset verified automatically when present |
+| --- | --- |
+| Local archive with `--checksum sha256:...` | Strongest: checksum ties the installed binary to the declared archive |
+| GitHub Release with `SHA256SUMS` | Release asset is verified automatically when checksums are present |
 | Direct URL with `--checksum` | Checksum ties the download to the declared identity |
 | Direct URL with `--insecure-skip-checksum` | None: the downloaded binary may differ from the declared source |
 | Local binary with `--dev` | None: appropriate only for binaries you built locally |
@@ -348,6 +286,6 @@ External plugins are native OS subprocesses. They are not sandboxed, not contain
 
 - Always supply `--checksum` for direct URL installs.
 - Run `bomly plugin verify <id>` before enabling any plugin installed from an external source.
-- Treat `bomly plugin enable` as the explicit trust decision for granting execution privileges. Do not enable plugins you did not build or obtain from a source you control.
-- Prefer `github:owner/repo@tag` installs — they resolve the asset for your current OS and architecture and verify against the published SHA256SUMS automatically.
-- Repository-declared plugins are never executed automatically. Bomly requires an explicit `bomly plugin enable` on the host before any external plugin participates in a scan.
+- Treat `bomly plugin enable` as the explicit trust decision for granting execution privileges.
+- Prefer `github:owner/repo@tag` installs when releases publish `SHA256SUMS`.
+- Do not enable plugins you did not build or obtain from a source you control.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -120,7 +120,7 @@ Install a plugin:
 bomly plugin install ./dist/bomly-plugin-example.tar.gz
 bomly plugin install ./bin/bomly-example-gomod-detector --dev
 bomly plugin install https://example.com/bomly-plugin-example.tar.gz --checksum sha256:...
-bomly plugin install github:acme/bomly-plugin-example@v1.2.0
+bomly plugin install github:security-team/bomly-plugin-gomod@v1.2.0
 ```
 
 Check a plugin:
@@ -145,13 +145,13 @@ Plugin selectors use the same `+/-` grammar as built-in components:
 
 ```bash
 # Use only this detector.
-bomly scan --detectors acme.detector.example
+bomly scan --detectors security-team.detector.gomod
 
 # Add an external matcher to the default matcher set.
-bomly scan --enrich --matchers +acme.matcher.example
+bomly scan --enrich --matchers +security-team.matcher.vulnfeed
 
 # Use one auditor explicitly.
-bomly scan --audit --auditors acme.auditor.example
+bomly scan --audit --auditors security-team.auditor.policy
 ```
 
 Detector plugins can participate in subproject discovery. Their manifest records `detectorDescriptor.packageManagerSupport`, and each support entry names a package manager plus evidence patterns such as `go.mod`. Bomly uses those patterns during runtime preparation so external detectors can join the same scan-planning flow as built-ins.
@@ -164,7 +164,7 @@ Per-plugin configuration lives under `plugins.<plugin-id>`:
 
 ```yaml
 plugins:
-  acme.matcher.example:
+  security-team.matcher.vulnfeed:
     api_base: https://api.example.com
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ How Bomly thinks about your project.
 - [Matchers](MATCHERS.md) — enriching the graph with vulnerability, license, lifecycle data
 - [Auditors](AUDITORS.md) — evaluating the graph against policy
 - [Reachability](REACHABILITY.md) — narrowing findings to code your app actually calls
-- [Plugins](PLUGINS.md) — extending Bomly with external detectors, matchers, auditors
+- [Plugins](PLUGINS.md) — install, trust, configure, and package external plugins
+- Plugin implementation guides: [detector](plugins/how-to-implement-detector.md), [matcher](plugins/how-to-implement-matcher.md), [auditor](plugins/how-to-implement-auditor.md)
 - [Glossary](GLOSSARY.md) — every term, one sentence each
 
 ## Reference

--- a/docs/plugins/how-to-implement-auditor.md
+++ b/docs/plugins/how-to-implement-auditor.md
@@ -1,0 +1,189 @@
+# How To Implement An Auditor Plugin
+
+An auditor plugin evaluates the dependency graph and package registry after detection and optional enrichment. Use an auditor when you want to produce findings, risk scores, or policy-style decisions from data Bomly already has.
+
+External auditor plugins are served with `sdk.ServeAuditor`.
+
+## Minimum Shape
+
+Create a Go `main` package that imports the Bomly SDK:
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const pluginID = "acme.auditor.example"
+
+type auditor struct{}
+
+func (a *auditor) Metadata(context.Context) (*sdk.PluginMetadata, error) {
+    return &sdk.PluginMetadata{
+        ID:               pluginID,
+        Name:             "Acme Example Auditor",
+        Version:          "0.1.0",
+        Kind:             sdk.PluginKindAuditor,
+        PluginAPIVersion: sdk.PluginAPIVersion,
+    }, nil
+}
+
+func (a *auditor) Descriptor(context.Context) (*sdk.AuditorDescriptor, error) {
+    return &sdk.AuditorDescriptor{
+        Name:    pluginID,
+        Enabled: true,
+        Origin:  sdk.ExternalOrigin,
+    }, nil
+}
+
+func (a *auditor) Ready(context.Context, *sdk.AuditRequest) (*sdk.ReadyResponse, error) {
+    return &sdk.ReadyResponse{Ready: true}, nil
+}
+
+func (a *auditor) Applicable(context.Context, *sdk.AuditRequest) (*sdk.ApplicableResponse, error) {
+    return &sdk.ApplicableResponse{Applicable: true}, nil
+}
+
+func (a *auditor) Audit(ctx context.Context, req *sdk.AuditRequest) (*sdk.AuditResponse, error) {
+    finding := sdk.Finding{
+        ID:          "acme-policy-example",
+        Kind:        sdk.FindingKindPackage,
+        PackageRef:  "pkg:npm/lodash@4.17.21",
+        Disposition: sdk.FindingDispositionFail,
+        Title:       "Example policy finding",
+        Source:      pluginID,
+    }
+
+    return &sdk.AuditResponse{
+        Findings:        []sdk.Finding{finding},
+        AuditorRuns:     []string{pluginID},
+        AuditorFindings: map[string]int{pluginID: 1},
+    }, nil
+}
+
+func main() {
+    sdk.ServeAuditor(&auditor{})
+}
+```
+
+## What Each Hook Does
+
+- `Metadata` returns the plugin identity. The ID, version, kind, and API version must match the installed manifest.
+- `Descriptor` describes the auditor registration. Use `sdk.ExternalOrigin` for external plugins.
+- `Ready` reports whether the plugin can run in the current environment.
+- `Applicable` reports whether the auditor should run for the current request.
+- `Audit` reads `sdk.AuditRequest` and returns findings, risk scores, and run metadata.
+
+## Read Graph And Registry Data
+
+Bomly gives auditors the same core scan data used by built-in auditors:
+
+- `req.Graph` contains dependency nodes and edges.
+- `req.Registry` contains package records keyed by PURL.
+- `req.BaselineGraph` may be present for diff-style workflows.
+- `req.Target` may be present when a command focuses on one dependency.
+
+Auditors should emit reference-style findings that point at registry packages by PURL:
+
+```go
+finding := sdk.Finding{
+    ID:              "GHSA-example",
+    Kind:            sdk.FindingKindVulnerability,
+    PackageRef:      "pkg:npm/lodash@4.17.21",
+    VulnerabilityID: "GHSA-example",
+    Disposition:     sdk.FindingDispositionFail,
+    Source:          pluginID,
+}
+```
+
+Do not copy full package or vulnerability records into findings. Keep the finding focused on the decision and references.
+
+## Configuration And HTTP
+
+Per-plugin config lives under `plugins.<plugin-id>`:
+
+```yaml
+plugins:
+  acme.auditor.example:
+    policy_file: ./bomly-policy.yaml
+```
+
+Read it with:
+
+```go
+type config struct {
+    PolicyFile string `json:"policy_file"`
+}
+
+var cfg config
+if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
+    return nil, err
+}
+```
+
+Auditors should normally evaluate data already present in `req.Graph` and `req.Registry`. If an auditor intentionally calls an external service, document that behavior and use Bomly's SDK HTTP provider so proxy settings work consistently:
+
+```go
+provider, err := sdk.NewHTTPClientProviderFromEnv()
+if err != nil {
+    return nil, err
+}
+client := provider.Client(20 * time.Second)
+_ = client
+```
+
+## Package And Install
+
+For development, build and install the binary directly:
+
+```bash
+go build -o ./bin/acme-auditor ./cmd/acme-auditor
+bomly plugin install ./bin/acme-auditor --dev
+bomly plugin enable acme.auditor.example
+```
+
+For distribution, package a `bomly-plugin.json` manifest with the binary:
+
+```text
+bomly-plugin.json
+bin/
+  acme-auditor
+README.md
+LICENSE
+```
+
+## Test It
+
+Check installation and runtime readiness:
+
+```bash
+bomly plugin verify acme.auditor.example
+bomly plugin test acme.auditor.example
+bomly plugin doctor acme.auditor.example
+```
+
+Run only this auditor:
+
+```bash
+bomly scan --path ./my-project --audit --auditors acme.auditor.example --json
+```
+
+Or add it to the default auditor set:
+
+```bash
+bomly scan --path ./my-project --audit --auditors +acme.auditor.example
+```
+
+## Implementation Checklist
+
+- Return stable `PluginMetadata` and keep it in sync with the manifest.
+- Read `req.Graph` and `req.Registry`; emit reference-style findings.
+- Return `AuditorRuns` with the auditor ID.
+- Use actionable finding summaries and dispositions.
+- Avoid external network calls unless the plugin explicitly documents them.
+- Wrap errors with useful context and avoid panics.
+- Do not log secrets, tokens, or credentials.
+- Add unit tests for policy evaluation and finding construction.

--- a/docs/plugins/how-to-implement-auditor.md
+++ b/docs/plugins/how-to-implement-auditor.md
@@ -17,14 +17,14 @@ import (
     "github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const pluginID = "acme.auditor.example"
+const pluginID = "security-team.auditor.policy"
 
 type auditor struct{}
 
 func (a *auditor) Metadata(context.Context) (*sdk.PluginMetadata, error) {
     return &sdk.PluginMetadata{
         ID:               pluginID,
-        Name:             "Acme Example Auditor",
+        Name:             "Security Team Policy Auditor",
         Version:          "0.1.0",
         Kind:             sdk.PluginKindAuditor,
         PluginAPIVersion: sdk.PluginAPIVersion,
@@ -49,7 +49,7 @@ func (a *auditor) Applicable(context.Context, *sdk.AuditRequest) (*sdk.Applicabl
 
 func (a *auditor) Audit(ctx context.Context, req *sdk.AuditRequest) (*sdk.AuditResponse, error) {
     finding := sdk.Finding{
-        ID:          "acme-policy-example",
+        ID:          "security-team-policy-example",
         Kind:        sdk.FindingKindPackage,
         PackageRef:  "pkg:npm/lodash@4.17.21",
         Disposition: sdk.FindingDispositionFail,
@@ -107,7 +107,7 @@ Per-plugin config lives under `plugins.<plugin-id>`:
 
 ```yaml
 plugins:
-  acme.auditor.example:
+  security-team.auditor.policy:
     policy_file: ./bomly-policy.yaml
 ```
 
@@ -140,9 +140,9 @@ _ = client
 For development, build and install the binary directly:
 
 ```bash
-go build -o ./bin/acme-auditor ./cmd/acme-auditor
-bomly plugin install ./bin/acme-auditor --dev
-bomly plugin enable acme.auditor.example
+go build -o ./bin/security-team-policy-auditor ./cmd/security-team-policy-auditor
+bomly plugin install ./bin/security-team-policy-auditor --dev
+bomly plugin enable security-team.auditor.policy
 ```
 
 For distribution, package a `bomly-plugin.json` manifest with the binary:
@@ -150,7 +150,7 @@ For distribution, package a `bomly-plugin.json` manifest with the binary:
 ```text
 bomly-plugin.json
 bin/
-  acme-auditor
+  security-team-policy-auditor
 README.md
 LICENSE
 ```
@@ -160,21 +160,21 @@ LICENSE
 Check installation and runtime readiness:
 
 ```bash
-bomly plugin verify acme.auditor.example
-bomly plugin test acme.auditor.example
-bomly plugin doctor acme.auditor.example
+bomly plugin verify security-team.auditor.policy
+bomly plugin test security-team.auditor.policy
+bomly plugin doctor security-team.auditor.policy
 ```
 
 Run only this auditor:
 
 ```bash
-bomly scan --path ./my-project --audit --auditors acme.auditor.example --json
+bomly scan --path ./my-project --audit --auditors security-team.auditor.policy --json
 ```
 
 Or add it to the default auditor set:
 
 ```bash
-bomly scan --path ./my-project --audit --auditors +acme.auditor.example
+bomly scan --path ./my-project --audit --auditors +security-team.auditor.policy
 ```
 
 ## Implementation Checklist

--- a/docs/plugins/how-to-implement-detector.md
+++ b/docs/plugins/how-to-implement-detector.md
@@ -1,0 +1,181 @@
+# How To Implement A Detector Plugin
+
+A detector plugin turns project evidence into a Bomly dependency graph. Use a detector when Bomly needs a new way to read dependency data, such as a new package manager, a specialized manifest format, or an internal dependency source.
+
+External detector plugins are served with `sdk.ServeDetector`.
+
+## Minimum Shape
+
+Create a Go `main` package that imports the Bomly SDK:
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const pluginID = "acme.detector.example"
+
+type detector struct{}
+
+func (d *detector) Metadata(context.Context) (*sdk.PluginMetadata, error) {
+    return &sdk.PluginMetadata{
+        ID:               pluginID,
+        Name:             "Acme Example Detector",
+        Version:          "0.1.0",
+        Kind:             sdk.PluginKindDetector,
+        PluginAPIVersion: sdk.PluginAPIVersion,
+    }, nil
+}
+
+func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
+    return &sdk.DetectorDescriptor{
+        Name:         pluginID,
+        Enabled:      true,
+        Origin:       sdk.ExternalOrigin,
+        Capabilities: []string{"dependency-detection"},
+    }, nil
+}
+
+func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
+    return []sdk.PackageManagerSupport{
+        sdk.Support(sdk.PackageManagerGoMod, "go.mod"),
+    }, nil
+}
+
+func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
+    return &sdk.ReadyResponse{Ready: true}, nil
+}
+
+func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
+    return &sdk.ApplicableResponse{Applicable: true}, nil
+}
+
+func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
+    graph := sdk.New()
+    dep := sdk.NewDependency(sdk.Dependency{
+        Ecosystem: string(sdk.EcosystemGo),
+        Name:      "example.com/app",
+        Version:   "v0.0.0",
+        PURL:      "pkg:golang/example.com/app@v0.0.0",
+        FoundBy:   pluginID,
+    })
+    if err := graph.AddNode(dep); err != nil {
+        return nil, err
+    }
+    return &sdk.DetectResponse{
+        SubprojectInfo:      req.Subproject,
+        RootExecutionTarget: req.ExecutionTarget,
+        DetectorName:        pluginID,
+        Origin:              sdk.ExternalOrigin,
+        Graphs: &sdk.GraphContainer{
+            Entries: []sdk.GraphEntry{{
+                Manifest: sdk.ManifestMetadata{Path: "go.mod", Kind: sdk.ManifestKind("go.mod")},
+                Graph:    graph,
+            }},
+        },
+    }, nil
+}
+
+func main() {
+    sdk.ServeDetector(&detector{})
+}
+```
+
+The working example in this repository is [`examples/plugins/go-module-detector`](../../examples/plugins/go-module-detector).
+
+## What Each Hook Does
+
+- `Metadata` returns the plugin identity. The ID, version, kind, and API version must match the installed manifest.
+- `Descriptor` describes the detector registration. Use `sdk.ExternalOrigin` for external plugins.
+- `PackageManagerSupport` tells Bomly which package managers and evidence patterns can plan this detector.
+- `Ready` reports whether the plugin can run in the current environment.
+- `Applicable` reports whether the plugin should run for the current request.
+- `Detect` reads the request and returns a `sdk.DetectResponse` containing one or more manifest-scoped graphs.
+
+Detector plugins may also implement:
+
+```go
+func (d *detector) Install(context.Context, *sdk.DetectRequest) (*sdk.InstallResponse, error)
+```
+
+Use `Install` only for install-first detectors that prepare dependencies before graph resolution. Do not install package managers themselves; Bomly assumes required package managers already exist.
+
+## Build The Graph
+
+Use SDK graph helpers instead of constructing graph internals by hand:
+
+```go
+parent := sdk.NewDependency(sdk.Dependency{Name: "app", Version: "0.0.0", PURL: "pkg:generic/app@0.0.0"})
+child := sdk.NewDependency(sdk.Dependency{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"})
+
+graph := sdk.New()
+if err := graph.AddNode(parent); err != nil {
+    return nil, err
+}
+if err := graph.AddNode(child); err != nil {
+    return nil, err
+}
+if err := graph.AddEdge(parent.ID, child.ID); err != nil {
+    return nil, err
+}
+```
+
+Return `req.Subproject` and `req.ExecutionTarget` in the response so Bomly can keep the result tied to the planned scan target.
+
+## Package And Install
+
+For development, build and install the binary directly:
+
+```bash
+go build -o ./bin/acme-detector ./cmd/acme-detector
+bomly plugin install ./bin/acme-detector --dev
+bomly plugin enable acme.detector.example
+```
+
+For distribution, package a `bomly-plugin.json` manifest with the binary:
+
+```text
+bomly-plugin.json
+bin/
+  acme-detector
+README.md
+LICENSE
+```
+
+The detector manifest must include `detectorDescriptor.packageManagerSupport`; Bomly uses it for subproject discovery and scan planning.
+
+## Test It
+
+Check installation and runtime readiness:
+
+```bash
+bomly plugin verify acme.detector.example
+bomly plugin test acme.detector.example
+bomly plugin doctor acme.detector.example
+```
+
+Run only this detector:
+
+```bash
+bomly scan --path ./my-project --detectors acme.detector.example --json
+```
+
+Or add it to the default detector set:
+
+```bash
+bomly scan --path ./my-project --detectors +acme.detector.example
+```
+
+## Implementation Checklist
+
+- Return stable `PluginMetadata` and keep it in sync with the manifest.
+- Declare accurate package-manager support and evidence patterns.
+- Wrap errors with useful context.
+- Avoid panics in normal flow.
+- Do not log secrets, tokens, or credentials.
+- Keep network calls explicit and explain them in the plugin README.
+- Add local unit tests for parsing and graph construction.

--- a/docs/plugins/how-to-implement-detector.md
+++ b/docs/plugins/how-to-implement-detector.md
@@ -17,14 +17,14 @@ import (
     "github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const pluginID = "acme.detector.example"
+const pluginID = "security-team.detector.gomod"
 
 type detector struct{}
 
 func (d *detector) Metadata(context.Context) (*sdk.PluginMetadata, error) {
     return &sdk.PluginMetadata{
         ID:               pluginID,
-        Name:             "Acme Example Detector",
+        Name:             "Security Team Go Module Detector",
         Version:          "0.1.0",
         Kind:             sdk.PluginKindDetector,
         PluginAPIVersion: sdk.PluginAPIVersion,
@@ -131,9 +131,9 @@ Return `req.Subproject` and `req.ExecutionTarget` in the response so Bomly can k
 For development, build and install the binary directly:
 
 ```bash
-go build -o ./bin/acme-detector ./cmd/acme-detector
-bomly plugin install ./bin/acme-detector --dev
-bomly plugin enable acme.detector.example
+go build -o ./bin/security-team-gomod-detector ./cmd/security-team-gomod-detector
+bomly plugin install ./bin/security-team-gomod-detector --dev
+bomly plugin enable security-team.detector.gomod
 ```
 
 For distribution, package a `bomly-plugin.json` manifest with the binary:
@@ -141,7 +141,7 @@ For distribution, package a `bomly-plugin.json` manifest with the binary:
 ```text
 bomly-plugin.json
 bin/
-  acme-detector
+  security-team-gomod-detector
 README.md
 LICENSE
 ```
@@ -153,21 +153,21 @@ The detector manifest must include `detectorDescriptor.packageManagerSupport`; B
 Check installation and runtime readiness:
 
 ```bash
-bomly plugin verify acme.detector.example
-bomly plugin test acme.detector.example
-bomly plugin doctor acme.detector.example
+bomly plugin verify security-team.detector.gomod
+bomly plugin test security-team.detector.gomod
+bomly plugin doctor security-team.detector.gomod
 ```
 
 Run only this detector:
 
 ```bash
-bomly scan --path ./my-project --detectors acme.detector.example --json
+bomly scan --path ./my-project --detectors security-team.detector.gomod --json
 ```
 
 Or add it to the default detector set:
 
 ```bash
-bomly scan --path ./my-project --detectors +acme.detector.example
+bomly scan --path ./my-project --detectors +security-team.detector.gomod
 ```
 
 ## Implementation Checklist

--- a/docs/plugins/how-to-implement-matcher.md
+++ b/docs/plugins/how-to-implement-matcher.md
@@ -1,0 +1,192 @@
+# How To Implement A Matcher Plugin
+
+A matcher plugin enriches packages after detection. Use a matcher when you want to add vulnerability data, license data, lifecycle information, health signals, or other package metadata to Bomly's package registry.
+
+External matcher plugins are served with `sdk.ServeMatcher`.
+
+## Minimum Shape
+
+Create a Go `main` package that imports the Bomly SDK:
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const pluginID = "acme.matcher.example"
+
+type matcher struct{}
+
+func (m *matcher) Metadata(context.Context) (*sdk.PluginMetadata, error) {
+    return &sdk.PluginMetadata{
+        ID:               pluginID,
+        Name:             "Acme Example Matcher",
+        Version:          "0.1.0",
+        Kind:             sdk.PluginKindMatcher,
+        PluginAPIVersion: sdk.PluginAPIVersion,
+    }, nil
+}
+
+func (m *matcher) Descriptor(context.Context) (*sdk.MatcherDescriptor, error) {
+    return &sdk.MatcherDescriptor{
+        Name:         pluginID,
+        Enabled:      true,
+        Origin:       sdk.ExternalOrigin,
+        Priority:     100,
+        Capabilities: []string{"package-enrichment"},
+    }, nil
+}
+
+func (m *matcher) Ready(context.Context, *sdk.MatchRequest) (*sdk.ReadyResponse, error) {
+    return &sdk.ReadyResponse{Ready: true}, nil
+}
+
+func (m *matcher) Applicable(context.Context, *sdk.MatchRequest) (*sdk.ApplicableResponse, error) {
+    return &sdk.ApplicableResponse{Applicable: true}, nil
+}
+
+func (m *matcher) Match(ctx context.Context, req *sdk.MatchRequest) (*sdk.MatchResponse, error) {
+    registry := req.Registry
+    if registry == nil {
+        registry = sdk.NewPackageRegistry()
+    }
+
+    pkg := registry.Ensure("pkg:npm/lodash@4.17.21")
+    pkg.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
+    pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
+        ID:     "GHSA-example",
+        Source: "acme",
+    })
+
+    return &sdk.MatchResponse{
+        Registry:    registry,
+        MatcherRuns: []string{pluginID},
+    }, nil
+}
+
+func main() {
+    sdk.ServeMatcher(&matcher{})
+}
+```
+
+## What Each Hook Does
+
+- `Metadata` returns the plugin identity. The ID, version, kind, and API version must match the installed manifest.
+- `Descriptor` describes the matcher registration. Use `sdk.ExternalOrigin` for external plugins.
+- `Ready` reports whether the plugin can run in the current environment.
+- `Applicable` reports whether the matcher should run for the current request.
+- `Match` reads `sdk.MatchRequest` and returns a `sdk.MatchResponse` with the enriched registry.
+
+## Use The Registry
+
+Bomly separates dependency instances from package records:
+
+- `req.Graph` contains dependency nodes and edges.
+- `req.Registry` contains canonical package records keyed by PURL.
+- Matchers enrich registry packages and return the updated registry.
+
+Use `Ensure` when a package may already exist:
+
+```go
+pkg := req.Registry.Ensure("pkg:npm/lodash@4.17.21")
+pkg.Licenses = append(pkg.Licenses, sdk.PackageLicense{SPDXExpression: "MIT"})
+pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
+    ID:     "GHSA-example",
+    Source: "acme",
+})
+```
+
+Prefer canonical PURLs. Auditors and output rendering use PURLs to connect findings, vulnerabilities, and packages.
+
+## Configuration, HTTP, And Cache
+
+Per-plugin config lives under `plugins.<plugin-id>`:
+
+```yaml
+plugins:
+  acme.matcher.example:
+    api_base: https://api.example.com
+```
+
+Read it with:
+
+```go
+type config struct {
+    APIBase string `json:"api_base"`
+}
+
+var cfg config
+if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
+    return nil, err
+}
+```
+
+If the matcher calls an external service, use Bomly's SDK HTTP provider so proxy settings work consistently:
+
+```go
+provider, err := sdk.NewHTTPClientProviderFromEnv()
+if err != nil {
+    return nil, err
+}
+client := provider.Client(20 * time.Second)
+_ = client
+```
+
+If the matcher produces deterministic output for a fixed input and service version, add caching inside the plugin. Cache failures should be non-fatal: log a warning and continue without cached data.
+
+## Package And Install
+
+For development, build and install the binary directly:
+
+```bash
+go build -o ./bin/acme-matcher ./cmd/acme-matcher
+bomly plugin install ./bin/acme-matcher --dev
+bomly plugin enable acme.matcher.example
+```
+
+For distribution, package a `bomly-plugin.json` manifest with the binary:
+
+```text
+bomly-plugin.json
+bin/
+  acme-matcher
+README.md
+LICENSE
+```
+
+## Test It
+
+Check installation and runtime readiness:
+
+```bash
+bomly plugin verify acme.matcher.example
+bomly plugin test acme.matcher.example
+bomly plugin doctor acme.matcher.example
+```
+
+Run only this matcher during enrichment:
+
+```bash
+bomly scan --path ./my-project --enrich --matchers acme.matcher.example --json
+```
+
+Or add it to the default matcher set:
+
+```bash
+bomly scan --path ./my-project --enrich --matchers +acme.matcher.example
+```
+
+## Implementation Checklist
+
+- Return stable `PluginMetadata` and keep it in sync with the manifest.
+- Enrich `req.Registry`; do not replace graph identity.
+- Return `MatcherRuns` with the matcher ID.
+- Keep external network calls behind explicit enrichment.
+- Honor proxy settings through the SDK HTTP provider.
+- Wrap errors with useful context and avoid panics.
+- Do not log secrets, tokens, or credentials.
+- Add unit tests for mapping service responses into registry package data.

--- a/docs/plugins/how-to-implement-matcher.md
+++ b/docs/plugins/how-to-implement-matcher.md
@@ -17,14 +17,14 @@ import (
     "github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const pluginID = "acme.matcher.example"
+const pluginID = "security-team.matcher.vulnfeed"
 
 type matcher struct{}
 
 func (m *matcher) Metadata(context.Context) (*sdk.PluginMetadata, error) {
     return &sdk.PluginMetadata{
         ID:               pluginID,
-        Name:             "Acme Example Matcher",
+        Name:             "Security Team Vulnerability Feed Matcher",
         Version:          "0.1.0",
         Kind:             sdk.PluginKindMatcher,
         PluginAPIVersion: sdk.PluginAPIVersion,
@@ -59,7 +59,7 @@ func (m *matcher) Match(ctx context.Context, req *sdk.MatchRequest) (*sdk.MatchR
     pkg.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
     pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
         ID:     "GHSA-example",
-        Source: "acme",
+        Source: "security-team",
     })
 
     return &sdk.MatchResponse{
@@ -96,7 +96,7 @@ pkg := req.Registry.Ensure("pkg:npm/lodash@4.17.21")
 pkg.Licenses = append(pkg.Licenses, sdk.PackageLicense{SPDXExpression: "MIT"})
 pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
     ID:     "GHSA-example",
-    Source: "acme",
+    Source: "security-team",
 })
 ```
 
@@ -108,7 +108,7 @@ Per-plugin config lives under `plugins.<plugin-id>`:
 
 ```yaml
 plugins:
-  acme.matcher.example:
+  security-team.matcher.vulnfeed:
     api_base: https://api.example.com
 ```
 
@@ -143,9 +143,9 @@ If the matcher produces deterministic output for a fixed input and service versi
 For development, build and install the binary directly:
 
 ```bash
-go build -o ./bin/acme-matcher ./cmd/acme-matcher
-bomly plugin install ./bin/acme-matcher --dev
-bomly plugin enable acme.matcher.example
+go build -o ./bin/security-team-vulnfeed-matcher ./cmd/security-team-vulnfeed-matcher
+bomly plugin install ./bin/security-team-vulnfeed-matcher --dev
+bomly plugin enable security-team.matcher.vulnfeed
 ```
 
 For distribution, package a `bomly-plugin.json` manifest with the binary:
@@ -153,7 +153,7 @@ For distribution, package a `bomly-plugin.json` manifest with the binary:
 ```text
 bomly-plugin.json
 bin/
-  acme-matcher
+  security-team-vulnfeed-matcher
 README.md
 LICENSE
 ```
@@ -163,21 +163,21 @@ LICENSE
 Check installation and runtime readiness:
 
 ```bash
-bomly plugin verify acme.matcher.example
-bomly plugin test acme.matcher.example
-bomly plugin doctor acme.matcher.example
+bomly plugin verify security-team.matcher.vulnfeed
+bomly plugin test security-team.matcher.vulnfeed
+bomly plugin doctor security-team.matcher.vulnfeed
 ```
 
 Run only this matcher during enrichment:
 
 ```bash
-bomly scan --path ./my-project --enrich --matchers acme.matcher.example --json
+bomly scan --path ./my-project --enrich --matchers security-team.matcher.vulnfeed --json
 ```
 
 Or add it to the default matcher set:
 
 ```bash
-bomly scan --path ./my-project --enrich --matchers +acme.matcher.example
+bomly scan --path ./my-project --enrich --matchers +security-team.matcher.vulnfeed
 ```
 
 ## Implementation Checklist

--- a/examples/plugins/go-module-detector/README.md
+++ b/examples/plugins/go-module-detector/README.md
@@ -37,5 +37,4 @@ Run it explicitly:
 bomly scan --path ./some-go-module --detectors bomly.example.gomod-detector --format json
 ```
 
-For the full plugin workflow, see [docs/PLUGINS.md](../../../docs/PLUGINS.md).
-
+For the full plugin workflow, see [docs/PLUGINS.md](../../../docs/PLUGINS.md). For the detector authoring walkthrough, see [How To Implement A Detector Plugin](../../../docs/plugins/how-to-implement-detector.md).

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -91,7 +91,7 @@ bomly scan --detectors go-detector
 bomly scan --detectors -syft-detector
 
 # Add an external plugin detector
-bomly scan --detectors +acme.detector.example
+bomly scan --detectors +security-team.detector.gomod
 `+"```"+`
 
 Pass the bare detector name to filter to only that detector, `+"`+name`"+` to add it on top of defaults, or `+"`-name`"+` to remove it.
@@ -256,7 +256,7 @@ bomly scan --enrich --matchers osv
 bomly scan --enrich --matchers -depsdev-license-checker,-clearlydefined-license-checker
 
 # Add an external plugin matcher
-bomly scan --enrich --matchers +acme.matcher.example
+bomly scan --enrich --matchers +security-team.matcher.vulnfeed
 `+"```"+`
 
 ## Network endpoints


### PR DESCRIPTION
## Summary
- Rewrite `docs/PLUGINS.md` as a friendlier managed plugin hub for installing, trusting, configuring, packaging, and troubleshooting plugins
- Add separate implementation guides for detector, matcher, and auditor plugins under `docs/plugins/`
- Update README navigation and the example detector README so readers can find the hub and type-specific guides
- Clarify that external analyzer plugins are not currently supported, even though built-in analyzers can appear in plugin listings

## Validation
- Ran a local documentation link existence check for the touched docs
- `make test`

## Notes
- Docs-only change
- Did not run `make generate`; generated config/schema/support docs are unchanged
- Did not run smoke tests; no CLI behavior or golden outputs changed