### PR TITLE
Fix progress streamer stage updates

### DIFF
--- a/internal/cli/cmd_progress.go
+++ b/internal/cli/cmd_progress.go
@@ -251,6 +251,41 @@ func auditProgressChildren(auditorRuns []string, auditorFindings map[string]int,
 	return children
 }
 
+// analyzerProgressChildren returns ✔ children for each successful reachability
+// analyzer run and ⚠ children for each warning.
+func analyzerProgressChildren(analyzerRuns []string, analyzerStats map[string]sdk.ReachabilityStats, warnings []engine.PipelineWarning) []progress.Child {
+	children := make([]progress.Child, 0, len(analyzerRuns)+len(warnings))
+	for _, name := range analyzerRuns {
+		children = append(children, progress.Child{
+			Icon:   progress.CheckMark,
+			Label:  humanizeAnalyzerSource(name),
+			Detail: analyzerProgressDetail(analyzerStats[name]),
+		})
+	}
+	children = append(children, warningProgressChildren(warnings)...)
+	return children
+}
+
+func analyzerProgressDetail(stats sdk.ReachabilityStats) string {
+	parts := make([]string, 0, 4)
+	if stats.Reachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d reachable", stats.Reachable))
+	}
+	if stats.Unreachable > 0 {
+		parts = append(parts, fmt.Sprintf("%d unreachable", stats.Unreachable))
+	}
+	if stats.Unknown > 0 {
+		parts = append(parts, fmt.Sprintf("%d unknown", stats.Unknown))
+	}
+	if stats.NotApplicable > 0 {
+		parts = append(parts, fmt.Sprintf("%d not applicable", stats.NotApplicable))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
 // diffPolicyOutcomeProgressChild summarizes introduced diff findings using
 // the same introduced-only failure semantics as `bomly diff --audit`.
 func diffPolicyOutcomeProgressChild(audit *diffengine.Audit) progress.Child {
@@ -337,6 +372,10 @@ func humanizeDetectorName(name string) string {
 		}
 	}
 	return strings.Join(parts, " ") + " Detector"
+}
+
+func humanizeAnalyzerSource(name string) string {
+	return titleWords(strings.ReplaceAll(strings.TrimSpace(name), "-", " "))
 }
 
 // humanizeAuditorSource converts an auditor source name to a display name.

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -153,6 +153,11 @@ func newDiffCmd() *cobra.Command {
 				warnings := append(append([]engine.PipelineWarning{}, diffResult.Base.MatchWarnings...), diffResult.Head.MatchWarnings...)
 				prog.CompleteStep("Enriched packages", matchProgressChildren(stats, warnings))
 			}
