### PR TITLE
fix(smoke): expect 0.0.0-dev version for --dev plugin install

### DIFF
--- a/test/smoke/fixture_compile_test.go
+++ b/test/smoke/fixture_compile_test.go
@@ -1,0 +1,148 @@
+// This file intentionally has no build tag. It compiles as part of
+// `go test ./...` (make test) so that SDK changes which break the embedded
+// example-plugin fixture surface immediately, instead of only in the slow,
+// smoke-tagged golden-update workflow.
+
+package smoke
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// examplePluginMainSource is the Go source for the example managed detector
+// plugin. The smoke-tagged plugin workflow tests write it to disk and build it
+// at runtime; TestExamplePluginFixtureCompiles below compile-checks it without
+// the `smoke` build tag. Keep it in sync with the sdk plugin API.
+const examplePluginMainSource = `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const pluginID = "bomly.example.gomod-detector"
+
+type detector struct{}
+
+func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
+	return &sdk.DetectorDescriptor{
+		Name: pluginID,
+	}, nil
+}
+
+func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
+	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGoMod, "go.mod")}, nil
+}
+
+func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
+	return &sdk.ReadyResponse{Ready: true}, nil
+}
+
+func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
+	return &sdk.ApplicableResponse{Applicable: true}, nil
+}
+
+func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
+	moduleName, err := readModuleName(filepath.Join(req.ProjectPath, "go.mod"))
+	if err != nil {
+		return nil, err
+	}
+	pkg := sdk.NewDependency(sdk.Dependency{
+		Ecosystem: string(sdk.EcosystemGo),
+		Name:      moduleName,
+		Version:   "v0.0.0",
+		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
+		FoundBy:   pluginID,
+	})
+	graph := sdk.New()
+	if err := graph.AddNode(pkg); err != nil {
+		return nil, err
+	}
+	return &sdk.DetectResponse{
+		SubprojectInfo:      req.Subproject,
+		RootExecutionTarget: req.ExecutionTarget,
+		DetectorName:        pluginID,
+		Origin:              sdk.ExternalOrigin,
+		Graphs: &sdk.GraphContainer{
+			Entries: []sdk.GraphEntry{{
+				Manifest: sdk.ManifestMetadata{
+					Path: filepath.Join(req.ProjectPath, "go.mod"),
+					Kind: sdk.ManifestKind("go.mod"),
+				},
+				Graph: graph,
+			}},
+		},
+	}, nil
+}
+
+func readModuleName(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "module ") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(line, "module"))
+		if name == "" {
+			return "", fmt.Errorf("go.mod module directive is empty")
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("go.mod does not contain a module directive")
+}
+
+func main() {
+	sdk.ServeDetector(&detector{})
+}
+`
+
+// TestExamplePluginFixtureCompiles builds examplePluginMainSource against the
+// live sdk package via a throwaway module that replaces github.com/bomly-dev/
+// bomly-cli with this checkout. It runs without the `smoke` build tag so a
+// breaking sdk change fails `make test` rather than slipping through to the
+// golden-update workflow.
+func TestExamplePluginFixtureCompiles(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not found on PATH: %v", err)
+	}
+
+	root := fixtureRepoRoot(t)
+	srcDir := t.TempDir()
+
+	goMod := "module bomly-fixture-compile\n\ngo 1.25\n\nrequire github.com/bomly-dev/bomly-cli v0.0.0\n\nreplace github.com/bomly-dev/bomly-cli => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(examplePluginMainSource), 0o644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	cmd := exec.Command("go", "build", "-mod=mod", "-o", filepath.Join(t.TempDir(), "plugin-fixture"), ".")
+	cmd.Dir = srcDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("example plugin fixture failed to compile against the sdk: %v\n%s\n"+
+			"Update examplePluginMainSource in test/smoke/fixture_compile_test.go to match the current sdk plugin API.", err, out)
+	}
+}
+
+// fixtureRepoRoot returns the repo root relative to this file (test/smoke/).
+func fixtureRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine caller file for repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -155,96 +155,9 @@ func writeExamplePluginSource(t *testing.T, dir string) {
 	}
 }
 
