### PR TITLE
chore: rebrand the PR review action to Bomly Guard

### DIFF
--- a/.github/workflows/bomly-guard.yml
+++ b/.github/workflows/bomly-guard.yml
@@ -1,4 +1,4 @@
-name: Bomly Review
+name: Bomly Guard
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
   security-events: write
 
 jobs:
-  review:
+  guard:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -19,8 +19,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Review dependency changes
-        uses: bomly-dev/bomly-review-action@v1
+      - name: Run Bomly Guard
+        uses: bomly-dev/bomly-guard@v1
         with:
-          fail-on-severity: high
+          fail-on: high
           comment-summary-in-pr: always

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Bomly uses GitHub Actions for:
 
 See [docs/development/CI.md](docs/development/CI.md) for workflow triggers, required checks, release packaging, checksum handling, and the planned future attestation step.
 
-To gate your **own** repository's pull requests, drop in the [Bomly review action](https://github.com/bomly-dev/bomly-review-action) — it diffs and audits dependency changes on each PR and posts a summary comment. See [docs/CI_INTEGRATION.md](docs/CI_INTEGRATION.md) for that and direct-CLI recipes across GitHub Actions, GitLab, Jenkins, Azure, and CircleCI.
+To gate your **own** repository's pull requests, drop in the [Bomly Guard action](https://github.com/bomly-dev/bomly-guard) — it diffs and audits dependency changes on each PR and posts a summary comment. See [docs/CI_INTEGRATION.md](docs/CI_INTEGRATION.md) for that and direct-CLI recipes across GitHub Actions, GitLab, Jenkins, Azure, and CircleCI.
 
 Contributor guidance lives in [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -79,12 +79,12 @@ This fails only when the PR **introduces** a new high finding, ignoring pre-exis
 
 Cuts cold-start enrichment time from minutes to seconds. Cache TTLs are listed in [Matchers](MATCHERS.md#cache); a 24h TTL means cache hits stay fresh for a day even if the cache key changes.
 
-### Turnkey PR reviews with the Bomly review action
+### Turnkey PR reviews with the Bomly Guard action
 
-The recipes above call the CLI directly. For GitHub pull requests, the [**Bomly review action**](https://github.com/bomly-dev/bomly-review-action) wraps the same `bomly diff --enrich --audit` flow into a single step: it installs the CLI, diffs the PR against its base, posts a Markdown summary comment, and uploads SARIF to the Security tab.
+The recipes above call the CLI directly. For GitHub pull requests, the [**Bomly Guard action**](https://github.com/bomly-dev/bomly-guard) wraps the same `bomly diff --enrich --audit` flow into a single step: it installs the CLI, diffs the PR against its base, posts a Markdown summary comment, and uploads SARIF to the Security tab.
 
 ```yaml
-name: Bomly Review
+name: Bomly Guard
 
 on:
   pull_request:
@@ -95,19 +95,19 @@ permissions:
   security-events: write
 
 jobs:
-  review:
+  guard:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # full history so the base and head refs resolve
-      - uses: bomly-dev/bomly-review-action@v1
+      - uses: bomly-dev/bomly-guard@v1
         with:
-          fail-on-severity: high
+          fail-on: high
           deny-licenses: GPL-3.0-only
 ```
 
-The action's inputs map onto the CLI policy flags (`fail-on-severity` → `--fail-on`, `deny-licenses` → `--deny-license`, `protected-packages` → `--protected-package`, and so on), so the policy you enforce locally is the policy it enforces on PRs. See the [action README](https://github.com/bomly-dev/bomly-review-action#readme) for the full input list. Bomly dogfoods this action — see the `Bomly Review` workflow in [docs/development/CI.md](development/CI.md).
+The action's inputs map onto the CLI policy flags (`fail-on` → `--fail-on`, `deny-licenses` → `--deny-license`, `protected-packages` → `--protected-package`, and so on), so the policy you enforce locally is the policy it enforces on PRs. See the [action README](https://github.com/bomly-dev/bomly-guard#readme) for the full input list. Bomly dogfoods this action — see the `Bomly Guard` workflow in [docs/development/CI.md](development/CI.md).
 
 ## GitLab CI
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -12,7 +12,7 @@ bomly diff --base main --head HEAD --enrich --audit --fail-on high
 
 `diff` classifies findings as introduced / resolved / persisted and only `--fail-on` matches against the introduced set, so a clean PR passes even on a repo with known debt. Exit code `2` means a new high finding; see [Exit codes](EXIT_CODES.md).
 
-→ Turnkey version for GitHub PRs: the [Bomly review action](https://github.com/bomly-dev/bomly-review-action) ([setup](CI_INTEGRATION.md#turnkey-pr-reviews-with-the-bomly-review-action)).
+→ Turnkey version for GitHub PRs: the [Bomly Guard action](https://github.com/bomly-dev/bomly-guard) ([setup](CI_INTEGRATION.md#turnkey-pr-reviews-with-the-bomly-guard-action)).
 
 ## Generate and publish an SBOM
 

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -10,7 +10,7 @@ Bomly uses GitHub Actions for validation, security analysis, smoke coverage, and
 | `CodeQL`               | Pull requests, pushes to `main`, weekly        | Static security/quality analysis for Go; results surface in the Security tab                                           |
 | `Scorecard`            | Pushes to `main`, weekly, manual dispatch      | OpenSSF Scorecard supply-chain checks; publishes results and uploads SARIF                                             |
 | `Dependency review`    | Pull requests                                  | GitHub dependency-review of added/changed dependencies; fails on high-severity introductions                          |
-| `Bomly Review`         | Pull requests                                  | Dogfoods the Bomly review action to diff and audit dependency changes on each PR                                       |
+| `Bomly Guard`          | Pull requests                                  | Dogfoods the Bomly Guard action to diff and audit dependency changes on each PR                                        |
 | `Smoke`                | Merge queue, nightly schedule, manual dispatch | Slow end-to-end coverage against real repositories, SBOMs, and containers before merge, plus scheduled drift detection |
 | `Update Smoke Goldens` | Manual dispatch                                | Regenerate golden files on a chosen ref and open a PR when the changes are intentional                                 |
 | `Auto Version`         | Manual dispatch                                | Bump `cmd/bomly/main.go`, create a semver tag, and start the release workflow                                          |


### PR DESCRIPTION
## What changed

The dependency-review GitHub Action was renamed `bomly-dev/bomly-review-action` → **`bomly-dev/bomly-guard`** (the old repo redirects; `v1` tag exists). This updates every reference in this repo to the new action.

- **`.github/workflows/bomly-review.yml` → `bomly-guard.yml`** — workflow `name` `Bomly Review` → `Bomly Guard`, job `review` → `guard`, step now `uses: bomly-dev/bomly-guard@v1`.
- **Fixed the action input** — `fail-on-severity: high` → `fail-on: high`. The new action exposes **`fail-on`** (which accepts severity tokens like `high`); `fail-on-severity` was never one of its inputs (it had been borrowed from GitHub's `actions/dependency-review-action`). `comment-summary-in-pr` **is** a real input and is kept as-is.
- **Docs** (`README.md`, `docs/USE_CASES.md`, `docs/CI_INTEGRATION.md`, `docs/development/CI.md`) — updated the action URL, display name, the example workflow snippet, and the input→flag mapping (`fail-on` → `--fail-on`). Also fixed the `USE_CASES.md` cross-link anchor to track the renamed `CI_INTEGRATION.md` heading.

## Why

The action was rebranded to **Bomly Guard**; the workflow and docs still pointed at the old name, so the dogfood workflow referenced a now-redirecting repo and a non-existent input.

## Reviewer notes

- The `fail-on-severity` in `.github/workflows/dependency-review.yml` is GitHub's **official** `actions/dependency-review-action` (which genuinely has that input) — intentionally left untouched.
- Input names verified against `bomly-dev/bomly-guard`'s `action.yml` at `v1`.
- Markdown table in `development/CI.md` re-padded so column boundaries stay aligned.

## ⚠️ Action required by repo admins

Branch-protection **required-check contexts** that reference `Bomly Review` must be updated to `Bomly Guard` (the workflow/job rename changes the check context name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI integration guides to reference Bomly Guard for dependency auditing in pull requests across multiple documentation files.

* **Chores**
  * Updated GitHub Actions workflow configuration to use Bomly Guard action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->