### PR TITLE
fix(smoke): update embedded plugin fixture to current SDK

### DIFF
--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -164,32 +164,13 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const (
-	pluginID      = "bomly.example.gomod-detector"
-	pluginVersion = "0.1.0"
-)
+const pluginID = "bomly.example.gomod-detector"
 
 type detector struct{}
 
-func (d *detector) Metadata(context.Context) (*sdk.PluginMetadata, error) {
-	return &sdk.PluginMetadata{
-		ID:               pluginID,
-		Name:             "Bomly Example Go Module Detector",
-		Version:          pluginVersion,
-		Kind:             sdk.PluginKindDetector,
-		PluginAPIVersion: sdk.PluginAPIVersion,
-		Description:      "Example managed detector plugin that reads a local go.mod and returns the module itself as a single package.",
-		Homepage:         "https://github.com/bomly-dev/bomly-plugin-bun-lock-detector",
-		License:          "Apache-2.0",
-	}, nil
-}
-
 func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
 	return &sdk.DetectorDescriptor{
-		Name:         pluginID,
-		Enabled:      true,
-		Origin:       sdk.ExternalOrigin,
-		Capabilities: []string{"dependency-detection"},
+		Name: pluginID,
 	}, nil
 }
 


### PR DESCRIPTION
### What
Updates the embedded example detector plugin in `test/smoke/plugin_test.go` (`examplePluginMainSource`) so it compiles against the current SDK.

### Why
`TestPluginWorkflows` writes that fixture to disk and `go build`s it at runtime. A prior SDK refactor (`96431ef`, #130) removed `sdk.PluginMetadata` and the `Enabled`/`Origin`/`Capabilities` fields on `DetectorDescriptor`, but the fixture was never updated. Smoke tests sit behind the `smoke` build tag, so `make test` never compiles the fixture — the breakage only surfaced in the golden-update workflow:

```
undefined: sdk.PluginMetadata
unknown field Enabled in struct literal of type sdk.DetectorDescriptor
unknown field Origin in struct literal of type sdk.DetectorDescriptor
unknown field Capabilities in struct literal of type sdk.DetectorDescriptor
```

### Changes
- Removed the obsolete `Metadata()` method — no longer part of the `ServedDetector` interface; plugin metadata now comes from the `bomly-plugin.json` manifest.
- Trimmed `Descriptor()` to the still-supported `Name` field. `ValidateDetectorDescriptor` only requires a non-empty name, and `PackageManagerSupport` is supplied via its own method, so installation still resolves the gomod support correctly.
- Dropped the now-unused `pluginVersion` const.

### Verification
- `go vet -tags smoke ./test/smoke/` passes.
- Extracted `examplePluginMainSource` into a temp module with a `replace` to the repo root and `go build` succeeded — this mirrors exactly what `buildExamplePlugin` does at runtime.
- Full `make smoke ARGS="-update"` not run locally (slow + requires network); CI golden-update workflow will regenerate `plugin-scan-*` goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)