### PR TITLE
fix(plugin): store entrypoint checksum instead of archive checksum

### DIFF
--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -246,12 +246,12 @@ func installLocalArtifact(ctx context.Context, tempDir, source string, opts Inst
 }
 
 func installArchiveAtPath(ctx context.Context, tempDir, archivePath, source, expectedChecksum string, skipChecksum bool) (Manifest, string, error) {
-	checksum, err := checksumFile(archivePath)
+	archiveChecksum, err := checksumFile(archivePath)
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	if expectedChecksum != "" && checksum != expectedChecksum {
-		return Manifest{}, "", fmt.Errorf("plugin checksum mismatch: expected %s, got %s", expectedChecksum, checksum)
+	if expectedChecksum != "" && archiveChecksum != expectedChecksum {
+		return Manifest{}, "", fmt.Errorf("plugin checksum mismatch: expected %s, got %s", expectedChecksum, archiveChecksum)
 	}
 	if !skipChecksum && expectedChecksum == "" && isRemoteURL(source) {
 		return Manifest{}, "", errors.New("plugin checksum is required for URL installs")
@@ -285,7 +285,11 @@ func installArchiveAtPath(ctx context.Context, tempDir, archivePath, source, exp
 	if err := writeRuntimeSnapshot(tempDir, snapshot); err != nil {
 		return Manifest{}, "", err
 	}
-	return manifest, checksum, nil
+	entrypointChecksum, err := checksumFile(fullEntrypoint)
+	if err != nil {
+		return Manifest{}, "", err
+	}
+	return manifest, entrypointChecksum, nil
 }
 
 func extractArchive(archivePath, targetDir string) error {


### PR DESCRIPTION
## Summary

- `installArchiveAtPath` stored the SHA256 of the downloaded **archive** (`.zip`/`.tar.gz`) in the installed plugin record
- `Verify` recomputes the checksum against the extracted **entrypoint binary** — two different files that can never produce the same hash
- This caused `bomly plugin verify` to always report a checksum mismatch for freshly installed archive-based plugins

## What changed

The archive checksum is still computed and validated against the expected value from `SHA256SUMS` during install (download integrity is preserved). What gets **stored** in the plugin record — and later re-checked by `verify` — is now the SHA256 of the extracted entrypoint binary, matching exactly what `verify.go` recomputes.

The `--dev-binary` install path was already correct (it hashes the binary directly) and is unchanged.

## Reviewer notes

Plugins installed **before this fix** have a stale archive checksum in their record. They will fail verification and need to be reinstalled to pick up a correct binary checksum.

## Test plan

- [x] `go test ./internal/plugin/...` passes
- [ ] Install a plugin from a local archive and confirm `bomly plugin verify` no longer reports a checksum mismatch
- [ ] Install with a mismatched `--checksum` and confirm the download is still rejected during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)