### PR TITLE
Fix independent progress stage redraws

### DIFF
--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -232,6 +232,7 @@ type Progress struct {
 
 	mu              sync.Mutex
 	active          []*Step
+	completed       []*Step
 	pastToID        map[string]string
 	promoted        map[string]struct{}
 	frame           int
@@ -408,8 +409,9 @@ func (p *Progress) CompleteStep(doneLabel string, children []Child) {
 		p.mu.Unlock()
 		return
 	}
-	if p.wasPromotedLocked(doneLabel) {
+	if p.updatePromotedLocked(doneLabel, children) {
 		p.mu.Unlock()
+		p.draw()
 		return
 	}
 	s := p.findStepLocked(doneLabel)
@@ -441,16 +443,25 @@ func (p *Progress) CompleteStep(doneLabel string, children []Child) {
 	p.holdAfterDone(doneAt)
 }
 
-func (p *Progress) wasPromotedLocked(label string) bool {
-	if label == "" {
+func (p *Progress) updatePromotedLocked(doneLabel string, children []Child) bool {
+	if doneLabel == "" {
 		return false
 	}
-	if _, ok := p.promoted[label]; ok {
-		return true
+	id := doneLabel
+	if mapped, ok := p.pastToID[doneLabel]; ok {
+		id = mapped
 	}
-	if id, ok := p.pastToID[label]; ok {
-		_, ok = p.promoted[id]
-		return ok
+	for _, s := range p.completed {
+		if s.id != id && s.done != doneLabel {
+			continue
+		}
+		if doneLabel != "" {
+			s.done = doneLabel
+		}
+		if len(s.children) == 0 && len(children) > 0 {
+			s.children = children
+		}
+		return true
 	}
 	return false
 }
@@ -696,7 +707,7 @@ func (p *Progress) CompleteStage(label string, total int) {
 	} else if s.done == "" {
 		s.done = label
 	}
-	s.state = stepFinishing
+	s.state = stepSucceeded
 	s.doneAt = time.Now()
 	doneAt := s.doneAt
 	p.mu.Unlock()
@@ -856,6 +867,7 @@ func (p *Progress) draw() {
 // remaining live region. Must be called with p.mu held.
 func (p *Progress) drawLocked() {
 	promotions := p.collectPromotionsLocked()
+	p.completed = append(p.completed, promotions...)
 	frame := spin.Frames[p.frame]
 	prev := p.lastDrawnLines
 
@@ -883,13 +895,16 @@ func (p *Progress) drawLocked() {
 		buf.WriteString("\r")
 	}
 
-	// Write promoted (now permanent) blocks above the new live region.
-	for _, promo := range promotions {
-		buf.WriteString(renderFrozenBlock(promo))
+	// Write completed blocks above the live region. They stay in the render
+	// model so command code can attach children after engine stages finish.
+	newLines := 0
+	for _, completed := range p.completed {
+		block := renderFrozenBlock(completed)
+		buf.WriteString(block)
+		newLines += strings.Count(block, "\n")
 	}
 
 	// Write the new live region.
-	newLines := 0
 	for _, s := range p.active {
 		buf.WriteString(renderActiveLine(s, frame))
 		buf.WriteString("\n")

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -153,8 +153,8 @@ func TestStepCompletionPromotion(t *testing.T) {
 	if active != 1 {
 		t.Fatalf("expected 1 active step after promotion, got %d", active)
 	}
-	if gotDrawn != 1 {
-		t.Fatalf("expected lastDrawnLines=1 after promotion, got %d", gotDrawn)
+	if gotDrawn != 3 {
+		t.Fatalf("expected lastDrawnLines=3 after promoted block plus active step, got %d", gotDrawn)
 	}
 }
 
@@ -268,7 +268,7 @@ func TestStageDoneLabelLookup_PromotesViaCompleteStep(t *testing.T) {
 	}
 }
 
-func TestCompleteStageWaitsForLaterSummaryChildren(t *testing.T) {
+func TestCompleteStagePromotesThenAcceptsLaterSummaryChildren(t *testing.T) {
 	var buf safeBuffer
 	p := New(&buf, true, "")
 	t.Cleanup(p.Stop)
@@ -290,12 +290,13 @@ func TestCompleteStageWaitsForLaterSummaryChildren(t *testing.T) {
 	p.mu.Lock()
 	active := len(p.active)
 	promoted := len(p.promoted)
+	completed := len(p.completed)
 	p.mu.Unlock()
-	if active != 2 {
-		t.Fatalf("expected completed stage to wait for summary children, got %d active steps", active)
+	if active != 1 {
+		t.Fatalf("expected completed stage to leave the live region, got %d active steps", active)
 	}
-	if promoted != 0 {
-		t.Fatalf("expected no promoted stages before CompleteStep, got %d", promoted)
+	if promoted == 0 || completed != 1 {
+		t.Fatalf("expected completed stage to be promoted before summary, promoted=%d completed=%d", promoted, completed)
 	}
 
 	p.CompleteStep("Detected Dependencies", []Child{{Icon: CheckMark, Label: "Maven", Detail: "[12 packages]"}})
@@ -304,12 +305,13 @@ func TestCompleteStageWaitsForLaterSummaryChildren(t *testing.T) {
 	p.mu.Lock()
 	active = len(p.active)
 	promoted = len(p.promoted)
+	completed = len(p.completed)
 	p.mu.Unlock()
 	if active != 1 {
 		t.Fatalf("expected only next stage to remain active after summary, got %d active steps", active)
 	}
-	if promoted == 0 {
-		t.Fatal("expected summarized stage to be promoted")
+	if promoted == 0 || completed != 1 {
+		t.Fatalf("expected summarized stage to remain promoted, promoted=%d completed=%d", promoted, completed)
 	}
 
 	out = buf.String()


### PR DESCRIPTION
## Summary

- Let completed stages leave the live loading region independently again.
- Keep completed stages in the progress renderer model so late `CompleteStep(..., children)` calls can attach detector, matcher, analyzer, and auditor child rows.
- Update progress tests for promoted stages receiving later children and for redraw line accounting.

## Root Cause

The previous fix preserved child rows by keeping completed stages live until command code supplied children. That restored the child reports, but it also meant completed detection, enrichment, analysis, and audit bars stayed in the active live region until the whole pipeline finished.

This change lets `CompleteStage` promote each stage immediately, while retaining promoted blocks in memory so the renderer can redraw them with child rows once the CLI summary arrives.

## Validation

- `go test ./internal/progress`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI progress renderer now maintains a persistent history of completed steps, displaying them consistently above the active step during operations.
  * Enhanced rendering of multi-stage progress for improved clarity and accuracy.

* **Tests**
  * Updated progress rendering tests to reflect new state transition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->