### PR TITLE
Fix TUI badge contrast and posture notes

### DIFF
--- a/internal/tui/posture_test.go
+++ b/internal/tui/posture_test.go
@@ -110,6 +110,48 @@ func TestPostureTab_ScanEmptyStateHints(t *testing.T) {
 	}
 }
 
+func TestPostureTab_CheckNotesFitSplitPane(t *testing.T) {
+	g := sdk.New()
+	registry := sdk.NewPackageRegistry()
+	const purl = "pkg:golang/github.com/anchore/go-struct-converter@1.0.0"
+	dep := sdk.NewDependency(sdk.Dependency{Name: "go-struct-converter", Version: "1.0.0", PURL: purl})
+	regPkg := registry.Ensure(purl)
+	regPkg.Name = "go-struct-converter"
+	regPkg.Version = "1.0.0"
+	regPkg.Scorecard = newTestScorecardTUI("github.com/anchore/go-struct-converter", 2.0,
+		sdk.PackageScorecardCheck{Name: "CI-Best-Practices", Score: 0, Reason: "agg note should stay visible"},
+	)
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("add package: %v", err)
+	}
+
+	consolidated := consolidatedForInteractive(t, []sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: "/tmp/demo"},
+			RelativePath:    ".",
+			PrimaryDetector: "go-detector",
+			Ecosystem:       sdk.EcosystemGo,
+		},
+		DetectorName: "go-detector",
+		Graphs:       engine.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "go.mod"}),
+	}})
+	graphValue, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph: %v", err)
+	}
+
+	model := NewScan(output.ProjectDescriptor{Name: "demo", Path: "/tmp/demo"}, consolidated, graphValue, nil).WithRegistry(registry).WithEnrichEnabled(true)
+	model.SelectView(6)
+
+	plain := render.StripANSI(model.View(140, 34))
+	if !strings.Contains(plain, "agg 2.0/10") {
+		t.Fatalf("expected posture check notes to fit the split pane; got:\n%s", plain)
+	}
+	if strings.Contains(plain, "agg 2...") {
+		t.Fatalf("posture check notes were truncated:\n%s", plain)
+	}
+}
+
 func TestTopAffectedLines_FitBoxBudget(t *testing.T) {
 	pkg := sdk.NewDependency(sdk.Dependency{
 		Name:    "org.springframework:spring-web",

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -1544,8 +1544,8 @@ func (m *ScanModel) buildPostureListModel() *listModel {
 			}
 		}
 		repoWidth = maxRepo
-		if repoWidth > 56 {
-			repoWidth = 56
+		if repoWidth > 32 {
+			repoWidth = 32
 		}
 		if repoWidth < 24 {
 			repoWidth = 24
@@ -1557,7 +1557,11 @@ func (m *ScanModel) buildPostureListModel() *listModel {
 	var listTitle, listHeader string
 	switch group {
 	case "check":
-		items, listTitle, listHeader = m.postureItemsByCheck(rows, repoWidth)
+		checkRepoWidth := repoWidth
+		if checkRepoWidth > 24 {
+			checkRepoWidth = 24
+		}
+		items, listTitle, listHeader = m.postureItemsByCheck(rows, checkRepoWidth)
 	default:
 		items = m.postureItemsByRepository(rows, repoWidth)
 		listTitle = fmt.Sprintf("Repositories (%d)", len(rows))

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1455,13 +1455,34 @@ func TestInteractiveStatusBadge_UsesDistinctReadableColors(t *testing.T) {
 	if direct == runtime {
 		t.Fatal("expected direct relationship badge to differ from runtime scope badge")
 	}
-	if !strings.Contains(direct, render.BgCyan) || !strings.Contains(direct, render.White) {
+	if !strings.Contains(direct, render.BgBlue) || !strings.Contains(direct, render.White) {
 		t.Fatalf("expected direct badge to use the interactive relationship palette, got %q", direct)
 	}
 
 	manifest := statusBadge("manifest")
-	if !strings.Contains(manifest, render.BgBlue) || !strings.Contains(manifest, render.Yellow) {
+	if !strings.Contains(manifest, render.BgYellow) || !strings.Contains(manifest, render.Black) {
 		t.Fatalf("expected manifest badge to use a neutral high-contrast style, got %q", manifest)
+	}
+}
+
+func TestInteractiveBadges_UseTerminalSafeForegrounds(t *testing.T) {
+	samples := []string{
+		statusBadge("manifest"),
+		statusBadge("direct"),
+		statusBadge("changed"),
+		statusBadge("unknown"),
+		badgeView(badge{label: "runtime", kind: "scope-runtime"}),
+		badgeView(badge{label: "medium", kind: "severity-medium"}),
+		badgeView(badge{label: "low", kind: "severity-low"}),
+		badgeView(badge{label: "unknown", kind: "unknown"}),
+	}
+	for _, sample := range samples {
+		if strings.Contains(sample, render.Blue) || strings.Contains(sample, render.Yellow+render.Bold) {
+			t.Fatalf("badge uses a risky colored foreground: %q", sample)
+		}
+		if !strings.Contains(sample, render.White) && !strings.Contains(sample, render.Black) {
+			t.Fatalf("badge must use white or black text for terminal contrast: %q", sample)
+		}
 	}
 }
 

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -139,42 +139,42 @@ func statusBadge(status string) string {
 	label := " " + strings.ToUpper(valueOrDash(status)) + " "
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "manifest":
-		return render.Style(label, render.BgBlue, render.Yellow, render.Bold)
+		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "self":
-		return render.Style(label, render.BgGreen, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "parent":
-		return render.Style(label, render.BgCyan, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "ancestor":
-		return render.Style(label, render.BgMagenta, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "root":
-		return render.Style(label, render.BgBlue, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "direct":
-		return render.Style(label, render.BgCyan, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "transitive":
-		return render.Style(label, render.BgMagenta, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "added":
-		return render.Style(label, render.BgGreen, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgGreen, render.Black)
 	case "removed":
-		return render.Style(label, render.BgRed, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "changed":
-		return render.Style(label, render.BgYellow, render.Bold)
+		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "unchanged":
-		return render.Style(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "new": // audit-delta "introduced" (display-side label)
-		return render.Style(label, render.BgRed, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "old": // audit-delta "persisted"
-		return render.Style(label, render.BgYellow, render.Bold)
+		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "fixed": // audit-delta "resolved"
-		return render.Style(label, render.BgGreen, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgGreen, render.Black)
 	case "retired": // license-delta "retired"
-		return render.Style(label, render.BgRed, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "introduced", "persisted", "resolved":
 		// Internal data may still feed the long words through (older code
 		// paths, tests). Translate to the short equivalent here and recurse
 		// into the colored branches above for the same coloring.
 		return statusBadge(auditStatusLabel(status))
 	default:
-		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	}
 }
 
@@ -182,26 +182,30 @@ func badgeView(badge badge) string {
 	label := " " + strings.ToUpper(valueOrDash(badge.label)) + " "
 	switch badge.kind {
 	case "scope-runtime":
-		return render.Style(label, render.BgGreen, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgGreen, render.Black)
 	case "scope-development":
-		return render.Style(label, render.BgYellow, render.Bold)
+		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "severity-critical":
-		return render.Style(label, render.BgRed, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "severity-high":
-		return render.Style(label, render.BgRed, render.White)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "severity-medium":
-		return render.Style(label, render.BgYellow, render.Bold)
+		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "severity-low":
-		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "reachability-reachable":
-		return render.Style(label, render.BgRed, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "reachability-unreachable":
-		return render.Style(label, render.BgBlue, render.White, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	case "repeated":
-		return render.Style(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	default:
-		return render.Style(label, render.BgCyan, render.Blue, render.Bold)
+		return terminalSafeBadge(label, render.BgBlue, render.White)
 	}
+}
+
+func terminalSafeBadge(label, background, foreground string) string {
+	return render.Style(label, background, foreground, render.Bold)
 }
 
 func severityRank(s string) int {


### PR DESCRIPTION
## Summary

- Revised TUI badge rendering to use a small terminal-safe ANSI palette with black or white foreground text.
- Reserved more space for the Posture tab checks Notes column so aggregate score notes do not truncate in split-pane layouts.
- Added regression tests for badge foreground contrast and posture check-note visibility.

## Root Cause

Some badges combined colored foregrounds with colored backgrounds, which could become unreadable depending on terminal theme and OS rendering. The Posture checks table also sized repository labels without enough budget for the selected-row prefix, score badge, and Notes column.

## Validation

- `go test ./internal/tui`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated status badge colors for improved terminal compatibility and readability. Badges now use consistent, high-contrast color combinations.
  * Adjusted Posture view column widths for better layout fitting.

* **Tests**
  * Added test coverage for note text display in the Posture view.
  * Added validation test for terminal-safe badge colors across all badge variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->