### PR TITLE
fix(smoke): update verify assertion and regenerate stale plugin goldens

### DIFF
--- a/test/smoke/plugin_test.go
+++ b/test/smoke/plugin_test.go
@@ -41,7 +41,7 @@ func TestPluginWorkflows(t *testing.T) {
 		if verifyCode != 0 {
 			t.Fatalf("plugin verify exited %d\nstderr:\n%s", verifyCode, verifyStderr)
 		}
-		if !strings.Contains(verifyStdout, "[ok] runtime metadata matches manifest") {
+		if !strings.Contains(verifyStdout, "[ok] runtime descriptor matches installed snapshot") {
 			t.Fatalf("unexpected verify output:\n%s", verifyStdout)
 		}
 

--- a/test/smoke/testdata/golden/plugin-scan-archive.golden.json
+++ b/test/smoke/testdata/golden/plugin-scan-archive.golden.json
@@ -2,21 +2,21 @@
   "command": "scan",
   "manifests": [
     {
+      "dependencies": [
+        {
+          "depends_on": [],
+          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "licenses": [],
+          "name": "example.com/plugin-smoke",
+          "package_ref": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "version": "v0.0.0"
+        }
+      ],
       "detector": "bomly.example.gomod-detector",
       "ecosystem": "go",
       "kind": "go.mod",
       "package_manager": "gomod",
-      "packages": [
-        {
-          "dependencies": [],
-          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "licenses": [],
-          "name": "example.com/plugin-smoke",
-          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "version": "v0.0.0",
-          "vulnerabilities": []
-        }
-      ],
       "path": "go.mod",
       "subproject": "."
     }
@@ -24,6 +24,16 @@
   "metadata": {
     "duration_ms": 0
   },
+  "packages": [
+    {
+      "ecosystem": "go",
+      "licenses": [],
+      "name": "example.com/plugin-smoke",
+      "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+      "version": "v0.0.0",
+      "vulnerabilities": []
+    }
+  ],
   "project": {
     "ecosystem": "go",
     "name": "\u003cnormalized\u003e",

--- a/test/smoke/testdata/golden/plugin-scan-dev.golden.json
+++ b/test/smoke/testdata/golden/plugin-scan-dev.golden.json
@@ -2,21 +2,21 @@
   "command": "scan",
   "manifests": [
     {
+      "dependencies": [
+        {
+          "depends_on": [],
+          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "licenses": [],
+          "name": "example.com/plugin-smoke",
+          "package_ref": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+          "version": "v0.0.0"
+        }
+      ],
       "detector": "bomly.example.gomod-detector",
       "ecosystem": "go",
       "kind": "go.mod",
       "package_manager": "gomod",
-      "packages": [
-        {
-          "dependencies": [],
-          "id": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "licenses": [],
-          "name": "example.com/plugin-smoke",
-          "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
-          "version": "v0.0.0",
-          "vulnerabilities": []
-        }
-      ],
       "path": "go.mod",
       "subproject": "."
     }
@@ -24,6 +24,16 @@
   "metadata": {
     "duration_ms": 0
   },
+  "packages": [
+    {
+      "ecosystem": "go",
+      "licenses": [],
+      "name": "example.com/plugin-smoke",
+      "purl": "pkg:golang/example.com/plugin-smoke@v0.0.0",
+      "version": "v0.0.0",
+      "vulnerabilities": []
+    }
+  ],
   "project": {
     "ecosystem": "go",
     "name": "\u003cnormalized\u003e",


### PR DESCRIPTION
The dev-install verify assertion expected the pre-refactor wording "[ok] runtime metadata matches manifest"; the CLI now emits "[ok] runtime descriptor matches installed snapshot" (internal/plugin/verify.go). Update the assertion to match.

Also regenerate plugin-scan-dev/-archive goldens, which were still in the old manifests->packages shape. They were stale because TestPluginWorkflows has been failing since before #135 migrated machine-readable output to the three-collection model (manifests->dependencies + top-level packages), so its goldens never got refreshed. All other smoke goldens were already migrated by #135; `make smoke ARGS="-update"` now only touches these two.

Verified locally: TestPluginWorkflows and TestExamplePluginFixtureCompiles pass with and without -update.