### PR TITLE
Shorten unknown license finding ID

### DIFF
--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -9,7 +9,10 @@ import (
 	"github.com/github/go-spdx/v2/spdxexp"
 )
 
-const auditorName = "license"
+const (
+	auditorName             = "license"
+	unknownLicenseFindingID = "BOMLY-LIC-UNKNOWN"
+)
 
 // Auditor evaluates package licenses against allow/deny SPDX policy.
 type Auditor struct {
@@ -131,8 +134,12 @@ func registryLicenseValues(registry *sdk.PackageRegistry, purl string) []string 
 }
 
 func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
+	findingID := fmt.Sprintf("%s:%s:%s", auditorName, id, purl)
+	if id == "unknown-license" {
+		findingID = unknownLicenseFindingID
+	}
 	f := sdk.Finding{
-		ID:          fmt.Sprintf("%s:%s:%s", auditorName, id, purl),
+		ID:          findingID,
 		Kind:        sdk.FindingKindLicense,
 		Title:       title,
 		Severity:    "unknown",

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -2,6 +2,7 @@ package license
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -57,5 +58,42 @@ func TestLicenseAuditorAllowDeny(t *testing.T) {
 				t.Errorf("want finding=%v got=%v", tt.wantFinding, hasFinding)
 			}
 		})
+	}
+}
+
+func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
+	_ = g.AddNode(root)
+	dep := sdk.NewDependency(sdk.Dependency{
+		Name:        "very-long-package-name-with-output-hostile-length",
+		Version:     "1.2.3",
+		Ecosystem:   "npm",
+		BuildSystem: "npm",
+	})
+	purl := sdk.CanonicalPackageURLFromDependency(dep)
+	dep.PackageRef = purl
+	_ = g.AddNode(dep)
+	_ = g.AddEdge(root.ID, dep.ID)
+
+	result, err := Auditor{}.Audit(context.Background(), sdk.AuditRequest{
+		Graph:    g,
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %#v", result.Findings)
+	}
+	finding := result.Findings[0]
+	if finding.ID != unknownLicenseFindingID {
+		t.Fatalf("finding ID = %q, want %q", finding.ID, unknownLicenseFindingID)
+	}
+	if strings.Contains(finding.ID, dep.Name) || strings.Contains(finding.ID, purl) {
+		t.Fatalf("finding ID should not include package identity: %q", finding.ID)
+	}
+	if finding.PackageRef != purl {
+		t.Fatalf("finding package ref = %q, want %q", finding.PackageRef, purl)
 	}
 }

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -2,7 +2,6 @@ package diff
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/auditors/license"
@@ -120,8 +119,8 @@ func TestRun_UnknownLicenseFindingIsEmittedForFocusedPackage(t *testing.T) {
 		t.Fatalf("expected 1 introduced unknown-license finding, got %#v", result.Audit.Introduced)
 	}
 	finding := result.Audit.Introduced[0]
-	if !strings.Contains(finding.ID, "unknown-license") {
-		t.Fatalf("expected unknown-license finding, got %#v", finding)
+	if finding.ID != "BOMLY-LIC-UNKNOWN" {
+		t.Fatalf("expected compact unknown-license finding ID, got %#v", finding)
 	}
 	if finding.PackageRef != react.PURL {
 		t.Fatalf("expected finding package ref %q, got %q", react.PURL, finding.PackageRef)

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -779,7 +779,7 @@ func findingKindOf(f output.AuditFinding) string {
 	return "other"
 }
 
-// findingRule pulls the rule keyword from an AuditFinding.ID. Built-in
+// findingRule pulls the rule keyword from an AuditFinding.ID. Most built-in
 // auditors format IDs as "<auditor>:<rule>:<package-id>" (see
 // internal/auditors/{license,package}/auditor.go). The rule chunk is the
 // 2nd colon-separated field; we additionally strip a trailing "-license"
@@ -789,6 +789,10 @@ func findingRule(f output.AuditFinding, fallback string) string {
 	id := strings.TrimSpace(f.ID)
 	if id == "" {
 		return fallback
+	}
+	switch strings.ToUpper(id) {
+	case "BOMLY-LIC-UNKNOWN":
+		return "unknown"
 	}
 	parts := strings.SplitN(id, ":", 3)
 	if len(parts) < 2 {
@@ -813,7 +817,7 @@ func severityRowKeys() []string {
 
 func licenseRuleRowKeys() []string {
 	// Mirrors the rule IDs in internal/auditors/license/auditor.go:
-	//   unknown-license / invalid-license / denied-license
+	//   BOMLY-LIC-UNKNOWN / invalid-license / denied-license
 	// Plus an "other" row so external license auditors land somewhere.
 	return []string{"unknown", "invalid", "denied", "other"}
 }

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -437,6 +437,7 @@ func TestFindingRule_StripsAuditorPrefixAndSuffix(t *testing.T) {
 	cases := []struct {
 		id, fallback, want string
 	}{
+		{"BOMLY-LIC-UNKNOWN", "fb", "unknown"},
 		{"license:unknown-license:pkg@1", "fb", "unknown"},
 		{"license:invalid-license:pkg@1", "fb", "invalid"},
 		{"license:denied-license:pkg@1", "fb", "denied"},


### PR DESCRIPTION
## Summary
- Use a compact `BOMLY-LIC-UNKNOWN` finding ID for unknown license audit findings.
- Keep package identity in `PackageRef` so JSON, SARIF, and diff behavior still distinguish affected packages.
- Teach the diff TUI rule grouping to classify the compact ID as an unknown license finding.

## Why
Unknown license findings previously embedded the package URL in the finding ID, producing very long IDs that made rendered output awkward. The root cause was the license auditor using the same package-qualified ID template for unknown-license findings as it uses for package-specific license policy violations.

## Validation
- `go test ./internal/auditors/license ./internal/engine/diff ./internal/tui`
- `make test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized identification format for unknown or unrecognized license findings across the audit engine and user interface, improving consistency in how such cases are handled and displayed.

* **Tests**
  * Added test cases to verify correct identification and display of unknown license findings throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->