### PR TITLE
fix(docs): correct ecosystem doc link depth to repo-root pages

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -26,7 +26,7 @@ bomly scan --audit --fail-on critical    # correct
 bomly scan --audit --fail-on severe      # exit 4
 ```
 
-See [Auditors](AUDITORS.md#-fail-on) for the grammar.
+See [Auditors](AUDITORS.md#--fail-on) for the grammar.
 
 ## "--format sarif requires --audit" (exit 4)
 

--- a/docs/detectors/ecosystems/alpm/README.md
+++ b/docs/detectors/ecosystems/alpm/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `alpm` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/apk/README.md
+++ b/docs/detectors/ecosystems/apk/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `apk` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/conda/README.md
+++ b/docs/detectors/ecosystems/conda/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `conda` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/cpp/README.md
+++ b/docs/detectors/ecosystems/cpp/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `cpp` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/dart/README.md
+++ b/docs/detectors/ecosystems/dart/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `dart` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/dotnet/README.md
+++ b/docs/detectors/ecosystems/dotnet/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `dotnet` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/dpkg/README.md
+++ b/docs/detectors/ecosystems/dpkg/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `dpkg` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/elixir/README.md
+++ b/docs/detectors/ecosystems/elixir/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `elixir` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/erlang/README.md
+++ b/docs/detectors/ecosystems/erlang/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `erlang` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/github-actions/README.md
+++ b/docs/detectors/ecosystems/github-actions/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `github-actions` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/go/README.md
+++ b/docs/detectors/ecosystems/go/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `go` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/haskell/README.md
+++ b/docs/detectors/ecosystems/haskell/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `haskell` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/homebrew/README.md
+++ b/docs/detectors/ecosystems/homebrew/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `homebrew` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/lua/README.md
+++ b/docs/detectors/ecosystems/lua/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `lua` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/maven/README.md
+++ b/docs/detectors/ecosystems/maven/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `maven` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/maven/gradle.md
+++ b/docs/detectors/ecosystems/maven/gradle.md
@@ -91,7 +91,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Gradle packages, the analyzer is `jvmreach` at **Tier-3 (package)** — same caveats as Maven. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Gradle packages, the analyzer is `jvmreach` at **Tier-3 (package)** — same caveats as Maven. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 For multi-project builds, `jvmreach` reads standard `include(...)` declarations and `projectDir` overrides automatically. Dynamically computed settings and composite `includeBuild` closures remain best-effort.
 

--- a/docs/detectors/ecosystems/maven/maven.md
+++ b/docs/detectors/ecosystems/maven/maven.md
@@ -98,7 +98,7 @@ Re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Maven packages, the analyzer is `jvmreach` at **Tier-3 (package)**. It walks `.java`, `.kt`, `.kts`, `.scala`, `.groovy` source files under the project root, parses top-of-file `import` statements, and maps fully-qualified-name prefixes to Maven coordinates via a curated longest-prefix map. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Maven packages, the analyzer is `jvmreach` at **Tier-3 (package)**. It walks `.java`, `.kt`, `.kts`, `.scala`, `.groovy` source files under the project root, parses top-of-file `import` statements, and maps fully-qualified-name prefixes to Maven coordinates via a curated longest-prefix map. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 For multi-module reactors, `jvmreach` reads parent `<modules>` declarations recursively and follows source namespace imports between consumed sibling modules before attributing external artifacts.
 

--- a/docs/detectors/ecosystems/nix/README.md
+++ b/docs/detectors/ecosystems/nix/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `nix` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/npm/README.md
+++ b/docs/detectors/ecosystems/npm/README.md
@@ -14,5 +14,5 @@ Package managers Bomly recognizes in the `npm` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/npm/npm.md
+++ b/docs/detectors/ecosystems/npm/npm.md
@@ -90,7 +90,7 @@ bomly explain lodash --path ./monorepo
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For npm packages, the analyzer is `jsreach` at **Tier-3 (package)**. It walks app source from `package.json` entry points and reports a package as reachable when there is any path from app source to that package through the npm dep graph. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe) — Tier-3 "unreachable" is a triage signal, not a safety guarantee.
+For npm packages, the analyzer is `jsreach` at **Tier-3 (package)**. It walks app source from `package.json` entry points and reports a package as reachable when there is any path from app source to that package through the npm dep graph. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe) — Tier-3 "unreachable" is a triage signal, not a safety guarantee.
 
 In workspace monorepos, `jsreach` automatically follows imports between consumed sibling packages by workspace package name. Unused siblings do not widen the reachable set.
 

--- a/docs/detectors/ecosystems/npm/pnpm.md
+++ b/docs/detectors/ecosystems/npm/pnpm.md
@@ -77,7 +77,7 @@ Bomly scans each pnpm workspace as a separate subproject. `injected: true` depen
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For pnpm packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For pnpm packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 `jsreach` reads `pnpm-workspace.yaml` package patterns automatically and follows imports between consumed sibling packages without depending on installed symlinks.
 

--- a/docs/detectors/ecosystems/npm/yarn.md
+++ b/docs/detectors/ecosystems/npm/yarn.md
@@ -79,7 +79,7 @@ Bomly walks Berry workspaces and scans each as a subproject. Plug-and-Play (`.pn
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Yarn packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Yarn packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 `jsreach` reads workspace arrays and Yarn-style `workspaces.packages` objects automatically, then follows imports between consumed sibling packages by package name.
 