-const examplePluginMainSource = `package main
-
-import (
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/bomly-dev/bomly-cli/sdk"
-)
-
-const pluginID = "bomly.example.gomod-detector"
-
-type detector struct{}
-
-func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
-	return &sdk.DetectorDescriptor{
-		Name: pluginID,
-	}, nil
-}
-
-func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
-	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGoMod, "go.mod")}, nil
-}
-
-func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
-	return &sdk.ReadyResponse{Ready: true}, nil
-}
-
-func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
-	return &sdk.ApplicableResponse{Applicable: true}, nil
-}
-
-func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
-	moduleName, err := readModuleName(filepath.Join(req.ProjectPath, "go.mod"))
-	if err != nil {
-		return nil, err
-	}
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
-		Name:      moduleName,
-		Version:   "v0.0.0",
-		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
-		FoundBy:   pluginID,
-	})
-	graph := sdk.New()
-	if err := graph.AddNode(pkg); err != nil {
-		return nil, err
-	}
-	return &sdk.DetectResponse{
-		SubprojectInfo:      req.Subproject,
-		RootExecutionTarget: req.ExecutionTarget,
-		DetectorName:        pluginID,
-		Origin:              sdk.ExternalOrigin,
-		Graphs: &sdk.GraphContainer{
-			Entries: []sdk.GraphEntry{{
-				Manifest: sdk.ManifestMetadata{
-					Path: filepath.Join(req.ProjectPath, "go.mod"),
-					Kind: sdk.ManifestKind("go.mod"),
-				},
-				Graph: graph,
-			}},
-		},
-	}, nil
-}
-
-func readModuleName(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read go.mod: %w", err)
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "module ") {
-			continue
-		}
-		name := strings.TrimSpace(strings.TrimPrefix(line, "module"))
-		if name == "" {
-			return "", fmt.Errorf("go.mod module directive is empty")
-		}
-		return name, nil
-	}
-	return "", fmt.Errorf("go.mod does not contain a module directive")
-}
-
-func main() {
-	sdk.ServeDetector(&detector{})
-}
-`
+// examplePluginMainSource lives in the build-tag-free fixture_compile_test.go
+// so it is compile-checked by `make test`; it is reused here for the
+// end-to-end smoke workflow.
 
 const examplePluginManifest = `{
   "schemaVersion": "bomly.plugin.package.v1",

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -27,7 +27,10 @@ func TestPluginWorkflows(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("plugin install --dev exited %d\nstderr:\n%s", code, stderr)
 		}
-		if !strings.Contains(stdout, "Installed "+plugin.ID+"@"+plugin.Version) {
+		// A --dev install synthesizes the manifest from the plugin's runtime
+		// gRPC descriptor (which carries no version), so the version is stamped
+		// "0.0.0-dev" rather than the manifest version used by archive installs.
+		if !strings.Contains(stdout, "Installed "+plugin.ID+"@0.0.0-dev") {
 			t.Fatalf("unexpected install output:\n%s", stdout)
 		}
 		if _, enableStderr, enableCode := runBomlyWithEnv(t, env, "plugin", "enable", plugin.ID); enableCode != 0 {


### PR DESCRIPTION
Follow-up to #137 (merged), which fixed the embedded plugin fixture build. This addresses the next failure the golden-update workflow surfaced and adds a guard so this whole class of breakage is caught by `make test`.

### 1. Fix stale `--dev` install assertion
The `dev-install-scan` subtest asserted the install banner reported the manifest version (`0.1.0`), but a `--dev` install synthesizes its manifest from the plugin's runtime gRPC descriptor (`manifestFromRuntimeSnapshot` in `internal/plugin/types.go`), which carries no version, so it is stamped `0.0.0-dev`. Archive installs read `bomly-plugin.json` and still report `0.1.0`, so that assertion is unchanged.

```
plugin_test.go:31: unexpected install output:
    Installed bomly.example.gomod-detector@0.0.0-dev
```

This stale assertion was introduced by the same refactor (`96431ef`, #130) that broke the fixture build; the build error masked it until #137 landed.

### 2. Compile-check the fixture in `make test`
The embedded example-plugin source is built at runtime **only** by the smoke-tagged plugin workflow tests, so SDK changes that break it slip past `make test` and surface only in the slow golden-update workflow — which is exactly how this regression reached `main` twice in a row, one layer at a time.

`examplePluginMainSource` now lives in a **build-tag-free** `test/smoke/fixture_compile_test.go`, and `TestExamplePluginFixtureCompiles` builds it against the live `sdk` package via a throwaway `replace` module. It runs as part of `go test ./...`, so fixture/SDK drift fails fast. The smoke workflow reuses the same const for its end-to-end runs.

### Verification
- `go vet ./test/smoke/` and `go vet -tags smoke ./test/smoke/` both pass.
- `go test ./test/smoke/ -run TestExamplePluginFixtureCompiles` passes (builds in ~0.4s, no `go.mod`/`go.sum` mutation).
- The `archive-install-scan` assertion (`@0.1.0`) is untouched.
- Full `make smoke ARGS="-update"` not run locally (slow + network); the golden-update workflow will regenerate `plugin-scan-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)