### PR TITLE
Claude/smoke dev install version

### DIFF
--- a/test/smoke/fixture_compile_test.go
+++ b/test/smoke/fixture_compile_test.go
@@ -1,0 +1,148 @@
+// This file intentionally has no build tag. It compiles as part of
+// `go test ./...` (make test) so that SDK changes which break the embedded
+// example-plugin fixture surface immediately, instead of only in the slow,
+// smoke-tagged golden-update workflow.
+
+package smoke
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// examplePluginMainSource is the Go source for the example managed detector
+// plugin. The smoke-tagged plugin workflow tests write it to disk and build it
+// at runtime; TestExamplePluginFixtureCompiles below compile-checks it without
+// the `smoke` build tag. Keep it in sync with the sdk plugin API.
+const examplePluginMainSource = `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+const pluginID = "bomly.example.gomod-detector"
+
+type detector struct{}
+
+func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
+	return &sdk.DetectorDescriptor{
+		Name: pluginID,
+	}, nil
+}
+
+func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
+	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGoMod, "go.mod")}, nil
+}
+
+func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
+	return &sdk.ReadyResponse{Ready: true}, nil
+}
+
+func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
+	return &sdk.ApplicableResponse{Applicable: true}, nil
+}
+
+func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
+	moduleName, err := readModuleName(filepath.Join(req.ProjectPath, "go.mod"))
+	if err != nil {
+		return nil, err
+	}
+	pkg := sdk.NewDependency(sdk.Dependency{
+		Ecosystem: string(sdk.EcosystemGo),
+		Name:      moduleName,
+		Version:   "v0.0.0",
+		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
+		FoundBy:   pluginID,
+	})
+	graph := sdk.New()
+	if err := graph.AddNode(pkg); err != nil {
+		return nil, err
+	}
+	return &sdk.DetectResponse{
+		SubprojectInfo:      req.Subproject,
+		RootExecutionTarget: req.ExecutionTarget,
+		DetectorName:        pluginID,
+		Origin:              sdk.ExternalOrigin,
+		Graphs: &sdk.GraphContainer{
+			Entries: []sdk.GraphEntry{{
+				Manifest: sdk.ManifestMetadata{
+					Path: filepath.Join(req.ProjectPath, "go.mod"),
+					Kind: sdk.ManifestKind("go.mod"),
+				},
+				Graph: graph,
+			}},
+		},
+	}, nil
+}
+
+func readModuleName(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "module ") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(line, "module"))
+		if name == "" {
+			return "", fmt.Errorf("go.mod module directive is empty")
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("go.mod does not contain a module directive")
+}
+
+func main() {
+	sdk.ServeDetector(&detector{})
+}
+`
+
+// TestExamplePluginFixtureCompiles builds examplePluginMainSource against the
+// live sdk package via a throwaway module that replaces github.com/bomly-dev/
+// bomly-cli with this checkout. It runs without the `smoke` build tag so a
+// breaking sdk change fails `make test` rather than slipping through to the
+// golden-update workflow.
+func TestExamplePluginFixtureCompiles(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not found on PATH: %v", err)
+	}
+
+	root := fixtureRepoRoot(t)
+	srcDir := t.TempDir()
+
+	goMod := "module bomly-fixture-compile\n\ngo 1.25\n\nrequire github.com/bomly-dev/bomly-cli v0.0.0\n\nreplace github.com/bomly-dev/bomly-cli => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(examplePluginMainSource), 0o644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	cmd := exec.Command("go", "build", "-mod=mod", "-o", filepath.Join(t.TempDir(), "plugin-fixture"), ".")
+	cmd.Dir = srcDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("example plugin fixture failed to compile against the sdk: %v\n%s\n"+
+			"Update examplePluginMainSource in test/smoke/fixture_compile_test.go to match the current sdk plugin API.", err, out)
+	}
+}
+
+// fixtureRepoRoot returns the repo root relative to this file (test/smoke/).
+func fixtureRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine caller file for repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -155,96 +155,9 @@ func writeExamplePluginSource(t *testing.T, dir string) {
 	}
 }
 