--- a/docs/detectors/ecosystems/ocaml/README.md
+++ b/docs/detectors/ecosystems/ocaml/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `ocaml` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/php/README.md
+++ b/docs/detectors/ecosystems/php/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `php` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/portage/README.md
+++ b/docs/detectors/ecosystems/portage/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `portage` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/prolog/README.md
+++ b/docs/detectors/ecosystems/prolog/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `prolog` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/python/README.md
+++ b/docs/detectors/ecosystems/python/README.md
@@ -17,5 +17,5 @@ Package managers Bomly recognizes in the `python` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/python/pip.md
+++ b/docs/detectors/ecosystems/python/pip.md
@@ -93,7 +93,7 @@ Re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For pip-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. It walks every `.py` file under the project root, records imports, and maps module names to PyPI distribution names. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe) and the module-to-distribution map in `internal/analyzers/pyreach/moduletodist.go`.
+For pip-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. It walks every `.py` file under the project root, records imports, and maps module names to PyPI distribution names. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe) and the module-to-distribution map in `internal/analyzers/pyreach/moduletodist.go`.
 
 ## Limitations
 

--- a/docs/detectors/ecosystems/python/pipenv.md
+++ b/docs/detectors/ecosystems/python/pipenv.md
@@ -57,7 +57,7 @@ bomly scan --install-first --detectors pipenv-detector \
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Pipenv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Pipenv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/docs/detectors/ecosystems/python/poetry.md
+++ b/docs/detectors/ecosystems/python/poetry.md
@@ -81,7 +81,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Poetry-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Poetry-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/docs/detectors/ecosystems/python/uv.md
+++ b/docs/detectors/ecosystems/python/uv.md
@@ -88,7 +88,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For uv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For uv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/docs/detectors/ecosystems/r/README.md
+++ b/docs/detectors/ecosystems/r/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `r` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/rpm/README.md
+++ b/docs/detectors/ecosystems/rpm/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `rpm` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/ruby/README.md
+++ b/docs/detectors/ecosystems/ruby/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `ruby` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/rust/README.md
+++ b/docs/detectors/ecosystems/rust/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `rust` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/sbom/README.md
+++ b/docs/detectors/ecosystems/sbom/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `sbom` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/scala/README.md
+++ b/docs/detectors/ecosystems/scala/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `scala` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/snap/README.md
+++ b/docs/detectors/ecosystems/snap/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `snap` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/swift/README.md
+++ b/docs/detectors/ecosystems/swift/README.md
@@ -13,5 +13,5 @@ Package managers Bomly recognizes in the `swift` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/terraform/README.md
+++ b/docs/detectors/ecosystems/terraform/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `terraform` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/docs/detectors/ecosystems/wordpress/README.md
+++ b/docs/detectors/ecosystems/wordpress/README.md
@@ -12,5 +12,5 @@ Package managers Bomly recognizes in the `wordpress` ecosystem:
 
 - Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.
 - Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.
-- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).
+- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).
 - Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -525,7 +525,7 @@ func renderEcosystemReadme(ecosystem sdk.Ecosystem, entries []registry.PackageMa
 	b.WriteString("\n## How to read this\n\n")
 	b.WriteString("- Each package-manager page documents the exact commands Bomly runs (if any), the network behavior, and the lockfile or manifest formats supported.\n")
 	b.WriteString("- Bomly tries detector chains from left to right. Later detectors in the chain are fallbacks Bomly uses when the preferred detector cannot produce graph data.\n")
-	b.WriteString("- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../DETECTORS.md#install-first).\n")
+	b.WriteString("- Install-first support means `--install-first` can run the package manager's normal install command before graph resolution. This downloads packages and modifies the filesystem; see [docs/DETECTORS.md](../../../DETECTORS.md#install-first).\n")
 	b.WriteString("- Syft-backed entries provide broad compatibility, especially for containers and ecosystems without native Bomly graph resolution.\n")
 	return b.String()
 }

--- a/internal/support/prose/detectors/gradle.md
+++ b/internal/support/prose/detectors/gradle.md
@@ -76,7 +76,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Gradle packages, the analyzer is `jvmreach` at **Tier-3 (package)** — same caveats as Maven. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Gradle packages, the analyzer is `jvmreach` at **Tier-3 (package)** — same caveats as Maven. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 For multi-project builds, `jvmreach` reads standard `include(...)` declarations and `projectDir` overrides automatically. Dynamically computed settings and composite `includeBuild` closures remain best-effort.
 

--- a/internal/support/prose/detectors/maven.md
+++ b/internal/support/prose/detectors/maven.md
@@ -83,7 +83,7 @@ Re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Maven packages, the analyzer is `jvmreach` at **Tier-3 (package)**. It walks `.java`, `.kt`, `.kts`, `.scala`, `.groovy` source files under the project root, parses top-of-file `import` statements, and maps fully-qualified-name prefixes to Maven coordinates via a curated longest-prefix map. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Maven packages, the analyzer is `jvmreach` at **Tier-3 (package)**. It walks `.java`, `.kt`, `.kts`, `.scala`, `.groovy` source files under the project root, parses top-of-file `import` statements, and maps fully-qualified-name prefixes to Maven coordinates via a curated longest-prefix map. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 For multi-module reactors, `jvmreach` reads parent `<modules>` declarations recursively and follows source namespace imports between consumed sibling modules before attributing external artifacts.
 

--- a/internal/support/prose/detectors/npm.md
+++ b/internal/support/prose/detectors/npm.md
@@ -75,7 +75,7 @@ bomly explain lodash --path ./monorepo
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For npm packages, the analyzer is `jsreach` at **Tier-3 (package)**. It walks app source from `package.json` entry points and reports a package as reachable when there is any path from app source to that package through the npm dep graph. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe) — Tier-3 "unreachable" is a triage signal, not a safety guarantee.
+For npm packages, the analyzer is `jsreach` at **Tier-3 (package)**. It walks app source from `package.json` entry points and reports a package as reachable when there is any path from app source to that package through the npm dep graph. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe) — Tier-3 "unreachable" is a triage signal, not a safety guarantee.
 
 In workspace monorepos, `jsreach` automatically follows imports between consumed sibling packages by workspace package name. Unused siblings do not widen the reachable set.
 

--- a/internal/support/prose/detectors/pip.md
+++ b/internal/support/prose/detectors/pip.md
@@ -78,7 +78,7 @@ Re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For pip-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. It walks every `.py` file under the project root, records imports, and maps module names to PyPI distribution names. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe) and the module-to-distribution map in `internal/analyzers/pyreach/moduletodist.go`.
+For pip-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. It walks every `.py` file under the project root, records imports, and maps module names to PyPI distribution names. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe) and the module-to-distribution map in `internal/analyzers/pyreach/moduletodist.go`.
 
 ## Limitations
 

