### PR TITLE
Use N/A severity for policy findings

### DIFF
--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -14,6 +14,7 @@ import (
 const (
 	auditorName             = "license"
 	unknownLicenseFindingID = "UNKNOWN"
+	licenseSeverityNA       = "n/a"
 )
 
 // Auditor evaluates package licenses against allow/deny SPDX policy.
@@ -144,7 +145,7 @@ func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) 
 		ID:          findingID,
 		Kind:        sdk.FindingKindLicense,
 		Title:       title,
-		Severity:    "unknown",
+		Severity:    licenseSeverityNA,
 		Source:      auditorName,
 		Auditor:     auditorName,
 		Disposition: disposition,

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -99,6 +99,37 @@ func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
 	if finding.PackageRef != purl {
 		t.Fatalf("finding package ref = %q, want %q", finding.PackageRef, purl)
 	}
+	if finding.Severity != licenseSeverityNA {
+		t.Fatalf("finding severity = %q, want %q", finding.Severity, licenseSeverityNA)
+	}
+}
+
+func TestLicenseAuditorDeniedLicensesUseNASeverity(t *testing.T) {
+	g := sdk.New()
+	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
+	_ = g.AddNode(root)
+	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", BuildSystem: "npm"})
+	purl := sdk.CanonicalPackageURLFromDependency(dep)
+	dep.PackageRef = purl
+	_ = g.AddNode(dep)
+	_ = g.AddEdge(root.ID, dep.ID)
+
+	registry := sdk.NewPackageRegistry()
+	registry.Ensure(purl).Licenses = []sdk.PackageLicense{{SPDXExpression: "GPL-3.0-only"}}
+
+	result, err := Auditor{AllowLicenses: []string{"MIT"}}.Audit(context.Background(), sdk.AuditRequest{
+		Graph:    g,
+		Registry: registry,
+	})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %#v", result.Findings)
+	}
+	if got := result.Findings[0].Severity; got != licenseSeverityNA {
+		t.Fatalf("finding severity = %q, want %q", got, licenseSeverityNA)
+	}
 }
 
 func TestLicenseAuditorUnknownLicenseIDsDifferByPackage(t *testing.T) {

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -9,7 +9,10 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const auditorName = "package"
+const (
+	auditorName       = "package"
+	packageSeverityNA = "n/a"
+)
 
 // Auditor protects against denied packages and suspiciously similar package names.
 type Auditor struct {
@@ -101,7 +104,7 @@ func finding(pkg *sdk.Dependency, id, title string, disposition sdk.FindingDispo
 		ID:             fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
 		Kind:           sdk.FindingKindPackage,
 		Title:          title,
-		Severity:       "unknown",
+		Severity:       packageSeverityNA,
 		Source:         auditorName,
 		Auditor:        auditorName,
 		Disposition:    disposition,

--- a/internal/auditors/package/auditor_test.go
+++ b/internal/auditors/package/auditor_test.go
@@ -222,6 +222,11 @@ func TestAudit(t *testing.T) {
 			if got := len(result.Findings); got != tc.wantFindingCount {
 				t.Errorf("finding count = %d, want %d; findings: %v", got, tc.wantFindingCount, findingIDs(result.Findings))
 			}
+			for _, finding := range result.Findings {
+				if finding.Severity != packageSeverityNA {
+					t.Errorf("finding %q severity = %q, want %q", finding.ID, finding.Severity, packageSeverityNA)
+				}
+			}
 			for _, wantID := range tc.wantFindingIDs {
 				found := false
 				for _, f := range result.Findings {

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -53,7 +53,7 @@ func fixtureDiffPayload() output.DiffResponse {
 		Audit: &output.DiffAudit{
 			Introduced: []output.AuditFinding{
 				{ID: "CVE-2024-0001", Kind: "vulnerability", Severity: "high", Source: "osv", Package: output.PackageRef{Name: "react", Version: "19.0.0"}},
-				{ID: "license:unknown-license:zod@3.23.0", Kind: string(sdk.FindingKindLicense), Severity: "unknown", Auditor: "license", Source: "license", Package: output.PackageRef{Name: "zod", Version: "3.23.0"}},
+				{ID: "license:unknown-license:zod@3.23.0", Kind: string(sdk.FindingKindLicense), Severity: "n/a", Auditor: "license", Source: "license", Package: output.PackageRef{Name: "zod", Version: "3.23.0"}},
 			},
 			Persisted: []output.AuditFinding{
 				{ID: "CVE-2023-9999", Kind: "vulnerability", Severity: "medium", Source: "osv", Package: output.PackageRef{Name: "lodash", Version: "4.17.20"}},
@@ -1152,7 +1152,7 @@ func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
 			Kind:     string(sdk.FindingKindLicense),
 			Auditor:  "license",
 			Source:   "license",
-			Severity: "unknown",
+			Severity: "n/a",
 		})
 	}
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
@@ -1216,7 +1216,7 @@ func TestVulnsOutcomePanels_ScopedToVulns(t *testing.T) {
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
 			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "critical"},
-			{ID: "license:unknown-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license", Source: "license", Severity: "unknown"},
+			{ID: "license:unknown-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license", Source: "license", Severity: "n/a"},
 		},
 		Persisted: []output.AuditFinding{
 			{ID: "CVE-2", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "medium"},
@@ -1330,8 +1330,8 @@ func TestFindingsOutcomePanels_ByKindReadsFindingKind(t *testing.T) {
 
 func TestNextFindingGroup_CyclesStatusKindPackage(t *testing.T) {
 	// Severity is intentionally excluded from the Findings axis — license
-	// and package auditors emit Severity="unknown" for everything, so
-	// "severity" grouping is degenerate. Lock that exclusion in.
+	// and package auditors use non-vulnerability severity labels, so "severity"
+	// grouping is degenerate. Lock that exclusion in.
 	cases := []struct{ in, want string }{
 		{"status", "kind"},
 		{"kind", "package"},

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -1695,7 +1695,7 @@ func (m *ScanModel) findingItems(findings []sdk.Finding) []listItem {
 func (m *ScanModel) findingGroupKey(finding sdk.Finding, group string) string {
 	switch group {
 	case "severity":
-		return titleCase(valueOrDefault(finding.Severity, "unknown"))
+		return titleCase(valueOrDefault(finding.Severity, "n/a"))
 	case "component":
 		return valueOrDefault(m.findingPackageName(finding), "unknown component")
 	case "ecosystem":


### PR DESCRIPTION
## Summary

- Change license auditor findings to report `n/a` severity instead of `unknown`.
- Change package auditor findings to report `n/a` severity instead of `unknown`.
- Update TUI fixtures and scan grouping fallback so non-vulnerability finding severity no longer looks like an audit classification failure.

## Why

Policy findings for licenses and package rules are not vulnerability severity assessments. Reporting them as `unknown` can read like Bomly failed to audit or classify the finding. `n/a` better communicates that severity is not applicable for these finding kinds.

## Validation

- `go test ./internal/auditors/license ./internal/auditors/package ./internal/tui`
- `git diff --check`
- `make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated audit findings to display severity as "n/a" instead of "unknown" for license and package audit results, providing clearer indication that these findings are not vulnerability-based.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->