### PR TITLE
Publish docs manifest + landing-page sync triggers

### DIFF
--- a/.github/workflows/notify-landing-yank.yml
+++ b/.github/workflows/notify-landing-yank.yml
@@ -16,9 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint landing-page token
+        # Bomly Release app, scoped to bomly-landing-page. repository_dispatch
+        # needs contents:write on the target.
+        uses: actions/create-github-app-token@v3
+        id: landing-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bomly-dev
+          repositories: bomly-landing-page
+          permission-contents: write
+
       - name: Trigger docs removal on landing page
         env:
-          GH_TOKEN: ${{ secrets.LANDING_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.landing-token.outputs.token }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/notify-landing-yank.yml
+++ b/.github/workflows/notify-landing-yank.yml
@@ -1,0 +1,29 @@
+name: Notify landing page (docs yank)
+
+# When a GitHub Release is deleted or unpublished (a yank), tell
+# bomly-landing-page to remove that version's docs and drop it from the
+# version selector. The landing workflow opens a PR with the removal.
+
+on:
+  release:
+    types: [deleted, unpublished]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger docs removal on landing page
+        env:
+          GH_TOKEN: ${{ secrets.LANDING_DISPATCH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh api repos/bomly-dev/bomly-landing-page/dispatches \
+            --method POST \
+            --input - <<EOF
+          {"event_type":"bomly-release-yanked","client_payload":{"version":"${TAG}"}}
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,9 +199,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint landing-page token
+        # Bomly Release app, scoped to bomly-landing-page. repository_dispatch
+        # needs contents:write on the target.
+        uses: actions/create-github-app-token@v3
+        id: landing-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bomly-dev
+          repositories: bomly-landing-page
+          permission-contents: write
+
       - name: Trigger docs sync on landing page
         env:
-          GH_TOKEN: ${{ secrets.LANDING_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.landing-token.outputs.token }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,3 +191,22 @@ jobs:
           gh release download "${TAG}" --dir dist --pattern '*.tar.gz' --pattern '*.zip'
           find dist -maxdepth 1 -type f | sort | xargs sha256sum > dist/SHA256SUMS
           gh release upload "${TAG}" dist/SHA256SUMS --clobber
+
+  notify-landing:
+    # Ask bomly-landing-page to sync this version's docs. The landing workflow
+    # checks this repo out at TAG, runs its sync script, and opens a PR.
+    needs: create-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger docs sync on landing page
+        env:
+          GH_TOKEN: ${{ secrets.LANDING_DISPATCH_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh api repos/bomly-dev/bomly-landing-page/dispatches \
+            --method POST \
+            --input - <<EOF
+          {"event_type":"bomly-release","client_payload":{"version":"${TAG}"}}
+          EOF

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,160 @@
+{
+  "groups": [
+    {
+      "id": "start",
+      "label": "Getting started",
+      "description": "Install Bomly and run your first scan."
+    },
+    {
+      "id": "concepts",
+      "label": "How it works",
+      "description": "What Bomly does, and why each piece exists."
+    },
+    {
+      "id": "reference",
+      "label": "Reference",
+      "description": "Generated specifications and supported matrices."
+    },
+    {
+      "id": "operations",
+      "label": "Operations",
+      "description": "Running Bomly in CI and extending it with plugins."
+    },
+    {
+      "id": "experimental",
+      "label": "Experimental",
+      "description": "Features that are still maturing."
+    }
+  ],
+  "docs": [
+    {
+      "slug": "getting-started",
+      "title": "Getting started",
+      "description": "First scan, enrich, audit, diff — all in five minutes.",
+      "group": "start"
+    },
+    {
+      "slug": "installation",
+      "title": "Installation",
+      "description": "Install methods, `bomly` vs `bomly-lite`, checksum verification, upgrade, uninstall.",
+      "group": "start"
+    },
+    {
+      "slug": "use-cases",
+      "title": "Use cases",
+      "description": "Recipes for PR gates, SBOMs, triage, and license and offline scans.",
+      "group": "start"
+    },
+    {
+      "slug": "scan-targets",
+      "title": "Scan targets",
+      "description": "Local directories, Git repositories, container images, and existing SBOMs.",
+      "group": "start"
+    },
+    {
+      "slug": "output-formats",
+      "title": "Output formats",
+      "description": "Text, JSON, SARIF, and SBOM artifacts — when to use each and how to combine them.",
+      "group": "start"
+    },
+    {
+      "slug": "sbom",
+      "title": "SBOM formats",
+      "description": "SPDX 2.3 vs. CycloneDX 1.6, when to pick which, ingest and conversion recipes.",
+      "group": "start"
+    },
+    {
+      "slug": "architecture",
+      "title": "Architecture",
+      "description": "How the scan pipeline is structured: targets, detectors, matchers, auditors.",
+      "group": "concepts"
+    },
+    {
+      "slug": "detectors",
+      "title": "Detectors",
+      "description": "How Bomly discovers projects and turns evidence into a dependency graph.",
+      "group": "concepts",
+      "hasChildren": true
+    },
+    {
+      "slug": "matchers",
+      "title": "Matchers",
+      "description": "How Bomly enriches packages with vulnerability, license, and lifecycle data.",
+      "group": "concepts",
+      "hasChildren": true
+    },
+    {
+      "slug": "auditors",
+      "title": "Auditors",
+      "description": "How Bomly turns vulnerability data into actionable findings.",
+      "group": "concepts"
+    },
+    {
+      "slug": "glossary",
+      "title": "Glossary",
+      "description": "Every Bomly term, one sentence each.",
+      "group": "concepts"
+    },
+    {
+      "slug": "support-matrix",
+      "title": "Support matrix",
+      "description": "Every ecosystem and package manager Bomly can identify today.",
+      "group": "reference"
+    },
+    {
+      "slug": "config-reference",
+      "title": "Config reference",
+      "description": "All config keys, environment variables, and defaults.",
+      "group": "reference"
+    },
+    {
+      "slug": "exit-codes",
+      "title": "Exit codes",
+      "description": "Process exit values and what each one means for scripts and CI.",
+      "group": "reference"
+    },
+    {
+      "slug": "tui",
+      "title": "Interactive TUI",
+      "description": "Keybindings, tabs, and filters for the --interactive terminal UI.",
+      "group": "reference"
+    },
+    {
+      "slug": "models",
+      "title": "Domain models",
+      "description": "The SDK types behind detection, matching, and audit, and how they connect.",
+      "group": "reference"
+    },
+    {
+      "slug": "ci-integration",
+      "title": "CI integration",
+      "description": "Drop-in recipes for GitHub Actions, GitLab, Jenkins, Azure DevOps, and CircleCI.",
+      "group": "operations"
+    },
+    {
+      "slug": "bomly-guard",
+      "title": "Bomly Guard",
+      "description": "The turnkey GitHub Action that gates pull requests on dependency changes via `bomly diff`.",
+      "group": "operations"
+    },
+    {
+      "slug": "troubleshooting",
+      "title": "Troubleshooting",
+      "description": "Common errors and how to fix them, organized by exit code and symptom.",
+      "group": "operations"
+    },
+    {
+      "slug": "plugins",
+      "title": "Plugins",
+      "description": "Install, enable, verify, and build external detectors, matchers, and auditors.",
+      "group": "operations"
+    },
+    {
+      "slug": "reachability",
+      "title": "Reachability",
+      "description": "Confirm whether a vulnerability is actually reachable from your code. Experimental.",
+      "group": "experimental",
+      "experimental": true
+    }
+  ]
+}

--- a/internal/support/manifest_test.go
+++ b/internal/support/manifest_test.go
@@ -1,0 +1,93 @@
+package support
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// docs/manifest.json drives the landing page's per-version navigation. It must
+// stay in 1:1 sync with the top-level user-facing docs in docs/ — every doc
+// needs a manifest entry, and every manifest entry needs a doc — so the nav
+// can't silently drift from the docs themselves. Nested docs (detectors/,
+// matchers/, schemas/, auditors/, plugins/, …) are auto-discovered by the
+// renderer and are intentionally not listed in the manifest.
+func TestDocsManifestMatchesTopLevelDocs(t *testing.T) {
+	docsDir := filepath.Join("..", "..", "docs")
+
+	raw, err := os.ReadFile(filepath.Join(docsDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest.json: %v", err)
+	}
+	var manifest struct {
+		Groups []struct {
+			ID string `json:"id"`
+		} `json:"groups"`
+		Docs []struct {
+			Slug  string `json:"slug"`
+			Group string `json:"group"`
+		} `json:"docs"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("parse manifest.json: %v", err)
+	}
+
+	groupIDs := map[string]bool{}
+	for _, g := range manifest.Groups {
+		groupIDs[g.ID] = true
+	}
+
+	manifestSlugs := map[string]bool{}
+	for _, d := range manifest.Docs {
+		if manifestSlugs[d.Slug] {
+			t.Errorf("manifest.json lists slug %q more than once", d.Slug)
+		}
+		manifestSlugs[d.Slug] = true
+		if !groupIDs[d.Group] {
+			t.Errorf("manifest doc %q references unknown group %q", d.Slug, d.Group)
+		}
+	}
+
+	entries, err := os.ReadDir(docsDir)
+	if err != nil {
+		t.Fatalf("read docs dir: %v", err)
+	}
+	docSlugs := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(strings.ToLower(name), ".md") {
+			continue
+		}
+		if strings.EqualFold(name, "README.md") {
+			continue
+		}
+		slug := strings.ReplaceAll(strings.TrimSuffix(strings.ToLower(name), ".md"), "_", "-")
+		docSlugs[slug] = true
+	}
+
+	for _, slug := range sortedKeys(docSlugs) {
+		if !manifestSlugs[slug] {
+			t.Errorf("doc %q has no entry in docs/manifest.json", slug)
+		}
+	}
+	for _, slug := range sortedKeys(manifestSlugs) {
+		if !docSlugs[slug] {
+			t.Errorf("manifest entry %q has no corresponding docs/%s.md", slug, strings.ToUpper(strings.ReplaceAll(slug, "-", "_")))
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## What

Makes the CLI the source of truth for the landing page's docs navigation, and wires release events to the landing page's docs sync ([bomly-landing-page#6](https://github.com/bomly-dev/bomly-landing-page/pull/6)).

- **`docs/manifest.json`** — machine-readable nav (groups, order, titles, descriptions, `experimental`/`hasChildren`) for every top-level doc. The landing page renders per-version nav from this; nested docs (detectors/matchers/schemas) stay auto-discovered.
- **`internal/support/manifest_test.go`** — drift guard: fails if the manifest and the top-level `docs/*.md` fall out of 1:1 sync.
- **`release.yml`** — new `notify-landing` job mints a **Bomly Release app** token scoped to bomly-landing-page and fires a `repository_dispatch` (`bomly-release`) on tag push.
- **`notify-landing-yank.yml`** — on a release being deleted/unpublished, fires `bomly-release-yanked` so the landing page removes that version's docs.

## Credentials

Reuses the **Bomly Release** app (same `vars.RELEASE_BOT_CLIENT_ID` + `secrets.RELEASE_BOT_PRIVATE_KEY` already used by `auto-version.yml`) — **no new `LANDING_DISPATCH_TOKEN`**. Requirements:
- The app is installed on **bomly-landing-page** with **Contents: write** (needed for `repository_dispatch`).
- `RELEASE_BOT_CLIENT_ID` / `RELEASE_BOT_PRIVATE_KEY` are already present in this repo.

## Merge order

Merge [bomly-landing-page#6](https://github.com/bomly-dev/bomly-landing-page/pull/6) **first** (its sync workflow must be on `main` to receive dispatches), then this PR, then cut a release to exercise the chain end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)