--- a/internal/support/prose/detectors/pipenv.md
+++ b/internal/support/prose/detectors/pipenv.md
@@ -42,7 +42,7 @@ bomly scan --install-first --detectors pipenv-detector \
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Pipenv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Pipenv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/internal/support/prose/detectors/pnpm.md
+++ b/internal/support/prose/detectors/pnpm.md
@@ -62,7 +62,7 @@ Bomly scans each pnpm workspace as a separate subproject. `injected: true` depen
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For pnpm packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For pnpm packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 `jsreach` reads `pnpm-workspace.yaml` package patterns automatically and follows imports between consumed sibling packages without depending on installed symlinks.
 

--- a/internal/support/prose/detectors/poetry.md
+++ b/internal/support/prose/detectors/poetry.md
@@ -66,7 +66,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Poetry-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Poetry-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/internal/support/prose/detectors/uv.md
+++ b/internal/support/prose/detectors/uv.md
@@ -73,7 +73,7 @@ Re-lock and re-scan.
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For uv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For uv-managed packages, the analyzer is `pyreach` at **Tier-3 (package)**. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 ## Limitations
 

--- a/internal/support/prose/detectors/yarn.md
+++ b/internal/support/prose/detectors/yarn.md
@@ -64,7 +64,7 @@ Bomly walks Berry workspaces and scans each as a subproject. Plug-and-Play (`.pn
 
 > **Experimental.** Reachability is opt-in via `--analyze`. The feature is stable in shape but may evolve; ecosystem coverage is expanding.
 
-For Yarn packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../REACHABILITY.md#unreachable-is-not-safe).
+For Yarn packages, the analyzer is `jsreach` at **Tier-3 (package)** — same caveats as npm. See [REACHABILITY.md](../../../REACHABILITY.md#unreachable-is-not-safe).
 
 `jsreach` reads workspace arrays and Yarn-style `workspaces.packages` objects automatically, then follows imports between consumed sibling packages by package name.
 


### PR DESCRIPTION
## What changed

The per-ecosystem detector docs live at `docs/detectors/ecosystems/<eco>/` (three levels under `docs/`), but their links to root reference pages used `../../` (two levels), resolving to **non-existent** `docs/detectors/DETECTORS.md` and `docs/detectors/REACHABILITY.md`. Classic off-by-one from when these docs moved under an `ecosystems/` subdirectory without updating the relative link depth.

Fixed at the source so generated output stays correct, then regenerated:

- **`internal/support/component_docs.go`** — the generator's hardcoded `../../DETECTORS.md` install-first link → `../../../DETECTORS.md`.
- **`internal/support/prose/detectors/*.md`** (9 files) — `../../REACHABILITY.md` → `../../../REACHABILITY.md` (these prose snippets are embedded into the per-package-manager pages, which sit at the same depth).
- **`make generate`** — regenerated the 41 ecosystem `README.md` files and the affected PM pages.

Also fixes one broken anchor:

- **`docs/TROUBLESHOOTING.md`** — `AUDITORS.md#-fail-on` → `AUDITORS.md#--fail-on` (the `## \`--fail-on\`` header slugifies to two hyphens).

## Why

These were broken navigation links in published docs — surfaced by a JetBrains/Qodana doc inspection (90 "unresolved file reference" + 1 "unresolved header reference" findings, of which these were the genuinely-broken subset).

## Reviewer notes

- Fixes are made in the **source** (generator + prose), not by hand-editing generated files — the regenerated docs are included so the diff is reviewable.
- Verified **0** broken two-level links remain and every new `../../../` path resolves to an existing file.
- `make generate` is **idempotent** — re-running produces no further drift.
- Findings intentionally left out of scope as false positives: trailing-slash directory links (`detectors/ecosystems/`, `matchers/`), and the matcher prose `../AUDITORS.md` (flagged at the source location but correct relative to its embed location `docs/matchers/`).

## Out of band (not in this PR)

- `.github/workflows/bomly-review.yml` references `bomly-dev/bomly-review-action@v1`, which the inspection reports as a 404. Left untouched pending confirmation of whether that action is private / not-yet-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)