### PR TITLE
Fix interactive pane bar clipping

### DIFF
--- a/internal/tui/posture.go
+++ b/internal/tui/posture.go
@@ -277,16 +277,15 @@ func postureTopFailingLines(rows []postureRow, width int) []string {
 	if len(checks) == 0 {
 		return []string{render.Style("No failing checks across scored repos.", render.Dim)}
 	}
-	labelWidth := width / 2
-	if labelWidth < 18 {
-		labelWidth = 18
+	if width < 32 {
+		width = 32
 	}
-	if labelWidth > 32 {
-		labelWidth = 32
+	baseLabelWidth := width / 2
+	if baseLabelWidth < 18 {
+		baseLabelWidth = 18
 	}
-	barWidth := width - labelWidth - 12
-	if barWidth < 8 {
-		barWidth = 8
+	if baseLabelWidth > 32 {
+		baseLabelWidth = 32
 	}
 	out := make([]string, 0, len(checks))
 	maxFail := 0
@@ -296,9 +295,23 @@ func postureTopFailingLines(rows []postureRow, width int) []string {
 		}
 	}
 	for idx, c := range checks {
+		labelWidth := baseLabelWidth
+		suffix := fmt.Sprintf(" %d/%d", c.Failing, c.Total)
+		barWidth := width - labelWidth - 1 - len(suffix) - 2
+		if barWidth < 8 {
+			barWidth = 8
+			labelWidth = width - barWidth - 1 - len(suffix) - 2
+			if labelWidth < 8 {
+				labelWidth = 8
+				barWidth = width - labelWidth - 1 - len(suffix) - 2
+				if barWidth < 1 {
+					barWidth = 1
+				}
+			}
+		}
 		label := padRight(truncateToWidth(c.Name, labelWidth), labelWidth)
 		bar := coloredBarLine(c.Failing, maxFail, barWidth, paletteColor(idx))
-		out = append(out, label+render.Style(" ", render.Dim)+bar+fmt.Sprintf(" %d/%d", c.Failing, c.Total))
+		out = append(out, label+render.Style(" ", render.Dim)+bar+suffix)
 	}
 	return out
 }

--- a/internal/tui/posture_test.go
+++ b/internal/tui/posture_test.go
@@ -110,6 +110,35 @@ func TestPostureTab_ScanEmptyStateHints(t *testing.T) {
 	}
 }
 
+func TestTopAffectedLines_FitBoxBudget(t *testing.T) {
+	pkg := sdk.NewDependency(sdk.Dependency{
+		Name:    "org.springframework:spring-web",
+		Version: "6.0.0",
+		Scopes:  sdk.ScopesOf(sdk.ScopeRuntime),
+	})
+	rows := make([]packageVulnerabilityRow, 0, 12)
+	for i := 0; i < 12; i++ {
+		rows = append(rows, packageVulnerabilityRow{
+			pkg:           pkg,
+			vulnerability: sdk.Vulnerability{ID: "CVE-2026-" + string(rune('A'+i))},
+		})
+	}
+
+	for _, width := range []int{58, 90, 132, 140} {
+		lines := topAffectedLines(rows, 5, width)
+		if len(lines) != 1 {
+			t.Fatalf("topAffectedLines(width=%d) produced %d lines, want 1", width, len(lines))
+		}
+		plain := render.StripANSI(lines[0])
+		if visible := len([]rune(plain)); visible > width-2 {
+			t.Errorf("top affected line at width=%d has %d visible cols, want <= %d.\nLine: %q", width, visible, width-2, plain)
+		}
+		if !strings.HasSuffix(plain, " 12") {
+			t.Errorf("top affected line at width=%d lost count suffix:\n%s", width, plain)
+		}
+	}
+}
+
 func TestPostureRowsFromGraph_DedupesAndSortsWorstFirst(t *testing.T) {
 	g := sdk.New()
 	registry := sdk.NewPackageRegistry()
@@ -154,6 +183,35 @@ func TestPostureRowsFromGraph_DedupesAndSortsWorstFirst(t *testing.T) {
 	}
 	if len(mono.packages) != 2 {
 		t.Errorf("expected monorepo row to dedupe 2 packages; got %d", len(mono.packages))
+	}
+}
+
+func TestPostureTopFailingLines_FitBoxBudget(t *testing.T) {
+	rows := make([]postureRow, 0, 196)
+	for i := 0; i < 196; i++ {
+		rows = append(rows, postureRow{
+			repository: "github.com/example/repo",
+			card: newTestScorecardTUI("github.com/example/repo", 4.8,
+				sdk.PackageScorecardCheck{Name: "CI-Best-Practices", Score: 1},
+				sdk.PackageScorecardCheck{Name: "Security-Policy", Score: 2},
+			),
+		})
+	}
+
+	for _, width := range []int{58, 90, 132, 140} {
+		lines := postureTopFailingLines(rows, width)
+		if len(lines) == 0 {
+			t.Fatalf("postureTopFailingLines(width=%d) produced no lines", width)
+		}
+		for _, line := range lines {
+			plain := render.StripANSI(line)
+			if visible := len([]rune(plain)); visible > width-2 {
+				t.Errorf("posture failing line at width=%d has %d visible cols, want <= %d.\nLine: %q", width, visible, width-2, plain)
+			}
+			if !strings.HasSuffix(plain, " 196/196") {
+				t.Errorf("posture failing line at width=%d lost failure suffix:\n%s", width, plain)
+			}
+		}
 	}
 }
 

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -1047,7 +1047,9 @@ func (m *ScanModel) buildVulnsListModel() *listModel {
 		detailTitle: "Vulnerability Details",
 		topPanels: []listPanel{
 			{title: "Severity Summary", lines: vulnerabilitySummaryLines(all), color: render.Red, weight: 1},
-			{title: "Top Affected", lines: topAffectedLines(all, 5, 140), color: render.Green, weight: 2},
+			{title: "Top Affected", lines: topAffectedLines(all, 5, 140), buildLines: func(width int) []string {
+				return topAffectedLines(all, 5, width)
+			}, color: render.Green, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
 		filterHelp:     "Use / to search; Enter focuses details; Esc clears search; v cycles severity filter; g groups vulnerabilities; 1-7 switch tabs",
@@ -1213,6 +1215,9 @@ func topAffectedLines(vulnerabilities []packageVulnerabilityRow, limit, width in
 	maxVal := maxCount(counts)
 	lines := make([]string, 0, len(keys))
 	for idx, key := range keys {
+		if width < 32 {
+			width = 32
+		}
 		labelWidth := width / 3
 		if labelWidth < 18 {
 			labelWidth = 18
@@ -1220,11 +1225,20 @@ func topAffectedLines(vulnerabilities []packageVulnerabilityRow, limit, width in
 		if labelWidth > 34 {
 			labelWidth = 34
 		}
-		barWidth := width - labelWidth - 3
+		suffix := fmt.Sprintf(" %d", counts[key])
+		barWidth := width - labelWidth - 1 - len(suffix) - 2
 		if barWidth < 10 {
 			barWidth = 10
+			labelWidth = width - barWidth - 1 - len(suffix) - 2
+			if labelWidth < 8 {
+				labelWidth = 8
+				barWidth = width - labelWidth - 1 - len(suffix) - 2
+				if barWidth < 1 {
+					barWidth = 1
+				}
+			}
 		}
-		lines = append(lines, padRight(truncateToWidth(key, labelWidth), labelWidth)+render.Style(" ", render.Dim)+coloredBarLine(counts[key], maxVal, barWidth, paletteColor(idx))+" "+fmt.Sprintf("%d", counts[key]))
+		lines = append(lines, padRight(truncateToWidth(key, labelWidth), labelWidth)+render.Style(" ", render.Dim)+coloredBarLine(counts[key], maxVal, barWidth, paletteColor(idx))+suffix)
 	}
 	return lines
 }
@@ -1564,7 +1578,9 @@ func (m *ScanModel) buildPostureListModel() *listModel {
 		detailTitle: "Repository Posture",
 		topPanels: []listPanel{
 			{title: "Posture Summary", lines: postureSummaryLines(rows), color: render.Yellow, weight: 1},
-			{title: "Top Failing Checks", lines: postureTopFailingLines(rows, 140), color: render.Red, weight: 2},
+			{title: "Top Failing Checks", lines: postureTopFailingLines(rows, 140), buildLines: func(width int) []string {
+				return postureTopFailingLines(rows, width)
+			}, color: render.Red, weight: 2},
 		},
 		navigationHelp: interactiveCommonNavigationHelp,
 		filterHelp:     "Use / to search; g cycles group (repository/check); Enter focuses details; 1-7 switch tabs",

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -137,10 +137,11 @@ type listModel struct {
 }
 
 type listPanel struct {
-	title  string
-	lines  []string
-	color  string
-	weight int
+	title      string
+	lines      []string
+	buildLines func(width int) []string
+	color      string
+	weight     int
 }
 
 const interactiveCommonNavigationHelp = "Up/Down or j/k move; Enter focus details (Up/Down scroll, Esc back); Home/End jump; q quits"
@@ -815,7 +816,11 @@ func renderListPanels(panels []listPanel, width int) []string {
 		if color == "" {
 			color = render.Cyan
 		}
-		rendered = append(rendered, boxView(panel.title, panel.lines, panelWidth, panelHeight, color))
+		lines := panel.lines
+		if panel.buildLines != nil {
+			lines = panel.buildLines(panelWidth - 2)
+		}
+		rendered = append(rendered, boxView(panel.title, lines, panelWidth, panelHeight, color))
 	}
 	out := make([]string, 0, panelHeight)
 	for row := 0; row < panelHeight; row++ {


### PR DESCRIPTION
## Summary

Fixes clipped progress bars in the interactive TUI top panels for:

- Vulnerabilities tab: Top Affected
- Posture tab: Top Failing Checks

The panels were precomputing chart lines against a nominal width and not fully reserving space for box padding plus trailing count suffixes, so wide bars could overrun the visible content area and get truncated with ellipses.

## Changes

- Let top panels optionally build their lines with the actual rendered panel width.
- Reworked the affected-component and failing-check bar width calculations to reserve space for padding and count suffixes.
- Added regression coverage that checks visible ANSI-stripped line widths fit within the box budget and keep the numeric suffix intact.

## Validation

- `go test ./internal/tui`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI panels now dynamically adapt their layout based on available terminal width for better display in narrow windows.

* **Tests**
  * Added tests to verify the "Top Affected Lines" and "Top Failing Lines" panels fit within allocated space constraints across varying widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->