### PR TITLE
Fix TUI branding and unknown license IDs

### DIFF
--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -2,6 +2,8 @@ package license
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
 	"strings"
 
@@ -11,7 +13,7 @@ import (
 
 const (
 	auditorName             = "license"
-	unknownLicenseFindingID = "BOMLY-LIC-UNKNOWN"
+	unknownLicenseFindingID = "UNKNOWN"
 )
 
 // Auditor evaluates package licenses against allow/deny SPDX policy.
@@ -136,7 +138,7 @@ func registryLicenseValues(registry *sdk.PackageRegistry, purl string) []string 
 func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
 	findingID := fmt.Sprintf("%s:%s:%s", auditorName, id, purl)
 	if id == "unknown-license" {
-		findingID = unknownLicenseFindingID
+		findingID = unknownLicenseID(purl)
 	}
 	f := sdk.Finding{
 		ID:          findingID,
@@ -152,6 +154,18 @@ func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) 
 		f.DependencyRefs = []string{depID}
 	}
 	return f
+}
+
+func unknownLicenseID(purl string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(purl)))
+	encoded := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(sum[:]))
+	if len(encoded) > 12 {
+		encoded = encoded[:12]
+	}
+	if len(encoded) < 12 {
+		return unknownLicenseFindingID + "-" + encoded
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", unknownLicenseFindingID, encoded[:4], encoded[4:8], encoded[8:12])
 }
 
 func packageExempt(dep *sdk.Dependency, exemptions []string) bool {

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -87,13 +87,42 @@ func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
 		t.Fatalf("expected 1 finding, got %#v", result.Findings)
 	}
 	finding := result.Findings[0]