+			if current.Analyze {
+				runs, stats := combineAnalyzerProgress(diffResult.Base, diffResult.Head)
+				warnings := append(append([]engine.PipelineWarning{}, diffResult.Base.AnalyzeWarnings...), diffResult.Head.AnalyzeWarnings...)
+				prog.CompleteStep("Analyzed reachability", analyzerProgressChildren(runs, stats, warnings))
+			}
 
 			auditPayload := diffAuditOutput(diffResult.Audit, diffResult.Base.Registry, diffResult.Head.Registry)
 			if current.Audit {
@@ -258,6 +263,23 @@ func combineAuditProgress(results ...engine.PipelineResult) ([]string, map[strin
 		}
 	}
 	return runs, counts
+}
+
+func combineAnalyzerProgress(results ...engine.PipelineResult) ([]string, map[string]sdk.ReachabilityStats) {
+	var runs []string
+	statsByName := make(map[string]sdk.ReachabilityStats)
+	for _, result := range results {
+		runs = uniqueStrings(runs, result.AnalyzerRuns)
+		for name, stats := range result.AnalyzerStats {
+			existing := statsByName[name]
+			existing.Reachable += stats.Reachable
+			existing.Unreachable += stats.Unreachable
+			existing.Unknown += stats.Unknown
+			existing.NotApplicable += stats.NotApplicable
+			statsByName[name] = existing
+		}
+	}
+	return runs, statsByName
 }
 
 func combineMatcherStats(groups ...[]sdk.MatcherStats) []sdk.MatcherStats {

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -95,6 +95,9 @@ func newExplainCmd() *cobra.Command {
 			if len(explainResult.MatcherStats) > 0 || len(explainResult.MatchWarnings) > 0 {
 				prog.CompleteStep("Enriched packages", matchProgressChildren(explainResult.MatcherStats, explainResult.MatchWarnings))
 			}
+			if context.ResolvedConfig.Analyze {
+				prog.CompleteStep("Analyzed reachability", analyzerProgressChildren(explainResult.AnalyzerRuns, explainResult.AnalyzerStats, explainResult.AnalyzeWarnings))
+			}
 
 			targets := make([]output.ExplainTargetResponse, 0, len(explainResult.Targets))
 			for _, target := range explainResult.Targets {

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -90,6 +90,9 @@ func newScanCmd() *cobra.Command {
 			if len(pipeResult.MatcherStats) > 0 || len(pipeResult.MatchWarnings) > 0 {
 				prog.CompleteStep("Enriched packages", matchProgressChildren(pipeResult.MatcherStats, pipeResult.MatchWarnings))
 			}
+			if commandCtx.ResolvedConfig.Analyze {
+				prog.CompleteStep("Analyzed reachability", analyzerProgressChildren(pipeResult.AnalyzerRuns, pipeResult.AnalyzerStats, pipeResult.AnalyzeWarnings))
+			}
 
 			consolidated := pipeResult.Consolidated
 			selectedGraph := pipeResult.Graph

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -57,9 +57,9 @@ const (
 var spin = bspinner.MiniDot
 
 // stageDoneLabels maps an engine stage's active (present-progressive) label to
-// the past-tense label the CLI later supplies via CompleteStep. Populated
-// implicitly at Start time so that CompleteStep("Detected Dependencies", …)
-// finds the same step opened by StartStage("Detecting dependencies", …).
+// the past-tense label shown when the stage completes. Populated implicitly at
+// Start time so that CompleteStep("Detected Dependencies", …) finds the same
+// step opened by StartStage("Detecting dependencies", …) when it is still live.
 var stageDoneLabels = map[string]string{
 	"Detecting dependencies": "Detected Dependencies",
 	"Enriching packages":     "Enriched packages",
@@ -233,6 +233,7 @@ type Progress struct {
 	mu              sync.Mutex
 	active          []*Step
 	pastToID        map[string]string
+	promoted        map[string]struct{}
 	frame           int
 	lastDrawnLines  int
 	cursorHidden    bool
@@ -287,6 +288,7 @@ func New(writer io.Writer, enabled bool, label string) *Progress {
 		writer:          writer,
 		enabled:         enabled,
 		pastToID:        make(map[string]string),
+		promoted:        make(map[string]struct{}),
 		minStepDuration: readMinStepDuration(),
 	}
 	if !p.enabled {
@@ -371,6 +373,7 @@ func (p *Progress) StartWithDoneLabel(id, activeLabel, doneLabel string) *Step {
 		startedAt: time.Now(),
 	}
 	p.active = append(p.active, s)
+	delete(p.promoted, id)
 	if activeLabel != "" {
 		p.pastToID[activeLabel] = id
 	}
@@ -405,6 +408,10 @@ func (p *Progress) CompleteStep(doneLabel string, children []Child) {
 		p.mu.Unlock()
 		return
 	}
+	if p.wasPromotedLocked(doneLabel) {
+		p.mu.Unlock()
+		return
+	}
 	s := p.findStepLocked(doneLabel)
 	now := time.Now()
 	if s == nil {
@@ -432,6 +439,20 @@ func (p *Progress) CompleteStep(doneLabel string, children []Child) {
 	doneAt := s.doneAt
 	p.mu.Unlock()
 	p.holdAfterDone(doneAt)
+}
+
+func (p *Progress) wasPromotedLocked(label string) bool {
+	if label == "" {
+		return false
+	}
+	if _, ok := p.promoted[label]; ok {
+		return true
+	}
+	if id, ok := p.pastToID[label]; ok {
+		_, ok = p.promoted[id]
+		return ok
+	}
+	return false
 }
 
 // Advance flushes any prior implicit/in-flight steps and starts a new
@@ -659,22 +680,27 @@ func (p *Progress) CompleteStage(label string, total int) {
 		total = 0
 	}
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if p.finished {
+		p.mu.Unlock()
 		return
 	}
 	s := p.findStepByActiveLabelLocked(label)
 	if s == nil {
+		p.mu.Unlock()
 		return
 	}
 	s.total = total
 	s.completed = total
-	// Engine signaled completion but the CLI still needs to supply the
-	// past-tense label + children. Hold the step in the region with a ✔
-	// icon and a full bar until CompleteStep arrives.
-	if s.state == stepActive {
-		s.state = stepFinishing
+	if done, ok := stageDoneLabels[label]; ok {
+		s.done = done
+	} else if s.done == "" {
+		s.done = label
 	}
+	s.state = stepSucceeded
+	s.doneAt = time.Now()
+	doneAt := s.doneAt
+	p.mu.Unlock()
+	p.holdAfterDone(doneAt)
 }
 
 // Success promotes the most-recent active step (or the step matching label
@@ -898,6 +924,10 @@ func (p *Progress) collectPromotionsLocked() []*Step {
 				continue
 			}
 			promos = append(promos, s)
+			if p.promoted == nil {
+				p.promoted = make(map[string]struct{})
+			}
+			p.promoted[s.id] = struct{}{}
 			continue
 		}
 		kept = append(kept, s)

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -268,6 +268,63 @@ func TestStageDoneLabelLookup_PromotesViaCompleteStep(t *testing.T) {
 	}
 }
 
+func TestCompleteStagePromotesBeforeLaterSummary(t *testing.T) {
+	var buf safeBuffer
+	p := New(&buf, true, "")
+	t.Cleanup(p.Stop)
+
+	p.StartStage("Detecting dependencies", 1)
+	p.AdvanceStage("Detecting dependencies", 1, 1)
+	p.CompleteStage("Detecting dependencies", 1)
+	p.StartStage("Enriching packages", 1)
+	drainAfter()
+
+	out := buf.String()
+	if !strings.Contains(out, "Detected Dependencies") {
+		t.Fatalf("expected completed detection to be promoted independently, got %q", out)
+	}
+	if !strings.Contains(out, "Enriching packages") {
+		t.Fatalf("expected next stage to remain live, got %q", out)
+	}
+
+	p.mu.Lock()
+	active := len(p.active)
+	promoted := len(p.promoted)
+	p.mu.Unlock()
+	if active != 1 {
+		t.Fatalf("expected only next stage to remain active, got %d", active)
+	}
+	if promoted == 0 {
+		t.Fatalf("expected completed stage to be tracked as promoted")
+	}
+}
+
+func TestCompleteStepIgnoresAlreadyPromotedStage(t *testing.T) {
+	var buf safeBuffer
+	p := New(&buf, true, "")
+	t.Cleanup(p.Stop)
+
+	p.StartStage("Detecting dependencies", 1)
+	p.AdvanceStage("Detecting dependencies", 1, 1)
+	p.CompleteStage("Detecting dependencies", 1)
+	p.StartStage("Enriching packages", 1)
+	drainAfter()
+
+	p.CompleteStep("Detected Dependencies", []Child{{Icon: CheckMark, Label: "Maven", Detail: "[12 packages]"}})
+	drainAfter()
+
+	p.mu.Lock()
+	active := len(p.active)
+	p.mu.Unlock()
+	if active != 1 {
+		t.Fatalf("late summary should not synthesize a duplicate active step, got %d active steps", active)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Maven") {
+		t.Fatalf("late summary for promoted stage should not render duplicate children, got %q", out)
+	}
+}
+
 func TestMinStepDuration_CompleteBlocksForMinDuration(t *testing.T) {
 	t.Setenv(minStepEnvVar, "300")
 
@@ -291,17 +348,12 @@ func TestMinStepDuration_CompleteBlocksForMinDuration(t *testing.T) {
 	}
 }
 
-func TestMinStepDuration_CompleteStepBlocksForMinDuration(t *testing.T) {
+func TestMinStepDuration_CompleteStepBlocksForSyntheticStep(t *testing.T) {
 	t.Setenv(minStepEnvVar, "300")
 
 	var buf safeBuffer
 	p := New(&buf, true, "")
 	t.Cleanup(p.Stop)
-
-	// Engine-style: StartStage opens the step, CompleteStep finalises it.
-	p.StartStage("Detecting dependencies", 1)
-	p.AdvanceStage("Detecting dependencies", 1, 1)
-	p.CompleteStage("Detecting dependencies", 1)
 
 	start := time.Now()
 	p.CompleteStep("Detected Dependencies", nil)
@@ -312,6 +364,28 @@ func TestMinStepDuration_CompleteStepBlocksForMinDuration(t *testing.T) {
 	}
 	if elapsed > 1500*time.Millisecond {
 		t.Fatalf("CompleteStep blocked too long; took %s", elapsed)
+	}
+}
+
+func TestMinStepDuration_CompleteStageBlocksForMinDuration(t *testing.T) {
+	t.Setenv(minStepEnvVar, "300")
+
+	var buf safeBuffer
+	p := New(&buf, true, "")
+	t.Cleanup(p.Stop)
+
+	p.StartStage("Detecting dependencies", 1)
+	p.AdvanceStage("Detecting dependencies", 1, 1)
+
+	start := time.Now()
+	p.CompleteStage("Detecting dependencies", 1)
+	elapsed := time.Since(start)
+
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("CompleteStage should block ~300ms; took %s", elapsed)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("CompleteStage blocked too long; took %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Promote engine-completed progress stages immediately instead of keeping them live until the full pipeline returns.
- Ignore late CLI completion summaries for stages that have already been promoted, preventing them from completing the wrong active stage.
- Add reachability analyzer progress summaries for scan, diff, and explain, with regression coverage for promoted-stage behavior.

## Root Cause

The progress renderer treated `CompleteStage` as an intermediate finishing state and waited for a later `CompleteStep` call to attach child details. Those later calls only happen after the entire detection, enrichment, analysis, and audit pipeline returns, so completed stages stayed in the live region until all stages finished.

## Validation

- `go test ./internal/progress ./internal/cli`
- `make test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress now displays "Analyzed reachability" results with detailed statistics when analysis is enabled across CLI commands.

* **Bug Fixes**
  * Improved progress tracking to prevent duplicate step rendering.

* **Tests**
  * Enhanced test coverage for progress promotion and duplicate-suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->