### PR TITLE
Polish progress output formatting

### DIFF
--- a/internal/cli/cmd_progress.go
+++ b/internal/cli/cmd_progress.go
@@ -380,6 +380,13 @@ func humanizeAnalyzerSource(name string) string {
 
 // humanizeAuditorSource converts an auditor source name to a display name.
 func humanizeAuditorSource(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "Auditor"
+	}
+	if strings.Contains(strings.ToLower(source), "auditor") {
+		return source
+	}
 	switch strings.ToLower(source) {
 	case "vulnerability":
 		return "Vulnerability Auditor"
@@ -395,8 +402,9 @@ func humanizeAuditorSource(source string) string {
 		if isAcronym(source) {
 			return strings.ToUpper(source) + " Auditor"
 		}
-		if len(source) > 0 {
-			return strings.ToUpper(source[:1]) + source[1:] + " Auditor"
+		label := titleWords(strings.ReplaceAll(source, "-", " "))
+		if label != "" {
+			return label + " Auditor"
 		}
 		return "Auditor"
 	}

--- a/internal/cli/cmd_progress_test.go
+++ b/internal/cli/cmd_progress_test.go
@@ -45,6 +45,21 @@ func TestAuditProgressChildren_UsesAuditorRunsNotFindingSources(t *testing.T) {
 	}
 }
 
+func TestAuditProgressChildren_DoesNotRepeatAuditorSuffix(t *testing.T) {
+	children := auditProgressChildren(
+		[]string{"Meme Dependency Auditor"},
+		map[string]int{"Meme Dependency Auditor": 0},
+		nil,
+	)
+
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %#v", children)
+	}
+	if children[0].Label != "Meme Dependency Auditor" {
+		t.Fatalf("unexpected auditor label: %#v", children[0])
+	}
+}
+
 func TestSubprojectProgressChildren_UsesGitIdentityWhenConcreteTargetIsFilesystem(t *testing.T) {
 	children := subprojectProgressChildren([]sdk.DetectionResult{{
 		SubprojectInfo: sdk.Subproject{

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -32,9 +32,10 @@ const (
 	CrossMark   = "✘"
 	WarningMark = "⚠"
 
-	titleWidth      = 35
-	childLabelWidth = 25
-	barWidth        = 20
+	titleWidth         = 35
+	childLabelWidth    = 25
+	maxChildLabelWidth = 38
+	barWidth           = 20
 
 	hideCursorSeq = "\x1b[?25l"
 	showCursorSeq = "\x1b[?25h"
@@ -991,9 +992,10 @@ func renderFrozenBlock(s *Step) string {
 	if len(s.children) == 0 {
 		return head
 	}
+	labelWidth := frozenChildLabelWidth(s.children)
 	t := tree.New().EnumeratorStyle(treeStyle)
 	for _, c := range s.children {
-		t = t.Child(renderChildNode(c))
+		t = t.Child(renderChildNode(c, labelWidth))
 	}
 	body := strings.TrimRight(t.String(), "\n")
 
@@ -1007,7 +1009,20 @@ func renderFrozenBlock(s *Step) string {
 	return buf.String()
 }
 
-func renderChildNode(c Child) string {
+func frozenChildLabelWidth(children []Child) int {
+	width := childLabelWidth
+	for _, child := range children {
+		if childWidth := lipgloss.Width(child.Label); childWidth > width {
+			width = childWidth
+		}
+	}
+	if width > maxChildLabelWidth {
+		return maxChildLabelWidth
+	}
+	return width
+}
+
+func renderChildNode(c Child, labelWidth int) string {
 	var icon string
 	if c.Icon != "" {
 		switch c.Icon {
@@ -1021,11 +1036,43 @@ func renderChildNode(c Child) string {
 			icon = c.Icon + " "
 		}
 	}
-	label := lipgloss.NewStyle().Width(childLabelWidth).Render(c.Label)
+	label := padRightVisible(truncateVisible(c.Label, labelWidth), labelWidth)
 	if c.Detail != "" {
 		return icon + label + " " + detailStyle.Render(c.Detail)
 	}
 	return icon + label
+}
+
+func truncateVisible(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	if width <= 3 {
+		return takeRunes(value, width)
+	}
+	return takeRunes(value, width-3) + "..."
+}
+
+func takeRunes(value string, count int) string {
+	if count <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= count {
+		return value
+	}
+	return string(runes[:count])
+}
+
+func padRightVisible(value string, width int) string {
+	padding := width - lipgloss.Width(value)
+	if padding <= 0 {
+		return value
+	}
+	return value + strings.Repeat(" ", padding)
 }
 
 // completedTask is preserved for source-level compatibility with prior tests

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -158,6 +158,30 @@ func TestStepCompletionPromotion(t *testing.T) {
 	}
 }
 
+func TestFrozenBlockKeepsLongChildLabelsOnOneLine(t *testing.T) {
+	block := renderFrozenBlock(&Step{
+		done:  "Enriched packages",
+		state: stepSucceeded,
+		children: []Child{
+			{Icon: CheckMark, Label: "ClearlyDefined License Matcher", Detail: "[43 unmatched packages]"},
+			{Icon: CheckMark, Label: "endoflife.date Lifecycle Matcher", Detail: "[7 matched packages, 323 unmatched packages]"},
+		},
+	})
+
+	if strings.Contains(block, "\n      Matcher") {
+		t.Fatalf("expected long matcher labels to stay on one tree row, got:\n%s", block)
+	}
+	if !strings.Contains(block, "ClearlyDefined License Matcher") {
+		t.Fatalf("expected ClearlyDefined label, got:\n%s", block)
+	}
+	if !strings.Contains(block, "endoflife.date Lifecycle Matcher") {
+		t.Fatalf("expected endoflife label, got:\n%s", block)
+	}
+	if !strings.Contains(block, "ClearlyDefined License Matcher  ") || !strings.Contains(block, "[43 unmatched packages]") {
+		t.Fatalf("expected label column and detail to render together, got:\n%s", block)
+	}
+}
+
 func TestConcurrentSteps_NoRace(t *testing.T) {
 	var buf safeBuffer
 	p := New(&buf, true, "")


### PR DESCRIPTION
## Summary

- Preserve auditor display names that already include `Auditor` so progress rows do not repeat the suffix.
- Render completed progress child labels with a dynamic, capped label column so long matcher names stay aligned with their details.
- Add regressions for auditor suffix handling and long matcher progress rows.

## Validation

- `go test ./internal/cli ./internal/progress`
- `make test`
- `git diff --check`