-	if finding.ID != unknownLicenseFindingID {
-		t.Fatalf("finding ID = %q, want %q", finding.ID, unknownLicenseFindingID)
+	if !strings.HasPrefix(finding.ID, unknownLicenseFindingID+"-") {
+		t.Fatalf("finding ID = %q, want %q prefix", finding.ID, unknownLicenseFindingID+"-")
+	}
+	if parts := strings.Split(finding.ID, "-"); len(parts) != 4 || len(parts[1]) != 4 || len(parts[2]) != 4 || len(parts[3]) != 4 {
+		t.Fatalf("finding ID = %q, want compact UNKNOWN-xxxx-xxxx-xxxx shape", finding.ID)
 	}
 	if strings.Contains(finding.ID, dep.Name) || strings.Contains(finding.ID, purl) {
 		t.Fatalf("finding ID should not include package identity: %q", finding.ID)
 	}
 	if finding.PackageRef != purl {
 		t.Fatalf("finding package ref = %q, want %q", finding.PackageRef, purl)
+	}
+}
+
+func TestLicenseAuditorUnknownLicenseIDsDifferByPackage(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
+	_ = g.AddNode(root)
+	for _, name := range []string{"left-pad", "is-odd"} {
+		dep := sdk.NewDependency(sdk.Dependency{Name: name, Version: "1.0.0", Ecosystem: "npm", BuildSystem: "npm"})
+		dep.PackageRef = sdk.CanonicalPackageURLFromDependency(dep)
+		_ = g.AddNode(dep)
+		_ = g.AddEdge(root.ID, dep.ID)
+	}
+
+	result, err := Auditor{}.Audit(context.Background(), sdk.AuditRequest{
+		Graph:    g,
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(result.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %#v", result.Findings)
+	}
+	if result.Findings[0].ID == result.Findings[1].ID {
+		t.Fatalf("unknown license finding IDs should differ by package, got %q", result.Findings[0].ID)
 	}
 }

--- a/internal/cli/render/ansi.go
+++ b/internal/cli/render/ansi.go
@@ -25,6 +25,8 @@ const (
 
 	BgBlue    = "\x1b[44m"
 	BgCyan    = "\x1b[44m"
+	BgBrand   = "\x1b[48;2;232;155;92m"
+	BgNeutral = "\x1b[100m"
 	BgGreen   = "\x1b[42m"
 	BgRed     = "\x1b[41m"
 	BgYellow  = "\x1b[43m"

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/auditors/license"
@@ -119,7 +120,7 @@ func TestRun_UnknownLicenseFindingIsEmittedForFocusedPackage(t *testing.T) {
 		t.Fatalf("expected 1 introduced unknown-license finding, got %#v", result.Audit.Introduced)
 	}
 	finding := result.Audit.Introduced[0]
-	if finding.ID != "BOMLY-LIC-UNKNOWN" {
+	if !strings.HasPrefix(finding.ID, "UNKNOWN-") || len(strings.Split(finding.ID, "-")) != 4 {
 		t.Fatalf("expected compact unknown-license finding ID, got %#v", finding)
 	}
 	if finding.PackageRef != react.PURL {

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -790,8 +790,7 @@ func findingRule(f output.AuditFinding, fallback string) string {
 	if id == "" {
 		return fallback
 	}
-	switch strings.ToUpper(id) {
-	case "BOMLY-LIC-UNKNOWN":
+	if strings.HasPrefix(strings.ToUpper(id), "UNKNOWN-") {
 		return "unknown"
 	}
 	parts := strings.SplitN(id, ":", 3)
@@ -817,7 +816,7 @@ func severityRowKeys() []string {
 
 func licenseRuleRowKeys() []string {
 	// Mirrors the rule IDs in internal/auditors/license/auditor.go:
-	//   BOMLY-LIC-UNKNOWN / invalid-license / denied-license
+	//   UNKNOWN-xxxx-xxxx-xxxx / invalid-license / denied-license
 	// Plus an "other" row so external license auditors land somewhere.
 	return []string{"unknown", "invalid", "denied", "other"}
 }

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -437,7 +437,7 @@ func TestFindingRule_StripsAuditorPrefixAndSuffix(t *testing.T) {
 	cases := []struct {
 		id, fallback, want string
 	}{
-		{"BOMLY-LIC-UNKNOWN", "fb", "unknown"},
+		{"UNKNOWN-as12-1235-fqwe", "fb", "unknown"},
 		{"license:unknown-license:pkg@1", "fb", "unknown"},
 		{"license:invalid-license:pkg@1", "fb", "invalid"},
 		{"license:denied-license:pkg@1", "fb", "denied"},

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -441,8 +441,8 @@ func (m *ScanModel) scanTopBar() string {
 	if strings.TrimSpace(m.project.TargetRef) != "" {
 		targetParts = append(targetParts, render.Style("ref: "+m.project.TargetRef, render.Cyan, render.Bold))
 	}
-	return render.Style(" bomly ", render.BgCyan, render.Blue, render.Bold) + " " +
-		render.Style(m.commandLabel(), render.BgBlue, render.White, render.Bold) + " " +
+	return render.Style(" Bomly ", render.BgBrand, render.White, render.Bold) + " " +
+		render.Style(m.commandLabel(), render.BgNeutral, render.White, render.Bold) + " " +
 		strings.Join(targetParts, render.Style(" | ", render.Dim))
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1222,6 +1222,23 @@ func TestScanInteractiveModel_ExplainTopBarUsesQuery(t *testing.T) {
 	}
 }
 
+func TestScanInteractiveModel_TopBarUsesBrandBadge(t *testing.T) {
+	model := NewScan(output.ProjectDescriptor{Name: "demo-app", Path: "/tmp/demo-app"}, sdk.ConsolidatedGraph{}, sdk.New(), nil)
+	view := model.View(100, 20)
+	if !strings.Contains(view, render.Style(" Bomly ", render.BgBrand, render.White, render.Bold)) {
+		t.Fatalf("expected top bar to render Bomly with brand background and white text, got:\n%s", view)
+	}
+	if !strings.Contains(view, render.Style("SCAN", render.BgNeutral, render.White, render.Bold)) {
+		t.Fatalf("expected command label to use neutral badge, got:\n%s", view)
+	}
+}
+
+func TestFindingRule_ClassifiesCompactUnknownLicenseID(t *testing.T) {
+	if got := findingRule(output.AuditFinding{ID: "UNKNOWN-as12-1235-fqwe"}, "fallback"); got != "unknown" {
+		t.Fatalf("findingRule() = %q, want unknown", got)
+	}
+}
+
 func TestTopDependedOnComponentStats_UsesTransitiveDependents(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("root", "1.0.0")
@@ -1455,8 +1472,8 @@ func TestInteractiveStatusBadge_UsesDistinctReadableColors(t *testing.T) {
 	if direct == runtime {
 		t.Fatal("expected direct relationship badge to differ from runtime scope badge")
 	}
-	if !strings.Contains(direct, render.BgBlue) || !strings.Contains(direct, render.White) {
-		t.Fatalf("expected direct badge to use the interactive relationship palette, got %q", direct)
+	if !strings.Contains(direct, render.BgBrand) || !strings.Contains(direct, render.White) {
+		t.Fatalf("expected direct badge to use the interactive brand palette, got %q", direct)
 	}
 
 	manifest := statusBadge("manifest")

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -141,17 +141,17 @@ func statusBadge(status string) string {
 	case "manifest":
 		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "self":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "parent":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "ancestor":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "root":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "direct":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "transitive":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgBrand, render.White)
 	case "added":
 		return terminalSafeBadge(label, render.BgGreen, render.Black)
 	case "removed":
@@ -159,7 +159,7 @@ func statusBadge(status string) string {
 	case "changed":
 		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "unchanged":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	case "new": // audit-delta "introduced" (display-side label)
 		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "old": // audit-delta "persisted"
@@ -174,7 +174,7 @@ func statusBadge(status string) string {
 		// into the colored branches above for the same coloring.
 		return statusBadge(auditStatusLabel(status))
 	default:
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	}
 }
 
@@ -192,15 +192,15 @@ func badgeView(badge badge) string {
 	case "severity-medium":
 		return terminalSafeBadge(label, render.BgYellow, render.Black)
 	case "severity-low":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	case "reachability-reachable":
 		return terminalSafeBadge(label, render.BgRed, render.White)
 	case "reachability-unreachable":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	case "repeated":
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	default:
-		return terminalSafeBadge(label, render.BgBlue, render.White)
+		return terminalSafeBadge(label, render.BgNeutral, render.White)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Render the TUI Bomly top-bar badge with the brand background and white text.
- Move generic TUI labels away from the blue palette to brand or neutral backgrounds while keeping alert colors meaningful.
- Generate package-specific compact unknown-license finding IDs and remove the old shared unknown-license ID path.

## Why

The interactive UI had contrast and color-balance issues: the Bomly badge could disappear, and common labels made the screen read overwhelmingly blue. Unknown license findings also all shared the same ID, making multiple findings hard to distinguish.

## Validation

- `go test ./internal/tui ./internal/auditors/license ./internal/engine/diff`
- `git diff --check`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated TUI color palette with new brand and neutral background colors
  * Enhanced "Bomly" branding in the scan top bar with new visual styling
  * Refreshed badge styling throughout the interface for consistent appearance

* **Refactor**
  * Improved unknown license finding identification with deterministic package-based IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->