-const examplePluginMainSource = `package main
-
-import (
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/bomly-dev/bomly-cli/sdk"
-)
-
-const pluginID = "bomly.example.gomod-detector"
-
-type detector struct{}
-
-func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
-	return &sdk.DetectorDescriptor{
-		Name: pluginID,
-	}, nil
-}
-
-func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
-	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGoMod, "go.mod")}, nil
-}
-
-func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
-	return &sdk.ReadyResponse{Ready: true}, nil
-}
-
-func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
-	return &sdk.ApplicableResponse{Applicable: true}, nil
-}
-
-func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
-	moduleName, err := readModuleName(filepath.Join(req.ProjectPath, "go.mod"))
-	if err != nil {
-		return nil, err
-	}
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
-		Name:      moduleName,
-		Version:   "v0.0.0",
-		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
-		FoundBy:   pluginID,
-	})
-	graph := sdk.New()
-	if err := graph.AddNode(pkg); err != nil {
-		return nil, err
-	}
-	return &sdk.DetectResponse{
-		SubprojectInfo:      req.Subproject,
-		RootExecutionTarget: req.ExecutionTarget,
-		DetectorName:        pluginID,
-		Origin:              sdk.ExternalOrigin,
-		Graphs: &sdk.GraphContainer{
-			Entries: []sdk.GraphEntry{{
-				Manifest: sdk.ManifestMetadata{
-					Path: filepath.Join(req.ProjectPath, "go.mod"),
-					Kind: sdk.ManifestKind("go.mod"),
-				},
-				Graph: graph,
-			}},
-		},
-	}, nil
-}
-
-func readModuleName(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read go.mod: %w", err)
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "module ") {
-			continue
-		}
-		name := strings.TrimSpace(strings.TrimPrefix(line, "module"))
-		if name == "" {
-			return "", fmt.Errorf("go.mod module directive is empty")
-		}
-		return name, nil
-	}
-	return "", fmt.Errorf("go.mod does not contain a module directive")
-}
-
-func main() {
-	sdk.ServeDetector(&detector{})
-}
-`
+// examplePluginMainSource lives in the build-tag-free fixture_compile_test.go
+// so it is compile-checked by `make test`; it is reused here for the
+// end-to-end smoke workflow.
 
 const examplePluginManifest = `{
   "schemaVersion": "bomly.plugin.package.v1",

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -27,7 +27,10 @@ func TestPluginWorkflows(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("plugin install --dev exited %d\nstderr:\n%s", code, stderr)
 		}
-		if !strings.Contains(stdout, "Installed "+plugin.ID+"@"+plugin.Version) {
+		// A --dev install synthesizes the manifest from the plugin's runtime
+		// gRPC descriptor (which carries no version), so the version is stamped
+		// "0.0.0-dev" rather than the manifest version used by archive installs.
+		if !strings.Contains(stdout, "Installed "+plugin.ID+"@0.0.0-dev") {
 			t.Fatalf("unexpected install output:\n%s", stdout)
 		}
 		if _, enableStderr, enableCode := runBomlyWithEnv(t, env, "plugin", "enable", plugin.ID); enableCode != 0 {

--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -41,7 +41,7 @@ func TestPluginWorkflows(t *testing.T) {
 		if verifyCode != 0 {
 			t.Fatalf("plugin verify exited %d\nstderr:\n%s", verifyCode, verifyStderr)
 		}
-		if !strings.Contains(verifyStdout, "[ok] runtime metadata matches manifest") {
+		if !strings.Contains(verifyStdout, "[ok] runtime descriptor matches installed snapshot") {
 			t.Fatalf("unexpected verify output:\n%s", verifyStdout)
 		}
 

--- a/test/smoke/testdata/golden/plugin-scan-archive.golden.json
+++ b/test/smoke/testdata/golden/plugin-scan-archive.golden.json
@@ -2,21 +2,21 @@
   "command": "scan",
   "manifests": [
     {
+      "dependencies": [
+        {
+          "depends_on": [],
+          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "licenses": [],
+          "name": "example.com/plugin-smoke",
+          "package_ref": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "version": "v0.0.0"
+        }
+      ],
       "detector": "bomly.example.gomod-detector",
       "ecosystem": "go",
       "kind": "go.mod",
       "package_manager": "gomod",
-      "packages": [
-        {
-          "dependencies": [],
-          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "licenses": [],
-          "name": "example.com/plugin-smoke",
-          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "version": "v0.0.0",
-          "vulnerabilities": []
-        }
-      ],
       "path": "go.mod",
       "subproject": "."
     }
@@ -24,6 +24,16 @@
   "metadata": {
     "duration_ms": 0
   },
+  "packages": [
+    {
+      "ecosystem": "go",
+      "licenses": [],
+      "name": "example.com/plugin-smoke",
+      "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+      "version": "v0.0.0",
+      "vulnerabilities": []
+    }
+  ],
   "project": {
     "ecosystem": "go",
     "name": "\u003cnormalized\u003e",

--- a/test/smoke/testdata/golden/plugin-scan-dev.golden.json
+++ b/test/smoke/testdata/golden/plugin-scan-dev.golden.json
@@ -2,21 +2,21 @@
   "command": "scan",
   "manifests": [
     {
+      "dependencies": [
+        {
+          "depends_on": [],
+          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "licenses": [],
+          "name": "example.com/plugin-smoke",
+          "package_ref": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "version": "v0.0.0"
+        }
+      ],
       "detector": "bomly.example.gomod-detector",
       "ecosystem": "go",
       "kind": "go.mod",
       "package_manager": "gomod",
-      "packages": [
-        {
-          "dependencies": [],
-          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "licenses": [],
-          "name": "example.com/plugin-smoke",
-          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "version": "v0.0.0",
-          "vulnerabilities": []
-        }
-      ],
       "path": "go.mod",
       "subproject": "."
     }
@@ -24,6 +24,16 @@
   "metadata": {
     "duration_ms": 0
   },
+  "packages": [
+    {
+      "ecosystem": "go",
+      "licenses": [],
+      "name": "example.com/plugin-smoke",
+      "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+      "version": "v0.0.0",
+      "vulnerabilities": []
+    }
+  ],
   "project": {
     "ecosystem": "go",
     "name": "\u003cnormalized\u003e",


### PR DESCRIPTION
This pull request improves the reliability and accuracy of plugin smoke tests by ensuring the example plugin fixture is always compiled against the current SDK, updating test assertions for recent output changes, and aligning golden test output with the latest schema. The changes also refactor the handling of the example plugin source for better maintainability.

**Test infrastructure improvements:**

* Added a new test `TestExamplePluginFixtureCompiles` in `test/smoke/fixture_compile_test.go` that builds the example plugin source against the live SDK during regular test runs, ensuring SDK-breaking changes are caught early. The example plugin source was moved here to guarantee it is always compile-checked. [[1]](diffhunk://#diff-0c8235c48bf30ddb5d168dc709ff05e9cbc7d680e410b6ba9f607e3e0026b778R1-R148) [[2]](diffhunk://#diff-b81484eeada001d264134b6b71298a671444744845ec4f812b61acab256433e7L155-R160)

**Test assertion updates:**

* Updated assertions in `test/smoke/plugin_test.go` to match the current plugin install and verify output, specifically accounting for the version string "0.0.0-dev" and the new verification message. [[1]](diffhunk://#diff-b81484eeada001d264134b6b71298a671444744845ec4f812b61acab256433e7L30-R33) [[2]](diffhunk://#diff-b81484eeada001d264134b6b71298a671444744845ec4f812b61acab256433e7L41-R44)

**Golden file/schema alignment:**

* Updated golden test output files (`plugin-scan-archive.golden.json`, `plugin-scan-dev.golden.json`) to match the latest schema, including renaming fields (e.g., `dependencies` instead of `packages`, `depends_on` instead of `dependencies`), adding `package_ref`, and introducing a top-level `packages` array.

**Code organization/maintenance:**

* Refactored the example plugin source handling in `plugin_test.go` to reference the single source of truth in `fixture_compile_test.go`, reducing duplication and ensuring consistency.