### PR TITLE
Type finite SDK fields

### DIFF
--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -24,7 +24,7 @@ findings (reference-style) ─(PackageRef + VulnerabilityID)─┘
 ```go
 type Dependency struct {
     // Identity
-    ID, Name, Version, PURL, Ecosystem, Type, Org, BuildSystem, Language string
+    ID, Name, Version, PURL, Ecosystem, Type, Org, PackageManager, Language string
 
     // Detection metadata
     Scopes      []Scope             // runtime / development / unknown; supports multiple

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -23,13 +23,16 @@ findings (reference-style) ─(PackageRef + VulnerabilityID)─┘
 
 ```go
 type Dependency struct {
-    // Identity
-    ID, Name, Version, PURL, Ecosystem, Type, Org, PackageManager, Language string
+    Coordinates
+    ID string
 
     // Detection metadata
     Scopes      []Scope             // runtime / development / unknown; supports multiple
     Locations   []PackageLocation   // manifest paths + line/column
-    FoundBy     []string            // detector names
+    CPEs        []string
+    Digests     []Digest
+    Copyright   string
+    FoundBy     string              // detector name
     ResolvedURL string
     Metadata    map[string]any      // including detection-time licenses under MetadataKeyDetectionLicenses
 
@@ -52,17 +55,18 @@ Dependencies **do not** carry `Licenses`, `Vulnerabilities`, or `Scorecard` fiel
 
 ```go
 type Package struct {
-    // Identity (PURL is the primary key in PackageRegistry)
-    PURL, Ecosystem, Name, Version string
-    CPEs                           []string
-    Digests                        []PackageDigest
+    Coordinates
+    ID string                       // registry/database identifier; defaults to PURL in PackageRegistry
 
     // Enrichment
+    CPEs            []string
+    Digests         []Digest
     Licenses        []PackageLicense
     Vulnerabilities []Vulnerability       // OSV-aligned
     Scorecard       *PackageScorecard
     EOL             *PackageEOL
     Copyright       string
+    ResolvedURL     string
     Metadata        map[string]any
     Matched         bool                  // set by any matcher that touched this package
 }

--- a/docs/plugins/how-to-implement-detector.md
+++ b/docs/plugins/how-to-implement-detector.md
@@ -48,11 +48,13 @@ func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.Applica
 func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
     graph := sdk.New()
     dep := sdk.NewDependency(sdk.Dependency{
-        Ecosystem: string(sdk.EcosystemNPM),
-        Name:      "is-odd",
-        Version:   "3.0.1",
-        PURL:      "pkg:npm/is-odd@3.0.1",
-        FoundBy:   pluginID,
+        Coordinates: sdk.Coordinates{
+            Ecosystem: sdk.EcosystemNPM,
+            Name:      "is-odd",
+            Version:   "3.0.1",
+            PURL:      "pkg:npm/is-odd@3.0.1",
+        },
+        FoundBy: pluginID,
     })
     if err := graph.AddNode(dep); err != nil {
         return nil, err
@@ -97,8 +99,12 @@ Use `Install` only for install-first detectors that prepare dependencies before 
 Use SDK graph helpers instead of constructing graph internals by hand:
 
 ```go
-parent := sdk.NewDependency(sdk.Dependency{Name: "app", Version: "0.0.0", PURL: "pkg:generic/app@0.0.0"})
-child := sdk.NewDependency(sdk.Dependency{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"})
+parent := sdk.NewDependency(sdk.Dependency{
+    Coordinates: sdk.Coordinates{Name: "app", Version: "0.0.0", PURL: "pkg:generic/app@0.0.0"},
+})
+child := sdk.NewDependency(sdk.Dependency{
+    Coordinates: sdk.Coordinates{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"},
+})
 
 graph := sdk.New()
 if err := graph.AddNode(parent); err != nil {

--- a/internal/analyzers/govulncheck/analyzer.go
+++ b/internal/analyzers/govulncheck/analyzer.go
@@ -391,13 +391,13 @@ func isGoPackage(pkg *model.Dependency) bool {
 	if pkg == nil {
 		return false
 	}
-	if strings.EqualFold(pkg.Ecosystem, string(model.EcosystemGo)) {
+	if pkg.Ecosystem == model.EcosystemGo {
 		return true
 	}
-	if strings.EqualFold(pkg.BuildSystem, "gomod") || strings.EqualFold(pkg.BuildSystem, "go") {
+	if pkg.PackageManager == model.PackageManagerGoMod {
 		return true
 	}
-	if strings.EqualFold(pkg.Language, string(model.LanguageGo)) {
+	if pkg.Language == model.LanguageGo {
 		return true
 	}
 	return false

--- a/internal/analyzers/govulncheck/analyzer_test.go
+++ b/internal/analyzers/govulncheck/analyzer_test.go
@@ -39,12 +39,10 @@ func newGoModuleDir(t *testing.T) string {
 // (keyed by the dependency's PURL) carries the supplied vulnerabilities.
 func newGoGraph(moduleDir string, vulns ...model.Vulnerability) (*model.Graph, *model.PackageRegistry) {
 	g := model.New()
-	dep := model.NewDependency(model.Dependency{
-		Name:           "example.com/lib",
+	dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "example.com/lib",
 		Version:        "v1.0.0",
 		Ecosystem:      "go",
-		PackageManager: "gomod",
-		Locations:      []model.PackageLocation{{RealPath: filepath.Join(moduleDir, "go.sum")}},
+		PackageManager: "gomod"}, Locations: []model.PackageLocation{{RealPath: filepath.Join(moduleDir, "go.sum")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -215,7 +213,7 @@ func TestAnalyzerApplicableRequiresGoVulns(t *testing.T) {
 	// build a graph+registry where dep's package carries the given vulns.
 	build := func(name, ecosystem string, vulns ...model.Vulnerability) (*model.Graph, *model.PackageRegistry) {
 		g := model.New()
-		dep := model.NewDependency(model.Dependency{Name: name, Ecosystem: model.Ecosystem(ecosystem)})
+		dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: name, Ecosystem: model.Ecosystem(ecosystem)}})
 		purl := model.CanonicalPackageURLFromDependency(dep)
 		dep.PackageRef = purl
 		_ = g.AddNode(dep)

--- a/internal/analyzers/govulncheck/analyzer_test.go
+++ b/internal/analyzers/govulncheck/analyzer_test.go
@@ -40,11 +40,11 @@ func newGoModuleDir(t *testing.T) string {
 func newGoGraph(moduleDir string, vulns ...model.Vulnerability) (*model.Graph, *model.PackageRegistry) {
 	g := model.New()
 	dep := model.NewDependency(model.Dependency{
-		Name:        "example.com/lib",
-		Version:     "v1.0.0",
-		Ecosystem:   "go",
-		BuildSystem: "gomod",
-		Locations:   []model.PackageLocation{{RealPath: filepath.Join(moduleDir, "go.sum")}},
+		Name:           "example.com/lib",
+		Version:        "v1.0.0",
+		Ecosystem:      "go",
+		PackageManager: "gomod",
+		Locations:      []model.PackageLocation{{RealPath: filepath.Join(moduleDir, "go.sum")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -215,7 +215,7 @@ func TestAnalyzerApplicableRequiresGoVulns(t *testing.T) {
 	// build a graph+registry where dep's package carries the given vulns.
 	build := func(name, ecosystem string, vulns ...model.Vulnerability) (*model.Graph, *model.PackageRegistry) {
 		g := model.New()
-		dep := model.NewDependency(model.Dependency{Name: name, Ecosystem: ecosystem})
+		dep := model.NewDependency(model.Dependency{Name: name, Ecosystem: model.Ecosystem(ecosystem)})
 		purl := model.CanonicalPackageURLFromDependency(dep)
 		dep.PackageRef = purl
 		_ = g.AddNode(dep)

--- a/internal/analyzers/govulncheck/parse.go
+++ b/internal/analyzers/govulncheck/parse.go
@@ -152,12 +152,12 @@ func positionToSDK(p *position) model.SourcePosition {
 	return model.SourcePosition{File: p.Filename, Line: p.Line, Column: p.Column}
 }
 
-func symbolKind(t traceEntry) string {
+func symbolKind(t traceEntry) model.SymbolKind {
 	if t.Receiver != "" {
-		return "method"
+		return model.SymbolKindMethod
 	}
 	if t.Function != "" {
-		return "function"
+		return model.SymbolKindFunction
 	}
 	return ""
 }

--- a/internal/analyzers/govulncheck/testdata_test.go
+++ b/internal/analyzers/govulncheck/testdata_test.go
@@ -23,10 +23,8 @@ func goFixture(parts ...string) string {
 func TestDiscoverModuleRootsFromTestdata(t *testing.T) {
 	root := goFixture("module")
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "example.com/lib",
-		Ecosystem: model.EcosystemGo,
-		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "nested", "file.go")}},
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "example.com/lib",
+		Ecosystem: model.EcosystemGo}, Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "nested", "file.go")}},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
@@ -120,10 +118,9 @@ func TestGovulncheckFailureReasons(t *testing.T) {
 func TestGovulncheckAnalyzerMarksUnknownWithoutModuleRoot(t *testing.T) {
 	const purl = "pkg:golang/example.com/lib"
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "example.com/lib",
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "example.com/lib",
 		Ecosystem: model.EcosystemGo,
-		PURL:      purl,
+		PURL:      purl},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
@@ -154,7 +151,7 @@ func TestGovulncheckLookupFindingAndImportedModuleAliases(t *testing.T) {
 			t.Fatalf("lookupFinding(%+v) missed", vuln)
 		}
 	}
-	pkg := model.NewDependency(model.Dependency{Name: "example.com/lib"})
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "example.com/lib"}})
 	if !packageImportedByModule(pkg, map[string]struct{}{"example.com/lib": {}}) {
 		t.Fatal("package name was not matched against imported module set")
 	}

--- a/internal/analyzers/govulncheck/testdata_test.go
+++ b/internal/analyzers/govulncheck/testdata_test.go
@@ -25,7 +25,7 @@ func TestDiscoverModuleRootsFromTestdata(t *testing.T) {
 	g := model.New()
 	pkg := model.NewDependency(model.Dependency{
 		Name:      "example.com/lib",
-		Ecosystem: string(model.EcosystemGo),
+		Ecosystem: model.EcosystemGo,
 		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "nested", "file.go")}},
 	})
 	if err := g.AddNode(pkg); err != nil {
@@ -122,7 +122,7 @@ func TestGovulncheckAnalyzerMarksUnknownWithoutModuleRoot(t *testing.T) {
 	g := model.New()
 	pkg := model.NewDependency(model.Dependency{
 		Name:      "example.com/lib",
-		Ecosystem: string(model.EcosystemGo),
+		Ecosystem: model.EcosystemGo,
 		PURL:      purl,
 	})
 	if err := g.AddNode(pkg); err != nil {

--- a/internal/analyzers/jsreach/analyzer_test.go
+++ b/internal/analyzers/jsreach/analyzer_test.go
@@ -49,12 +49,12 @@ func newNPMProjectDir(t *testing.T) string {
 func addNPMDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, org, name, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
 	dep := model.NewDependency(model.Dependency{
-		Name:        name,
-		Org:         org,
-		Version:     version,
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Locations:   []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
+		Name:           name,
+		Org:            org,
+		Version:        version,
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl

--- a/internal/analyzers/jsreach/analyzer_test.go
+++ b/internal/analyzers/jsreach/analyzer_test.go
@@ -48,13 +48,11 @@ func newNPMProjectDir(t *testing.T) string {
 // Returns the dependency node.
 func addNPMDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, org, name, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
-	dep := model.NewDependency(model.Dependency{
-		Name:           name,
+	dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: name,
 		Org:            org,
 		Version:        version,
-		Ecosystem:      "npm",
-		PackageManager: "npm",
-		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
+		Ecosystem:      model.EcosystemNPM,
+		PackageManager: model.PackageManagerNPM}, Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "package-lock.json")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -178,7 +176,7 @@ func TestAnalyzerApplicableRequiresNPMVulns(t *testing.T) {
 
 	// go package with vuln → not applicable
 	g, reg := newSeed()
-	goDep := model.NewDependency(model.Dependency{Name: "lib", Ecosystem: "go"})
+	goDep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lib", Ecosystem: model.EcosystemGo}})
 	goDep.PackageRef = model.CanonicalPackageURLFromDependency(goDep)
 	_ = g.AddNode(goDep)
 	reg.Ensure(goDep.PackageRef).Vulnerabilities = []model.Vulnerability{{ID: "x"}}
@@ -264,8 +262,8 @@ func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
 
 func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
-	a := model.NewDependency(model.Dependency{Name: "a", Version: "1.0.0", Ecosystem: "npm"})
-	b := model.NewDependency(model.Dependency{Name: "b", Version: "1.0.0", Ecosystem: "npm"})
+	a := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "a", Version: "1.0.0", Ecosystem: model.EcosystemNPM}})
+	b := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "b", Version: "1.0.0", Ecosystem: model.EcosystemNPM}})
 	if err := g.AddNode(a); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analyzers/jsreach/discover.go
+++ b/internal/analyzers/jsreach/discover.go
@@ -327,15 +327,15 @@ func isNPMPackage(pkg *model.Dependency) bool {
 	if pkg == nil {
 		return false
 	}
-	if strings.EqualFold(pkg.Ecosystem, string(model.EcosystemNPM)) {
+	if pkg.Ecosystem == model.EcosystemNPM {
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(pkg.BuildSystem)) {
-	case "npm", "pnpm", "yarn":
+	switch pkg.PackageManager {
+	case model.PackageManagerNPM, model.PackageManagerPNPM, model.PackageManagerYarn:
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(pkg.Language)) {
-	case "javascript", "typescript":
+	switch pkg.Language {
+	case model.LanguageJavaScript, model.LanguageTypeScript:
 		return true
 	}
 	return false

--- a/internal/analyzers/jsreach/runner_testdata_test.go
+++ b/internal/analyzers/jsreach/runner_testdata_test.go
@@ -75,7 +75,7 @@ func TestJSDescriptorAndRunnerResult(t *testing.T) {
 func TestJSStandaloneApplyRunnerResult(t *testing.T) {
 	const purl = "pkg:npm/lodash"
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{Name: "lodash", Ecosystem: "npm", PURL: purl})
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lodash", Ecosystem: model.EcosystemNPM, PURL: purl}})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analyzers/jsreach/workspace_test.go
+++ b/internal/analyzers/jsreach/workspace_test.go
@@ -109,8 +109,8 @@ func TestAnalyzerTraversesConsumedWorkspaceMembers(t *testing.T) {
 	reg := model.NewPackageRegistry()
 	lodashPURL := "pkg:npm/lodash@1"
 	leftPadPURL := "pkg:npm/left-pad@1"
-	lodash := model.NewDependency(model.Dependency{Name: "lodash", Version: "1", Ecosystem: "npm", PURL: lodashPURL})
-	leftPad := model.NewDependency(model.Dependency{Name: "left-pad", Version: "1", Ecosystem: "npm", PURL: leftPadPURL})
+	lodash := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lodash", Version: "1", Ecosystem: model.EcosystemNPM, PURL: lodashPURL}})
+	leftPad := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "left-pad", Version: "1", Ecosystem: model.EcosystemNPM, PURL: leftPadPURL}})
 	reg.Ensure(lodashPURL).Vulnerabilities = []model.Vulnerability{{ID: "lodash"}}
 	reg.Ensure(leftPadPURL).Vulnerabilities = []model.Vulnerability{{ID: "left-pad"}}
 	_ = g.AddNode(lodash)
@@ -157,7 +157,7 @@ func newNPMGraph(t *testing.T, name, version string, vulns ...model.Vulnerabilit
 	t.Helper()
 	purl := "pkg:npm/" + name + "@" + version
 	g := model.New()
-	dep := model.NewDependency(model.Dependency{Name: name, Version: version, Ecosystem: "npm", PURL: purl})
+	dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: name, Version: version, Ecosystem: model.EcosystemNPM, PURL: purl}})
 	if err := g.AddNode(dep); err != nil {
 		t.Fatalf("add node: %v", err)
 	}

--- a/internal/analyzers/jsreach/workspace_testdata_test.go
+++ b/internal/analyzers/jsreach/workspace_testdata_test.go
@@ -80,10 +80,8 @@ func TestDiscoverWorkspaceHierarchiesFromTestdata(t *testing.T) {
 func TestDiscoverProjectRootsDeduplicatesGraphAndTargetSources(t *testing.T) {
 	root := workspaceFixture("npm-array")
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "lodash",
-		Ecosystem: "npm",
-		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "package-lock.json")}},
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lodash",
+		Ecosystem: model.EcosystemNPM}, Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "package-lock.json")}},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
@@ -198,8 +196,8 @@ func TestAnalyzerBuiltInRunnerTraversesWorkspaceTestdata(t *testing.T) {
 	reg := model.NewPackageRegistry()
 	lodashPURL := "pkg:npm/lodash@1"
 	leftPadPURL := "pkg:npm/left-pad@1"
-	lodash := model.NewDependency(model.Dependency{Name: "lodash", Version: "1", Ecosystem: "npm", PURL: lodashPURL})
-	leftPad := model.NewDependency(model.Dependency{Name: "left-pad", Version: "1", Ecosystem: "npm", PURL: leftPadPURL})
+	lodash := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lodash", Version: "1", Ecosystem: model.EcosystemNPM, PURL: lodashPURL}})
+	leftPad := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "left-pad", Version: "1", Ecosystem: model.EcosystemNPM, PURL: leftPadPURL}})
 	reg.Ensure(lodashPURL).Vulnerabilities = []model.Vulnerability{{ID: "lodash"}}
 	reg.Ensure(leftPadPURL).Vulnerabilities = []model.Vulnerability{{ID: "left-pad"}}
 	if err := g.AddNode(lodash); err != nil {

--- a/internal/analyzers/jvmreach/analyzer_test.go
+++ b/internal/analyzers/jvmreach/analyzer_test.go
@@ -57,13 +57,11 @@ func newSeed() (*model.Graph, *model.PackageRegistry) {
 // package keyed by the dependency PURL carrying those vulnerabilities.
 func addJVMDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, group, artifact, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
-	dep := model.NewDependency(model.Dependency{
-		Name:           artifact,
+	dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: artifact,
 		Org:            group,
 		Version:        version,
 		Ecosystem:      model.EcosystemMaven,
-		PackageManager: "maven",
-		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
+		PackageManager: "maven"}, Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -194,8 +192,8 @@ func TestAnalyzerMarksTransitiveDepReachable(t *testing.T) {
 
 func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
-	a := model.NewDependency(model.Dependency{Name: "a", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven})
-	b := model.NewDependency(model.Dependency{Name: "b", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven})
+	a := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "a", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven}})
+	b := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "b", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven}})
 	if err := g.AddNode(a); err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +219,7 @@ func TestAnalyzerApplicableRequiresJVMVulns(t *testing.T) {
 	a := Analyzer{}
 
 	g, reg := newSeed()
-	pyDep := model.NewDependency(model.Dependency{Name: "requests", Ecosystem: model.EcosystemPython})
+	pyDep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "requests", Ecosystem: model.EcosystemPython}})
 	pyDep.PackageRef = model.CanonicalPackageURLFromDependency(pyDep)
 	_ = g.AddNode(pyDep)
 	reg.Ensure(pyDep.PackageRef).Vulnerabilities = []model.Vulnerability{{ID: "x"}}

--- a/internal/analyzers/jvmreach/analyzer_test.go
+++ b/internal/analyzers/jvmreach/analyzer_test.go
@@ -58,12 +58,12 @@ func newSeed() (*model.Graph, *model.PackageRegistry) {
 func addJVMDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, group, artifact, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
 	dep := model.NewDependency(model.Dependency{
-		Name:        artifact,
-		Org:         group,
-		Version:     version,
-		Ecosystem:   string(model.EcosystemMaven),
-		BuildSystem: "maven",
-		Locations:   []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
+		Name:           artifact,
+		Org:            group,
+		Version:        version,
+		Ecosystem:      model.EcosystemMaven,
+		PackageManager: "maven",
+		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "pom.xml")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -194,8 +194,8 @@ func TestAnalyzerMarksTransitiveDepReachable(t *testing.T) {
 
 func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
-	a := model.NewDependency(model.Dependency{Name: "a", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
-	b := model.NewDependency(model.Dependency{Name: "b", Org: "g", Version: "1", Ecosystem: string(model.EcosystemMaven)})
+	a := model.NewDependency(model.Dependency{Name: "a", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven})
+	b := model.NewDependency(model.Dependency{Name: "b", Org: "g", Version: "1", Ecosystem: model.EcosystemMaven})
 	if err := g.AddNode(a); err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestAnalyzerApplicableRequiresJVMVulns(t *testing.T) {
 	a := Analyzer{}
 
 	g, reg := newSeed()
-	pyDep := model.NewDependency(model.Dependency{Name: "requests", Ecosystem: string(model.EcosystemPython)})
+	pyDep := model.NewDependency(model.Dependency{Name: "requests", Ecosystem: model.EcosystemPython})
 	pyDep.PackageRef = model.CanonicalPackageURLFromDependency(pyDep)
 	_ = g.AddNode(pyDep)
 	reg.Ensure(pyDep.PackageRef).Vulnerabilities = []model.Vulnerability{{ID: "x"}}

--- a/internal/analyzers/jvmreach/discover.go
+++ b/internal/analyzers/jvmreach/discover.go
@@ -339,16 +339,16 @@ func isJVMPackage(pkg *model.Dependency) bool {
 	if pkg == nil {
 		return false
 	}
-	switch strings.ToLower(pkg.Ecosystem) {
-	case string(model.EcosystemMaven), string(model.EcosystemScala):
+	switch pkg.Ecosystem {
+	case model.EcosystemMaven, model.EcosystemScala:
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(pkg.BuildSystem)) {
-	case "maven", "gradle", "sbt":
+	switch pkg.PackageManager {
+	case model.PackageManagerMaven, model.PackageManagerGradle, model.PackageManagerSBT:
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(pkg.Language)) {
-	case string(model.LanguageJava), string(model.LanguageKotlin), string(model.LanguageScala), string(model.LanguageGroovy):
+	switch pkg.Language {
+	case model.LanguageJava, model.LanguageKotlin, model.LanguageScala, model.LanguageGroovy:
 		return true
 	}
 	return false

--- a/internal/analyzers/jvmreach/modules_test.go
+++ b/internal/analyzers/jvmreach/modules_test.go
@@ -96,8 +96,8 @@ func TestAnalyzerTraversesConsumedMavenModules(t *testing.T) {
 	reg := model.NewPackageRegistry()
 	jacksonPURL := "pkg:maven/com.fasterxml.jackson.core/jackson-databind@1"
 	log4jPURL := "pkg:maven/org.apache.logging.log4j/log4j-core@1"
-	jackson := model.NewDependency(model.Dependency{Name: "jackson-databind", Org: "com.fasterxml.jackson.core", Version: "1", Ecosystem: "maven", PURL: jacksonPURL})
-	log4j := model.NewDependency(model.Dependency{Name: "log4j-core", Org: "org.apache.logging.log4j", Version: "1", Ecosystem: "maven", PURL: log4jPURL})
+	jackson := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "jackson-databind", Org: "com.fasterxml.jackson.core", Version: "1", Ecosystem: "maven", PURL: jacksonPURL}})
+	log4j := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "log4j-core", Org: "org.apache.logging.log4j", Version: "1", Ecosystem: "maven", PURL: log4jPURL}})
 	reg.Ensure(jacksonPURL).Vulnerabilities = []model.Vulnerability{{ID: "jackson"}}
 	reg.Ensure(log4jPURL).Vulnerabilities = []model.Vulnerability{{ID: "log4j"}}
 	_ = g.AddNode(jackson)

--- a/internal/analyzers/jvmreach/modules_testdata_test.go
+++ b/internal/analyzers/jvmreach/modules_testdata_test.go
@@ -128,11 +128,9 @@ func TestGradleIncludedProjectPaths(t *testing.T) {
 func TestDiscoverProjectRootsDeduplicatesGraphAndTargetSources(t *testing.T) {
 	root := moduleFixture("maven-reactor")
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "jackson-databind",
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "jackson-databind",
 		Org:       "com.fasterxml.jackson.core",
-		Ecosystem: "maven",
-		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "app", "pom.xml")}},
+		Ecosystem: "maven"}, Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "app", "pom.xml")}},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
@@ -233,8 +231,8 @@ func TestAnalyzerBuiltInRunnerTraversesMavenReactorTestdata(t *testing.T) {
 	reg := model.NewPackageRegistry()
 	jacksonPURL := "pkg:maven/com.fasterxml.jackson.core/jackson-databind@1"
 	log4jPURL := "pkg:maven/org.apache.logging.log4j/log4j-core@1"
-	jackson := model.NewDependency(model.Dependency{Name: "jackson-databind", Org: "com.fasterxml.jackson.core", Version: "1", Ecosystem: "maven", PURL: jacksonPURL})
-	log4j := model.NewDependency(model.Dependency{Name: "log4j-core", Org: "org.apache.logging.log4j", Version: "1", Ecosystem: "maven", PURL: log4jPURL})
+	jackson := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "jackson-databind", Org: "com.fasterxml.jackson.core", Version: "1", Ecosystem: "maven", PURL: jacksonPURL}})
+	log4j := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "log4j-core", Org: "org.apache.logging.log4j", Version: "1", Ecosystem: "maven", PURL: log4jPURL}})
 	reg.Ensure(jacksonPURL).Vulnerabilities = []model.Vulnerability{{ID: "jackson"}}
 	reg.Ensure(log4jPURL).Vulnerabilities = []model.Vulnerability{{ID: "log4j"}}
 	if err := g.AddNode(jackson); err != nil {

--- a/internal/analyzers/jvmreach/runner_testdata_test.go
+++ b/internal/analyzers/jvmreach/runner_testdata_test.go
@@ -65,11 +65,10 @@ func TestJVMDescriptorAndRunnerResult(t *testing.T) {
 func TestJVMStandaloneApplyRunnerResult(t *testing.T) {
 	const purl = "pkg:maven/com.fasterxml.jackson.core/jackson-databind"
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "jackson-databind",
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "jackson-databind",
 		Org:       "com.fasterxml.jackson.core",
 		Ecosystem: model.EcosystemMaven,
-		PURL:      purl,
+		PURL:      purl},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)

--- a/internal/analyzers/jvmreach/runner_testdata_test.go
+++ b/internal/analyzers/jvmreach/runner_testdata_test.go
@@ -68,7 +68,7 @@ func TestJVMStandaloneApplyRunnerResult(t *testing.T) {
 	pkg := model.NewDependency(model.Dependency{
 		Name:      "jackson-databind",
 		Org:       "com.fasterxml.jackson.core",
-		Ecosystem: string(model.EcosystemMaven),
+		Ecosystem: model.EcosystemMaven,
 		PURL:      purl,
 	})
 	if err := g.AddNode(pkg); err != nil {

--- a/internal/analyzers/pyreach/analyzer_test.go
+++ b/internal/analyzers/pyreach/analyzer_test.go
@@ -51,12 +51,10 @@ func newSeed() (*model.Graph, *model.PackageRegistry) {
 // registry package keyed by the dependency PURL carrying them.
 func addPyDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, name, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
-	dep := model.NewDependency(model.Dependency{
-		Name:           name,
+	dep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: name,
 		Version:        version,
 		Ecosystem:      model.EcosystemPython,
-		PackageManager: "pip",
-		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		PackageManager: "pip"}, Locations: []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -183,7 +181,7 @@ func TestAnalyzerApplicableRequiresPythonVulns(t *testing.T) {
 	a := Analyzer{}
 
 	g, reg := newSeed()
-	goDep := model.NewDependency(model.Dependency{Name: "lib", Ecosystem: "go"})
+	goDep := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lib", Ecosystem: "go"}})
 	goDep.PackageRef = model.CanonicalPackageURLFromDependency(goDep)
 	_ = g.AddNode(goDep)
 	reg.Ensure(goDep.PackageRef).Vulnerabilities = []model.Vulnerability{{ID: "x"}}
@@ -271,8 +269,8 @@ func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
 
 func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
-	a := model.NewDependency(model.Dependency{Name: "a", Version: "1.0.0", Ecosystem: model.EcosystemPython})
-	b := model.NewDependency(model.Dependency{Name: "b", Version: "1.0.0", Ecosystem: model.EcosystemPython})
+	a := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "a", Version: "1.0.0", Ecosystem: model.EcosystemPython}})
+	b := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "b", Version: "1.0.0", Ecosystem: model.EcosystemPython}})
 	if err := g.AddNode(a); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analyzers/pyreach/analyzer_test.go
+++ b/internal/analyzers/pyreach/analyzer_test.go
@@ -52,11 +52,11 @@ func newSeed() (*model.Graph, *model.PackageRegistry) {
 func addPyDep(t *testing.T, g *model.Graph, reg *model.PackageRegistry, projectDir, name, version string, vulns ...model.Vulnerability) *model.Dependency {
 	t.Helper()
 	dep := model.NewDependency(model.Dependency{
-		Name:        name,
-		Version:     version,
-		Ecosystem:   string(model.EcosystemPython),
-		BuildSystem: "pip",
-		Locations:   []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
+		Name:           name,
+		Version:        version,
+		Ecosystem:      model.EcosystemPython,
+		PackageManager: "pip",
+		Locations:      []model.PackageLocation{{RealPath: filepath.Join(projectDir, "requirements.txt")}},
 	})
 	purl := model.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -271,8 +271,8 @@ func TestAnalyzerDoesNotExpandThroughUnimportedRoots(t *testing.T) {
 
 func TestComputeReachablePackageHopsHandlesCycles(t *testing.T) {
 	g := model.New()
-	a := model.NewDependency(model.Dependency{Name: "a", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
-	b := model.NewDependency(model.Dependency{Name: "b", Version: "1.0.0", Ecosystem: string(model.EcosystemPython)})
+	a := model.NewDependency(model.Dependency{Name: "a", Version: "1.0.0", Ecosystem: model.EcosystemPython})
+	b := model.NewDependency(model.Dependency{Name: "b", Version: "1.0.0", Ecosystem: model.EcosystemPython})
 	if err := g.AddNode(a); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analyzers/pyreach/discover.go
+++ b/internal/analyzers/pyreach/discover.go
@@ -135,12 +135,12 @@ func isPythonPackage(pkg *model.Dependency) bool {
 	if pkg == nil {
 		return false
 	}
-	if strings.EqualFold(pkg.Ecosystem, string(model.EcosystemPython)) {
+	if pkg.Ecosystem == model.EcosystemPython {
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(pkg.BuildSystem)) {
-	case "pip", "pipenv", "poetry", "uv", "pdm", "setuppy", "setup.py":
+	switch pkg.PackageManager {
+	case model.PackageManagerPip, model.PackageManagerPipenv, model.PackageManagerPoetry, model.PackageManagerUV, model.PackageManagerPDM, model.PackageManagerSetupPy:
 		return true
 	}
-	return strings.EqualFold(pkg.Language, string(model.LanguagePython))
+	return pkg.Language == model.LanguagePython
 }

--- a/internal/analyzers/pyreach/testdata_test.go
+++ b/internal/analyzers/pyreach/testdata_test.go
@@ -25,7 +25,7 @@ func TestDiscoverProjectRootsFromTestdata(t *testing.T) {
 	g := model.New()
 	pkg := model.NewDependency(model.Dependency{
 		Name:      "requests",
-		Ecosystem: string(model.EcosystemPython),
+		Ecosystem: model.EcosystemPython,
 		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "pkg", "helpers.py")}},
 	})
 	if err := g.AddNode(pkg); err != nil {

--- a/internal/analyzers/pyreach/testdata_test.go
+++ b/internal/analyzers/pyreach/testdata_test.go
@@ -23,10 +23,8 @@ func pythonFixture(parts ...string) string {
 func TestDiscoverProjectRootsFromTestdata(t *testing.T) {
 	root := pythonFixture("project")
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{
-		Name:      "requests",
-		Ecosystem: model.EcosystemPython,
-		Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "pkg", "helpers.py")}},
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "requests",
+		Ecosystem: model.EcosystemPython}, Locations: []model.PackageLocation{{RealPath: filepath.Join(root, "pkg", "helpers.py")}},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -18,7 +18,7 @@ func TestLicenseAuditorAllowDeny(t *testing.T) {
 		g := sdk.New()
 		root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 		_ = g.AddNode(root)
-		dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", BuildSystem: "npm"})
+		dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
 		purl := sdk.CanonicalPackageURLFromDependency(dep)
 		dep.PackageRef = purl
 		_ = g.AddNode(dep)
@@ -66,10 +66,10 @@ func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
 	dep := sdk.NewDependency(sdk.Dependency{
-		Name:        "very-long-package-name-with-output-hostile-length",
-		Version:     "1.2.3",
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
+		Name:           "very-long-package-name-with-output-hostile-length",
+		Version:        "1.2.3",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
 	})
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -108,7 +108,7 @@ func TestLicenseAuditorDeniedLicensesUseNASeverity(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
-	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", BuildSystem: "npm"})
+	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
 	_ = g.AddNode(dep)
@@ -137,7 +137,7 @@ func TestLicenseAuditorUnknownLicenseIDsDifferByPackage(t *testing.T) {
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
 	for _, name := range []string{"left-pad", "is-odd"} {
-		dep := sdk.NewDependency(sdk.Dependency{Name: name, Version: "1.0.0", Ecosystem: "npm", BuildSystem: "npm"})
+		dep := sdk.NewDependency(sdk.Dependency{Name: name, Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
 		dep.PackageRef = sdk.CanonicalPackageURLFromDependency(dep)
 		_ = g.AddNode(dep)
 		_ = g.AddEdge(root.ID, dep.ID)

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -18,7 +18,7 @@ func TestLicenseAuditorAllowDeny(t *testing.T) {
 		g := sdk.New()
 		root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 		_ = g.AddNode(root)
-		dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
+		dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lib", Version: "1.0.0", Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM}})
 		purl := sdk.CanonicalPackageURLFromDependency(dep)
 		dep.PackageRef = purl
 		_ = g.AddNode(dep)
@@ -65,11 +65,10 @@ func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
-	dep := sdk.NewDependency(sdk.Dependency{
-		Name:           "very-long-package-name-with-output-hostile-length",
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "very-long-package-name-with-output-hostile-length",
 		Version:        "1.2.3",
-		Ecosystem:      "npm",
-		PackageManager: "npm",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM},
 	})
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
@@ -108,7 +107,7 @@ func TestLicenseAuditorDeniedLicensesUseNASeverity(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
-	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lib", Version: "1.0.0", Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM}})
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 	dep.PackageRef = purl
 	_ = g.AddNode(dep)
@@ -137,7 +136,7 @@ func TestLicenseAuditorUnknownLicenseIDsDifferByPackage(t *testing.T) {
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
 	for _, name := range []string{"left-pad", "is-odd"} {
-		dep := sdk.NewDependency(sdk.Dependency{Name: name, Version: "1.0.0", Ecosystem: "npm", PackageManager: "npm"})
+		dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: name, Version: "1.0.0", Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM}})
 		dep.PackageRef = sdk.CanonicalPackageURLFromDependency(dep)
 		_ = g.AddNode(dep)
 		_ = g.AddEdge(root.ID, dep.ID)

--- a/internal/auditors/package/auditor_test.go
+++ b/internal/auditors/package/auditor_test.go
@@ -9,12 +9,13 @@ import (
 
 // pkg is a convenience constructor for tests.
 func pkg(id, name, version, scope string) *sdk.Dependency {
-	return &sdk.Dependency{
-		ID:         id,
-		Name:       name,
-		Version:    version,
-		Scopes:     sdk.ScopesOf(sdk.Scope(scope)),
-		PURL:       id,
+	return &sdk.Dependency{Coordinates: sdk.Coordinates{Name: name,
+		Version: version,
+
+		PURL: id}, ID: id,
+
+		Scopes: sdk.ScopesOf(sdk.Scope(scope)),
+
 		PackageRef: id,
 	}
 }

--- a/internal/auditors/vulnerability/auditor.go
+++ b/internal/auditors/vulnerability/auditor.go
@@ -81,7 +81,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 				ID:              vulnerability.ID,
 				Kind:            sdk.FindingKindVulnerability,
 				Title:           title,
-				Severity:        strings.ToLower(strings.TrimSpace(vulnerability.ParsedSeverity)),
+				Severity:        sdk.ParseSeverityLevel(string(vulnerability.ParsedSeverity)),
 				Reasons:         append([]string(nil), vulnerability.Reasons...),
 				Source:          vulnerability.Source,
 				Auditor:         auditorName,

--- a/internal/cli/opts/options.go
+++ b/internal/cli/opts/options.go
@@ -400,11 +400,11 @@ func httpClientConfigFromResolved(current config.Resolved) sdk.HTTPClientConfig 
 // ProjectDescriptor returns a descriptor for the main project being analyzed,
 // summarizing its name, path, ecosystem, and package manager.
 func (o *Options) ProjectDescriptor() output.ProjectDescriptor {
-	ecosystem := "multiple"
-	packageManager := "multiple"
+	ecosystem := sdk.EcosystemOther
+	packageManager := sdk.PackageManagerMultiple
 	if len(o.subprojects) == 1 {
-		ecosystem = string(o.subprojects[0].Ecosystem)
-		packageManager = o.subprojects[0].PrimaryPackageManager().Name()
+		ecosystem = o.subprojects[0].Ecosystem
+		packageManager = o.subprojects[0].PrimaryPackageManager()
 	}
 	location := displayTargetLocation(o.executionTarget)
 	return output.ProjectDescriptor{
@@ -430,8 +430,8 @@ func (o *Options) ProjectDescriptorForSubproject(subproject sdk.Subproject) outp
 		Path:           displayTargetLocation(subproject.ExecutionTarget),
 		TargetType:     displayTargetType(subproject.ExecutionTarget),
 		TargetRef:      subproject.ExecutionTarget.Ref,
-		Ecosystem:      string(subproject.Ecosystem),
-		PackageManager: subproject.PrimaryPackageManager().Name(),
+		Ecosystem:      subproject.Ecosystem,
+		PackageManager: subproject.PrimaryPackageManager(),
 	}
 }
 

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -121,14 +121,14 @@ func vulnerabilityTextSections(results output.DiffVulnerabilityResults, includeR
 		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
 		for _, change := range results.Added {
 			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
-			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s%s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Red))
+			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s%s", strings.ToUpper(ValueOrDash(string(change.Vulnerability.Severity))), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Red))
 		}
 	}
 	if len(results.Removed) > 0 {
 		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
 		for _, change := range results.Removed {
 			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
-			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s%s", strings.ToUpper(ValueOrDash(change.Vulnerability.Severity)), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Green))
+			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s%s", strings.ToUpper(ValueOrDash(string(change.Vulnerability.Severity))), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Green))
 		}
 	}
 	return append(lines, "")
@@ -146,8 +146,8 @@ func policyTextSections(audit output.DiffAudit, includeReachability bool) []stri
 		}
 		lines = append(lines, title)
 		for _, finding := range sortDiffAuditFindings(findings) {
-			disposition := strings.ToUpper(ValueOrDash(finding.Disposition))
-			line := fmt.Sprintf("  - [%s/%s] %s", strings.ToUpper(ValueOrDash(finding.Severity)), disposition, ValueOrDash(finding.ID))
+			disposition := strings.ToUpper(ValueOrDash(string(finding.Disposition)))
+			line := fmt.Sprintf("  - [%s/%s] %s", strings.ToUpper(ValueOrDash(string(finding.Severity))), disposition, ValueOrDash(finding.ID))
 			if pkgLabel := DiffPackageDisplayName(finding.Package); pkgLabel != "" {
 				line += " " + pkgLabel
 			}
@@ -253,8 +253,8 @@ func diffAuditFindingsSummary(summary *output.AuditSummary) string {
 func sortDiffAuditFindings(findings []output.AuditFinding) []output.AuditFinding {
 	sorted := append([]output.AuditFinding(nil), findings...)
 	sort.Slice(sorted, func(i, j int) bool {
-		si := severityRankTable(sorted[i].Severity)
-		sj := severityRankTable(sorted[j].Severity)
+		si := severityRankTable(string(sorted[i].Severity))
+		sj := severityRankTable(string(sorted[j].Severity))
 		if si != sj {
 			return si < sj
 		}
@@ -289,9 +289,9 @@ func DiffPackageDisplayName(pkg output.PackageRef) string {
 func DiffManifestDisplayLabel(manifest output.DiffManifestResult) string {
 	label := manifest.Path
 	if strings.TrimSpace(label) == "" {
-		label = manifest.Kind
+		label = string(manifest.Kind)
 	}
-	if strings.TrimSpace(manifest.PackageManager) != "" {
+	if strings.TrimSpace(manifest.PackageManager.Name()) != "" {
 		return fmt.Sprintf("%s (%s)", label, manifest.PackageManager)
 	}
 	return label

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -130,9 +130,9 @@ func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabi
 	for _, change := range sortVulnerabilityChanges(changes) {
 		vuln := change.Vulnerability
 		row := []string{
-			findingIcon(status, vuln.Severity, ""),
+			findingIcon(status, string(vuln.Severity), ""),
 			status,
-			strings.ToUpper(valueOrDash(vuln.Severity)),
+			strings.ToUpper(valueOrDash(string(vuln.Severity))),
 			vuln.ID,
 			DiffPackageDisplayName(change.Package),
 		}
@@ -235,11 +235,11 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding,
 	rows := make([][]string, 0, len(findings))
 	for _, finding := range sortDiffAuditFindings(findings) {
 		row := []string{
-			findingIcon(status, finding.Severity, finding.Disposition),
+			findingIcon(status, string(finding.Severity), string(finding.Disposition)),
 			status,
 			valueOrDash(finding.Auditor),
-			strings.ToUpper(valueOrDash(finding.Severity)),
-			findingDisposition(finding.Disposition),
+			strings.ToUpper(valueOrDash(string(finding.Severity))),
+			findingDisposition(string(finding.Disposition)),
 			valueOrDash(finding.ID),
 			DiffPackageDisplayName(finding.Package),
 		}
@@ -312,8 +312,8 @@ func sortChangedPackages(changes []output.DiffChangedPackage) []output.DiffChang
 func sortVulnerabilityChanges(changes []output.DiffVulnerabilityChange) []output.DiffVulnerabilityChange {
 	sorted := append([]output.DiffVulnerabilityChange(nil), changes...)
 	sort.Slice(sorted, func(i, j int) bool {
-		if severityRankTable(sorted[i].Vulnerability.Severity) != severityRankTable(sorted[j].Vulnerability.Severity) {
-			return severityRankTable(sorted[i].Vulnerability.Severity) < severityRankTable(sorted[j].Vulnerability.Severity)
+		if severityRankTable(string(sorted[i].Vulnerability.Severity)) != severityRankTable(string(sorted[j].Vulnerability.Severity)) {
+			return severityRankTable(string(sorted[i].Vulnerability.Severity)) < severityRankTable(string(sorted[j].Vulnerability.Severity))
 		}
 		if sorted[i].Vulnerability.ID != sorted[j].Vulnerability.ID {
 			return sorted[i].Vulnerability.ID < sorted[j].Vulnerability.ID

--- a/internal/cli/render/explain.go
+++ b/internal/cli/render/explain.go
@@ -62,7 +62,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 			return err
 		}
 		for _, vulnerability := range target.Dependency.Vulnerabilities {
-			if _, err := fmt.Fprintf(w, "- %s %s (%s)\n", explainSeverityLabel(vulnerability.Severity), vulnerability.ID, ValueOrDash(vulnerability.Source)); err != nil {
+			if _, err := fmt.Fprintf(w, "- %s %s (%s)\n", explainSeverityLabel(string(vulnerability.Severity)), vulnerability.ID, ValueOrDash(vulnerability.Source)); err != nil {
 				return err
 			}
 			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Title:   ", Dim), ValueOrDash(vulnerability.Title)); err != nil {
@@ -101,7 +101,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 			return err
 		}
 		for _, finding := range target.Findings {
-			if _, err := fmt.Fprintf(w, "- %s %s\n", explainSeverityLabel(finding.Severity), finding.ID); err != nil {
+			if _, err := fmt.Fprintf(w, "- %s %s\n", explainSeverityLabel(string(finding.Severity)), finding.ID); err != nil {
 				return err
 			}
 			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Title:   ", Dim), ValueOrDash(finding.Title)); err != nil {
@@ -173,7 +173,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 		for idx, license := range target.Dependency.Licenses {
 			label := license.Identifier()
 			if license.Type != "" {
-				label += " [" + license.Type + "]"
+				label += " [" + string(license.Type) + "]"
 			}
 			if _, err := fmt.Fprintf(w, "- License %d: %s\n", idx+1, ValueOrDash(label)); err != nil {
 				return err

--- a/internal/cli/render/explain_markdown.go
+++ b/internal/cli/render/explain_markdown.go
@@ -86,7 +86,7 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 			rows := make([][]string, 0, len(target.Dependency.Vulnerabilities))
 			for _, vulnerability := range target.Dependency.Vulnerabilities {
 				row := []string{
-					strings.ToUpper(ValueOrDash(vulnerability.Severity)),
+					strings.ToUpper(ValueOrDash(string(vulnerability.Severity))),
 					valueOrDash(vulnerability.ID),
 				}
 				if payload.Metadata.ReachabilityEnabled {
@@ -119,7 +119,7 @@ func explainImpactMarkdown(payload output.ExplainResponse) []string {
 				}
 				lines = append(lines, fmt.Sprintf(
 					"- [%s] `%s`: %s%s",
-					markdownInline(ValueOrDash(finding.Severity)),
+					markdownInline(ValueOrDash(string(finding.Severity))),
 					markdownInline(ValueOrDash(finding.ID)),
 					markdownText(title),
 					suffix,

--- a/internal/cli/render/reachability_test.go
+++ b/internal/cli/render/reachability_test.go
@@ -12,7 +12,7 @@ import (
 func TestScanRendersReachabilityColumnWhenEnabled(t *testing.T) {
 	g := model.New()
 	const libPURL = "pkg:go/lib@1.0.0"
-	pkg := model.NewDependency(model.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "go", PURL: libPURL})
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lib", Version: "1.0.0", Ecosystem: model.EcosystemGo, PURL: libPURL}})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestExplainTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
 
 func TestScanOmitsReachabilityColumnWhenDisabled(t *testing.T) {
 	g := model.New()
-	pkg := model.NewDependency(model.Dependency{Name: "lib", Version: "1.0.0", Ecosystem: "go"})
+	pkg := model.NewDependency(model.Dependency{Coordinates: model.Coordinates{Name: "lib", Version: "1.0.0", Ecosystem: model.EcosystemGo}})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/render/scan.go
+++ b/internal/cli/render/scan.go
@@ -74,8 +74,8 @@ func Scan(manifests []output.ScanManifest, g *sdk.Graph, registry *sdk.PackageRe
 		sorted := make([]sdk.Finding, len(findings))
 		copy(sorted, findings)
 		sort.Slice(sorted, func(i, j int) bool {
-			si := severityRankTable(sorted[i].Severity)
-			sj := severityRankTable(sorted[j].Severity)
+			si := severityRankTable(string(sorted[i].Severity))
+			sj := severityRankTable(string(sorted[j].Severity))
 			if si != sj {
 				return si < sj
 			}
@@ -252,7 +252,7 @@ func renderUniqueLicensesTable(g *sdk.Graph, registry *sdk.PackageRegistry) stri
 				row.value = strings.TrimSpace(license.Value)
 			}
 			if row.sourceType == "" {
-				row.sourceType = strings.TrimSpace(license.Type)
+				row.sourceType = strings.TrimSpace(string(license.Type))
 			}
 			row.packages[pkg.ID] = struct{}{}
 		}

--- a/internal/cli/render/scan_markdown.go
+++ b/internal/cli/render/scan_markdown.go
@@ -57,7 +57,7 @@ func scanManifestMarkdown(payload output.ScanResponse) []string {
 		rows = append(rows, []string{
 			subproject,
 			ValueOrDash(manifest.Path),
-			ValueOrDash(manifest.PackageManager),
+			ValueOrDash(manifest.PackageManager.Name()),
 			fmt.Sprintf("%d", len(manifest.Dependencies)),
 		})
 	}
@@ -107,7 +107,7 @@ func scanFindingsMarkdown(payload output.ScanResponse) []string {
 			title = finding.ID
 		}
 		row := []string{
-			strings.ToUpper(ValueOrDash(finding.Severity)),
+			strings.ToUpper(ValueOrDash(string(finding.Severity))),
 			valueOrDash(finding.ID),
 			pkg,
 		}

--- a/internal/cli/scan_cmd_test.go
+++ b/internal/cli/scan_cmd_test.go
@@ -86,11 +86,9 @@ func newScanTestGraph(t *testing.T) (*sdk.Graph, *sdk.PackageRegistry) {
 		{id: "zod@3.23.0", name: "zod", version: "3.23.0", purl: "pkg:npm/zod@3.23.0", scope: sdk.ScopeDevelopment, license: "Apache-2.0"},
 		{id: "loose-envify@1.4.0", name: "loose-envify", version: "1.4.0", purl: "pkg:npm/loose-envify@1.4.0", scope: sdk.ScopeRuntime},
 	} {
-		dep := sdk.NewDependencyWithID(f.id, sdk.Dependency{
-			Name:    f.name,
+		dep := sdk.NewDependencyWithID(f.id, sdk.Dependency{Coordinates: sdk.Coordinates{Name: f.name,
 			Version: f.version,
-			PURL:    f.purl,
-			Scopes:  sdk.ScopesOf(f.scope),
+			PURL:    f.purl}, Scopes: sdk.ScopesOf(f.scope),
 		})
 		if f.license != "" {
 			sdk.SetDetectionLicenses(dep, []sdk.PackageLicense{{SPDXExpression: f.license}})

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -246,12 +246,11 @@ func depGraphFromMetadataWithScope(raw []byte, scopeFilter sdk.Scope) (*sdk.Grap
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemRust,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemRust,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "rust",
+		Language:       "rust"},
 	})
 
 }
@@ -261,15 +260,13 @@ func packageNode(pkg metadataPackage, id string, workspace map[string]struct{}) 
 	if _, ok := workspace[id]; ok {
 		pkgType = "application"
 	}
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemRust,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemRust,
 		Name:           pkg.Name,
 		Version:        pkg.Version,
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.ParsePackageType(pkgType),
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version),
-		ResolvedURL:    pkg.Source,
+		PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version)}, ResolvedURL: pkg.Source,
 	})
 
 }
@@ -329,14 +326,13 @@ func depGraphFromLockWithScope(lockRaw, manifestRaw []byte, scopeFilter sdk.Scop
 		return nil, fmt.Errorf("cargo.toml does not contain a package name")
 	}
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemRust,
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemRust,
 		Name:           manifest.Name,
 		Version:        manifest.Version,
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.PackageTypeApplication,
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL("cargo", "", manifest.Name, manifest.Version),
+		PURL:           sdk.BuildPackageURL("cargo", "", manifest.Name, manifest.Version)},
 	})
 
 	if err := g.AddNode(root); err != nil {

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -247,11 +247,11 @@ func depGraphFromMetadataWithScope(raw []byte, scopeFilter sdk.Scope) (*sdk.Grap
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemRust),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerCargo.Name(),
-		Type:        "application",
-		Language:    "rust",
+		Ecosystem:      sdk.EcosystemRust,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerCargo,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "rust",
 	})
 
 }
@@ -262,14 +262,14 @@ func packageNode(pkg metadataPackage, id string, workspace map[string]struct{}) 
 		pkgType = "application"
 	}
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemRust),
-		Name:        pkg.Name,
-		Version:     pkg.Version,
-		BuildSystem: sdk.PackageManagerCargo.Name(),
-		Type:        pkgType,
-		Language:    "rust",
-		PURL:        sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version),
-		ResolvedURL: pkg.Source,
+		Ecosystem:      sdk.EcosystemRust,
+		Name:           pkg.Name,
+		Version:        pkg.Version,
+		PackageManager: sdk.PackageManagerCargo,
+		Type:           sdk.ParsePackageType(pkgType),
+		Language:       "rust",
+		PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version),
+		ResolvedURL:    pkg.Source,
 	})
 
 }
@@ -330,13 +330,13 @@ func depGraphFromLockWithScope(lockRaw, manifestRaw []byte, scopeFilter sdk.Scop
 	}
 	g := sdk.New()
 	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemRust),
-		Name:        manifest.Name,
-		Version:     manifest.Version,
-		BuildSystem: sdk.PackageManagerCargo.Name(),
-		Type:        "application",
-		Language:    "rust",
-		PURL:        sdk.BuildPackageURL("cargo", "", manifest.Name, manifest.Version),
+		Ecosystem:      sdk.EcosystemRust,
+		Name:           manifest.Name,
+		Version:        manifest.Version,
+		PackageManager: sdk.PackageManagerCargo,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "rust",
+		PURL:           sdk.BuildPackageURL("cargo", "", manifest.Name, manifest.Version),
 	})
 
 	if err := g.AddNode(root); err != nil {

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -311,25 +311,23 @@ func rootDependencies(values []string) []string {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemSwift,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemSwift,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerCocoaPods,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "swift",
+		Language:       "swift"},
 	})
 
 }
 
 func packageNode(name, version, checksum string) *sdk.Dependency { //nolint:unparam
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemSwift,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemSwift,
 		Name:           name,
 		Version:        strings.TrimSpace(version),
 		PackageManager: sdk.PackageManagerCocoaPods,
 		Type:           "pod",
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL("cocoapods", "", name, version),
+		PURL:           sdk.BuildPackageURL("cocoapods", "", name, version)},
 	})
 
 	if strings.TrimSpace(checksum) != "" {

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -312,24 +312,24 @@ func rootDependencies(values []string) []string {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemSwift),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerCocoaPods.Name(),
-		Type:        "application",
-		Language:    "swift",
+		Ecosystem:      sdk.EcosystemSwift,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerCocoaPods,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "swift",
 	})
 
 }
 
 func packageNode(name, version, checksum string) *sdk.Dependency { //nolint:unparam
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemSwift),
-		Name:        name,
-		Version:     strings.TrimSpace(version),
-		BuildSystem: sdk.PackageManagerCocoaPods.Name(),
-		Type:        "pod",
-		Language:    "swift",
-		PURL:        sdk.BuildPackageURL("cocoapods", "", name, version),
+		Ecosystem:      sdk.EcosystemSwift,
+		Name:           name,
+		Version:        strings.TrimSpace(version),
+		PackageManager: sdk.PackageManagerCocoaPods,
+		Type:           "pod",
+		Language:       "swift",
+		PURL:           sdk.BuildPackageURL("cocoapods", "", name, version),
 	})
 
 	if strings.TrimSpace(checksum) != "" {

--- a/internal/detectors/common.go
+++ b/internal/detectors/common.go
@@ -17,7 +17,7 @@ func InferManifestMetadata(req sdk.DetectionRequest, evidencePatterns []string) 
 	}
 	return sdk.ManifestMetadata{
 		Path: path,
-		Kind: kind,
+		Kind: sdk.ManifestKind(kind),
 	}
 }
 

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -148,12 +148,11 @@ func depGraphFromLock(raw []byte, manifest composerManifest) (*sdk.Graph, error)
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemPHP,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPHP,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerComposer,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "php",
+		Language:       "php"},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -265,15 +264,14 @@ func depGraphFromLock(raw []byte, manifest composerManifest) (*sdk.Graph, error)
 
 func packageNode(name, version string) *sdk.Dependency {
 	org, packageName := splitPackageName(name)
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemPHP,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPHP,
 		Org:            org,
 		Name:           packageName,
 		Version:        version,
 		PURL:           sdk.BuildPackageURL("composer", org, packageName, version),
 		PackageManager: sdk.PackageManagerComposer,
 		Type:           sdk.PackageTypePackage,
-		Language:       "php",
+		Language:       "php"},
 	})
 
 }

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -149,11 +149,11 @@ func depGraphFromLock(raw []byte, manifest composerManifest) (*sdk.Graph, error)
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemPHP),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerComposer.Name(),
-		Type:        "application",
-		Language:    "php",
+		Ecosystem:      sdk.EcosystemPHP,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerComposer,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "php",
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -266,14 +266,14 @@ func depGraphFromLock(raw []byte, manifest composerManifest) (*sdk.Graph, error)
 func packageNode(name, version string) *sdk.Dependency {
 	org, packageName := splitPackageName(name)
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemPHP),
-		Org:         org,
-		Name:        packageName,
-		Version:     version,
-		PURL:        sdk.BuildPackageURL("composer", org, packageName, version),
-		BuildSystem: sdk.PackageManagerComposer.Name(),
-		Type:        "package",
-		Language:    "php",
+		Ecosystem:      sdk.EcosystemPHP,
+		Org:            org,
+		Name:           packageName,
+		Version:        version,
+		PURL:           sdk.BuildPackageURL("composer", org, packageName, version),
+		PackageManager: sdk.PackageManagerComposer,
+		Type:           sdk.PackageTypePackage,
+		Language:       "php",
 	})
 
 }

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -296,24 +296,24 @@ func parseConanRef(value string) (conanRef, bool) {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemCPP),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerConan.Name(),
-		Type:        "application",
-		Language:    "cpp",
+		Ecosystem:      sdk.EcosystemCPP,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerConan,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "cpp",
 	})
 
 }
 
 func packageNode(ref conanRef) *sdk.Dependency {
 	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemCPP),
-		Name:        strings.TrimSpace(ref.Name),
-		Version:     strings.TrimSpace(ref.Version),
-		BuildSystem: sdk.PackageManagerConan.Name(),
-		Type:        "package",
-		Language:    "cpp",
-		PURL:        sdk.BuildPackageURL("conan", "", ref.Name, ref.Version),
+		Ecosystem:      sdk.EcosystemCPP,
+		Name:           strings.TrimSpace(ref.Name),
+		Version:        strings.TrimSpace(ref.Version),
+		PackageManager: sdk.PackageManagerConan,
+		Type:           sdk.PackageTypePackage,
+		Language:       "cpp",
+		PURL:           sdk.BuildPackageURL("conan", "", ref.Name, ref.Version),
 	})
 
 	if strings.EqualFold(strings.TrimSpace(ref.Context), "build") {

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -295,25 +295,23 @@ func parseConanRef(value string) (conanRef, bool) {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemCPP,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemCPP,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerConan,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "cpp",
+		Language:       "cpp"},
 	})
 
 }
 
 func packageNode(ref conanRef) *sdk.Dependency {
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemCPP,
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemCPP,
 		Name:           strings.TrimSpace(ref.Name),
 		Version:        strings.TrimSpace(ref.Version),
 		PackageManager: sdk.PackageManagerConan,
 		Type:           sdk.PackageTypePackage,
 		Language:       "cpp",
-		PURL:           sdk.BuildPackageURL("conan", "", ref.Name, ref.Version),
+		PURL:           sdk.BuildPackageURL("conan", "", ref.Name, ref.Version)},
 	})
 
 	if strings.EqualFold(strings.TrimSpace(ref.Context), "build") {

--- a/internal/detectors/githubactions/detector.go
+++ b/internal/detectors/githubactions/detector.go
@@ -358,15 +358,14 @@ func resolveReference(ref, callerRelPath string, workflowNodes map[string]*sdk.D
 	if strings.Contains(name, ".github/workflows/") {
 		typeName = "workflow"
 	}
-	return sdk.NewDependency(sdk.Dependency{
-			Ecosystem:      sdk.EcosystemGitHub,
-			Org:            org,
-			Name:           packageName,
-			Version:        version,
-			Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGitHub,
+			Org:     org,
+			Name:    packageName,
+			Version: version,
+
 			PackageManager: sdk.PackageManagerGitHubActions,
 			Type:           sdk.ParsePackageType(typeName),
-			Language:       "yaml",
+			Language:       "yaml"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime),
 		}),
 
 		nil
@@ -397,28 +396,26 @@ func splitExternalActionName(value string) (string, string) {
 
 func localWorkflowNode(relPath string) *sdk.Dependency {
 	cleanPath := filepath.ToSlash(filepath.Clean(relPath))
-	return sdk.NewDependencyWithID("workflow:"+cleanPath, sdk.Dependency{
-		Ecosystem:      sdk.EcosystemGitHub,
-		Name:           cleanPath,
-		Version:        "local",
-		Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+	return sdk.NewDependencyWithID("workflow:"+cleanPath, sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGitHub,
+		Name:    cleanPath,
+		Version: "local",
+
 		PackageManager: sdk.PackageManagerGitHubActions,
 		Type:           sdk.PackageTypeWorkflow,
-		Language:       "yaml",
+		Language:       "yaml"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime),
 	})
 
 }
 
 func localActionNode(relPath string) *sdk.Dependency {
 	cleanPath := filepath.ToSlash(filepath.Clean(relPath))
-	return sdk.NewDependencyWithID("action:"+cleanPath, sdk.Dependency{
-		Ecosystem:      sdk.EcosystemGitHub,
-		Name:           cleanPath,
-		Version:        "local",
-		Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+	return sdk.NewDependencyWithID("action:"+cleanPath, sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGitHub,
+		Name:    cleanPath,
+		Version: "local",
+
 		PackageManager: sdk.PackageManagerGitHubActions,
 		Type:           sdk.PackageTypeAction,
-		Language:       "yaml",
+		Language:       "yaml"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime),
 	})
 
 }

--- a/internal/detectors/githubactions/detector.go
+++ b/internal/detectors/githubactions/detector.go
@@ -359,14 +359,14 @@ func resolveReference(ref, callerRelPath string, workflowNodes map[string]*sdk.D
 		typeName = "workflow"
 	}
 	return sdk.NewDependency(sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemGitHub),
-			Org:         org,
-			Name:        packageName,
-			Version:     version,
-			Scopes:      sdk.ScopesOf(sdk.ScopeRuntime),
-			BuildSystem: sdk.PackageManagerGitHubActions.Name(),
-			Type:        typeName,
-			Language:    "yaml",
+			Ecosystem:      sdk.EcosystemGitHub,
+			Org:            org,
+			Name:           packageName,
+			Version:        version,
+			Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+			PackageManager: sdk.PackageManagerGitHubActions,
+			Type:           sdk.ParsePackageType(typeName),
+			Language:       "yaml",
 		}),
 
 		nil
@@ -398,13 +398,13 @@ func splitExternalActionName(value string) (string, string) {
 func localWorkflowNode(relPath string) *sdk.Dependency {
 	cleanPath := filepath.ToSlash(filepath.Clean(relPath))
 	return sdk.NewDependencyWithID("workflow:"+cleanPath, sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemGitHub),
-		Name:        cleanPath,
-		Version:     "local",
-		Scopes:      sdk.ScopesOf(sdk.ScopeRuntime),
-		BuildSystem: sdk.PackageManagerGitHubActions.Name(),
-		Type:        "workflow",
-		Language:    "yaml",
+		Ecosystem:      sdk.EcosystemGitHub,
+		Name:           cleanPath,
+		Version:        "local",
+		Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+		PackageManager: sdk.PackageManagerGitHubActions,
+		Type:           sdk.PackageTypeWorkflow,
+		Language:       "yaml",
 	})
 
 }
@@ -412,13 +412,13 @@ func localWorkflowNode(relPath string) *sdk.Dependency {
 func localActionNode(relPath string) *sdk.Dependency {
 	cleanPath := filepath.ToSlash(filepath.Clean(relPath))
 	return sdk.NewDependencyWithID("action:"+cleanPath, sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemGitHub),
-		Name:        cleanPath,
-		Version:     "local",
-		Scopes:      sdk.ScopesOf(sdk.ScopeRuntime),
-		BuildSystem: sdk.PackageManagerGitHubActions.Name(),
-		Type:        "action",
-		Language:    "yaml",
+		Ecosystem:      sdk.EcosystemGitHub,
+		Name:           cleanPath,
+		Version:        "local",
+		Scopes:         sdk.ScopesOf(sdk.ScopeRuntime),
+		PackageManager: sdk.PackageManagerGitHubActions,
+		Type:           sdk.PackageTypeAction,
+		Language:       "yaml",
 	})
 
 }

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -212,9 +212,8 @@ func depGraphFromGoListWithScope(raw []byte, rootModule string, directRequires [
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemGo,
-		Name:      rootModule,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGo,
+		Name: rootModule},
 	})
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add root node: %w", err)
@@ -352,10 +351,9 @@ func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNod
 }
 
 func packageFromModuleNode(node moduleNode, scope sdk.Scope, directLines map[string]int) *sdk.Dependency {
-	dep := sdk.Dependency{
-		Ecosystem: sdk.EcosystemGo,
-		Name:      node.Path,
-		Version:   node.Version,
+	dep := sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGo,
+		Name:    node.Path,
+		Version: node.Version},
 	}
 	if scope != sdk.ScopeUnknown {
 		dep.Scopes = []sdk.Scope{scope}
@@ -373,10 +371,9 @@ func packageFromModuleNode(node moduleNode, scope sdk.Scope, directLines map[str
 }
 
 func moduleNodeID(node moduleNode) string {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemGo,
-		Name:      node.Path,
-		Version:   node.Version,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGo,
+		Name:    node.Path,
+		Version: node.Version},
 	}).ID
 }
 

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -213,7 +213,7 @@ func depGraphFromGoListWithScope(raw []byte, rootModule string, directRequires [
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
+		Ecosystem: sdk.EcosystemGo,
 		Name:      rootModule,
 	})
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -353,7 +353,7 @@ func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNod
 
 func packageFromModuleNode(node moduleNode, scope sdk.Scope, directLines map[string]int) *sdk.Dependency {
 	dep := sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
+		Ecosystem: sdk.EcosystemGo,
 		Name:      node.Path,
 		Version:   node.Version,
 	}
@@ -374,7 +374,7 @@ func packageFromModuleNode(node moduleNode, scope sdk.Scope, directLines map[str
 
 func moduleNodeID(node moduleNode) string {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
+		Ecosystem: sdk.EcosystemGo,
 		Name:      node.Path,
 		Version:   node.Version,
 	}).ID

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -259,10 +259,9 @@ func depGraphFromGradleOutput(raw []byte, rootName string) (*sdk.Graph, error) {
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemMaven,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemMaven,
 		Name:           rootName,
-		PackageManager: sdk.PackageManagerGradle,
+		PackageManager: sdk.PackageManagerGradle},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -378,11 +377,10 @@ func gradleNodeFromToken(token string, scope sdk.Scope) (*sdk.Dependency, bool) 
 		if name == "" {
 			return nil, false
 		}
-		return sdk.NewDependency(sdk.Dependency{
-				Ecosystem:      sdk.EcosystemMaven,
-				Name:           name,
-				Scopes:         sdk.ScopesOf(scope),
-				PackageManager: sdk.PackageManagerGradle,
+		return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemMaven,
+				Name: name,
+
+				PackageManager: sdk.PackageManagerGradle}, Scopes: sdk.ScopesOf(scope),
 			}),
 
 			true
@@ -395,13 +393,12 @@ func gradleNodeFromToken(token string, scope sdk.Scope) (*sdk.Dependency, bool) 
 
 	version := parts[len(parts)-1]
 	name := strings.Join(parts[1:len(parts)-1], ":")
-	return sdk.NewDependency(sdk.Dependency{
-			Ecosystem:      sdk.EcosystemMaven,
-			Name:           name,
-			Version:        version,
-			Scopes:         sdk.ScopesOf(scope),
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemMaven,
+			Name:    name,
+			Version: version,
+
 			Org:            parts[0],
-			PackageManager: sdk.PackageManagerGradle,
+			PackageManager: sdk.PackageManagerGradle}, Scopes: sdk.ScopesOf(scope),
 		}),
 
 		true

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -260,9 +260,9 @@ func depGraphFromGradleOutput(raw []byte, rootName string) (*sdk.Graph, error) {
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemMaven),
-		Name:        rootName,
-		BuildSystem: sdk.PackageManagerGradle.Name(),
+		Ecosystem:      sdk.EcosystemMaven,
+		Name:           rootName,
+		PackageManager: sdk.PackageManagerGradle,
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -379,10 +379,10 @@ func gradleNodeFromToken(token string, scope sdk.Scope) (*sdk.Dependency, bool) 
 			return nil, false
 		}
 		return sdk.NewDependency(sdk.Dependency{
-				Ecosystem:   string(sdk.EcosystemMaven),
-				Name:        name,
-				Scopes:      sdk.ScopesOf(scope),
-				BuildSystem: sdk.PackageManagerGradle.Name(),
+				Ecosystem:      sdk.EcosystemMaven,
+				Name:           name,
+				Scopes:         sdk.ScopesOf(scope),
+				PackageManager: sdk.PackageManagerGradle,
 			}),
 
 			true
@@ -396,12 +396,12 @@ func gradleNodeFromToken(token string, scope sdk.Scope) (*sdk.Dependency, bool) 
 	version := parts[len(parts)-1]
 	name := strings.Join(parts[1:len(parts)-1], ":")
 	return sdk.NewDependency(sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemMaven),
-			Name:        name,
-			Version:     version,
-			Scopes:      sdk.ScopesOf(scope),
-			Org:         parts[0],
-			BuildSystem: sdk.PackageManagerGradle.Name(),
+			Ecosystem:      sdk.EcosystemMaven,
+			Name:           name,
+			Version:        version,
+			Scopes:         sdk.ScopesOf(scope),
+			Org:            parts[0],
+			PackageManager: sdk.PackageManagerGradle,
 		}),
 
 		true

--- a/internal/detectors/gradle/detector_test.go
+++ b/internal/detectors/gradle/detector_test.go
@@ -168,7 +168,7 @@ testRuntimeClasspath - Test runtime classpath of source set 'test'.
 		t.Fatalf("expected transitive dependency package")
 	}
 	guava, _ := g.Node("com.google.guava:guava@33.0.0-jre")
-	if guava.Ecosystem != "maven" || guava.Org != "com.google.guava" || guava.Name != "guava" || guava.BuildSystem != "gradle" {
+	if guava.Ecosystem != "maven" || guava.Org != "com.google.guava" || guava.Name != "guava" || guava.PackageManager != "gradle" {
 		t.Fatalf("unexpected gradle coordinates: %#v", guava)
 	}
 	if string(guava.PrimaryScope()) != string(sdk.ScopeRuntime) {

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -363,13 +363,12 @@ func nodeFromMavenCoords(coords string) (*sdk.Dependency, error) {
 		}
 	}
 
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemMaven,
-		Name:           name,
-		Version:        parts[versionIndex],
-		Scopes:         sdk.ScopesOf(scope),
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemMaven,
+		Name:    name,
+		Version: parts[versionIndex],
+
 		Org:            groupID,
-		PackageManager: sdk.PackageManagerMaven,
+		PackageManager: sdk.PackageManagerMaven}, Scopes: sdk.ScopesOf(scope),
 	}), nil
 }
 

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -364,12 +364,12 @@ func nodeFromMavenCoords(coords string) (*sdk.Dependency, error) {
 	}
 
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemMaven),
-		Name:        name,
-		Version:     parts[versionIndex],
-		Scopes:      sdk.ScopesOf(scope),
-		Org:         groupID,
-		BuildSystem: sdk.PackageManagerMaven.Name(),
+		Ecosystem:      sdk.EcosystemMaven,
+		Name:           name,
+		Version:        parts[versionIndex],
+		Scopes:         sdk.ScopesOf(scope),
+		Org:            groupID,
+		PackageManager: sdk.PackageManagerMaven,
 	}), nil
 }
 

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -105,7 +105,7 @@ func TestNodeFromMavenCoords_WithClassifier(t *testing.T) {
 	if node.Name != "demo-artifact:sources" {
 		t.Fatalf("expected classifier in package name, got %q", node.Name)
 	}
-	if node.Org != "com.example" || node.Ecosystem != "maven" || node.BuildSystem != "maven" {
+	if node.Org != "com.example" || node.Ecosystem != "maven" || node.PackageManager != "maven" {
 		t.Fatalf("unexpected maven package: %#v", node)
 	}
 	if node.QualifiedName() != "com.example:demo-artifact:sources" {

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -372,11 +372,11 @@ func parseMixManifest(raw string) map[string]mixPackage {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemElixir),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerMix.Name(),
-		Type:        "application",
-		Language:    "elixir",
+		Ecosystem:      sdk.EcosystemElixir,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerMix,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "elixir",
 	})
 
 }
@@ -388,13 +388,13 @@ func packageNode(pkg mixPackage) *sdk.Dependency {
 		source = "hex"
 	}
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemElixir),
-		Name:        strings.TrimSpace(pkg.Name),
-		Version:     version,
-		BuildSystem: sdk.PackageManagerMix.Name(),
-		Type:        "package",
-		Language:    "elixir",
-		PURL:        sdk.BuildPackageURL("hex", "", pkg.Name, version),
+		Ecosystem:      sdk.EcosystemElixir,
+		Name:           strings.TrimSpace(pkg.Name),
+		Version:        version,
+		PackageManager: sdk.PackageManagerMix,
+		Type:           sdk.PackageTypePackage,
+		Language:       "elixir",
+		PURL:           sdk.BuildPackageURL("hex", "", pkg.Name, version),
 		Metadata: map[string]any{
 			"source": source,
 		},

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -371,12 +371,11 @@ func parseMixManifest(raw string) map[string]mixPackage {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemElixir,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemElixir,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerMix,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "elixir",
+		Language:       "elixir"},
 	})
 
 }
@@ -387,17 +386,15 @@ func packageNode(pkg mixPackage) *sdk.Dependency {
 	if source == "" {
 		source = "hex"
 	}
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemElixir,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemElixir,
 		Name:           strings.TrimSpace(pkg.Name),
 		Version:        version,
 		PackageManager: sdk.PackageManagerMix,
 		Type:           sdk.PackageTypePackage,
 		Language:       "elixir",
-		PURL:           sdk.BuildPackageURL("hex", "", pkg.Name, version),
-		Metadata: map[string]any{
-			"source": source,
-		},
+		PURL:           sdk.BuildPackageURL("hex", "", pkg.Name, version)}, Metadata: map[string]any{
+		"source": source,
+	},
 	})
 
 }

--- a/internal/detectors/node/common.go
+++ b/internal/detectors/node/common.go
@@ -143,10 +143,10 @@ func DepGraphFromNPMNode(root *NPMListNode) (*sdk.Graph, error) {
 		rootName = "root"
 	}
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemNPM),
+		Ecosystem: sdk.EcosystemNPM,
 		Name:      rootName,
 		Version:   root.Version,
-		Type:      "application",
+		Type:      sdk.PackageTypeApplication,
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -171,7 +171,7 @@ func DepGraphFromNPMNode(root *NPMListNode) (*sdk.Graph, error) {
 				name = depName
 			}
 			node := sdk.NewDependency(sdk.Dependency{
-				Ecosystem: string(sdk.EcosystemNPM),
+				Ecosystem: sdk.EcosystemNPM,
 				Name:      name,
 				Version:   depNode.Version,
 			})
@@ -204,10 +204,10 @@ func DepGraphFromPNPMJSON(raw []byte) (*sdk.Graph, error) {
 	depsGraph := sdk.New()
 	for _, root := range roots {
 		rootNode := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: string(sdk.EcosystemNPM),
+			Ecosystem: sdk.EcosystemNPM,
 			Name:      root.Name,
 			Version:   root.Version,
-			Type:      "application",
+			Type:      sdk.PackageTypeApplication,
 		})
 
 		if err := AddNodeIfMissing(depsGraph, rootNode); err != nil {
@@ -230,7 +230,7 @@ func addPNPMDependencies(depsGraph *sdk.Graph, parentID string, deps map[string]
 			name = depName
 		}
 		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: string(sdk.EcosystemNPM),
+			Ecosystem: sdk.EcosystemNPM,
 			Name:      name,
 			Version:   depNode.Version,
 		})
@@ -275,9 +275,9 @@ func DepGraphFromYarnJSON(raw []byte) (*sdk.Graph, error) {
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemNPM),
+		Ecosystem: sdk.EcosystemNPM,
 		Name:      "root",
-		Type:      "application",
+		Type:      sdk.PackageTypeApplication,
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -297,7 +297,7 @@ func addYarnTree(depsGraph *sdk.Graph, parentID string, tree yarnTreeNode) error
 		return err
 	}
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemNPM),
+		Ecosystem: sdk.EcosystemNPM,
 		Name:      name,
 		Version:   version,
 	})

--- a/internal/detectors/node/common.go
+++ b/internal/detectors/node/common.go
@@ -142,11 +142,10 @@ func DepGraphFromNPMNode(root *NPMListNode) (*sdk.Graph, error) {
 	if rootName == "" {
 		rootName = "root"
 	}
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemNPM,
-		Name:      rootName,
-		Version:   root.Version,
-		Type:      sdk.PackageTypeApplication,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+		Name:    rootName,
+		Version: root.Version,
+		Type:    sdk.PackageTypeApplication},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -170,10 +169,9 @@ func DepGraphFromNPMNode(root *NPMListNode) (*sdk.Graph, error) {
 			if name == "" {
 				name = depName
 			}
-			node := sdk.NewDependency(sdk.Dependency{
-				Ecosystem: sdk.EcosystemNPM,
-				Name:      name,
-				Version:   depNode.Version,
+			node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+				Name:    name,
+				Version: depNode.Version},
 			})
 
 			if err := AddNodeIfMissing(depsGraph, node); err != nil {
@@ -203,11 +201,10 @@ func DepGraphFromPNPMJSON(raw []byte) (*sdk.Graph, error) {
 
 	depsGraph := sdk.New()
 	for _, root := range roots {
-		rootNode := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: sdk.EcosystemNPM,
-			Name:      root.Name,
-			Version:   root.Version,
-			Type:      sdk.PackageTypeApplication,
+		rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+			Name:    root.Name,
+			Version: root.Version,
+			Type:    sdk.PackageTypeApplication},
 		})
 
 		if err := AddNodeIfMissing(depsGraph, rootNode); err != nil {
@@ -229,10 +226,9 @@ func addPNPMDependencies(depsGraph *sdk.Graph, parentID string, deps map[string]
 		if name == "" {
 			name = depName
 		}
-		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: sdk.EcosystemNPM,
-			Name:      name,
-			Version:   depNode.Version,
+		node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+			Name:    name,
+			Version: depNode.Version},
 		})
 
 		if err := AddNodeIfMissing(depsGraph, node); err != nil {
@@ -274,10 +270,9 @@ func DepGraphFromYarnJSON(raw []byte) (*sdk.Graph, error) {
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemNPM,
-		Name:      "root",
-		Type:      sdk.PackageTypeApplication,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+		Name: "root",
+		Type: sdk.PackageTypeApplication},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -296,10 +291,9 @@ func addYarnTree(depsGraph *sdk.Graph, parentID string, tree yarnTreeNode) error
 	if err != nil {
 		return err
 	}
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemNPM,
-		Name:      name,
-		Version:   version,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+		Name:    name,
+		Version: version},
 	})
 
 	if err := AddNodeIfMissing(depsGraph, node); err != nil {

--- a/internal/detectors/node/common_test.go
+++ b/internal/detectors/node/common_test.go
@@ -29,11 +29,11 @@ func TestAnnotateScopesFromPackageJSON(t *testing.T) {
 	}
 
 	depsGraph := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0"})
-	react := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
-	scheduler := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "scheduler", Version: "0.23.0"})
-	vitest := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "vitest", Version: "2.0.0"})
-	chai := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "chai", Version: "5.1.0"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0"}})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "react", Version: "18.2.0"}})
+	scheduler := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "scheduler", Version: "0.23.0"}})
+	vitest := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "vitest", Version: "2.0.0"}})
+	chai := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "chai", Version: "5.1.0"}})
 	for _, pkg := range []*sdk.Dependency{root, react, scheduler, vitest, chai} {
 		if err := depsGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -78,10 +78,10 @@ func TestAnnotateScopesFromPackageJSON_DevelopmentFilterExcludesRuntime(t *testi
 	}
 
 	depsGraph := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0"})
-	react := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
-	vitest := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "vitest", Version: "2.0.0"})
-	shared := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "shared", Version: "1.0.0"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0"}})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "react", Version: "18.2.0"}})
+	vitest := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "vitest", Version: "2.0.0"}})
+	shared := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "shared", Version: "1.0.0"}})
 	for _, pkg := range []*sdk.Dependency{root, react, vitest, shared} {
 		if err := depsGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)

--- a/internal/detectors/node/lockfile_common.go
+++ b/internal/detectors/node/lockfile_common.go
@@ -20,7 +20,7 @@ func ParseIntegrityDigests(integrity string) []sdk.Digest {
 	digests := make([]sdk.Digest, 0, len(tokens))
 	for _, token := range tokens {
 		if idx := strings.Index(token, "-"); idx > 0 {
-			digests = append(digests, sdk.Digest{Algorithm: token[:idx], Value: token[idx+1:]})
+			digests = append(digests, sdk.Digest{Algorithm: sdk.DigestAlgorithm(token[:idx]), Value: token[idx+1:]})
 		}
 	}
 	return digests

--- a/internal/detectors/node/lockfile_integration_test.go
+++ b/internal/detectors/node/lockfile_integration_test.go
@@ -61,7 +61,7 @@ func requireResolvedURL(t *testing.T, g *sdk.Graph, name, version string) {
 }
 
 // requireDigest asserts that at least one digest with the given algorithm exists.
-func requireDigest(t *testing.T, g *sdk.Graph, name, version, algorithm string) {
+func requireDigest(t *testing.T, g *sdk.Graph, name, version string, algorithm sdk.DigestAlgorithm) {
 	t.Helper()
 	pkg := requirePackage(t, g, name, version)
 	for _, d := range pkg.Digests {

--- a/internal/detectors/node/npm/npm_lockfile_parser.go
+++ b/internal/detectors/node/npm/npm_lockfile_parser.go
@@ -118,7 +118,7 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 	if rootName == "" {
 		rootName = "root"
 	}
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: lockfile.Version, Type: sdk.PackageTypeApplication})
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: lockfile.Version, Type: sdk.PackageTypeApplication}})
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add npm root node: %w", err)
 	}
@@ -142,11 +142,9 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		if name == "" {
 			continue
 		}
-		pkg := sdk.Dependency{
-			Ecosystem:   sdk.EcosystemNPM,
-			Name:        name,
-			Version:     entry.Version,
-			Scopes:      sdk.ScopesOf(scopeFromNPMLockPackage(entry)),
+		pkg := sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+			Name:    name,
+			Version: entry.Version}, Scopes: sdk.ScopesOf(scopeFromNPMLockPackage(entry)),
 			ResolvedURL: entry.Resolved,
 			Digests:     node.ParseIntegrityDigests(entry.Integrity),
 		}
@@ -176,7 +174,7 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		for dependencyName, dependencyVersion := range packageDependencyVersions(packagePath, entry) {
 			targetID, ok := resolveNPMLockDependencyID(packagePath, dependencyName, dependencyVersion, lockfile, pathToID)
 			if !ok {
-				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
+				synthetic := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)}})
 				if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 					return nil, err
 				}

--- a/internal/detectors/node/npm/npm_lockfile_parser.go
+++ b/internal/detectors/node/npm/npm_lockfile_parser.go
@@ -118,7 +118,7 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 	if rootName == "" {
 		rootName = "root"
 	}
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: rootName, Version: lockfile.Version, Type: "application"})
+	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: lockfile.Version, Type: sdk.PackageTypeApplication})
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add npm root node: %w", err)
 	}
@@ -143,7 +143,7 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 			continue
 		}
 		pkg := sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemNPM),
+			Ecosystem:   sdk.EcosystemNPM,
 			Name:        name,
 			Version:     entry.Version,
 			Scopes:      sdk.ScopesOf(scopeFromNPMLockPackage(entry)),
@@ -176,7 +176,7 @@ func depGraphFromNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		for dependencyName, dependencyVersion := range packageDependencyVersions(packagePath, entry) {
 			targetID, ok := resolveNPMLockDependencyID(packagePath, dependencyName, dependencyVersion, lockfile, pathToID)
 			if !ok {
-				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
+				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
 				if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 					return nil, err
 				}

--- a/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
@@ -78,7 +78,7 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 	if rootName == "" {
 		rootName = "root"
 	}
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication})
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication}})
 	depsGraph := sdk.New()
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add pnpm root node: %w", err)
@@ -98,12 +98,10 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		if name == "" {
 			continue
 		}
-		pkg := sdk.Dependency{
-			Ecosystem:   sdk.EcosystemNPM,
-			Name:        name,
-			Version:     version,
-			ResolvedURL: entry.Resolution.Tarball,
-			Digests:     node.ParseIntegrityDigests(entry.Resolution.Integrity),
+		pkg := sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+			Name:    name,
+			Version: version}, ResolvedURL: entry.Resolution.Tarball,
+			Digests: node.ParseIntegrityDigests(entry.Resolution.Integrity),
 		}
 		if entry.Resolution.Integrity == "" && entry.Resolution.Hash != "" {
 			pkg.Digests = []sdk.Digest{{Algorithm: sdk.DigestAlgorithmSHA1, Value: entry.Resolution.Hash}}
@@ -150,7 +148,7 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		for dependencyName, dependencyVersion := range node.MergeStringMaps(entry.Dependencies, entry.OptionalDependencies) {
 			resolved, ok := resolvePNPMDependency(byName, dependencyName, dependencyVersion)
 			if !ok {
-				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
+				synthetic := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)}})
 				if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 					return nil, err
 				}

--- a/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
@@ -78,7 +78,7 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 	if rootName == "" {
 		rootName = "root"
 	}
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: rootName, Version: manifest.Version, Type: "application"})
+	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication})
 	depsGraph := sdk.New()
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add pnpm root node: %w", err)
@@ -99,14 +99,14 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 			continue
 		}
 		pkg := sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemNPM),
+			Ecosystem:   sdk.EcosystemNPM,
 			Name:        name,
 			Version:     version,
 			ResolvedURL: entry.Resolution.Tarball,
 			Digests:     node.ParseIntegrityDigests(entry.Resolution.Integrity),
 		}
 		if entry.Resolution.Integrity == "" && entry.Resolution.Hash != "" {
-			pkg.Digests = []sdk.Digest{{Algorithm: "sha1", Value: entry.Resolution.Hash}}
+			pkg.Digests = []sdk.Digest{{Algorithm: sdk.DigestAlgorithmSHA1, Value: entry.Resolution.Hash}}
 		}
 		if len(entry.Engines) > 0 {
 			pkg.Metadata = map[string]any{sdk.MetadataKeyNPM: &sdk.NPMPackageMetadata{Engines: entry.Engines}}
@@ -150,7 +150,7 @@ func depGraphFromPNPMLockfile(projectPath string) (*sdk.Graph, error) {
 		for dependencyName, dependencyVersion := range node.MergeStringMaps(entry.Dependencies, entry.OptionalDependencies) {
 			resolved, ok := resolvePNPMDependency(byName, dependencyName, dependencyVersion)
 			if !ok {
-				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
+				synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(dependencyVersion)})
 				if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 					return nil, err
 				}

--- a/internal/detectors/node/yarn/yarn_lockfile_parser.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser.go
@@ -40,7 +40,7 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication})
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication}})
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add yarn root node: %w", err)
 	}
@@ -56,12 +56,10 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 			return id, nil
 		}
 		entry := entries[idx]
-		pkg := sdk.Dependency{
-			Ecosystem:   sdk.EcosystemNPM,
-			Name:        entry.Name,
-			Version:     entry.Version,
-			ResolvedURL: entry.Resolved,
-			Digests:     node.ParseIntegrityDigests(entry.Integrity),
+		pkg := sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+			Name:    entry.Name,
+			Version: entry.Version}, ResolvedURL: entry.Resolved,
+			Digests: node.ParseIntegrityDigests(entry.Integrity),
 		}
 		pkgNode := sdk.NewDependency(pkg)
 		if err := node.AddNodeIfMissing(depsGraph, pkgNode); err != nil {
@@ -115,7 +113,7 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 				queue = append(queue, entryIdx)
 				continue
 			}
-			synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(requested)})
+			synthetic := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(requested)}})
 			if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 				return nil, err
 			}

--- a/internal/detectors/node/yarn/yarn_lockfile_parser.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser.go
@@ -40,7 +40,7 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: rootName, Version: manifest.Version, Type: "application"})
+	rootNode := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: rootName, Version: manifest.Version, Type: sdk.PackageTypeApplication})
 	if err := depsGraph.AddNode(rootNode); err != nil {
 		return nil, fmt.Errorf("add yarn root node: %w", err)
 	}
@@ -57,7 +57,7 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 		}
 		entry := entries[idx]
 		pkg := sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemNPM),
+			Ecosystem:   sdk.EcosystemNPM,
 			Name:        entry.Name,
 			Version:     entry.Version,
 			ResolvedURL: entry.Resolved,
@@ -115,7 +115,7 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 				queue = append(queue, entryIdx)
 				continue
 			}
-			synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemNPM), Name: dependencyName, Version: node.NormalizeVersionToken(requested)})
+			synthetic := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, Name: dependencyName, Version: node.NormalizeVersionToken(requested)})
 			if err := node.AddNodeIfMissing(depsGraph, synthetic); err != nil {
 				return nil, err
 			}

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -484,25 +484,23 @@ func firstNonEmpty(values ...string) string {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemDotNet,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemDotNet,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerNuGet,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "dotnet",
+		Language:       "dotnet"},
 	})
 
 }
 
 func packageNode(name, version string, pkg lockPackage) *sdk.Dependency {
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemDotNet,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemDotNet,
 		Name:           name,
 		Version:        version,
 		PackageManager: sdk.PackageManagerNuGet,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dotnet",
-		PURL:           sdk.BuildPackageURL("nuget", "", name, version),
+		PURL:           sdk.BuildPackageURL("nuget", "", name, version)},
 	})
 
 	if pkg.ContentHash != "" {

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -485,24 +485,24 @@ func firstNonEmpty(values ...string) string {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemDotNet),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerNuGet.Name(),
-		Type:        "application",
-		Language:    "dotnet",
+		Ecosystem:      sdk.EcosystemDotNet,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerNuGet,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "dotnet",
 	})
 
 }
 
 func packageNode(name, version string, pkg lockPackage) *sdk.Dependency {
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemDotNet),
-		Name:        name,
-		Version:     version,
-		BuildSystem: sdk.PackageManagerNuGet.Name(),
-		Type:        "package",
-		Language:    "dotnet",
-		PURL:        sdk.BuildPackageURL("nuget", "", name, version),
+		Ecosystem:      sdk.EcosystemDotNet,
+		Name:           name,
+		Version:        version,
+		PackageManager: sdk.PackageManagerNuGet,
+		Type:           sdk.PackageTypePackage,
+		Language:       "dotnet",
+		PURL:           sdk.BuildPackageURL("nuget", "", name, version),
 	})
 
 	if pkg.ContentHash != "" {

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -31,7 +31,7 @@ func writeFile(t *testing.T, dir, name, body string) {
 
 func mustPkg(t *testing.T, g *sdk.Graph, name, version string, extra ...func(*sdk.Dependency)) *sdk.Dependency {
 	t.Helper()
-	d := sdk.Dependency{Name: name, Version: version, Ecosystem: "test"}
+	d := sdk.Dependency{Coordinates: sdk.Coordinates{Name: name, Version: version, Ecosystem: "test"}}
 	for _, f := range extra {
 		f(&d)
 	}

--- a/internal/detectors/positions_test.go
+++ b/internal/detectors/positions_test.go
@@ -17,13 +17,11 @@ func TestAttachPositionsNilSafe(t *testing.T) {
 
 func TestAttachPositionsDoesNotDuplicate(t *testing.T) {
 	g := sdk.New()
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Name:      "foo",
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "foo",
 		Version:   "1.0.0",
-		Ecosystem: "test",
-		Locations: []sdk.PackageLocation{
-			{RealPath: "lock.txt", Position: &sdk.SourcePosition{File: "lock.txt", Line: 1}},
-		},
+		Ecosystem: "test"}, Locations: []sdk.PackageLocation{
+		{RealPath: "lock.txt", Position: &sdk.SourcePosition{File: "lock.txt", Line: 1}},
+	},
 	})
 	_ = g.AddNode(pkg)
 
@@ -43,7 +41,7 @@ func TestAttachPositionsDoesNotDuplicate(t *testing.T) {
 
 func TestAttachPositionsHonorsNameKey(t *testing.T) {
 	g := sdk.New()
-	pkg := sdk.NewDependency(sdk.Dependency{Name: "Foo", Version: "1", Ecosystem: "test"})
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "Foo", Version: "1", Ecosystem: "test"}})
 	_ = g.AddNode(pkg)
 
 	// Map keyed by lowercase name; nameKey lowercases the node.

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -166,25 +166,25 @@ func rootNode(manifest pubspec) *sdk.Dependency {
 		name = "root"
 	}
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemDart),
-		Name:        name,
-		Version:     strings.TrimSpace(manifest.Version),
-		BuildSystem: sdk.PackageManagerPub.Name(),
-		Type:        "application",
-		Language:    "dart",
+		Ecosystem:      sdk.EcosystemDart,
+		Name:           name,
+		Version:        strings.TrimSpace(manifest.Version),
+		PackageManager: sdk.PackageManagerPub,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "dart",
 	})
 
 }
 
 func packageNode(name string, pkg pubLockPackage) *sdk.Dependency {
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemDart),
-		Name:        name,
-		Version:     strings.TrimSpace(pkg.Version),
-		BuildSystem: sdk.PackageManagerPub.Name(),
-		Type:        "package",
-		Language:    "dart",
-		PURL:        sdk.BuildPackageURL("pub", "", name, pkg.Version),
+		Ecosystem:      sdk.EcosystemDart,
+		Name:           name,
+		Version:        strings.TrimSpace(pkg.Version),
+		PackageManager: sdk.PackageManagerPub,
+		Type:           sdk.PackageTypePackage,
+		Language:       "dart",
+		PURL:           sdk.BuildPackageURL("pub", "", name, pkg.Version),
 		Metadata: map[string]any{
 			"source": strings.TrimSpace(pkg.Source),
 		},

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -165,29 +165,26 @@ func rootNode(manifest pubspec) *sdk.Dependency {
 	if name == "" {
 		name = "root"
 	}
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemDart,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemDart,
 		Name:           name,
 		Version:        strings.TrimSpace(manifest.Version),
 		PackageManager: sdk.PackageManagerPub,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "dart",
+		Language:       "dart"},
 	})
 
 }
 
 func packageNode(name string, pkg pubLockPackage) *sdk.Dependency {
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemDart,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemDart,
 		Name:           name,
 		Version:        strings.TrimSpace(pkg.Version),
 		PackageManager: sdk.PackageManagerPub,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dart",
-		PURL:           sdk.BuildPackageURL("pub", "", name, pkg.Version),
-		Metadata: map[string]any{
-			"source": strings.TrimSpace(pkg.Source),
-		},
+		PURL:           sdk.BuildPackageURL("pub", "", name, pkg.Version)}, Metadata: map[string]any{
+		"source": strings.TrimSpace(pkg.Source),
+	},
 	})
 
 	if resolved := resolvedURL(pkg.Description); resolved != "" {

--- a/internal/detectors/pub/pub_native.go
+++ b/internal/detectors/pub/pub_native.go
@@ -148,13 +148,12 @@ func depGraphFromPubDepsJSON(raw []byte) (*sdk.Graph, error) {
 
 	var rootPkg *sdk.Dependency
 	if rootEntry != nil {
-		rootPkg = sdk.NewDependency(sdk.Dependency{
-			Ecosystem:      sdk.EcosystemDart,
+		rootPkg = sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemDart,
 			Name:           rootEntry.Name,
 			Version:        rootEntry.Version,
 			PackageManager: sdk.PackageManagerPub,
 			Type:           sdk.PackageTypeApplication,
-			Language:       "dart",
+			Language:       "dart"},
 		})
 
 	} else {

--- a/internal/detectors/pub/pub_native.go
+++ b/internal/detectors/pub/pub_native.go
@@ -149,12 +149,12 @@ func depGraphFromPubDepsJSON(raw []byte) (*sdk.Graph, error) {
 	var rootPkg *sdk.Dependency
 	if rootEntry != nil {
 		rootPkg = sdk.NewDependency(sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemDart),
-			Name:        rootEntry.Name,
-			Version:     rootEntry.Version,
-			BuildSystem: sdk.PackageManagerPub.Name(),
-			Type:        "application",
-			Language:    "dart",
+			Ecosystem:      sdk.EcosystemDart,
+			Name:           rootEntry.Name,
+			Version:        rootEntry.Version,
+			PackageManager: sdk.PackageManagerPub,
+			Type:           sdk.PackageTypeApplication,
+			Language:       "dart",
 		})
 
 	} else {

--- a/internal/detectors/python/common.go
+++ b/internal/detectors/python/common.go
@@ -183,9 +183,8 @@ func depGraphFromPipInspect(raw []byte) (*sdk.Graph, error) {
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemPython,
-		Name:      "root",
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
+		Name: "root"},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -197,10 +196,9 @@ func depGraphFromPipInspect(raw []byte) (*sdk.Graph, error) {
 		if pkg.Metadata.Name == "" {
 			continue
 		}
-		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: sdk.EcosystemPython,
-			Name:      normalizePythonName(pkg.Metadata.Name),
-			Version:   pkg.Metadata.Version,
+		node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
+			Name:    normalizePythonName(pkg.Metadata.Name),
+			Version: pkg.Metadata.Version},
 		})
 
 		if _, exists := nodesByName[node.Name]; !exists {

--- a/internal/detectors/python/common.go
+++ b/internal/detectors/python/common.go
@@ -184,7 +184,7 @@ func depGraphFromPipInspect(raw []byte) (*sdk.Graph, error) {
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemPython),
+		Ecosystem: sdk.EcosystemPython,
 		Name:      "root",
 	})
 
@@ -198,7 +198,7 @@ func depGraphFromPipInspect(raw []byte) (*sdk.Graph, error) {
 			continue
 		}
 		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: string(sdk.EcosystemPython),
+			Ecosystem: sdk.EcosystemPython,
 			Name:      normalizePythonName(pkg.Metadata.Name),
 			Version:   pkg.Metadata.Version,
 		})

--- a/internal/detectors/python/detector_test.go
+++ b/internal/detectors/python/detector_test.go
@@ -79,9 +79,9 @@ func TestDepGraphFromPipfileLock(t *testing.T) {
 
 func TestFilterPythonToolPackagesRemovesUndeclaredTools(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "root"})
-	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"})
-	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "root"}})
+	requests := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"}})
+	pip := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"}})
 	for _, pkg := range []*sdk.Dependency{root, requests, pip} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -112,9 +112,9 @@ func TestFilterPythonToolPackagesKeepsDeclaredTools(t *testing.T) {
 		t.Fatalf("write requirements: %v", err)
 	}
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "root"})
-	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"})
-	wheel := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "wheel", Version: "0.45.0"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "root"}})
+	pip := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"}})
+	wheel := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "wheel", Version: "0.45.0"}})
 	for _, pkg := range []*sdk.Dependency{root, pip, wheel} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -203,10 +203,10 @@ func TestAnnotateGraphScopes_DevelopmentFilterExcludesRuntime(t *testing.T) {
 	}
 
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "demo-app", Version: "1.0.0"})
-	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"})
-	pytest := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pytest", Version: "8.0.0"})
-	shared := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pluggy", Version: "1.5.0"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "demo-app", Version: "1.0.0"}})
+	requests := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"}})
+	pytest := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "pytest", Version: "8.0.0"}})
+	shared := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "pluggy", Version: "1.5.0"}})
 	for _, pkg := range []*sdk.Dependency{root, requests, pytest, shared} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -253,10 +253,9 @@ func TestAttachDeclaredPositions(t *testing.T) {
 
 	g := sdk.New()
 	for _, name := range []string{"requests", "flask", "numpy", "urllib3"} {
-		pkg := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: sdk.EcosystemPython,
-			Name:      name,
-			Version:   "0.0.0",
+		pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
+			Name:    name,
+			Version: "0.0.0"},
 		})
 
 		_ = g.AddNode(pkg)

--- a/internal/detectors/python/detector_test.go
+++ b/internal/detectors/python/detector_test.go
@@ -79,9 +79,9 @@ func TestDepGraphFromPipfileLock(t *testing.T) {
 
 func TestFilterPythonToolPackagesRemovesUndeclaredTools(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "root"})
-	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "requests", Version: "2.32.0"})
-	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "pip", Version: "25.0"})
+	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "root"})
+	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"})
+	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"})
 	for _, pkg := range []*sdk.Dependency{root, requests, pip} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -112,9 +112,9 @@ func TestFilterPythonToolPackagesKeepsDeclaredTools(t *testing.T) {
 		t.Fatalf("write requirements: %v", err)
 	}
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "root"})
-	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "pip", Version: "25.0"})
-	wheel := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "wheel", Version: "0.45.0"})
+	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "root"})
+	pip := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pip", Version: "25.0"})
+	wheel := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "wheel", Version: "0.45.0"})
 	for _, pkg := range []*sdk.Dependency{root, pip, wheel} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -203,10 +203,10 @@ func TestAnnotateGraphScopes_DevelopmentFilterExcludesRuntime(t *testing.T) {
 	}
 
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "demo-app", Version: "1.0.0"})
-	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "requests", Version: "2.32.0"})
-	pytest := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "pytest", Version: "8.0.0"})
-	shared := sdk.NewDependency(sdk.Dependency{Ecosystem: string(sdk.EcosystemPython), Name: "pluggy", Version: "1.5.0"})
+	root := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "demo-app", Version: "1.0.0"})
+	requests := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "requests", Version: "2.32.0"})
+	pytest := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pytest", Version: "8.0.0"})
+	shared := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemPython, Name: "pluggy", Version: "1.5.0"})
 	for _, pkg := range []*sdk.Dependency{root, requests, pytest, shared} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -254,7 +254,7 @@ func TestAttachDeclaredPositions(t *testing.T) {
 	g := sdk.New()
 	for _, name := range []string{"requests", "flask", "numpy", "urllib3"} {
 		pkg := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: string(sdk.EcosystemPython),
+			Ecosystem: sdk.EcosystemPython,
 			Name:      name,
 			Version:   "0.0.0",
 		})

--- a/internal/detectors/python/pipenv.go
+++ b/internal/detectors/python/pipenv.go
@@ -143,10 +143,10 @@ func depGraphFromPipfileLock(path string) (*sdk.Graph, error) {
 	}
 	depsGraph := sdk.New()
 	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemPython),
-		BuildSystem: sdk.PackageManagerPipenv.Name(),
-		Name:        "root",
-		Type:        "project",
+		Ecosystem:      sdk.EcosystemPython,
+		PackageManager: sdk.PackageManagerPipenv,
+		Name:           "root",
+		Type:           sdk.PackageTypeProject,
 	})
 
 	if err := depsGraph.AddNode(root); err != nil {
@@ -165,11 +165,11 @@ func addPipfileLockPackages(depsGraph *sdk.Graph, root *sdk.Dependency, packages
 	for name, pkg := range packages {
 		normalizedName := normalizePythonName(name)
 		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemPython),
-			BuildSystem: sdk.PackageManagerPipenv.Name(),
-			Name:        normalizedName,
-			Version:     strings.TrimPrefix(pkg.Version, "=="),
-			Scopes:      sdk.ScopesOf(scope),
+			Ecosystem:      sdk.EcosystemPython,
+			PackageManager: sdk.PackageManagerPipenv,
+			Name:           normalizedName,
+			Version:        strings.TrimPrefix(pkg.Version, "=="),
+			Scopes:         sdk.ScopesOf(scope),
 		})
 
 		if _, exists := depsGraph.Node(node.ID); !exists {

--- a/internal/detectors/python/pipenv.go
+++ b/internal/detectors/python/pipenv.go
@@ -142,11 +142,10 @@ func depGraphFromPipfileLock(path string) (*sdk.Graph, error) {
 		return nil, fmt.Errorf("pipfile.lock does not contain dependencies")
 	}
 	depsGraph := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemPython,
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
 		PackageManager: sdk.PackageManagerPipenv,
 		Name:           "root",
-		Type:           sdk.PackageTypeProject,
+		Type:           sdk.PackageTypeProject},
 	})
 
 	if err := depsGraph.AddNode(root); err != nil {
@@ -164,12 +163,10 @@ func depGraphFromPipfileLock(path string) (*sdk.Graph, error) {
 func addPipfileLockPackages(depsGraph *sdk.Graph, root *sdk.Dependency, packages map[string]pipfileLockPackage, scope sdk.Scope) error {
 	for name, pkg := range packages {
 		normalizedName := normalizePythonName(name)
-		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem:      sdk.EcosystemPython,
+		node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
 			PackageManager: sdk.PackageManagerPipenv,
 			Name:           normalizedName,
-			Version:        strings.TrimPrefix(pkg.Version, "=="),
-			Scopes:         sdk.ScopesOf(scope),
+			Version:        strings.TrimPrefix(pkg.Version, "==")}, Scopes: sdk.ScopesOf(scope),
 		})
 
 		if _, exists := depsGraph.Node(node.ID); !exists {

--- a/internal/detectors/python/poetrylock.go
+++ b/internal/detectors/python/poetrylock.go
@@ -72,14 +72,13 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 		if pkg.Name == "" {
 			continue
 		}
-		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem:      sdk.EcosystemPython,
+		node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
 			Name:           normalizePythonName(pkg.Name),
 			Version:        pkg.Version,
 			PackageManager: sdk.PackageManagerPoetry,
 			Language:       "python",
 			Type:           sdk.PackageTypePackage,
-			PURL:           sdk.BuildPackageURL("pypi", "", pkg.Name, pkg.Version),
+			PURL:           sdk.BuildPackageURL("pypi", "", pkg.Name, pkg.Version)},
 		})
 
 		for _, group := range pkg.Groups {
@@ -95,13 +94,12 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 	// Build the graph.
 	g := sdk.New()
 
-	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemPython,
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
 		Name:           rootName,
 		Version:        rootVersion,
 		PackageManager: sdk.PackageManagerPoetry,
 		Language:       "python",
-		Type:           sdk.PackageTypeApplication,
+		Type:           sdk.PackageTypeApplication},
 	})
 
 	if err := g.AddNode(root); err != nil {

--- a/internal/detectors/python/poetrylock.go
+++ b/internal/detectors/python/poetrylock.go
@@ -73,13 +73,13 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 			continue
 		}
 		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem:   string(sdk.EcosystemPython),
-			Name:        normalizePythonName(pkg.Name),
-			Version:     pkg.Version,
-			BuildSystem: sdk.PackageManagerPoetry.Name(),
-			Language:    "python",
-			Type:        "package",
-			PURL:        sdk.BuildPackageURL("pypi", "", pkg.Name, pkg.Version),
+			Ecosystem:      sdk.EcosystemPython,
+			Name:           normalizePythonName(pkg.Name),
+			Version:        pkg.Version,
+			PackageManager: sdk.PackageManagerPoetry,
+			Language:       "python",
+			Type:           sdk.PackageTypePackage,
+			PURL:           sdk.BuildPackageURL("pypi", "", pkg.Name, pkg.Version),
 		})
 
 		for _, group := range pkg.Groups {
@@ -96,12 +96,12 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 	g := sdk.New()
 
 	root := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemPython),
-		Name:        rootName,
-		Version:     rootVersion,
-		BuildSystem: sdk.PackageManagerPoetry.Name(),
-		Language:    "python",
-		Type:        "application",
+		Ecosystem:      sdk.EcosystemPython,
+		Name:           rootName,
+		Version:        rootVersion,
+		PackageManager: sdk.PackageManagerPoetry,
+		Language:       "python",
+		Type:           sdk.PackageTypeApplication,
 	})
 
 	if err := g.AddNode(root); err != nil {

--- a/internal/detectors/python/uvlock.go
+++ b/internal/detectors/python/uvlock.go
@@ -63,7 +63,7 @@ func depGraphFromUVLock(uvLockPath string) (*sdk.Graph, error) {
 			continue
 		}
 		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: string(sdk.EcosystemPython),
+			Ecosystem: sdk.EcosystemPython,
 			Name:      normalizePythonName(pkg.Name),
 			Version:   pkg.Version,
 		})

--- a/internal/detectors/python/uvlock.go
+++ b/internal/detectors/python/uvlock.go
@@ -62,10 +62,9 @@ func depGraphFromUVLock(uvLockPath string) (*sdk.Graph, error) {
 		if pkg.Name == "" {
 			continue
 		}
-		node := sdk.NewDependency(sdk.Dependency{
-			Ecosystem: sdk.EcosystemPython,
-			Name:      normalizePythonName(pkg.Name),
-			Version:   pkg.Version,
+		node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
+			Name:    normalizePythonName(pkg.Name),
+			Version: pkg.Version},
 		})
 
 		nodesByName[normalizePythonName(pkg.Name)] = node

--- a/internal/detectors/ruby/detector.go
+++ b/internal/detectors/ruby/detector.go
@@ -171,12 +171,11 @@ func depGraphFromLock(raw []byte, directScopes map[string]sdk.Scope) (*sdk.Graph
 	}
 
 	depsGraph := sdk.New()
-	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemRuby,
+	rootNode := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemRuby,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerBundler,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "ruby",
+		Language:       "ruby"},
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -445,13 +444,12 @@ func scopeForGroupLabels(labels []string) sdk.Scope {
 }
 
 func gemNode(name, version string) *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemRuby,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemRuby,
 		Name:           strings.TrimSpace(name),
 		Version:        strings.TrimSpace(version),
 		PackageManager: sdk.PackageManagerBundler,
 		Type:           "gem",
-		Language:       "ruby",
+		Language:       "ruby"},
 	})
 
 }

--- a/internal/detectors/ruby/detector.go
+++ b/internal/detectors/ruby/detector.go
@@ -172,11 +172,11 @@ func depGraphFromLock(raw []byte, directScopes map[string]sdk.Scope) (*sdk.Graph
 
 	depsGraph := sdk.New()
 	rootNode := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemRuby),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerBundler.Name(),
-		Type:        "application",
-		Language:    "ruby",
+		Ecosystem:      sdk.EcosystemRuby,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerBundler,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "ruby",
 	})
 
 	if err := depsGraph.AddNode(rootNode); err != nil {
@@ -446,12 +446,12 @@ func scopeForGroupLabels(labels []string) sdk.Scope {
 
 func gemNode(name, version string) *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemRuby),
-		Name:        strings.TrimSpace(name),
-		Version:     strings.TrimSpace(version),
-		BuildSystem: sdk.PackageManagerBundler.Name(),
-		Type:        "gem",
-		Language:    "ruby",
+		Ecosystem:      sdk.EcosystemRuby,
+		Name:           strings.TrimSpace(name),
+		Version:        strings.TrimSpace(version),
+		PackageManager: sdk.PackageManagerBundler,
+		Type:           "gem",
+		Language:       "ruby",
 	})
 
 }

--- a/internal/detectors/sbom/detector_test.go
+++ b/internal/detectors/sbom/detector_test.go
@@ -59,20 +59,18 @@ func TestDetectorResolveGraph_NormalizesImportedComponentIDs(t *testing.T) {
 
 func TestDetectorResolveGraph_PrefersImportedPURLIdentity(t *testing.T) {
 	g := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      "npm",
+	app := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "demo-app",
 		Version:        "1.0.0",
-		PURL:           "pkg:npm/demo-app@1.0.0",
+		PURL:           "pkg:npm/demo-app@1.0.0"},
 	})
 
-	react := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      "npm",
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})
 
 	for _, pkg := range []*sdk.Dependency{app, react} {

--- a/internal/detectors/sbom/detector_test.go
+++ b/internal/detectors/sbom/detector_test.go
@@ -60,19 +60,19 @@ func TestDetectorResolveGraph_NormalizesImportedComponentIDs(t *testing.T) {
 func TestDetectorResolveGraph_PrefersImportedPURLIdentity(t *testing.T) {
 	g := sdk.New()
 	app := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "demo-app",
-		Version:     "1.0.0",
-		PURL:        "pkg:npm/demo-app@1.0.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "demo-app",
+		Version:        "1.0.0",
+		PURL:           "pkg:npm/demo-app@1.0.0",
 	})
 
 	react := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})
 
 	for _, pkg := range []*sdk.Dependency{app, react} {
@@ -108,8 +108,8 @@ func TestDetectorResolveGraph_PrefersImportedPURLIdentity(t *testing.T) {
 	if reactPkg.PURL != "pkg:npm/react@18.2.0" {
 		t.Fatalf("expected react purl to be preserved, got %q", reactPkg.PURL)
 	}
-	if reactPkg.Ecosystem != "npm" || reactPkg.BuildSystem != "npm" {
-		t.Fatalf("expected react identity to be restored from SBOM, got ecosystem=%q buildSystem=%q", reactPkg.Ecosystem, reactPkg.BuildSystem)
+	if reactPkg.Ecosystem != "npm" || reactPkg.PackageManager != "npm" {
+		t.Fatalf("expected react identity to be restored from SBOM, got ecosystem=%q packageManager=%q", reactPkg.Ecosystem, reactPkg.PackageManager)
 	}
 }
 

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -154,26 +154,24 @@ func readOptional(path string) ([]byte, error) {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemScala,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemScala,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerSBT,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "scala",
+		Language:       "scala"},
 	})
 
 }
 
 func packageNode(pkg sbtPackage) *sdk.Dependency {
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemScala,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemScala,
 		Org:            strings.TrimSpace(pkg.Org),
 		Name:           strings.TrimSpace(pkg.Name),
 		Version:        strings.TrimSpace(pkg.Version),
 		PackageManager: sdk.PackageManagerSBT,
 		Type:           sdk.PackageTypePackage,
 		Language:       "scala",
-		PURL:           sdk.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version),
+		PURL:           sdk.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version)},
 	})
 
 	if pkg.Scope != "" {

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -155,25 +155,25 @@ func readOptional(path string) ([]byte, error) {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemScala),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerSBT.Name(),
-		Type:        "application",
-		Language:    "scala",
+		Ecosystem:      sdk.EcosystemScala,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerSBT,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "scala",
 	})
 
 }
 
 func packageNode(pkg sbtPackage) *sdk.Dependency {
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemScala),
-		Org:         strings.TrimSpace(pkg.Org),
-		Name:        strings.TrimSpace(pkg.Name),
-		Version:     strings.TrimSpace(pkg.Version),
-		BuildSystem: sdk.PackageManagerSBT.Name(),
-		Type:        "package",
-		Language:    "scala",
-		PURL:        sdk.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version),
+		Ecosystem:      sdk.EcosystemScala,
+		Org:            strings.TrimSpace(pkg.Org),
+		Name:           strings.TrimSpace(pkg.Name),
+		Version:        strings.TrimSpace(pkg.Version),
+		PackageManager: sdk.PackageManagerSBT,
+		Type:           sdk.PackageTypePackage,
+		Language:       "scala",
+		PURL:           sdk.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version),
 	})
 
 	if pkg.Scope != "" {

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -236,12 +236,11 @@ func readOptional(path string) ([]byte, error) {
 }
 
 func rootNode() *sdk.Dependency {
-	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemSwift,
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemSwift,
 		Name:           "root",
 		PackageManager: sdk.PackageManagerSwiftPM,
 		Type:           sdk.PackageTypeApplication,
-		Language:       "swift",
+		Language:       "swift"},
 	})
 
 }
@@ -258,17 +257,15 @@ func packageNode(pkg swiftPackage) *sdk.Dependency {
 		metadata["requirement"] = pkg.Requirement
 	}
 	namespace, name := packageIdentity(pkg.Repository, pkg.Name)
-	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      sdk.EcosystemSwift,
+	node := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemSwift,
 		Org:            namespace,
 		Name:           name,
 		Version:        strings.TrimSpace(pkg.Version),
 		PackageManager: sdk.PackageManagerSwiftPM,
 		Type:           sdk.PackageTypePackage,
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL("swift", namespace, name, pkg.Version),
-		ResolvedURL:    strings.TrimSpace(pkg.Repository),
-		Metadata:       metadata,
+		PURL:           sdk.BuildPackageURL("swift", namespace, name, pkg.Version)}, ResolvedURL: strings.TrimSpace(pkg.Repository),
+		Metadata: metadata,
 	})
 
 	// SwiftPM does not distinguish dev scope; all packages are runtime.

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -237,11 +237,11 @@ func readOptional(path string) ([]byte, error) {
 
 func rootNode() *sdk.Dependency {
 	return sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemSwift),
-		Name:        "root",
-		BuildSystem: sdk.PackageManagerSwiftPM.Name(),
-		Type:        "application",
-		Language:    "swift",
+		Ecosystem:      sdk.EcosystemSwift,
+		Name:           "root",
+		PackageManager: sdk.PackageManagerSwiftPM,
+		Type:           sdk.PackageTypeApplication,
+		Language:       "swift",
 	})
 
 }
@@ -259,16 +259,16 @@ func packageNode(pkg swiftPackage) *sdk.Dependency {
 	}
 	namespace, name := packageIdentity(pkg.Repository, pkg.Name)
 	node := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   string(sdk.EcosystemSwift),
-		Org:         namespace,
-		Name:        name,
-		Version:     strings.TrimSpace(pkg.Version),
-		BuildSystem: sdk.PackageManagerSwiftPM.Name(),
-		Type:        "package",
-		Language:    "swift",
-		PURL:        sdk.BuildPackageURL("swift", namespace, name, pkg.Version),
-		ResolvedURL: strings.TrimSpace(pkg.Repository),
-		Metadata:    metadata,
+		Ecosystem:      sdk.EcosystemSwift,
+		Org:            namespace,
+		Name:           name,
+		Version:        strings.TrimSpace(pkg.Version),
+		PackageManager: sdk.PackageManagerSwiftPM,
+		Type:           sdk.PackageTypePackage,
+		Language:       "swift",
+		PURL:           sdk.BuildPackageURL("swift", namespace, name, pkg.Version),
+		ResolvedURL:    strings.TrimSpace(pkg.Repository),
+		Metadata:       metadata,
 	})
 
 	// SwiftPM does not distinguish dev scope; all packages are runtime.

--- a/internal/detectors/syft/detector_test.go
+++ b/internal/detectors/syft/detector_test.go
@@ -268,10 +268,10 @@ func TestGraphFromSyftSBOM(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected dependency package %q", dependency.ID())
 	}
-	if mapped.Ecosystem != "maven" || mapped.Org != "com.example" || mapped.Type != string(syftpkg.JavaPkg) {
+	if mapped.Ecosystem != sdk.EcosystemMaven || mapped.Org != "com.example" || mapped.Type != sdk.ParsePackageType(string(syftpkg.JavaPkg)) {
 		t.Fatalf("unexpected mapped package identity: %#v", mapped)
 	}
-	if mapped.PURL != dependency.PURL || mapped.Language != dependency.Language.String() || mapped.FoundBy != dependency.FoundBy {
+	if mapped.PURL != dependency.PURL || mapped.Language != sdk.ParseLanguage(dependency.Language.String()) || mapped.FoundBy != dependency.FoundBy {
 		t.Fatalf("unexpected mapped package metadata: %#v", mapped)
 	}
 	if lics := sdk.DetectionLicenses(mapped); len(lics) != 1 || lics[0].Value != "Apache-2.0" {

--- a/internal/detectors/syft/graph.go
+++ b/internal/detectors/syft/graph.go
@@ -133,19 +133,18 @@ func graphFromSyftPackage(pkg syftpkg.Package) *sdk.Dependency {
 	licenses := pkg.Licenses.ToSlice()
 	locations := pkg.Locations.ToSlice()
 	parsedPURL := parsePackageURL(pkg.PURL)
+	packageManager := sdk.PackageManager(strings.ToLower(string(pkg.Type)))
 
-	node := sdk.NewDependencyWithID(string(pkg.ID()), sdk.Dependency{
-		Ecosystem:      sdk.Ecosystem(syftEcosystem(pkg, parsedPURL)),
+	node := sdk.NewDependencyWithID(string(pkg.ID()), sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.Ecosystem(syftEcosystem(pkg, parsedPURL)),
 		Name:           pkg.Name,
 		Version:        pkg.Version,
 		Org:            syftOrg(pkg, parsedPURL),
-		PackageManager: sdk.PackageManager(strings.ToLower(string(pkg.Type))),
+		PackageManager: packageManager,
 		Type:           sdk.ParsePackageType(string(pkg.Type)),
 		Language:       sdk.ParseLanguage(pkg.Language.String()),
-		PURL:           pkg.PURL,
-		FoundBy:        pkg.FoundBy,
-		Locations:      graphLocations(locations),
-		CPEs:           graphCPEs(pkg.CPEs),
+		PURL:           pkg.PURL}, FoundBy: pkg.FoundBy,
+		Locations: graphLocations(locations),
+		CPEs:      graphCPEs(pkg.CPEs),
 	})
 
 	if node.ID == "" {
@@ -301,6 +300,13 @@ func manifestMetadataFromPackage(pkg *sdk.Dependency, manager sdk.PackageManager
 	if pkg == nil {
 		return sdk.ManifestMetadata{}
 	}
+	kind := manager.Name()
+	if kind == "" {
+		kind = pkg.PackageManager.Name()
+	}
+	if kind == "" {
+		kind = string(pkg.PackageManager)
+	}
 
 	for _, location := range pkg.Locations {
 		candidate := firstNonEmpty(location.RealPath, location.AccessPath)
@@ -309,14 +315,10 @@ func manifestMetadataFromPackage(pkg *sdk.Dependency, manager sdk.PackageManager
 		}
 		return sdk.ManifestMetadata{
 			Path: normalizeGraphPath(candidate),
-			Kind: sdk.ManifestKind(pkg.Type),
+			Kind: sdk.ManifestKind(kind),
 		}
 	}
 
-	kind := manager.Name()
-	if kind == "" {
-		kind = pkg.PackageManager.Name()
-	}
 	return sdk.ManifestMetadata{Kind: sdk.ManifestKind(kind)}
 }
 

--- a/internal/detectors/syft/graph.go
+++ b/internal/detectors/syft/graph.go
@@ -135,17 +135,17 @@ func graphFromSyftPackage(pkg syftpkg.Package) *sdk.Dependency {
 	parsedPURL := parsePackageURL(pkg.PURL)
 
 	node := sdk.NewDependencyWithID(string(pkg.ID()), sdk.Dependency{
-		Ecosystem:   syftEcosystem(pkg, parsedPURL),
-		Name:        pkg.Name,
-		Version:     pkg.Version,
-		Org:         syftOrg(pkg, parsedPURL),
-		BuildSystem: string(pkg.Type),
-		Type:        string(pkg.Type),
-		Language:    pkg.Language.String(),
-		PURL:        pkg.PURL,
-		FoundBy:     pkg.FoundBy,
-		Locations:   graphLocations(locations),
-		CPEs:        graphCPEs(pkg.CPEs),
+		Ecosystem:      sdk.Ecosystem(syftEcosystem(pkg, parsedPURL)),
+		Name:           pkg.Name,
+		Version:        pkg.Version,
+		Org:            syftOrg(pkg, parsedPURL),
+		PackageManager: sdk.PackageManager(strings.ToLower(string(pkg.Type))),
+		Type:           sdk.ParsePackageType(string(pkg.Type)),
+		Language:       sdk.ParseLanguage(pkg.Language.String()),
+		PURL:           pkg.PURL,
+		FoundBy:        pkg.FoundBy,
+		Locations:      graphLocations(locations),
+		CPEs:           graphCPEs(pkg.CPEs),
 	})
 
 	if node.ID == "" {
@@ -178,7 +178,7 @@ func graphLicenses(licenses []syftpkg.License) []sdk.PackageLicense {
 		out = append(out, sdk.PackageLicense{
 			Value:          license.Value,
 			SPDXExpression: license.SPDXExpression,
-			Type:           string(license.Type),
+			Type:           sdk.LicenseType(license.Type),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -276,7 +276,7 @@ func manifestGroupKey(manifest sdk.ManifestMetadata, fallbackID string) string {
 		return manifest.Path
 	}
 	if manifest.Kind != "" {
-		return manifest.Kind + "::" + fallbackID
+		return string(manifest.Kind) + "::" + fallbackID
 	}
 	return fallbackID
 }
@@ -309,15 +309,15 @@ func manifestMetadataFromPackage(pkg *sdk.Dependency, manager sdk.PackageManager
 		}
 		return sdk.ManifestMetadata{
 			Path: normalizeGraphPath(candidate),
-			Kind: pkg.Type,
+			Kind: sdk.ManifestKind(pkg.Type),
 		}
 	}
 
 	kind := manager.Name()
 	if kind == "" {
-		kind = pkg.BuildSystem
+		kind = pkg.PackageManager.Name()
 	}
-	return sdk.ManifestMetadata{Kind: kind}
+	return sdk.ManifestMetadata{Kind: sdk.ManifestKind(kind)}
 }
 
 func normalizeGraphPath(value string) string {

--- a/internal/engine/consolidation/consolidation.go
+++ b/internal/engine/consolidation/consolidation.go
@@ -130,10 +130,10 @@ func normalizeSubprojectManifest(subproject sdk.Subproject, manifest sdk.Manifes
 	if isCoreDetector(origin) {
 		manifest.Path = normalizeNativeManifestPath(subproject, manifest.Path)
 	}
-	if strings.TrimSpace(manifest.Kind) == "" {
-		manifest.Kind = subproject.PrimaryPackageManager().Name()
+	if strings.TrimSpace(string(manifest.Kind)) == "" {
+		manifest.Kind = sdk.ManifestKind(subproject.PrimaryPackageManager().Name())
 	}
-	manifest.Kind = strings.TrimSpace(manifest.Kind)
+	manifest.Kind = sdk.ManifestKind(strings.TrimSpace(string(manifest.Kind)))
 	return manifest
 }
 

--- a/internal/engine/consolidation/consolidation_test.go
+++ b/internal/engine/consolidation/consolidation_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestNormalizeGraphPackageIdentity_CollapsesEquivalentPythonPackages(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependencyWithID("app@1.0.0", sdk.Dependency{Name: "app", Version: "1.0.0"})
-	pyA := sdk.NewDependencyWithID("Requests_Toolbelt@1.0.0RC1", sdk.Dependency{Ecosystem: "python", Name: "Requests_Toolbelt", Version: "1.0.0RC1"})
-	pyB := sdk.NewDependencyWithID("requests-toolbelt@1.0.0rc1", sdk.Dependency{Ecosystem: "python", Name: "requests-toolbelt", Version: "1.0.0rc1"})
+	root := sdk.NewDependencyWithID("app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "app", Version: "1.0.0"}})
+	pyA := sdk.NewDependencyWithID("Requests_Toolbelt@1.0.0RC1", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "python", Name: "Requests_Toolbelt", Version: "1.0.0RC1"}})
+	pyB := sdk.NewDependencyWithID("requests-toolbelt@1.0.0rc1", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "python", Name: "requests-toolbelt", Version: "1.0.0rc1"}})
 	for _, pkg := range []*sdk.Dependency{root, pyA, pyB} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("AddPackage(%q) error = %v", pkg.ID, err)
@@ -126,8 +126,8 @@ func TestConsolidateGraphs_RejectsMultipleExecutionTargets(t *testing.T) {
 
 func TestConsolidateGraphs_DeduplicatesManifestAndPrefersNative(t *testing.T) {
 	nativeGraph := sdk.New()
-	nativeRoot := sdk.NewDependency(sdk.Dependency{Ecosystem: "maven", Org: "org.owasp.webgoat", Name: "webgoat", Version: "1.0.0"})
-	nativeDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "maven", Org: "org.slf4j", Name: "slf4j-api", Version: "2.0.9"})
+	nativeRoot := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "maven", Org: "org.owasp.webgoat", Name: "webgoat", Version: "1.0.0"}})
+	nativeDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "maven", Org: "org.slf4j", Name: "slf4j-api", Version: "2.0.9"}})
 	if err := nativeGraph.AddNode(nativeRoot); err != nil {
 		t.Fatalf("add native root: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestConsolidateGraphs_DeduplicatesManifestAndPrefersNative(t *testing.T) {
 	}
 
 	syftGraph := sdk.New()
-	syftRoot := sdk.NewDependencyWithID("1234567890123456", sdk.Dependency{Ecosystem: "maven", Org: "org.owasp.webgoat", Name: "webgoat", Version: "1.0.0", PURL: "pkg:maven/org.owasp.webgoat/webgoat@1.0.0"})
+	syftRoot := sdk.NewDependencyWithID("1234567890123456", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "maven", Org: "org.owasp.webgoat", Name: "webgoat", Version: "1.0.0", PURL: "pkg:maven/org.owasp.webgoat/webgoat@1.0.0"}})
 	if err := syftGraph.AddNode(syftRoot); err != nil {
 		t.Fatalf("add syft root: %v", err)
 	}
@@ -203,8 +203,8 @@ func TestManifestDedupPriorityPrefersNativeOverSyft(t *testing.T) {
 
 func TestConsolidateGraphs_SynthesizesManifestRootWhenEntryHasMultipleRoots(t *testing.T) {
 	actionsGraph := sdk.New()
-	checkout := sdk.NewDependency(sdk.Dependency{Ecosystem: "github-actions", Name: "actions/checkout", Version: "v4.1.6"})
-	setupJava := sdk.NewDependency(sdk.Dependency{Ecosystem: "github-actions", Name: "actions/setup-java", Version: "v5"})
+	checkout := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "github-actions", Name: "actions/checkout", Version: "v4.1.6"}})
+	setupJava := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "github-actions", Name: "actions/setup-java", Version: "v5"}})
 	if err := actionsGraph.AddNode(checkout); err != nil {
 		t.Fatalf("add checkout: %v", err)
 	}
@@ -255,9 +255,9 @@ func TestConsolidateGraphs_SynthesizesManifestRootWhenEntryHasMultipleRoots(t *t
 
 func TestConsolidateGraphs_PrefersApplicationRootWhenEntryHasMultipleRoots(t *testing.T) {
 	npmGraph := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
-	react := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
-	orphan := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "string-width", Version: "2.1.1"})
+	app := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0", Type: sdk.PackageTypeApplication}})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "react", Version: "18.2.0"}})
+	orphan := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "string-width", Version: "2.1.1"}})
 	for _, pkg := range []*sdk.Dependency{app, react, orphan} {
 		if err := npmGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add %s: %v", pkg.ID, err)

--- a/internal/engine/consolidation/consolidation_test.go
+++ b/internal/engine/consolidation/consolidation_test.go
@@ -255,7 +255,7 @@ func TestConsolidateGraphs_SynthesizesManifestRootWhenEntryHasMultipleRoots(t *t
 
 func TestConsolidateGraphs_PrefersApplicationRootWhenEntryHasMultipleRoots(t *testing.T) {
 	npmGraph := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0", Type: "application"})
+	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "demo-app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
 	react := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
 	orphan := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "string-width", Version: "2.1.1"})
 	for _, pkg := range []*sdk.Dependency{app, react, orphan} {

--- a/internal/engine/consolidation/enrichment_test.go
+++ b/internal/engine/consolidation/enrichment_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBuildPackageRegistry_DeduplicatesByPURLAndLinksDependencies(t *testing.T) {
 	g := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: "application"})
+	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
 	libA := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "lib", Version: "1.2.3"})
 	for _, node := range []*sdk.Dependency{app, libA} {
 		if err := g.AddNode(node); err != nil {

--- a/internal/engine/consolidation/enrichment_test.go
+++ b/internal/engine/consolidation/enrichment_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestBuildPackageRegistry_DeduplicatesByPURLAndLinksDependencies(t *testing.T) {
 	g := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
-	libA := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "lib", Version: "1.2.3"})
+	app := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication}})
+	libA := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "lib", Version: "1.2.3"}})
 	for _, node := range []*sdk.Dependency{app, libA} {
 		if err := g.AddNode(node); err != nil {
 			t.Fatalf("AddNode(%q): %v", node.ID, err)
@@ -38,7 +38,7 @@ func TestBuildPackageRegistry_DeduplicatesByPURLAndLinksDependencies(t *testing.
 
 func TestBuildPackageRegistry_LiftsDetectionLicenses(t *testing.T) {
 	g := sdk.New()
-	lib := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "lib", Version: "1.2.3"})
+	lib := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "lib", Version: "1.2.3"}})
 	sdk.SetDetectionLicenses(lib, []sdk.PackageLicense{{Value: "MIT", Type: "declared"}})
 	if err := g.AddNode(lib); err != nil {
 		t.Fatalf("AddNode: %v", err)

--- a/internal/engine/consolidation/manifest.go
+++ b/internal/engine/consolidation/manifest.go
@@ -178,10 +178,9 @@ func ensureEntryRoot(g *sdk.Graph, manifest sdk.ManifestMetadata, idx int) error
 		kind = "manifest"
 	}
 
-	virtualRoot := sdk.NewDependencyWithID(rootID, sdk.Dependency{
-		Name:           manifestLabel,
+	virtualRoot := sdk.NewDependencyWithID(rootID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: manifestLabel,
 		Type:           sdk.PackageTypeManifest,
-		PackageManager: packageManagerFromManifestKind(kind),
+		PackageManager: packageManagerFromManifestKind(kind)},
 	})
 	if err := addNodeIfMissing(g, virtualRoot); err != nil {
 		return err

--- a/internal/engine/consolidation/manifest.go
+++ b/internal/engine/consolidation/manifest.go
@@ -173,15 +173,15 @@ func ensureEntryRoot(g *sdk.Graph, manifest sdk.ManifestMetadata, idx int) error
 	}
 	manifestLabel = strings.ReplaceAll(manifestLabel, "\\", "/")
 
-	kind := strings.TrimSpace(manifest.Kind)
+	kind := strings.TrimSpace(string(manifest.Kind))
 	if kind == "" {
 		kind = "manifest"
 	}
 
 	virtualRoot := sdk.NewDependencyWithID(rootID, sdk.Dependency{
-		Name:        manifestLabel,
-		Type:        "manifest",
-		BuildSystem: kind,
+		Name:           manifestLabel,
+		Type:           sdk.PackageTypeManifest,
+		PackageManager: packageManagerFromManifestKind(kind),
 	})
 	if err := addNodeIfMissing(g, virtualRoot); err != nil {
 		return err
@@ -211,11 +211,19 @@ func selectApplicationRoot(roots []*sdk.Dependency) *sdk.Dependency {
 		if root == nil {
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(root.Type), "application") {
+		if root.Type == sdk.PackageTypeApplication {
 			return root
 		}
 	}
 	return nil
+}
+
+func packageManagerFromManifestKind(kind string) sdk.PackageManager {
+	manager, err := sdk.ParsePackageManager(kind)
+	if err != nil {
+		return sdk.PackageManagerUnknown
+	}
+	return manager
 }
 
 func hasSingleRoot(g *sdk.Graph) bool {

--- a/internal/engine/diff/diff.go
+++ b/internal/engine/diff/diff.go
@@ -122,9 +122,8 @@ func focusedAuditGraph(packages []*sdk.Dependency) (*sdk.Graph, error) {
 		return focused, nil
 	}
 
-	root := sdk.NewDependencyWithID(diffAuditRootID, sdk.Dependency{
-		Name: "bomly-diff-audit-root",
-		Type: sdk.PackageTypeApplication,
+	root := sdk.NewDependencyWithID(diffAuditRootID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: "bomly-diff-audit-root",
+		Type: sdk.PackageTypeApplication},
 	})
 	if err := focused.AddNode(root); err != nil {
 		return nil, err

--- a/internal/engine/diff/diff.go
+++ b/internal/engine/diff/diff.go
@@ -124,7 +124,7 @@ func focusedAuditGraph(packages []*sdk.Dependency) (*sdk.Graph, error) {
 
 	root := sdk.NewDependencyWithID(diffAuditRootID, sdk.Dependency{
 		Name: "bomly-diff-audit-root",
-		Type: "application",
+		Type: sdk.PackageTypeApplication,
 	})
 	if err := focused.AddNode(root); err != nil {
 		return nil, err

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -167,11 +167,10 @@ func diffTestRequest() engine.PipelineRequest {
 
 func npmPackage(name, version string) *sdk.Dependency {
 	purl := "pkg:npm/" + name + "@" + version
-	return sdk.NewDependencyWithID(purl, sdk.Dependency{
-		Ecosystem: sdk.EcosystemNPM,
-		Name:      name,
-		Version:   version,
-		PURL:      purl,
+	return sdk.NewDependencyWithID(purl, sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
+		Name:    name,
+		Version: version,
+		PURL:    purl},
 	})
 }
 

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -168,7 +168,7 @@ func diffTestRequest() engine.PipelineRequest {
 func npmPackage(name, version string) *sdk.Dependency {
 	purl := "pkg:npm/" + name + "@" + version
 	return sdk.NewDependencyWithID(purl, sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemNPM),
+		Ecosystem: sdk.EcosystemNPM,
 		Name:      name,
 		Version:   version,
 		PURL:      purl,

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -152,7 +152,7 @@ func (p *Pipeline) logUnexpectedMultiRootGraph(stage, detector, subproject strin
 			continue
 		}
 		rootIDs = append(rootIDs, root.ID)
-		if strings.EqualFold(strings.TrimSpace(root.Type), "application") {
+		if root.Type == sdk.PackageTypeApplication {
 			hasApplicationRoot = true
 		}
 	}

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -443,7 +443,7 @@ func TestPipeline_ThreadsScopeFilterIntoInstallFirstDetector(t *testing.T) {
 func scopedTestGraph(t *testing.T) *sdk.Graph {
 	t.Helper()
 	graph := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: "application"})
+	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
 	runtimeDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	devDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "vitest", Version: "2.0.0", PURL: "pkg:npm/vitest@2.0.0", Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
 	for _, dep := range []*sdk.Dependency{app, runtimeDep, devDep} {
@@ -698,21 +698,21 @@ func TestPipeline_Run_PropagatesMatcherEnrichmentToRegistry(t *testing.T) {
 
 	nativeGraph := sdk.New()
 	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "app",
-		Version:     "1.0.0",
-		PURL:        "pkg:npm/app@1.0.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "app",
+		Version:        "1.0.0",
+		PURL:           "pkg:npm/app@1.0.0",
 	})
 	if err := nativeGraph.AddNode(nativeApp); err != nil {
 		t.Fatalf("add native app: %v", err)
 	}
 	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})
 	if err := nativeGraph.AddNode(nativeReact); err != nil {
 		t.Fatalf("add native react: %v", err)
@@ -723,20 +723,20 @@ func TestPipeline_Run_PropagatesMatcherEnrichmentToRegistry(t *testing.T) {
 
 	sbomGraph := sdk.New()
 	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "app",
-		Version:     "1.0.0",
-		PURL:        "pkg:npm/app@1.0.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "app",
+		Version:        "1.0.0",
+		PURL:           "pkg:npm/app@1.0.0",
 	})); err != nil {
 		t.Fatalf("add sbom app: %v", err)
 	}
 	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})); err != nil {
 		t.Fatalf("add sbom react: %v", err)
 	}

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -443,9 +443,9 @@ func TestPipeline_ThreadsScopeFilterIntoInstallFirstDetector(t *testing.T) {
 func scopedTestGraph(t *testing.T) *sdk.Graph {
 	t.Helper()
 	graph := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication})
-	runtimeDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
-	devDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "vitest", Version: "2.0.0", PURL: "pkg:npm/vitest@2.0.0", Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
+	app := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "app", Version: "1.0.0", Type: sdk.PackageTypeApplication}})
+	runtimeDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	devDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "vitest", Version: "2.0.0", PURL: "pkg:npm/vitest@2.0.0"}, Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
 	for _, dep := range []*sdk.Dependency{app, runtimeDep, devDep} {
 		if err := graph.AddNode(dep); err != nil {
 			t.Fatalf("add %q: %v", dep.ID, err)
@@ -509,11 +509,10 @@ func TestPipeline_Run_ProducesConsolidatedResult(t *testing.T) {
 func TestPipeline_Run_DeduplicatesAuditFindings(t *testing.T) {
 	registry := newTestRegistry()
 	g := sdk.New()
-	pkg := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem: "npm",
-		Name:      "react",
-		Version:   "18.2.0",
-		PURL:      "pkg:npm/react@18.2.0",
+	pkg := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
+		Name:    "react",
+		Version: "18.2.0",
+		PURL:    "pkg:npm/react@18.2.0"},
 	})
 	if err := g.AddNode(pkg); err != nil {
 		t.Fatalf("add package: %v", err)
@@ -554,8 +553,8 @@ func TestPipeline_Run_DeduplicatesAuditFindings(t *testing.T) {
 func TestPipeline_RunExplain_FocusesSelectedManifestAndAuditsComponent(t *testing.T) {
 	registry := newTestRegistry()
 	g := sdk.New()
-	app := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
-	dep := sdk.NewDependencyWithID("pkg:npm/dep@2.0.0", sdk.Dependency{Ecosystem: "npm", Name: "dep", Version: "2.0.0", PURL: "pkg:npm/dep@2.0.0"})
+	app := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"}})
+	dep := sdk.NewDependencyWithID("pkg:npm/dep@2.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "dep", Version: "2.0.0", PURL: "pkg:npm/dep@2.0.0"}})
 	if err := g.AddNode(app); err != nil {
 		t.Fatalf("add app: %v", err)
 	}
@@ -624,7 +623,7 @@ func TestPipeline_RunExplain_FocusesSelectedManifestAndAuditsComponent(t *testin
 func TestPipeline_RunExplain_ReturnsNotFoundWhenQueryIsAbsent(t *testing.T) {
 	registry := newTestRegistry()
 	g := sdk.New()
-	if err := g.AddNode(sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", Name: "app", Version: "1.0.0"})); err != nil {
+	if err := g.AddNode(sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "app", Version: "1.0.0"}})); err != nil {
 		t.Fatalf("add package: %v", err)
 	}
 	registry.registerDetector(fakeDetector{
@@ -697,22 +696,20 @@ func TestPipeline_Run_PropagatesMatcherEnrichmentToRegistry(t *testing.T) {
 	})
 
 	nativeGraph := sdk.New()
-	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{
-		Ecosystem:      "npm",
+	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "app",
 		Version:        "1.0.0",
-		PURL:           "pkg:npm/app@1.0.0",
+		PURL:           "pkg:npm/app@1.0.0"},
 	})
 	if err := nativeGraph.AddNode(nativeApp); err != nil {
 		t.Fatalf("add native app: %v", err)
 	}
-	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:      "npm",
+	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})
 	if err := nativeGraph.AddNode(nativeReact); err != nil {
 		t.Fatalf("add native react: %v", err)
@@ -722,21 +719,19 @@ func TestPipeline_Run_PropagatesMatcherEnrichmentToRegistry(t *testing.T) {
 	}
 
 	sbomGraph := sdk.New()
-	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{
-		Ecosystem:      "npm",
+	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "app",
 		Version:        "1.0.0",
-		PURL:           "pkg:npm/app@1.0.0",
+		PURL:           "pkg:npm/app@1.0.0"},
 	})); err != nil {
 		t.Fatalf("add sbom app: %v", err)
 	}
-	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{
-		Ecosystem:      "npm",
+	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})); err != nil {
 		t.Fatalf("add sbom react: %v", err)
 	}

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -315,7 +315,7 @@ func versionRequestFromPackage(pkg *sdk.Package) (versionRequest, cache.Key, boo
 		}
 	}
 	if versionKey, ok := versionKeyFromPackage(pkg); ok {
-		return versionRequest{VersionKey: versionKey}, cache.NewKey("", pkg.Name, pkg.Ecosystem, pkg.Version), true
+		return versionRequest{VersionKey: versionKey}, cache.NewKey("", pkg.Name, string(pkg.Ecosystem), pkg.Version), true
 	}
 	return versionRequest{}, cache.Key{}, false
 }
@@ -324,7 +324,7 @@ func versionKeyFromPackage(pkg *sdk.Package) (versionKey, bool) {
 	if pkg == nil {
 		return versionKey{}, false
 	}
-	system, ok := depsDevSystem(pkg.Ecosystem)
+	system, ok := depsDevSystem(string(pkg.Ecosystem))
 	if !ok {
 		return versionKey{}, false
 	}
@@ -370,7 +370,7 @@ func depsDevName(pkg *sdk.Package) (string, bool) {
 	}
 	name := strings.TrimSpace(pkg.Name)
 	org := strings.TrimSpace(pkg.Org)
-	switch strings.ToLower(strings.TrimSpace(pkg.Ecosystem)) {
+	switch strings.ToLower(strings.TrimSpace(string(pkg.Ecosystem))) {
 	case "npm":
 		if strings.HasPrefix(name, "@") {
 			return name, true

--- a/internal/matchers/depsdev/matcher_test.go
+++ b/internal/matchers/depsdev/matcher_test.go
@@ -15,11 +15,10 @@ import (
 
 func TestVersionRequestFromPackage(t *testing.T) {
 	t.Run("npm scoped package", func(t *testing.T) {
-		req, _, ok := versionRequestFromPackage(&sdk.Package{
-			Ecosystem: "npm",
-			Org:       "@types",
-			Name:      "node",
-			Version:   "20.12.0",
+		req, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{Ecosystem: "npm",
+			Org:     "@types",
+			Name:    "node",
+			Version: "20.12.0"},
 		})
 		if !ok {
 			t.Fatal("expected npm package to map to deps.dev request")
@@ -30,9 +29,8 @@ func TestVersionRequestFromPackage(t *testing.T) {
 	})
 
 	t.Run("maven from purl", func(t *testing.T) {
-		req, _, ok := versionRequestFromPackage(&sdk.Package{
-			PURL:    "pkg:maven/org.slf4j/slf4j-api@2.0.13",
-			Version: "2.0.13",
+		req, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:maven/org.slf4j/slf4j-api@2.0.13",
+			Version: "2.0.13"},
 		})
 		if !ok {
 			t.Fatal("expected maven purl to map to deps.dev request")
@@ -43,10 +41,9 @@ func TestVersionRequestFromPackage(t *testing.T) {
 	})
 
 	t.Run("unsupported ecosystem", func(t *testing.T) {
-		if _, _, ok := versionRequestFromPackage(&sdk.Package{
-			Ecosystem: "conan",
-			Name:      "openssl",
-			Version:   "1.1.1s",
+		if _, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{Ecosystem: "conan",
+			Name:    "openssl",
+			Version: "1.1.1s"},
 		}); ok {
 			t.Fatal("expected unsupported ecosystem to be rejected")
 		}
@@ -85,8 +82,8 @@ func TestCheckerMatch_EnrichesMissingOnly(t *testing.T) {
 	}
 
 	g := sdk.New()
-	missing := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0"})
-	existing := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "zod", Version: "3.23.0"})
+	missing := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "react", Version: "18.2.0"}})
+	existing := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "zod", Version: "3.23.0"}})
 	if err := g.AddNode(missing); err != nil {
 		t.Fatalf("add missing dependency: %v", err)
 	}

--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -266,7 +266,7 @@ func mapBuiltinMatch(m grypematch.Match) sdk.Vulnerability {
 		})
 	}
 	for _, advisoryRef := range vuln.Advisories {
-		advisory.References = append(advisory.References, sdk.Reference{URL: advisoryRef.Link, Type: sdk.ReferenceType(firstNonEmpty(advisoryRef.ID, string(sdk.ReferenceTypeAdvisory)))})
+		advisory.References = append(advisory.References, sdk.Reference{URL: advisoryRef.Link, Type: sdk.ReferenceTypeAdvisory})
 	}
 	for _, related := range vuln.RelatedVulnerabilities {
 		if related.ID != "" {

--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -110,8 +110,8 @@ func graphPkgToGrypePkg(p *sdk.Package) grypepkg.Package {
 		Name:     p.Name,
 		Version:  p.Version,
 		PURL:     p.PURL,
-		Type:     ecosystemToSyftType(p.Ecosystem),
-		Language: ecosystemToSyftLanguage(p.Ecosystem),
+		Type:     ecosystemToSyftType(string(p.Ecosystem)),
+		Language: ecosystemToSyftLanguage(string(p.Ecosystem)),
 	}
 }
 
@@ -241,7 +241,7 @@ func mapBuiltinMatch(m grypematch.Match) sdk.Vulnerability {
 		ID:                   vuln.ID,
 		Namespace:            vuln.Namespace,
 		FixedVersions:        append([]string(nil), vuln.Fix.Versions...),
-		FixState:             string(vuln.Fix.State),
+		FixState:             sdk.FixState(vuln.Fix.State),
 		AffectedVersionRange: constraintString(vuln.Constraint),
 		CPEs:                 cpeStrings(vuln.CPEs),
 	}
@@ -262,11 +262,11 @@ func mapBuiltinMatch(m grypematch.Match) sdk.Vulnerability {
 		advisory.FixAvailable = append(advisory.FixAvailable, sdk.FixAvailable{
 			Version: fix.Version,
 			Date:    dateString(fix.Date),
-			Kind:    fix.Kind,
+			Kind:    sdk.FixAvailableKind(fix.Kind),
 		})
 	}
 	for _, advisoryRef := range vuln.Advisories {
-		advisory.References = append(advisory.References, sdk.Reference{URL: advisoryRef.Link, Type: firstNonEmpty(advisoryRef.ID, "advisory")})
+		advisory.References = append(advisory.References, sdk.Reference{URL: advisoryRef.Link, Type: sdk.ReferenceType(firstNonEmpty(advisoryRef.ID, string(sdk.ReferenceTypeAdvisory)))})
 	}
 	for _, related := range vuln.RelatedVulnerabilities {
 		if related.ID != "" {
@@ -295,7 +295,7 @@ func builtinCVSS(scores []grypevuln.Cvss) []sdk.CVSSScore {
 		out = append(out, sdk.CVSSScore{
 			Vector:  score.Vector,
 			Score:   score.Metrics.BaseScore,
-			Version: score.Version,
+			Version: sdk.SeverityType(score.Version),
 			Source:  score.Source,
 		})
 	}

--- a/internal/matchers/grype/external.go
+++ b/internal/matchers/grype/external.go
@@ -222,7 +222,7 @@ func mapGrypeJSONMatch(m grypeJSONMatch) sdk.Vulnerability {
 		CVSS:                 jsonCVSS(m.Vulnerability.CVSS),
 		FixedVersions:        append([]string(nil), m.Vulnerability.Fix.Versions...),
 		FixedIn:              suggestedFixedVersion(m.MatchDetails),
-		FixState:             m.Vulnerability.Fix.State,
+		FixState:             sdk.FixState(m.Vulnerability.Fix.State),
 		FixAvailable:         jsonFixAvailable(m.Vulnerability.Fix.Available),
 		AffectedVersionRange: foundConstraint(m.MatchDetails),
 		References:           jsonReferences(m.Vulnerability.Advisories),
@@ -266,7 +266,7 @@ func jsonCVSS(values []grypeJSONCVSS) []sdk.CVSSScore {
 		out = append(out, sdk.CVSSScore{
 			Vector:  value.Vector,
 			Score:   value.Metrics.BaseScore,
-			Version: value.Version,
+			Version: sdk.SeverityType(value.Version),
 			Source:  value.Source,
 		})
 	}
@@ -276,7 +276,7 @@ func jsonCVSS(values []grypeJSONCVSS) []sdk.CVSSScore {
 func jsonFixAvailable(values []grypeJSONFixAvailable) []sdk.FixAvailable {
 	out := make([]sdk.FixAvailable, 0, len(values))
 	for _, value := range values {
-		out = append(out, sdk.FixAvailable{Version: value.Version, Date: value.Date, Kind: value.Kind})
+		out = append(out, sdk.FixAvailable{Version: value.Version, Date: value.Date, Kind: sdk.FixAvailableKind(value.Kind)})
 	}
 	return out
 }
@@ -284,7 +284,7 @@ func jsonFixAvailable(values []grypeJSONFixAvailable) []sdk.FixAvailable {
 func jsonReferences(values []grypeJSONAdvisory) []sdk.Reference {
 	out := make([]sdk.Reference, 0, len(values))
 	for _, value := range values {
-		out = append(out, sdk.Reference{URL: value.Link, Type: firstNonEmpty(value.ID, "advisory")})
+		out = append(out, sdk.Reference{URL: value.Link, Type: sdk.ReferenceType(firstNonEmpty(value.ID, string(sdk.ReferenceTypeAdvisory)))})
 	}
 	return out
 }

--- a/internal/matchers/grype/mapper.go
+++ b/internal/matchers/grype/mapper.go
@@ -18,7 +18,7 @@ type grypeAdvisory struct {
 	CVSS                 []sdk.CVSSScore
 	FixedVersions        []string
 	FixedIn              string
-	FixState             string
+	FixState             sdk.FixState
 	FixAvailable         []sdk.FixAvailable
 	AffectedVersionRange string
 	References           []sdk.Reference
@@ -35,10 +35,7 @@ func mapGrypeAdvisory(advisory grypeAdvisory) sdk.Vulnerability {
 	if fixedIn == "" && len(advisory.FixedVersions) > 0 {
 		fixedIn = strings.TrimSpace(advisory.FixedVersions[0])
 	}
-	severity := strings.ToLower(strings.TrimSpace(advisory.Severity))
-	if severity == "" {
-		severity = "unknown"
-	}
+	severity := sdk.ParseSeverityLevel(advisory.Severity)
 	description := strings.TrimSpace(advisory.Description)
 	title := strings.TrimSpace(advisory.ID)
 	if description != "" {
@@ -46,10 +43,10 @@ func mapGrypeAdvisory(advisory grypeAdvisory) sdk.Vulnerability {
 	}
 	refs := append([]sdk.Reference(nil), advisory.References...)
 	if advisory.DataSource != "" {
-		refs = appendUniqueReference(refs, sdk.Reference{URL: advisory.DataSource, Type: "data_source"})
+		refs = appendUniqueReference(refs, sdk.Reference{URL: advisory.DataSource, Type: sdk.ReferenceTypeDataSource})
 	}
 	for _, url := range advisory.URLs {
-		refs = appendUniqueReference(refs, sdk.Reference{URL: url, Type: "advisory"})
+		refs = appendUniqueReference(refs, sdk.Reference{URL: url, Type: sdk.ReferenceTypeAdvisory})
 	}
 
 	return sdk.Vulnerability{
@@ -85,7 +82,7 @@ func grypeReasons(advisory grypeAdvisory, fixedIn string) []string {
 		reasons = append(reasons, fmt.Sprintf("Fix available: upgrade to %s", fixedIn))
 	}
 	if advisory.FixState != "" {
-		reasons = append(reasons, "Fix state: "+advisory.FixState)
+		reasons = append(reasons, "Fix state: "+string(advisory.FixState))
 	}
 	if len(advisory.Aliases) > 0 {
 		reasons = append(reasons, "Also known as: "+strings.Join(dedupeStrings(advisory.Aliases), ", "))
@@ -98,11 +95,11 @@ func grypeReasons(advisory grypeAdvisory, fixedIn string) []string {
 
 func mergePackageVulnerability(base, incoming sdk.Vulnerability) sdk.Vulnerability {
 	base.Title = firstNonEmpty(base.Title, incoming.Title)
-	base.ParsedSeverity = firstNonEmpty(base.ParsedSeverity, incoming.ParsedSeverity)
+	base.ParsedSeverity = sdk.ParseSeverityLevel(firstNonEmpty(string(base.ParsedSeverity), string(incoming.ParsedSeverity)))
 	base.SeveritySource = firstNonEmpty(base.SeveritySource, incoming.SeveritySource)
 	base.Details = firstNonEmpty(base.Details, incoming.Details)
 	base.FixedIn = firstNonEmpty(base.FixedIn, incoming.FixedIn)
-	base.FixState = firstNonEmpty(base.FixState, incoming.FixState)
+	base.FixState = sdk.FixState(firstNonEmpty(string(base.FixState), string(incoming.FixState)))
 	base.AffectedVersionRange = firstNonEmpty(base.AffectedVersionRange, incoming.AffectedVersionRange)
 	base.DataSource = firstNonEmpty(base.DataSource, incoming.DataSource)
 	base.Namespace = firstNonEmpty(base.Namespace, incoming.Namespace)
@@ -172,7 +169,7 @@ func appendUniqueReferences(existing []sdk.Reference, values ...sdk.Reference) [
 	seen := make(map[string]struct{}, len(existing)+len(values))
 	out := make([]sdk.Reference, 0, len(existing)+len(values))
 	for _, ref := range existing {
-		key := ref.URL + "\x00" + ref.Type
+		key := ref.URL + "\x00" + string(ref.Type)
 		if strings.TrimSpace(ref.URL) == "" || key == "\x00" {
 			continue
 		}
@@ -183,7 +180,7 @@ func appendUniqueReferences(existing []sdk.Reference, values ...sdk.Reference) [
 		out = append(out, ref)
 	}
 	for _, ref := range values {
-		key := ref.URL + "\x00" + ref.Type
+		key := ref.URL + "\x00" + string(ref.Type)
 		if strings.TrimSpace(ref.URL) == "" || key == "\x00" {
 			continue
 		}
@@ -200,7 +197,7 @@ func appendUniqueCVSS(existing []sdk.CVSSScore, values ...sdk.CVSSScore) []sdk.C
 	seen := make(map[string]struct{}, len(existing)+len(values))
 	out := make([]sdk.CVSSScore, 0, len(existing)+len(values))
 	for _, score := range append(existing, values...) {
-		key := score.Source + "\x00" + score.Version + "\x00" + score.Vector
+		key := score.Source + "\x00" + string(score.Version) + "\x00" + score.Vector
 		if key == "\x00\x00" {
 			continue
 		}
@@ -217,7 +214,7 @@ func appendUniqueFixAvailable(existing []sdk.FixAvailable, values ...sdk.FixAvai
 	seen := make(map[string]struct{}, len(existing)+len(values))
 	out := make([]sdk.FixAvailable, 0, len(existing)+len(values))
 	for _, fix := range append(existing, values...) {
-		key := fix.Version + "\x00" + fix.Date + "\x00" + fix.Kind
+		key := fix.Version + "\x00" + fix.Date + "\x00" + string(fix.Kind)
 		if key == "\x00\x00" {
 			continue
 		}

--- a/internal/matchers/grype/matcher_test.go
+++ b/internal/matchers/grype/matcher_test.go
@@ -66,7 +66,7 @@ func TestMatch_DBNotPresent_AttemptsDownloadAndReturnsEmpty(t *testing.T) {
 		DistConfigOverride: &badDist,
 	}
 
-	dep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"}})
 	g := sdk.New()
 	if err := g.AddNode(dep); err != nil {
 		t.Fatalf("AddNode: %v", err)
@@ -99,11 +99,10 @@ func TestDBDir_DefaultUsesOSCacheDir(t *testing.T) {
 }
 
 func TestGraphPkgToGrypePkg_FieldMapping(t *testing.T) {
-	p := &sdk.Package{
-		Name:      "lodash",
+	p := &sdk.Package{Coordinates: sdk.Coordinates{Name: "lodash",
 		Version:   "4.17.15",
 		PURL:      "pkg:npm/lodash@4.17.15",
-		Ecosystem: "npm",
+		Ecosystem: "npm"},
 	}
 	gp := graphPkgToGrypePkg(p)
 	if gp.Name != "lodash" {

--- a/internal/matchers/licenses.go
+++ b/internal/matchers/licenses.go
@@ -39,7 +39,7 @@ func NormalizeLicenseSet(values []string, sourceType string) []sdk.PackageLicens
 		out = append(out, sdk.PackageLicense{
 			Value:          normalized,
 			SPDXExpression: normalized,
-			Type:           sourceType,
+			Type:           sdk.LicenseType(sourceType),
 		})
 	}
 	return out

--- a/internal/matchers/osv/mapper.go
+++ b/internal/matchers/osv/mapper.go
@@ -45,7 +45,7 @@ func mapSeverities(severities []Severity) []sdk.Severity {
 	}
 	out := make([]sdk.Severity, 0, len(severities))
 	for _, s := range severities {
-		out = append(out, sdk.Severity{Type: s.Type, Score: s.Score})
+		out = append(out, sdk.Severity{Type: sdk.SeverityType(strings.TrimSpace(s.Type)), Score: s.Score})
 	}
 	return out
 }
@@ -101,7 +101,7 @@ func firstNonEmpty(a, b string) string {
 
 // extractSeverity derives a normalized severity band from OSV severity entries.
 // Prefers CVSS v4 > v3.1 > v3 > v2 > unknown.
-func extractSeverity(severities []Severity) string {
+func extractSeverity(severities []Severity) sdk.SeverityLevel {
 	scores := map[string]float64{}
 	for _, s := range severities {
 		if score := parseCVSSScore(s.Type, s.Score); score > 0 {
@@ -113,7 +113,7 @@ func extractSeverity(severities []Severity) string {
 			return cvssScoreToBand(score)
 		}
 	}
-	return "unknown"
+	return sdk.SeverityUnknown
 }
 
 func parseCVSSScore(kind, raw string) float64 {
@@ -190,16 +190,16 @@ func normalizeCVSSVector(kind, raw string) (string, string) {
 	}
 }
 
-func cvssScoreToBand(score float64) string {
+func cvssScoreToBand(score float64) sdk.SeverityLevel {
 	switch {
 	case score >= 9.0:
-		return "critical"
+		return sdk.SeverityCritical
 	case score >= 7.0:
-		return "high"
+		return sdk.SeverityHigh
 	case score >= 4.0:
-		return "medium"
+		return sdk.SeverityMedium
 	default:
-		return "low"
+		return sdk.SeverityLow
 	}
 }
 
@@ -230,7 +230,7 @@ func buildCVSS(severities []Severity) []sdk.CVSSScore {
 		scores = append(scores, sdk.CVSSScore{
 			Vector:  strings.TrimSpace(severity.Score),
 			Score:   score,
-			Version: strings.TrimSpace(severity.Type),
+			Version: sdk.SeverityType(strings.TrimSpace(severity.Type)),
 			Source:  "osv",
 		})
 	}

--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -465,7 +465,7 @@ func buildQuery(dep *sdk.Dependency, purl string) (cache.Key, BatchQuery, bool) 
 	}
 
 	// Fall back to name + ecosystem + version
-	ecosystem := ecosystemToOSV(dep.Ecosystem)
+	ecosystem := ecosystemToOSV(string(dep.Ecosystem))
 	if ecosystem == "" {
 		return cache.Key{}, BatchQuery{}, false
 	}

--- a/internal/matchers/osv/matcher_test.go
+++ b/internal/matchers/osv/matcher_test.go
@@ -18,11 +18,10 @@ import (
 // --- buildQuery ---
 
 func TestBuildQuery_PURLBased(t *testing.T) {
-	dep := &sdk.Dependency{
-		Name:      "lodash",
+	dep := &sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash",
 		Version:   "4.17.15",
 		PURL:      "pkg:npm/lodash@4.17.15",
-		Ecosystem: "npm",
+		Ecosystem: "npm"},
 	}
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 	key, query, ok := buildQuery(dep, purl)
@@ -45,10 +44,9 @@ func TestBuildQuery_PURLBased(t *testing.T) {
 }
 
 func TestBuildQuery_NameEcosystemVersion(t *testing.T) {
-	dep := &sdk.Dependency{
-		Name:      "requests",
+	dep := &sdk.Dependency{Coordinates: sdk.Coordinates{Name: "requests",
 		Version:   "2.28.0",
-		Ecosystem: "python",
+		Ecosystem: "python"},
 	}
 	// Force the name+ecosystem fallback by passing an empty PURL.
 	key, query, ok := buildQuery(dep, "")
@@ -74,7 +72,7 @@ func TestBuildQuery_NameEcosystemVersion(t *testing.T) {
 }
 
 func TestBuildQuery_SkipsNoVersion(t *testing.T) {
-	dep := &sdk.Dependency{Name: "lodash", Ecosystem: "npm"}
+	dep := &sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash", Ecosystem: "npm"}}
 	_, _, ok := buildQuery(dep, "")
 	if ok {
 		t.Error("expected package without version to be skipped (no query built)")
@@ -82,7 +80,7 @@ func TestBuildQuery_SkipsNoVersion(t *testing.T) {
 }
 
 func TestBuildQuery_SkipsUnknownEcosystem(t *testing.T) {
-	dep := &sdk.Dependency{Name: "my-pkg", Version: "1.0.0", Ecosystem: "unknown-eco"}
+	dep := &sdk.Dependency{Coordinates: sdk.Coordinates{Name: "my-pkg", Version: "1.0.0", Ecosystem: "unknown-eco"}}
 	_, _, ok := buildQuery(dep, "")
 	if ok {
 		t.Error("expected package with unknown ecosystem and no PURL to be skipped")
@@ -161,11 +159,10 @@ func TestAudit_CacheHit_NoHTTPCall(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	dep := sdk.NewDependency(sdk.Dependency{
-		Name:      "lodash",
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash",
 		Version:   "4.17.15",
 		PURL:      "pkg:npm/lodash@4.17.15",
-		Ecosystem: "npm",
+		Ecosystem: "npm"},
 	})
 	purl := sdk.CanonicalPackageURLFromDependency(dep)
 
@@ -234,11 +231,10 @@ func TestAudit_OSVFailure_NonFatal(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	dep := sdk.NewDependency(sdk.Dependency{
-		Name:      "lodash",
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash",
 		Version:   "4.17.15",
 		PURL:      "pkg:npm/lodash@4.17.15",
-		Ecosystem: "npm",
+		Ecosystem: "npm"},
 	})
 	g := sdk.New()
 	if err := g.AddNode(dep); err != nil {

--- a/internal/matchers/osv/matcher_test.go
+++ b/internal/matchers/osv/matcher_test.go
@@ -293,18 +293,18 @@ func TestMarkKEVVulnerabilities_AppendsReason(t *testing.T) {
 func TestCvssScoreToBand(t *testing.T) {
 	tests := []struct {
 		score float64
-		want  string
+		want  sdk.SeverityLevel
 	}{
 		{9.0, "critical"},
 		{9.5, "critical"},
-		{10.0, "critical"},
-		{7.0, "high"},
-		{8.9, "high"},
-		{4.0, "medium"},
-		{6.9, "medium"},
-		{0.1, "low"},
-		{3.9, "low"},
-		{0.0, "low"},
+		{10.0, sdk.SeverityCritical},
+		{7.0, sdk.SeverityHigh},
+		{8.9, sdk.SeverityHigh},
+		{4.0, sdk.SeverityMedium},
+		{6.9, sdk.SeverityMedium},
+		{0.1, sdk.SeverityLow},
+		{3.9, sdk.SeverityLow},
+		{0.0, sdk.SeverityLow},
 	}
 	for _, tt := range tests {
 		got := cvssScoreToBand(tt.score)

--- a/internal/matchers/scorecard/matcher_test.go
+++ b/internal/matchers/scorecard/matcher_test.go
@@ -76,7 +76,7 @@ func TestMatch_AttachesScorecardToPackages(t *testing.T) {
 	})
 
 	matcher := newMatcher(t, base)
-	dep := sdk.NewDependency(sdk.Dependency{Name: "scorecard", Version: "v5.0.0", PURL: "pkg:github/ossf/scorecard@v5.0.0"})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "scorecard", Version: "v5.0.0", PURL: "pkg:github/ossf/scorecard@v5.0.0"}})
 	g := newGraph(t, dep)
 	registry := sdk.NewPackageRegistry()
 
@@ -116,7 +116,7 @@ func TestMatch_CacheHitSkipsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	dep1 := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"})
+	dep1 := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"}})
 	reg1 := sdk.NewPackageRegistry()
 	if _, err := matcher1.Match(context.Background(), sdk.MatchRequest{Graph: newGraph(t, dep1), Registry: reg1}); err != nil {
 		t.Fatalf("first Match: %v", err)
@@ -127,7 +127,7 @@ func TestMatch_CacheHitSkipsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New2: %v", err)
 	}
-	dep2 := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"})
+	dep2 := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"}})
 	reg2 := sdk.NewPackageRegistry()
 	if _, err := matcher2.Match(context.Background(), sdk.MatchRequest{Graph: newGraph(t, dep2), Registry: reg2}); err != nil {
 		t.Fatalf("second Match: %v", err)
@@ -146,7 +146,7 @@ func TestMatch_NotFoundCachedAsSentinel(t *testing.T) {
 	})
 
 	dir := t.TempDir()
-	dep1 := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/unscored/repo@1.0.0", Version: "1.0.0"})
+	dep1 := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/unscored/repo@1.0.0", Version: "1.0.0"}})
 	reg1 := sdk.NewPackageRegistry()
 	matcher, err := New(Config{APIBase: base, CacheDir: dir})
 	if err != nil {
@@ -160,7 +160,7 @@ func TestMatch_NotFoundCachedAsSentinel(t *testing.T) {
 	}
 
 	// Second invocation should hit the sentinel cache (no extra API call).
-	dep2 := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/unscored/repo@1.0.0", Version: "1.0.0"})
+	dep2 := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/unscored/repo@1.0.0", Version: "1.0.0"}})
 	reg2 := sdk.NewPackageRegistry()
 	if _, err := matcher.Match(context.Background(), sdk.MatchRequest{Graph: newGraph(t, dep2), Registry: reg2}); err != nil {
 		t.Fatalf("second Match: %v", err)
@@ -176,7 +176,7 @@ func TestMatch_ServerErrorIsNonFatal(t *testing.T) {
 	})
 
 	matcher := newMatcher(t, base)
-	dep := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/example/repo@1.0.0", Version: "1.0.0"})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/example/repo@1.0.0", Version: "1.0.0"}})
 	reg := sdk.NewPackageRegistry()
 	if _, err := matcher.Match(context.Background(), sdk.MatchRequest{Graph: newGraph(t, dep), Registry: reg}); err != nil {
 		t.Fatalf("Match must not return an error on transport failure; got %v", err)
@@ -194,7 +194,7 @@ func TestMatch_SkipsPackagesWithoutResolvableRepo(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	matcher := newMatcher(t, srv.URL)
-	dep := sdk.NewDependency(sdk.Dependency{PURL: "pkg:npm/internal-only@1.0.0", Version: "1.0.0"})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:npm/internal-only@1.0.0", Version: "1.0.0"}})
 	reg := sdk.NewPackageRegistry()
 	if _, err := matcher.Match(context.Background(), sdk.MatchRequest{Graph: newGraph(t, dep), Registry: reg}); err != nil {
 		t.Fatalf("Match: %v", err)
@@ -214,8 +214,8 @@ func TestMatch_ComponentModeOnlyEnrichesTarget(t *testing.T) {
 	})
 
 	matcher := newMatcher(t, base)
-	target := sdk.NewDependency(sdk.Dependency{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"})
-	other := sdk.NewDependency(sdk.Dependency{PURL: "pkg:golang/github.com/sirupsen/logrus@v1.9.0", Version: "v1.9.0"})
+	target := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:github/ossf/scorecard@v5.0.0", Version: "v5.0.0"}})
+	other := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{PURL: "pkg:golang/github.com/sirupsen/logrus@v1.9.0", Version: "v1.9.0"}})
 	g := newGraph(t, target, other)
 	reg := sdk.NewPackageRegistry()
 

--- a/internal/matchers/scorecard/reporesolve_test.go
+++ b/internal/matchers/scorecard/reporesolve_test.go
@@ -20,52 +20,37 @@ func TestResolveRepo(t *testing.T) {
 		},
 		{
 			name: "golang PURL with github.com module",
-			pkg: &sdk.Package{
-				PURL: "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/github.com/sirupsen/logrus@v1.9.0"}},
 			want: "github.com/sirupsen/logrus",
 		},
 		{
 			name: "golang PURL with github.com module and subpath",
-			pkg: &sdk.Package{
-				PURL: "pkg:golang/github.com/google/go-containerregistry/pkg/v1@v0.14.0",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/github.com/google/go-containerregistry/pkg/v1@v0.14.0"}},
 			want: "github.com/google/go-containerregistry",
 		},
 		{
 			name: "golang PURL with non-github module",
-			pkg: &sdk.Package{
-				PURL: "pkg:golang/golang.org/x/sys@v0.10.0",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/golang.org/x/sys@v0.10.0"}},
 			want: "",
 		},
 		{
 			name: "github PURL type",
-			pkg: &sdk.Package{
-				PURL: "pkg:github/ossf/scorecard@v5.0.0",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:github/ossf/scorecard@v5.0.0"}},
 			want: "github.com/ossf/scorecard",
 		},
 		{
 			name: "repository_url qualifier",
-			pkg: &sdk.Package{
-				PURL: "pkg:npm/lodash@4.17.15?repository_url=https://github.com/lodash/lodash.git",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:npm/lodash@4.17.15?repository_url=https://github.com/lodash/lodash.git"}},
 			want: "github.com/lodash/lodash",
 		},
 		{
 			name: "vcs_url qualifier with .git suffix",
-			pkg: &sdk.Package{
-				PURL: "pkg:npm/foo@1.0.0?vcs_url=https://github.com/example/foo.git",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:npm/foo@1.0.0?vcs_url=https://github.com/example/foo.git"}},
 			want: "github.com/example/foo",
 		},
 		{
 			name: "ResolvedURL https tarball",
-			pkg: &sdk.Package{
-				PURL:        "pkg:npm/bar@1.0.0",
-				ResolvedURL: "https://github.com/example/bar/archive/refs/tags/v1.0.0.tar.gz",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:npm/bar@1.0.0"}, ResolvedURL: "https://github.com/example/bar/archive/refs/tags/v1.0.0.tar.gz"},
 			want: "github.com/example/bar",
 		},
 		{
@@ -77,17 +62,12 @@ func TestResolveRepo(t *testing.T) {
 		},
 		{
 			name: "no github reference anywhere",
-			pkg: &sdk.Package{
-				PURL:        "pkg:npm/qux@1.0.0",
-				ResolvedURL: "https://registry.npmjs.org/qux/-/qux-1.0.0.tgz",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:npm/qux@1.0.0"}, ResolvedURL: "https://registry.npmjs.org/qux/-/qux-1.0.0.tgz"},
 			want: "",
 		},
 		{
 			name: "qualifier on non-github host",
-			pkg: &sdk.Package{
-				PURL: "pkg:npm/foo@1.0.0?repository_url=https://gitlab.com/example/foo.git",
-			},
+			pkg:  &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:npm/foo@1.0.0?repository_url=https://gitlab.com/example/foo.git"}},
 			want: "",
 		},
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -172,8 +172,8 @@ func BuildManifestFixTargets(
 
 				targets = append(targets, ManifestFixTarget{
 					ManifestPath:       manifest.Path,
-					ManifestKind:       manifest.Kind,
-					PackageManager:     manifest.PackageManager,
+					ManifestKind:       string(manifest.Kind),
+					PackageManager:     manifest.PackageManager.Name(),
 					TargetPackage:      targetInManifest.Name,
 					CurrentVersion:     targetInManifest.Version,
 					RecommendedVersion: recommendedVersion,

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPackageRefMarshalJSONAlwaysIncludesLicenses(t *testing.T) {
-	payload, err := json.Marshal(PackageFromGraphPackage(&sdk.Dependency{Name: "react", Version: "18.2.0"}))
+	payload, err := json.Marshal(PackageFromGraphPackage(&sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}}))
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
@@ -19,7 +19,7 @@ func TestPackageRefMarshalJSONAlwaysIncludesLicenses(t *testing.T) {
 }
 
 func TestPackageFromGraphPackageIncludesStructuredLicenses(t *testing.T) {
-	dep := &sdk.Dependency{Name: "react", Version: "18.2.0"}
+	dep := &sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}}
 	sdk.SetDetectionLicenses(dep, []sdk.PackageLicense{{
 		Value:          "MIT License",
 		SPDXExpression: "MIT",

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -23,7 +23,7 @@ func TestPackageFromGraphPackageIncludesStructuredLicenses(t *testing.T) {
 	sdk.SetDetectionLicenses(dep, []sdk.PackageLicense{{
 		Value:          "MIT License",
 		SPDXExpression: "MIT",
-		Type:           "external-depsdev",
+		Type:           sdk.LicenseType("external-depsdev"),
 	}})
 	ref := PackageFromGraphPackage(dep)
 

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -114,7 +114,7 @@ type sarifProperties struct {
 	LocationURIs           []string             `json:"location_uris,omitempty"`
 	FixedIn                string               `json:"fixed_in,omitempty"`
 	FixedVersions          []string             `json:"fixed_versions,omitempty"`
-	FixState               string               `json:"fix_state,omitempty"`
+	FixState               sdk.FixState         `json:"fix_state,omitempty"`
 	FixAvailable           []sdk.FixAvailable   `json:"fix_available,omitempty"`
 	SeveritySource         string               `json:"severity_source,omitempty"`
 	CVSS                   []sdk.CVSSScore      `json:"cvss,omitempty"`
@@ -171,7 +171,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, registry *sdk.PackageRegist
 			ID:               f.ID,
 			ShortDescription: sarifMessage{Text: f.Title},
 			FullDescription:  sarifMessage{Text: joinReasons(f.Reasons)},
-			DefaultConfig:    sarifRuleConfig{Level: severityToSARIFLevel(f.Severity)},
+			DefaultConfig:    sarifRuleConfig{Level: severityToSARIFLevel(string(f.Severity))},
 			HelpURI:          helpURI,
 		})
 	}
@@ -187,7 +187,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, registry *sdk.PackageRegist
 		locations, locationURIs := sarifLocationsForFinding(f, includeReachability, options)
 		result := sarifResult{
 			RuleID:    f.ID,
-			Level:     severityToSARIFLevel(f.Severity),
+			Level:     severityToSARIFLevel(string(f.Severity)),
 			Message:   sarifMessage{Text: msgText},
 			Locations: locations,
 		}

--- a/internal/output/sarif_reachability_test.go
+++ b/internal/output/sarif_reachability_test.go
@@ -46,7 +46,7 @@ func TestWriteSARIFEmitsCodeFlowsAndPropertiesForReachableFinding(t *testing.T) 
 			VulnerabilityID: "GHSA-test",
 			Kind:            model.FindingKindVulnerability,
 			PackageRef:      purl,
-			Severity:        "high",
+			Severity:        model.SeverityHigh,
 			Title:           "vuln",
 			Source:          "osv",
 		},
@@ -93,7 +93,7 @@ func TestWriteSARIFOmitsReachabilityWhenDisabled(t *testing.T) {
 			VulnerabilityID: "GHSA-test",
 			Kind:            model.FindingKindVulnerability,
 			PackageRef:      purl,
-			Severity:        "high",
+			Severity:        model.SeverityHigh,
 			Title:           "vuln",
 			Source:          "osv",
 		},
@@ -118,7 +118,7 @@ func TestWriteSARIFOmitsCodeFlowsWhenNoReachability(t *testing.T) {
 	const purl = "pkg:go/lib@1.0.0"
 	reg := fixtureRegistryWithVuln(purl, model.Vulnerability{ID: "X"})
 	findings := []model.Finding{
-		{ID: "X", VulnerabilityID: "X", Kind: model.FindingKindVulnerability, PackageRef: purl, Severity: "high", Title: "x", Source: "osv"},
+		{ID: "X", VulnerabilityID: "X", Kind: model.FindingKindVulnerability, PackageRef: purl, Severity: model.SeverityHigh, Title: "x", Source: "osv"},
 	}
 	var buf bytes.Buffer
 	if err := WriteSARIF(&buf, findings, reg, "bomly", "test"); err != nil {

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -199,9 +199,7 @@ func TestWriteSARIF_LocationsFallBackToRepoFile(t *testing.T) {
 
 func TestWriteSARIF_UsesDependencyLocationsFromGraph(t *testing.T) {
 	graph := sdk.New()
-	dep := sdk.NewDependencyWithID("lodash@4.17.15", sdk.Dependency{
-		Name:       "lodash",
-		PackageRef: sarifTestPURL,
+	dep := sdk.NewDependencyWithID("lodash@4.17.15", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash"}, PackageRef: sarifTestPURL,
 		Locations: []sdk.PackageLocation{
 			{
 				RealPath: "package-lock.json",
@@ -251,10 +249,8 @@ func TestWriteSARIF_UsesDependencyLocationsFromGraph(t *testing.T) {
 
 func TestWriteSARIF_RewritesNonFileLocationSchemes(t *testing.T) {
 	graph := sdk.New()
-	dep := sdk.NewDependencyWithID("actions:checkout@v5", sdk.Dependency{
-		Name:       "actions/checkout",
-		PackageRef: "actions:checkout@v5",
-		Locations:  []sdk.PackageLocation{{RealPath: "actions:checkout@v5"}},
+	dep := sdk.NewDependencyWithID("actions:checkout@v5", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "actions/checkout"}, PackageRef: "actions:checkout@v5",
+		Locations: []sdk.PackageLocation{{RealPath: "actions:checkout@v5"}},
 	})
 	if err := graph.AddNode(dep); err != nil {
 		t.Fatalf("AddNode: %v", err)

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -18,7 +18,7 @@ func TestWriteSARIF_ValidDocument(t *testing.T) {
 			Kind:       sdk.FindingKindVulnerability,
 			PackageRef: sarifTestPURL,
 			Title:      "Prototype pollution in lodash",
-			Severity:   "high",
+			Severity:   sdk.SeverityHigh,
 			Reasons:    []string{"Fix available: upgrade to 4.17.21"},
 			Source:     "osv",
 		},
@@ -27,7 +27,7 @@ func TestWriteSARIF_ValidDocument(t *testing.T) {
 			Kind:       sdk.FindingKindVulnerability,
 			PackageRef: sarifTestPURL,
 			Title:      "Prototype pollution",
-			Severity:   "critical",
+			Severity:   sdk.SeverityCritical,
 			Source:     "osv",
 		},
 	}
@@ -75,8 +75,8 @@ func TestWriteSARIF_ValidDocument(t *testing.T) {
 
 func TestWriteSARIF_RuleDeduplication(t *testing.T) {
 	findings := []sdk.Finding{
-		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Pollution", Severity: "high", Source: "osv"},
-		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Pollution", Severity: "high", Source: "osv"},
+		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Pollution", Severity: sdk.SeverityHigh, Source: "osv"},
+		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Pollution", Severity: sdk.SeverityHigh, Source: "osv"},
 	}
 
 	var buf bytes.Buffer
@@ -155,7 +155,7 @@ func TestSeverityToSARIFLevel(t *testing.T) {
 
 func TestWriteSARIF_OSVHelpURI(t *testing.T) {
 	findings := []sdk.Finding{
-		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Vuln", Severity: "high", Source: "osv"},
+		{ID: "CVE-2021-23337", PackageRef: sarifTestPURL, Title: "Vuln", Severity: sdk.SeverityHigh, Source: "osv"},
 	}
 	var buf bytes.Buffer
 	if err := WriteSARIF(&buf, findings, nil, "bomly", "0.1.0"); err != nil {
@@ -171,7 +171,7 @@ func TestWriteSARIF_OSVHelpURI(t *testing.T) {
 // available. Package identity stays in the SARIF properties bag.
 func TestWriteSARIF_LocationsFallBackToRepoFile(t *testing.T) {
 	findings := []sdk.Finding{
-		{ID: "CVE-2021-23337", Kind: sdk.FindingKindVulnerability, PackageRef: sarifTestPURL, Title: "Vuln", Severity: "high"},
+		{ID: "CVE-2021-23337", Kind: sdk.FindingKindVulnerability, PackageRef: sarifTestPURL, Title: "Vuln", Severity: sdk.SeverityHigh},
 	}
 	var buf bytes.Buffer
 	if err := WriteSARIF(&buf, findings, nil, "bomly", "0.1.0"); err != nil {
@@ -224,7 +224,7 @@ func TestWriteSARIF_UsesDependencyLocationsFromGraph(t *testing.T) {
 			PackageRef:     sarifTestPURL,
 			DependencyRefs: []string{dep.ID},
 			Title:          "Vuln",
-			Severity:       "high",
+			Severity:       sdk.SeverityHigh,
 		},
 	}
 
@@ -266,7 +266,7 @@ func TestWriteSARIF_RewritesNonFileLocationSchemes(t *testing.T) {
 			PackageRef:     "actions:checkout@v5",
 			DependencyRefs: []string{dep.ID},
 			Title:          "Denied action",
-			Severity:       "high",
+			Severity:       sdk.SeverityHigh,
 		},
 	}
 

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -30,19 +30,19 @@ type ReportOptions struct {
 
 // ProjectDescriptor describes the project being analyzed.
 type ProjectDescriptor struct {
-	Name           string `json:"name,omitempty"`
-	Path           string `json:"path"`
-	TargetType     string `json:"target_type,omitempty"`
-	TargetRef      string `json:"target_ref,omitempty"`
-	Ecosystem      string `json:"ecosystem"`
-	PackageManager string `json:"package_manager,omitempty"`
+	Name           string             `json:"name,omitempty"`
+	Path           string             `json:"path"`
+	TargetType     string             `json:"target_type,omitempty"`
+	TargetRef      string             `json:"target_ref,omitempty"`
+	Ecosystem      sdk.Ecosystem      `json:"ecosystem"`
+	PackageManager sdk.PackageManager `json:"package_manager,omitempty"`
 }
 
 // LicenseRef identifies one package license in command outputs.
 type LicenseRef struct {
-	Value          string `json:"value,omitempty"`
-	SPDXExpression string `json:"spdxExpression,omitempty"`
-	Type           string `json:"type,omitempty"`
+	Value          string          `json:"value,omitempty"`
+	SPDXExpression string          `json:"spdxExpression,omitempty"`
+	Type           sdk.LicenseType `json:"type,omitempty"`
 }
 
 // Identifier returns the most useful license identifier for display.
@@ -62,7 +62,7 @@ type VulnerabilityRef struct {
 	ID                   string               `json:"id"`
 	Source               string               `json:"source"`
 	Title                string               `json:"title,omitempty"`
-	Severity             string               `json:"severity,omitempty"`
+	Severity             sdk.SeverityLevel    `json:"severity,omitempty"`
 	SeveritySource       string               `json:"severity_source,omitempty"`
 	Aliases              []string             `json:"aliases,omitempty"`
 	Description          string               `json:"description,omitempty"`
@@ -70,7 +70,7 @@ type VulnerabilityRef struct {
 	CVSS                 []sdk.CVSSScore      `json:"cvss,omitempty"`
 	FixedIn              string               `json:"fixed_in,omitempty"`
 	FixedVersions        []string             `json:"fixed_versions,omitempty"`
-	FixState             string               `json:"fix_state,omitempty"`
+	FixState             sdk.FixState         `json:"fix_state,omitempty"`
 	FixAvailable         []sdk.FixAvailable   `json:"fix_available,omitempty"`
 	AffectedVersionRange string               `json:"affected_version_range,omitempty"`
 	References           []sdk.Reference      `json:"references,omitempty"`
@@ -321,34 +321,34 @@ func VulnerabilityRefsFromPackageVulnerabilities(vulnerabilities []sdk.Vulnerabi
 
 // AuditFinding is the serialized form of one normalized scan finding.
 type AuditFinding struct {
-	ID                   string               `json:"id"`
-	Kind                 string               `json:"kind"`
-	Severity             string               `json:"severity"`
-	Package              PackageRef           `json:"package"`
-	Title                string               `json:"title"`
-	Reasons              []string             `json:"reasons,omitempty"`
-	Source               string               `json:"source"`
-	Auditor              string               `json:"auditor,omitempty"`
-	Disposition          string               `json:"disposition,omitempty"`
-	FixedIn              string               `json:"fixed_in,omitempty"`
-	FixedVersions        []string             `json:"fixed_versions,omitempty"`
-	FixState             string               `json:"fix_state,omitempty"`
-	FixAvailable         []sdk.FixAvailable   `json:"fix_available,omitempty"`
-	Aliases              []string             `json:"aliases,omitempty"`
-	Description          string               `json:"description,omitempty"`
-	SeveritySource       string               `json:"severity_source,omitempty"`
-	CVSS                 []sdk.CVSSScore      `json:"cvss,omitempty"`
-	AffectedVersionRange string               `json:"affected_version_range,omitempty"`
-	References           []sdk.Reference      `json:"references,omitempty"`
-	KEVExploited         bool                 `json:"kev_exploited,omitempty"`
-	KnownExploited       []sdk.KnownExploited `json:"known_exploited,omitempty"`
-	EPSS                 []sdk.EPSSScore      `json:"epss,omitempty"`
-	CWEs                 []sdk.CWE            `json:"cwes,omitempty"`
-	RiskScore            float64              `json:"risk_score,omitempty"`
-	DataSource           string               `json:"data_source,omitempty"`
-	Namespace            string               `json:"namespace,omitempty"`
-	CPEs                 []string             `json:"cpes,omitempty"`
-	Reachability         *sdk.Reachability    `json:"reachability,omitempty"`
+	ID                   string                 `json:"id"`
+	Kind                 sdk.FindingKind        `json:"kind"`
+	Severity             sdk.SeverityLevel      `json:"severity"`
+	Package              PackageRef             `json:"package"`
+	Title                string                 `json:"title"`
+	Reasons              []string               `json:"reasons,omitempty"`
+	Source               string                 `json:"source"`
+	Auditor              string                 `json:"auditor,omitempty"`
+	Disposition          sdk.FindingDisposition `json:"disposition,omitempty"`
+	FixedIn              string                 `json:"fixed_in,omitempty"`
+	FixedVersions        []string               `json:"fixed_versions,omitempty"`
+	FixState             sdk.FixState           `json:"fix_state,omitempty"`
+	FixAvailable         []sdk.FixAvailable     `json:"fix_available,omitempty"`
+	Aliases              []string               `json:"aliases,omitempty"`
+	Description          string                 `json:"description,omitempty"`
+	SeveritySource       string                 `json:"severity_source,omitempty"`
+	CVSS                 []sdk.CVSSScore        `json:"cvss,omitempty"`
+	AffectedVersionRange string                 `json:"affected_version_range,omitempty"`
+	References           []sdk.Reference        `json:"references,omitempty"`
+	KEVExploited         bool                   `json:"kev_exploited,omitempty"`
+	KnownExploited       []sdk.KnownExploited   `json:"known_exploited,omitempty"`
+	EPSS                 []sdk.EPSSScore        `json:"epss,omitempty"`
+	CWEs                 []sdk.CWE              `json:"cwes,omitempty"`
+	RiskScore            float64                `json:"risk_score,omitempty"`
+	DataSource           string                 `json:"data_source,omitempty"`
+	Namespace            string                 `json:"namespace,omitempty"`
+	CPEs                 []string               `json:"cpes,omitempty"`
+	Reachability         *sdk.Reachability      `json:"reachability,omitempty"`
 }
 
 // AuditSummary aggregates finding counts by severity.
@@ -372,14 +372,14 @@ func FindingsFromScan(findings []sdk.Finding, registry *sdk.PackageRegistry) []A
 		pkg := lookupRegistryPackage(registry, f.PackageRef)
 		af := AuditFinding{
 			ID:          f.ID,
-			Kind:        string(f.Kind),
+			Kind:        f.Kind,
 			Severity:    f.Severity,
 			Package:     packageRefFromRegistryPackage(f.PackageRef, pkg),
 			Title:       f.Title,
 			Reasons:     f.Reasons,
 			Source:      f.Source,
 			Auditor:     f.Auditor,
-			Disposition: string(f.Disposition),
+			Disposition: f.Disposition,
 		}
 		if vuln := lookupVulnerability(pkg, f.VulnerabilityID, f.ID); vuln != nil {
 			af.Aliases = append([]string(nil), vuln.Aliases...)
@@ -631,7 +631,7 @@ func PackagesFromRegistry(registry *sdk.PackageRegistry) []ScanPackageEntry {
 			Purl:            pkg.PURL,
 			Name:            pkg.Name,
 			Version:         pkg.Version,
-			Ecosystem:       pkg.Ecosystem,
+			Ecosystem:       string(pkg.Ecosystem),
 			Matched:         pkg.Matched,
 			Licenses:        LicenseRefsFromGraphLicenses(pkg.Licenses),
 			Vulnerabilities: VulnerabilityRefsFromPackageVulnerabilities(pkg.Vulnerabilities),

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -28,13 +28,13 @@ type ScanResponse struct {
 
 // ScanManifest is one manifest-scoped dependency inventory in the scan payload.
 type ScanManifest struct {
-	Path           string           `json:"path,omitempty"`
-	Kind           string           `json:"kind,omitempty"`
-	Subproject     string           `json:"subproject,omitempty"`
-	Ecosystem      string           `json:"ecosystem,omitempty"`
-	PackageManager string           `json:"package_manager,omitempty"`
-	Detector       string           `json:"detector,omitempty"`
-	Dependencies   []ScanDependency `json:"dependencies"`
+	Path           string             `json:"path,omitempty"`
+	Kind           sdk.ManifestKind   `json:"kind,omitempty"`
+	Subproject     string             `json:"subproject,omitempty"`
+	Ecosystem      sdk.Ecosystem      `json:"ecosystem,omitempty"`
+	PackageManager sdk.PackageManager `json:"package_manager,omitempty"`
+	Detector       string             `json:"detector,omitempty"`
+	Dependencies   []ScanDependency   `json:"dependencies"`
 }
 
 // DiffResponse is the structured payload for the diff command.
@@ -125,10 +125,10 @@ type DiffChangedPackage struct {
 type DiffManifestResult struct {
 	Status         string               `json:"status"`
 	Path           string               `json:"path,omitempty"`
-	Kind           string               `json:"kind,omitempty"`
+	Kind           sdk.ManifestKind     `json:"kind,omitempty"`
 	Subproject     string               `json:"subproject,omitempty"`
-	Ecosystem      string               `json:"ecosystem,omitempty"`
-	PackageManager string               `json:"package_manager,omitempty"`
+	Ecosystem      sdk.Ecosystem        `json:"ecosystem,omitempty"`
+	PackageManager sdk.PackageManager   `json:"package_manager,omitempty"`
 	Added          []DiffPackageChange  `json:"added,omitempty"`
 	Removed        []DiffPackageChange  `json:"removed,omitempty"`
 	Changed        []DiffChangedPackage `json:"changed,omitempty"`
@@ -251,16 +251,16 @@ func ScanManifestsFromConsolidated(consolidated sdk.ConsolidatedGraph, registry 
 }
 
 func scanManifestFromConsolidated(manifest sdk.ConsolidatedManifest, idx int, registry *sdk.PackageRegistry) ScanManifest {
-	kind := strings.TrimSpace(manifest.Entry.Manifest.Kind)
+	kind := strings.TrimSpace(string(manifest.Entry.Manifest.Kind))
 	if kind == "" {
 		kind = "entry-" + strconv.Itoa(idx+1)
 	}
 	return ScanManifest{
 		Path:           normalizeScanManifestPath(manifest.Subproject, diffManifestPath(manifest.Subproject, manifest.Entry.Manifest), manifest.Entry.Manifest.Path),
-		Kind:           kind,
+		Kind:           sdk.ManifestKind(kind),
 		Subproject:     manifest.Subproject.RelativePath,
-		Ecosystem:      string(manifest.Subproject.Ecosystem),
-		PackageManager: manifest.Subproject.PrimaryPackageManager().Name(),
+		Ecosystem:      manifest.Subproject.Ecosystem,
+		PackageManager: manifest.Subproject.PrimaryPackageManager(),
 		Detector:       manifest.DetectorName,
 		Dependencies:   DependenciesFromGraph(manifest.Entry.Graph, registry),
 	}
@@ -326,8 +326,8 @@ func BuildDiffResponse(projectPath, baseRef, headRef string, baseConsolidated, h
 			Name:           filepathBase(projectPath),
 			Path:           projectPath,
 			TargetType:     "dependency diff",
-			Ecosystem:      "multiple",
-			PackageManager: "multiple",
+			Ecosystem:      sdk.EcosystemOther,
+			PackageManager: sdk.PackageManagerMultiple,
 		},
 		Comparison: DiffComparison{Base: baseRef, Head: headRef},
 		Results:    results,
@@ -522,10 +522,10 @@ type diffManifestSnapshot struct {
 
 type diffManifestRef struct {
 	Path           string
-	Kind           string
+	Kind           sdk.ManifestKind
 	Subproject     string
-	Ecosystem      string
-	PackageManager string
+	Ecosystem      sdk.Ecosystem
+	PackageManager sdk.PackageManager
 }
 
 func diffResultsFromConsolidated(baseConsolidated, headConsolidated sdk.ConsolidatedGraph, baseRegistry, headRegistry *sdk.PackageRegistry) (DiffResults, DiffSummary) {
@@ -800,16 +800,16 @@ func manifestSnapshotsByConsolidated(consolidated sdk.ConsolidatedGraph) map[str
 
 func diffManifestRefFromConsolidated(manifest sdk.ConsolidatedManifest, idx int) diffManifestRef {
 	pathValue := normalizeScanManifestPath(manifest.Subproject, diffManifestPath(manifest.Subproject, manifest.Entry.Manifest), manifest.Entry.Manifest.Path)
-	kind := strings.TrimSpace(manifest.Entry.Manifest.Kind)
+	kind := strings.TrimSpace(string(manifest.Entry.Manifest.Kind))
 	if kind == "" {
 		kind = "entry-" + strconv.Itoa(idx+1)
 	}
 	return diffManifestRef{
 		Path:           pathValue,
-		Kind:           kind,
+		Kind:           sdk.ManifestKind(kind),
 		Subproject:     manifest.Subproject.RelativePath,
-		Ecosystem:      string(manifest.Subproject.Ecosystem),
-		PackageManager: manifest.Subproject.PrimaryPackageManager().Name(),
+		Ecosystem:      manifest.Subproject.Ecosystem,
+		PackageManager: manifest.Subproject.PrimaryPackageManager(),
 	}
 }
 
@@ -867,9 +867,9 @@ func diffManifestKey(manifest diffManifestRef, idx int) string {
 		subproject = "."
 	}
 	if strings.TrimSpace(manifest.Path) == "" {
-		return strings.Join([]string{subproject, manifest.PackageManager, manifest.Kind, pathValue}, "::")
+		return strings.Join([]string{subproject, manifest.PackageManager.Name(), string(manifest.Kind), pathValue}, "::")
 	}
-	return strings.Join([]string{subproject, manifest.PackageManager, pathValue}, "::")
+	return strings.Join([]string{subproject, manifest.PackageManager.Name(), pathValue}, "::")
 }
 
 func diffManifestKeyForConsolidated(manifest sdk.ConsolidatedManifest, ref diffManifestRef, idx int) string {
@@ -931,7 +931,7 @@ func isSBOMManifest(subproject sdk.Subproject) bool {
 }
 
 func isSBOMDiffManifest(base, head diffManifestSnapshot) bool {
-	return base.Manifest.PackageManager == sdk.PackageManagerSBOM.Name() || head.Manifest.PackageManager == sdk.PackageManagerSBOM.Name()
+	return base.Manifest.PackageManager == sdk.PackageManagerSBOM || head.Manifest.PackageManager == sdk.PackageManagerSBOM
 }
 
 func filterSBOMPseudoPackageDiff(diff *sdk.Diff, baseGraph, headGraph *sdk.Graph) {
@@ -1142,8 +1142,8 @@ func fuzzyReconcileScore(before, after *sdk.Dependency) (float64, string) {
 }
 
 func sameEcosystemForFuzzy(before, after *sdk.Dependency) bool {
-	b := strings.ToLower(strings.TrimSpace(before.Ecosystem))
-	a := strings.ToLower(strings.TrimSpace(after.Ecosystem))
+	b := strings.ToLower(strings.TrimSpace(string(before.Ecosystem)))
+	a := strings.ToLower(strings.TrimSpace(string(after.Ecosystem)))
 	if b == "" || a == "" {
 		return true
 	}

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -30,7 +30,7 @@ func TestBuildScanResponseIncludesAuditData(t *testing.T) {
 	findings := []sdk.Finding{{
 		ID:         "OSV-1",
 		Kind:       sdk.FindingKindVulnerability,
-		Severity:   "high",
+		Severity:   sdk.SeverityHigh,
 		PackageRef: "pkg:npm/react@18.2.0",
 		Title:      "Prototype pollution",
 		Source:     "osv",
@@ -144,7 +144,7 @@ func TestBuildScanResponseDeduplicatesManifestAndPrefersNative(t *testing.T) {
 	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{
 		Name:      "demo-app",
 		Version:   "1.0.0",
-		Ecosystem: "npm",
+		Ecosystem: sdk.EcosystemNPM,
 		PURL:      "pkg:npm/demo-app@1.0.0",
 	})); err != nil {
 		t.Fatalf("add syft package: %v", err)
@@ -211,7 +211,7 @@ func TestBuildScanResponseDeduplicatesSameManifestWhenMetadataDiffers(t *testing
 	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{
 		Name:      "demo-app",
 		Version:   "1.0.0",
-		Ecosystem: "npm",
+		Ecosystem: sdk.EcosystemNPM,
 		PURL:      "pkg:npm/demo-app@1.0.0",
 	})); err != nil {
 		t.Fatalf("add syft package: %v", err)
@@ -305,7 +305,7 @@ func TestBuildExplainResponseGatesReachability(t *testing.T) {
 		}}}},
 		Findings: []output.AuditFinding{{
 			ID:           "OSV-REACH",
-			Kind:         "vulnerability",
+			Kind:         sdk.FindingKindVulnerability,
 			Package:      output.PackageRef{Name: "react"},
 			Reachability: &sdk.Reachability{Status: sdk.ReachabilityReachable, Tier: sdk.TierPackage},
 		}},
@@ -378,12 +378,12 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 func TestBuildDiffResponseEnrichesPackageDeltasFromRegistries(t *testing.T) {
 	baseGraph := sdk.New()
 	headGraph := sdk.New()
-	baseApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
-	baseLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.14", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "lodash", Version: "4.17.14", PURL: "pkg:npm/lodash@4.17.14"})
-	baseRemoved := sdk.NewDependencyWithID("pkg:npm/removed@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "removed", Version: "1.0.0", PURL: "pkg:npm/removed@1.0.0"})
-	headApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
-	headLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.15", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
-	headAdded := sdk.NewDependencyWithID("pkg:npm/added@1.0.0", sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "added", Version: "1.0.0", PURL: "pkg:npm/added@1.0.0"})
+	baseApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
+	baseLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.14", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.14", PURL: "pkg:npm/lodash@4.17.14"})
+	baseRemoved := sdk.NewDependencyWithID("pkg:npm/removed@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "removed", Version: "1.0.0", PURL: "pkg:npm/removed@1.0.0"})
+	headApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
+	headLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.15", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
+	headAdded := sdk.NewDependencyWithID("pkg:npm/added@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "added", Version: "1.0.0", PURL: "pkg:npm/added@1.0.0"})
 	for _, pkg := range []*sdk.Dependency{baseApp, baseLodash, baseRemoved} {
 		if err := baseGraph.AddNode(pkg); err != nil {
 			t.Fatalf("base AddNode(%q): %v", pkg.ID, err)
@@ -416,11 +416,11 @@ func TestBuildDiffResponseEnrichesPackageDeltasFromRegistries(t *testing.T) {
 		t.Fatalf("ConsolidateGraphs(head) error = %v", err)
 	}
 	baseRegistry := sdk.NewPackageRegistry()
-	baseRegistry.Ensure(baseLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-base", Source: "osv", ParsedSeverity: "high"}}
+	baseRegistry.Ensure(baseLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-base", Source: "osv", ParsedSeverity: sdk.SeverityHigh}}
 	baseRegistry.Ensure(baseRemoved.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "BSD-2-Clause"}}
 	headRegistry := sdk.NewPackageRegistry()
 	headRegistry.Ensure(headLodash.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
-	headRegistry.Ensure(headLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-head", Source: "osv", ParsedSeverity: "medium"}}
+	headRegistry.Ensure(headLodash.PURL).Vulnerabilities = []sdk.Vulnerability{{ID: "GHSA-head", Source: "osv", ParsedSeverity: sdk.SeverityMedium}}
 	headRegistry.Ensure(headAdded.PURL).Licenses = []sdk.PackageLicense{{SPDXExpression: "Apache-2.0"}}
 
 	response := output.BuildDiffResponse("/tmp/demo", "base", "head", baseConsolidated, headConsolidated, nil, time.Now().Add(-time.Second), output.ReportOptions{
@@ -493,7 +493,7 @@ func TestBuildDiffResponseGatesReachability(t *testing.T) {
 	audit := &output.DiffAudit{
 		Introduced: []output.AuditFinding{{
 			ID:           "OSV-REACH",
-			Kind:         "vulnerability",
+			Kind:         sdk.FindingKindVulnerability,
 			Package:      output.PackageFromGraphPackage(pkg),
 			Reachability: reachable,
 		}},
@@ -624,18 +624,18 @@ func TestBuildDiffResponseTreatsSBOMFilesAsSameManifestWhenOnlyEvidencePathDiffe
 func TestBuildDiffResponsePrunesSBOMPseudoRootPackages(t *testing.T) {
 	baseGraph := sdk.New()
 	githubRoot := sdk.NewDependencyWithID("pkg:github/bomly-dev/example@main", sdk.Dependency{
-		Ecosystem:   "github-actions",
-		BuildSystem: "sbom",
-		Name:        "com.github.bomly-dev/example",
-		Version:     "main",
-		PURL:        "pkg:github/bomly-dev/example@main",
+		Ecosystem:      sdk.EcosystemGitHub,
+		PackageManager: sdk.PackageManagerSBOM,
+		Name:           "com.github.bomly-dev/example",
+		Version:        "main",
+		PURL:           "pkg:github/bomly-dev/example@main",
 	})
 	shared := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})
 	for _, pkg := range []*sdk.Dependency{githubRoot, shared} {
 		if err := baseGraph.AddNode(pkg); err != nil {
@@ -650,11 +650,11 @@ func TestBuildDiffResponsePrunesSBOMPseudoRootPackages(t *testing.T) {
 	root := sdk.NewDependencyWithID("pkg:generic/root", sdk.Dependency{Name: "root", PURL: "pkg:generic/root"})
 	lockfile := sdk.NewDependencyWithID("pkg:generic/package-lock.json", sdk.Dependency{Name: "package-lock.json", PURL: "pkg:generic/package-lock.json"})
 	added := sdk.NewDependencyWithID("pkg:npm/zod@3.23.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "zod",
-		Version:     "3.23.0",
-		PURL:        "pkg:npm/zod@3.23.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "zod",
+		Version:        "3.23.0",
+		PURL:           "pkg:npm/zod@3.23.0",
 	})
 	for _, pkg := range []*sdk.Dependency{root, lockfile, shared, added} {
 		if err := headGraph.AddNode(pkg); err != nil {
@@ -697,21 +697,21 @@ func TestBuildScanResponsePreservesPropagatedLicensesAcrossDuplicateManifests(t 
 	projectRoot := "/tmp/demo"
 	nativeGraph := sdk.New()
 	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "app",
-		Version:     "1.0.0",
-		PURL:        "pkg:npm/app@1.0.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "app",
+		Version:        "1.0.0",
+		PURL:           "pkg:npm/app@1.0.0",
 	})
 	if err := nativeGraph.AddNode(nativeApp); err != nil {
 		t.Fatalf("add native app: %v", err)
 	}
 	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})
 	if err := nativeGraph.AddNode(nativeReact); err != nil {
 		t.Fatalf("add native react: %v", err)
@@ -722,20 +722,20 @@ func TestBuildScanResponsePreservesPropagatedLicensesAcrossDuplicateManifests(t 
 
 	sbomGraph := sdk.New()
 	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "app",
-		Version:     "1.0.0",
-		PURL:        "pkg:npm/app@1.0.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "app",
+		Version:        "1.0.0",
+		PURL:           "pkg:npm/app@1.0.0",
 	})); err != nil {
 		t.Fatalf("add sbom app: %v", err)
 	}
 	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "react",
-		Version:     "18.2.0",
-		PURL:        "pkg:npm/react@18.2.0",
+		Ecosystem:      sdk.EcosystemNPM,
+		PackageManager: sdk.PackageManagerNPM,
+		Name:           "react",
+		Version:        "18.2.0",
+		PURL:           "pkg:npm/react@18.2.0",
 	})); err != nil {
 		t.Fatalf("add sbom react: %v", err)
 	}
@@ -865,10 +865,10 @@ func TestBuildDiffResponseFuzzyReconcilesRenamedPackage(t *testing.T) {
 	baseGraph := sdk.New()
 	headGraph := sdk.New()
 
-	baseApp := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0"})
-	baseDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "left-pad", Version: "1.0.0"})
-	headApp := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "app", Version: "1.0.0"})
-	headDep := sdk.NewDependency(sdk.Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "leftpad", Version: "1.1.0"})
+	baseApp := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"})
+	baseDep := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "left-pad", Version: "1.0.0"})
+	headApp := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"})
+	headDep := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "leftpad", Version: "1.1.0"})
 
 	for _, pkg := range []*sdk.Dependency{baseApp, baseDep} {
 		if err := baseGraph.AddNode(pkg); err != nil {

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -141,11 +141,10 @@ func TestBuildScanResponseDeduplicatesManifestAndPrefersNative(t *testing.T) {
 	manifestPath := filepath.Join(projectRoot, "package-lock.json")
 
 	syftGraph := sdk.New()
-	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{
-		Name:      "demo-app",
+	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app",
 		Version:   "1.0.0",
 		Ecosystem: sdk.EcosystemNPM,
-		PURL:      "pkg:npm/demo-app@1.0.0",
+		PURL:      "pkg:npm/demo-app@1.0.0"},
 	})); err != nil {
 		t.Fatalf("add syft package: %v", err)
 	}
@@ -208,11 +207,10 @@ func TestBuildScanResponseDeduplicatesSameManifestWhenMetadataDiffers(t *testing
 
 	nativeGraph := newViewTestGraph(t)
 	syftGraph := sdk.New()
-	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{
-		Name:      "demo-app",
+	if err := syftGraph.AddNode(sdk.NewDependencyWithID("123", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app",
 		Version:   "1.0.0",
 		Ecosystem: sdk.EcosystemNPM,
-		PURL:      "pkg:npm/demo-app@1.0.0",
+		PURL:      "pkg:npm/demo-app@1.0.0"},
 	})); err != nil {
 		t.Fatalf("add syft package: %v", err)
 	}
@@ -378,12 +376,12 @@ func TestBuildDiffResponseAggregatesManifestChanges(t *testing.T) {
 func TestBuildDiffResponseEnrichesPackageDeltasFromRegistries(t *testing.T) {
 	baseGraph := sdk.New()
 	headGraph := sdk.New()
-	baseApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
-	baseLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.14", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.14", PURL: "pkg:npm/lodash@4.17.14"})
-	baseRemoved := sdk.NewDependencyWithID("pkg:npm/removed@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "removed", Version: "1.0.0", PURL: "pkg:npm/removed@1.0.0"})
-	headApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"})
-	headLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.15", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"})
-	headAdded := sdk.NewDependencyWithID("pkg:npm/added@1.0.0", sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "added", Version: "1.0.0", PURL: "pkg:npm/added@1.0.0"})
+	baseApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"}})
+	baseLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.14", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.14", PURL: "pkg:npm/lodash@4.17.14"}})
+	baseRemoved := sdk.NewDependencyWithID("pkg:npm/removed@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "removed", Version: "1.0.0", PURL: "pkg:npm/removed@1.0.0"}})
+	headApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0", PURL: "pkg:npm/app@1.0.0"}})
+	headLodash := sdk.NewDependencyWithID("pkg:npm/lodash@4.17.15", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"}})
+	headAdded := sdk.NewDependencyWithID("pkg:npm/added@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "added", Version: "1.0.0", PURL: "pkg:npm/added@1.0.0"}})
 	for _, pkg := range []*sdk.Dependency{baseApp, baseLodash, baseRemoved} {
 		if err := baseGraph.AddNode(pkg); err != nil {
 			t.Fatalf("base AddNode(%q): %v", pkg.ID, err)
@@ -623,19 +621,17 @@ func TestBuildDiffResponseTreatsSBOMFilesAsSameManifestWhenOnlyEvidencePathDiffe
 
 func TestBuildDiffResponsePrunesSBOMPseudoRootPackages(t *testing.T) {
 	baseGraph := sdk.New()
-	githubRoot := sdk.NewDependencyWithID("pkg:github/bomly-dev/example@main", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemGitHub,
+	githubRoot := sdk.NewDependencyWithID("pkg:github/bomly-dev/example@main", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGitHub,
 		PackageManager: sdk.PackageManagerSBOM,
 		Name:           "com.github.bomly-dev/example",
 		Version:        "main",
-		PURL:           "pkg:github/bomly-dev/example@main",
+		PURL:           "pkg:github/bomly-dev/example@main"},
 	})
-	shared := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	shared := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})
 	for _, pkg := range []*sdk.Dependency{githubRoot, shared} {
 		if err := baseGraph.AddNode(pkg); err != nil {
@@ -647,14 +643,13 @@ func TestBuildDiffResponsePrunesSBOMPseudoRootPackages(t *testing.T) {
 	}
 
 	headGraph := sdk.New()
-	root := sdk.NewDependencyWithID("pkg:generic/root", sdk.Dependency{Name: "root", PURL: "pkg:generic/root"})
-	lockfile := sdk.NewDependencyWithID("pkg:generic/package-lock.json", sdk.Dependency{Name: "package-lock.json", PURL: "pkg:generic/package-lock.json"})
-	added := sdk.NewDependencyWithID("pkg:npm/zod@3.23.0", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	root := sdk.NewDependencyWithID("pkg:generic/root", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "root", PURL: "pkg:generic/root"}})
+	lockfile := sdk.NewDependencyWithID("pkg:generic/package-lock.json", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "package-lock.json", PURL: "pkg:generic/package-lock.json"}})
+	added := sdk.NewDependencyWithID("pkg:npm/zod@3.23.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "zod",
 		Version:        "3.23.0",
-		PURL:           "pkg:npm/zod@3.23.0",
+		PURL:           "pkg:npm/zod@3.23.0"},
 	})
 	for _, pkg := range []*sdk.Dependency{root, lockfile, shared, added} {
 		if err := headGraph.AddNode(pkg); err != nil {
@@ -696,22 +691,20 @@ func TestBuildDiffResponsePrunesSBOMPseudoRootPackages(t *testing.T) {
 func TestBuildScanResponsePreservesPropagatedLicensesAcrossDuplicateManifests(t *testing.T) {
 	projectRoot := "/tmp/demo"
 	nativeGraph := sdk.New()
-	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	nativeApp := sdk.NewDependencyWithID("pkg:npm/app@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "app",
 		Version:        "1.0.0",
-		PURL:           "pkg:npm/app@1.0.0",
+		PURL:           "pkg:npm/app@1.0.0"},
 	})
 	if err := nativeGraph.AddNode(nativeApp); err != nil {
 		t.Fatalf("add native app: %v", err)
 	}
-	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	nativeReact := sdk.NewDependencyWithID("pkg:npm/react@18.2.0", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})
 	if err := nativeGraph.AddNode(nativeReact); err != nil {
 		t.Fatalf("add native react: %v", err)
@@ -721,21 +714,19 @@ func TestBuildScanResponsePreservesPropagatedLicensesAcrossDuplicateManifests(t 
 	}
 
 	sbomGraph := sdk.New()
-	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-app", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "app",
 		Version:        "1.0.0",
-		PURL:           "pkg:npm/app@1.0.0",
+		PURL:           "pkg:npm/app@1.0.0"},
 	})); err != nil {
 		t.Fatalf("add sbom app: %v", err)
 	}
-	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{
-		Ecosystem:      sdk.EcosystemNPM,
+	if err := sbomGraph.AddNode(sdk.NewDependencyWithID("SPDXRef-react", sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM,
 		PackageManager: sdk.PackageManagerNPM,
 		Name:           "react",
 		Version:        "18.2.0",
-		PURL:           "pkg:npm/react@18.2.0",
+		PURL:           "pkg:npm/react@18.2.0"},
 	})); err != nil {
 		t.Fatalf("add sbom react: %v", err)
 	}
@@ -865,10 +856,10 @@ func TestBuildDiffResponseFuzzyReconcilesRenamedPackage(t *testing.T) {
 	baseGraph := sdk.New()
 	headGraph := sdk.New()
 
-	baseApp := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"})
-	baseDep := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "left-pad", Version: "1.0.0"})
-	headApp := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"})
-	headDep := sdk.NewDependency(sdk.Dependency{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "leftpad", Version: "1.1.0"})
+	baseApp := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"}})
+	baseDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "left-pad", Version: "1.0.0"}})
+	headApp := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "app", Version: "1.0.0"}})
+	headDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemNPM, PackageManager: sdk.PackageManagerNPM, Name: "leftpad", Version: "1.1.0"}})
 
 	for _, pkg := range []*sdk.Dependency{baseApp, baseDep} {
 		if err := baseGraph.AddNode(pkg); err != nil {

--- a/internal/plugin/github_release_test.go
+++ b/internal/plugin/github_release_test.go
@@ -304,7 +304,7 @@ func (d *detector) Applicable(context.Context, *schemav1.DetectRequest) (*schema
 
 func (d *detector) Detect(ctx context.Context, req *schemav1.DetectRequest) (*schemav1.DetectResponse, error) {
 	packageNode := schemav1.NewDependencyWithID("example.com/demo@v1.0.0", schemav1.Dependency{
-		Ecosystem: string(schemav1.EcosystemGo),
+		Ecosystem: schemav1.EcosystemGo,
 		Name:      "example.com/demo",
 		Version:   "v1.0.0",
 		PURL:      "pkg:golang/example.com/demo@v1.0.0",

--- a/internal/plugin/github_release_test.go
+++ b/internal/plugin/github_release_test.go
@@ -304,10 +304,12 @@ func (d *detector) Applicable(context.Context, *schemav1.DetectRequest) (*schema
 
 func (d *detector) Detect(ctx context.Context, req *schemav1.DetectRequest) (*schemav1.DetectResponse, error) {
 	packageNode := schemav1.NewDependencyWithID("example.com/demo@v1.0.0", schemav1.Dependency{
-		Ecosystem: schemav1.EcosystemGo,
-		Name:      "example.com/demo",
-		Version:   "v1.0.0",
-		PURL:      "pkg:golang/example.com/demo@v1.0.0",
+		Coordinates: schemav1.Coordinates{
+			Ecosystem: schemav1.EcosystemGo,
+			Name:      "example.com/demo",
+			Version:   "v1.0.0",
+			PURL:      "pkg:golang/example.com/demo@v1.0.0",
+		},
 	})
 	graph := schemav1.New()
 	if err := graph.AddNode(packageNode); err != nil {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -348,7 +348,7 @@ func (d *detector) Detect(ctx context.Context, req *schemav1.DetectRequest) (*sc
 		name = "example.com/" + string(req.ScopeFilter)
 	}
 	packageNode := schemav1.NewDependencyWithID(name + "@v1.0.0", schemav1.Dependency{
-		Ecosystem: string(schemav1.EcosystemGo),
+		Ecosystem: schemav1.EcosystemGo,
 		Name:      name,
 		Version:   "v1.0.0",
 		PURL:      "pkg:golang/" + name + "@v1.0.0",

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -348,10 +348,12 @@ func (d *detector) Detect(ctx context.Context, req *schemav1.DetectRequest) (*sc
 		name = "example.com/" + string(req.ScopeFilter)
 	}
 	packageNode := schemav1.NewDependencyWithID(name + "@v1.0.0", schemav1.Dependency{
-		Ecosystem: schemav1.EcosystemGo,
-		Name:      name,
-		Version:   "v1.0.0",
-		PURL:      "pkg:golang/" + name + "@v1.0.0",
+		Coordinates: schemav1.Coordinates{
+			Ecosystem: schemav1.EcosystemGo,
+			Name:      name,
+			Version:   "v1.0.0",
+			PURL:      "pkg:golang/" + name + "@v1.0.0",
+		},
 	})
 	graph := schemav1.New()
 	if err := graph.AddNode(packageNode); err != nil {

--- a/internal/registry/discovery.go
+++ b/internal/registry/discovery.go
@@ -184,6 +184,8 @@ func pyprojectBelongsToManager(path string, manager sdk.PackageManager) bool {
 		return pyprojectHasTable(path, "tool.poetry")
 	case sdk.PackageManagerUV:
 		return pyprojectHasTable(path, "tool.uv")
+	case sdk.PackageManagerPDM:
+		return !pyprojectHasTable(path, "tool.poetry") && !pyprojectHasTable(path, "tool.uv")
 	default:
 		return true
 	}

--- a/internal/sbom/enrichment_test.go
+++ b/internal/sbom/enrichment_test.go
@@ -19,11 +19,10 @@ func enrichedGraphAndRegistry(t *testing.T) (*sdk.Graph, *sdk.PackageRegistry) {
 	const purl = "pkg:npm/react@18.2.0"
 
 	g := sdk.New()
-	react := sdk.NewDependencyWithID("react@18.2.0", sdk.Dependency{
-		Name:      "react",
+	react := sdk.NewDependencyWithID("react@18.2.0", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react",
 		Version:   "18.2.0",
 		PURL:      purl,
-		Ecosystem: "npm",
+		Ecosystem: "npm"},
 	})
 	if err := g.AddNode(react); err != nil {
 		t.Fatalf("add node: %v", err)

--- a/internal/sbom/graph.go
+++ b/internal/sbom/graph.go
@@ -21,31 +21,32 @@ func ToGraph(doc *Document) (*sdk.Graph, error) {
 			skipped[component.ID] = struct{}{}
 			continue
 		}
-		ecosystem := strings.TrimSpace(component.Ecosystem)
-		if ecosystem == "" {
+		ecosystem := sdk.Ecosystem(strings.TrimSpace(component.Ecosystem))
+		if ecosystem == sdk.EcosystemUnknown {
 			if purl := parsePURL(component.PURL); purl != nil {
-				ecosystem = string(ecosystemFromPURLType(purl.Type))
+				ecosystem = ecosystemFromPURLType(purl.Type)
 			}
 		}
-		buildSystem := strings.TrimSpace(component.PackageManager)
-		if buildSystem == "" {
-			if manager := packageManagerForPURL(component.PURL, ecosystem, component.PackageManager); manager != sdk.PackageManagerUnknown {
-				buildSystem = manager.Name()
-			}
+		packageManager := sdk.PackageManagerUnknown
+		if manager, err := sdk.ParsePackageManager(component.PackageManager); err == nil {
+			packageManager = manager
+		}
+		if packageManager == sdk.PackageManagerUnknown {
+			packageManager = packageManagerForPURL(component.PURL, string(ecosystem), component.PackageManager)
 		}
 		packageID := strings.TrimSpace(component.ID)
 		if purl := strings.TrimSpace(component.PURL); purl != "" {
 			packageID = purl
 		}
 		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{
-			Name:        component.Name,
-			Version:     component.Version,
-			Scopes:      sdk.ScopesOf(sdk.Scope(component.Scope)),
-			Ecosystem:   ecosystem,
-			BuildSystem: buildSystem,
-			Type:        component.Type,
-			PURL:        strings.TrimSpace(component.PURL),
-			Copyright:   component.Copyright,
+			Name:           component.Name,
+			Version:        component.Version,
+			Scopes:         sdk.ScopesOf(sdk.Scope(component.Scope)),
+			Ecosystem:      ecosystem,
+			PackageManager: packageManager,
+			Type:           sdk.ParsePackageType(component.Type),
+			PURL:           strings.TrimSpace(component.PURL),
+			Copyright:      component.Copyright,
 		})
 		sdk.SetDetectionLicenses(pkg, graphLicenses(component.Licenses))
 
@@ -108,7 +109,7 @@ func graphLicenses(licenses []License) []sdk.PackageLicense {
 		out = append(out, sdk.PackageLicense{
 			Value:          license.Value,
 			SPDXExpression: license.SPDXExpression,
-			Type:           license.Type,
+			Type:           sdk.LicenseType(license.Type),
 		})
 	}
 	return out

--- a/internal/sbom/graph.go
+++ b/internal/sbom/graph.go
@@ -38,15 +38,15 @@ func ToGraph(doc *Document) (*sdk.Graph, error) {
 		if purl := strings.TrimSpace(component.PURL); purl != "" {
 			packageID = purl
 		}
-		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{
-			Name:           component.Name,
-			Version:        component.Version,
-			Scopes:         sdk.ScopesOf(sdk.Scope(component.Scope)),
+		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: component.Name,
+			Version: component.Version,
+
 			Ecosystem:      ecosystem,
 			PackageManager: packageManager,
 			Type:           sdk.ParsePackageType(component.Type),
-			PURL:           strings.TrimSpace(component.PURL),
-			Copyright:      component.Copyright,
+			PURL:           strings.TrimSpace(component.PURL)}, Scopes: sdk.ScopesOf(sdk.Scope(component.Scope)),
+
+			Copyright: component.Copyright,
 		})
 		sdk.SetDetectionLicenses(pkg, graphLicenses(component.Licenses))
 

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -100,8 +100,8 @@ func TestMarshalDepGraphJSON_SPDX23ToolCreators(t *testing.T) {
 func TestMarshalDepGraphJSON_SPDX23Scope(t *testing.T) {
 	g := sdk.New()
 	app := sdk.NewDependencyRef("app", "1.0.0")
-	react := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf("runtime")})
-	vitest := sdk.NewDependency(sdk.Dependency{Name: "vitest", Version: "2.0.0", Scopes: sdk.ScopesOf("development")})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf("runtime")})
+	vitest := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "vitest", Version: "2.0.0"}, Scopes: sdk.ScopesOf("development")})
 	for _, n := range []*sdk.Dependency{app, react, vitest} {
 		if err := g.AddNode(n); err != nil {
 			t.Fatalf("add package %s: %v", n.ID, err)
@@ -146,12 +146,11 @@ func TestMarshalDepGraphJSON_SPDX23Scope(t *testing.T) {
 
 func TestMarshalDepGraphJSON_SPDX23PreservesPackageType(t *testing.T) {
 	g := sdk.New()
-	app := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: "npm",
-		Name:      "demo",
-		Version:   "1.0.0",
-		Type:      "application",
-		PURL:      "pkg:npm/demo@1.0.0",
+	app := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
+		Name:    "demo",
+		Version: "1.0.0",
+		Type:    "application",
+		PURL:    "pkg:npm/demo@1.0.0"},
 	})
 
 	if err := g.AddNode(app); err != nil {
@@ -186,13 +185,11 @@ func TestMarshalDepGraphJSON_SPDX23PreservesPackageType(t *testing.T) {
 
 func TestMarshalDepGraphJSON_SPDX23PreservesPURLAndCopyright(t *testing.T) {
 	g := sdk.New()
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      "npm",
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "accept",
 		Version:        "1.1.0",
-		PURL:           "pkg:npm/accept@1.1.0",
-		Copyright:      "Copyright (c) 2014, Walmart and other contributors.",
+		PURL:           "pkg:npm/accept@1.1.0"}, Copyright: "Copyright (c) 2014, Walmart and other contributors.",
 	})
 	sdk.SetDetectionLicenses(pkg, []sdk.PackageLicense{{SPDXExpression: "BSD-3-Clause"}})
 
@@ -267,8 +264,8 @@ func TestMarshalDepGraphJSON_CycloneDXVersions(t *testing.T) {
 func TestMarshalDepGraphJSON_CycloneDXScope(t *testing.T) {
 	g := sdk.New()
 	app := sdk.NewDependencyRef("app", "1.0.0")
-	runtimeDep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf("runtime")})
-	devDep := sdk.NewDependency(sdk.Dependency{Name: "vitest", Version: "2.0.0", Scopes: sdk.ScopesOf("development")})
+	runtimeDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf("runtime")})
+	devDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "vitest", Version: "2.0.0"}, Scopes: sdk.ScopesOf("development")})
 	for _, n := range []*sdk.Dependency{app, runtimeDep, devDep} {
 		if err := g.AddNode(n); err != nil {
 			t.Fatalf("add package %s: %v", n.ID, err)
@@ -335,12 +332,11 @@ func TestUnmarshalJSON_RoundTripTargets(t *testing.T) {
 
 func TestUnmarshalJSON_SPDX23RestoresPackageIdentityFromPURL(t *testing.T) {
 	g := sdk.New()
-	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      "npm",
+	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "accept",
 		Version:        "1.1.0",
-		PURL:           "pkg:npm/accept@1.1.0",
+		PURL:           "pkg:npm/accept@1.1.0"},
 	})); err != nil {
 		t.Fatalf("add package: %v", err)
 	}
@@ -391,12 +387,11 @@ func TestUnmarshalJSON_SPDX23RestoresPackageIdentityFromPURL(t *testing.T) {
 
 func TestUnmarshalJSON_CycloneDXPreservesPURL(t *testing.T) {
 	g := sdk.New()
-	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{
-		Ecosystem:      "npm",
+	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: "npm",
 		PackageManager: "npm",
 		Name:           "accept",
 		Version:        "1.1.0",
-		PURL:           "pkg:npm/accept@1.1.0",
+		PURL:           "pkg:npm/accept@1.1.0"},
 	})); err != nil {
 		t.Fatalf("add package: %v", err)
 	}

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -187,12 +187,12 @@ func TestMarshalDepGraphJSON_SPDX23PreservesPackageType(t *testing.T) {
 func TestMarshalDepGraphJSON_SPDX23PreservesPURLAndCopyright(t *testing.T) {
 	g := sdk.New()
 	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "accept",
-		Version:     "1.1.0",
-		PURL:        "pkg:npm/accept@1.1.0",
-		Copyright:   "Copyright (c) 2014, Walmart and other contributors.",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "accept",
+		Version:        "1.1.0",
+		PURL:           "pkg:npm/accept@1.1.0",
+		Copyright:      "Copyright (c) 2014, Walmart and other contributors.",
 	})
 	sdk.SetDetectionLicenses(pkg, []sdk.PackageLicense{{SPDXExpression: "BSD-3-Clause"}})
 
@@ -336,11 +336,11 @@ func TestUnmarshalJSON_RoundTripTargets(t *testing.T) {
 func TestUnmarshalJSON_SPDX23RestoresPackageIdentityFromPURL(t *testing.T) {
 	g := sdk.New()
 	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "accept",
-		Version:     "1.1.0",
-		PURL:        "pkg:npm/accept@1.1.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "accept",
+		Version:        "1.1.0",
+		PURL:           "pkg:npm/accept@1.1.0",
 	})); err != nil {
 		t.Fatalf("add package: %v", err)
 	}
@@ -384,19 +384,19 @@ func TestUnmarshalJSON_SPDX23RestoresPackageIdentityFromPURL(t *testing.T) {
 	if pkg.PURL != "pkg:npm/accept@1.1.0" {
 		t.Fatalf("expected graph package purl, got %q", pkg.PURL)
 	}
-	if pkg.Ecosystem != "npm" || pkg.BuildSystem != "npm" {
-		t.Fatalf("expected graph package identity restored, got ecosystem=%q buildSystem=%q", pkg.Ecosystem, pkg.BuildSystem)
+	if pkg.Ecosystem != "npm" || pkg.PackageManager != "npm" {
+		t.Fatalf("expected graph package identity restored, got ecosystem=%q packageManager=%q", pkg.Ecosystem, pkg.PackageManager)
 	}
 }
 
 func TestUnmarshalJSON_CycloneDXPreservesPURL(t *testing.T) {
 	g := sdk.New()
 	if err := g.AddNode(sdk.NewDependency(sdk.Dependency{
-		Ecosystem:   "npm",
-		BuildSystem: "npm",
-		Name:        "accept",
-		Version:     "1.1.0",
-		PURL:        "pkg:npm/accept@1.1.0",
+		Ecosystem:      "npm",
+		PackageManager: "npm",
+		Name:           "accept",
+		Version:        "1.1.0",
+		PURL:           "pkg:npm/accept@1.1.0",
 	})); err != nil {
 		t.Fatalf("add package: %v", err)
 	}

--- a/internal/sbom/transform.go
+++ b/internal/sbom/transform.go
@@ -30,9 +30,9 @@ func FromDepGraph(g *sdk.Graph, opts BuildOptions) (*Document, error) {
 			Version:        pkg.Version,
 			Scope:          string(pkg.PrimaryScope()),
 			PURL:           pkg.PURL,
-			Ecosystem:      pkg.Ecosystem,
-			PackageManager: pkg.BuildSystem,
-			Type:           pkg.Type,
+			Ecosystem:      string(pkg.Ecosystem),
+			PackageManager: pkg.PackageManager.Name(),
+			Type:           string(pkg.Type),
 			Copyright:      pkg.Copyright,
 			Licenses:       componentLicenses(sdk.DetectionLicenses(pkg)),
 		}
@@ -148,7 +148,7 @@ func enrichComponentFromRegistry(component *Component, registry *sdk.PackageRegi
 			if d.Value == "" {
 				continue
 			}
-			digests = append(digests, Digest{Algorithm: d.Algorithm, Value: d.Value})
+			digests = append(digests, Digest{Algorithm: string(d.Algorithm), Value: d.Value})
 		}
 		component.Digests = digests
 	}
@@ -174,7 +174,7 @@ func vulnerabilitiesFromPackage(vulns []sdk.Vulnerability) []Vulnerability {
 		vuln := Vulnerability{
 			ID:            v.ID,
 			Source:        v.Source,
-			Severity:      v.ParsedSeverity,
+			Severity:      string(v.ParsedSeverity),
 			FixedVersions: append([]string(nil), v.FixedVersions...),
 			Description:   v.Details,
 		}
@@ -184,7 +184,7 @@ func vulnerabilitiesFromPackage(vulns []sdk.Vulnerability) []Vulnerability {
 		if len(v.CVSS) > 0 {
 			vuln.Score = new(v.CVSS[0].Score)
 			vuln.Vector = v.CVSS[0].Vector
-			vuln.Method = cvssMethodForVersion(v.CVSS[0].Version)
+			vuln.Method = cvssMethodForVersion(string(v.CVSS[0].Version))
 		}
 		for _, cwe := range v.CWEs {
 			if id := cweNumber(cwe.ID); id > 0 {
@@ -243,7 +243,7 @@ func componentLicenses(licenses []sdk.PackageLicense) []License {
 		out = append(out, License{
 			Value:          license.Value,
 			SPDXExpression: license.SPDXExpression,
-			Type:           license.Type,
+			Type:           string(license.Type),
 		})
 	}
 	return out

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -193,7 +193,7 @@ func (m *DiffModel) CycleEcosystemFilter() {
 	ecos := map[string]struct{}{}
 	for _, mf := range m.payload.Results.Manifests {
 		if mf.Ecosystem != "" {
-			ecos[mf.Ecosystem] = struct{}{}
+			ecos[string(mf.Ecosystem)] = struct{}{}
 		}
 	}
 	options := []string{""}
@@ -645,7 +645,7 @@ func (m *DiffModel) computeOverviewStats() diffOverviewStats {
 	}
 
 	for _, mf := range m.payload.Results.Manifests {
-		eco := strings.TrimSpace(mf.Ecosystem)
+		eco := strings.TrimSpace(string(mf.Ecosystem))
 		if eco == "" {
 			eco = "unknown"
 		}
@@ -696,7 +696,7 @@ func (m *DiffModel) computeOverviewStats() diffOverviewStats {
 				out.findingsByKind[kind]++
 				switch kind {
 				case "vulnerability":
-					sev := strings.ToLower(strings.TrimSpace(f.Severity))
+					sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
 					if _, ok := out.vulnByStatus[sev]; !ok {
 						sev = "unknown"
 					}
@@ -760,7 +760,7 @@ func auditStatusTitle(status string) string {
 // classification done by isVulnerabilityFinding so this function and that
 // predicate never disagree.
 func findingKindOf(f output.AuditFinding) string {
-	if k := strings.ToLower(strings.TrimSpace(f.Kind)); k != "" {
+	if k := strings.ToLower(strings.TrimSpace(string(f.Kind))); k != "" {
 		switch k {
 		case "vuln", "advisory", "cve":
 			return "vulnerability"
@@ -1350,7 +1350,7 @@ func (m *DiffModel) collectComponentChanges() []flatComponentChange {
 	for _, mf := range m.payload.Results.Manifests {
 		mfKey := diffManifestKey(mf)
 		mfName := render.DiffManifestDisplayLabel(mf)
-		eco := valueOrDefault(mf.Ecosystem, "unknown")
+		eco := valueOrDefault(string(mf.Ecosystem), "unknown")
 		for _, change := range mf.Added {
 			out = append(out, flatComponentChange{
 				manifest: mf, manifestKey: mfKey, manifestName: mfName, ecosystem: eco,
@@ -1385,7 +1385,7 @@ func maxSeverity(vulns []output.VulnerabilityRef) string {
 	best := ""
 	bestRank := severityRank("zzz")
 	for _, v := range vulns {
-		sev := strings.ToLower(strings.TrimSpace(v.Severity))
+		sev := strings.ToLower(strings.TrimSpace(string(v.Severity)))
 		if sev == "" {
 			sev = "unknown"
 		}
@@ -1573,10 +1573,10 @@ func (m *DiffModel) componentsGroupDetails(key string, group componentsGroup, it
 			"",
 			render.Style("Manifest", render.Bold, render.Magenta),
 			render.Style("  Path: ", render.Dim)+valueOrDash(mf.Path),
-			render.Style("  Kind: ", render.Dim)+valueOrDash(mf.Kind),
+			render.Style("  Kind: ", render.Dim)+valueOrDash(string(mf.Kind)),
 			render.Style("  Subproject: ", render.Dim)+valueOrDash(mf.Subproject),
-			render.Style("  Ecosystem: ", render.Dim)+valueOrDash(mf.Ecosystem),
-			render.Style("  Package manager: ", render.Dim)+valueOrDash(mf.PackageManager),
+			render.Style("  Ecosystem: ", render.Dim)+valueOrDash(string(mf.Ecosystem)),
+			render.Style("  Package manager: ", render.Dim)+valueOrDash(mf.PackageManager.Name()),
 			render.Style("  Detector: ", render.Dim)+valueOrDash(m.detectorForManifest(mf)),
 			render.Style("  Status: ", render.Dim)+statusText(mf.Status),
 		)
@@ -1662,9 +1662,9 @@ func componentChangeDetails(c flatComponentChange) []string {
 		"",
 		render.Style("Manifest", render.Bold, render.Magenta),
 		render.Style("  Path: ", render.Dim) + valueOrDash(c.manifest.Path),
-		render.Style("  Kind: ", render.Dim) + valueOrDash(c.manifest.Kind),
+		render.Style("  Kind: ", render.Dim) + valueOrDash(string(c.manifest.Kind)),
 		render.Style("  Subproject: ", render.Dim) + valueOrDash(c.manifest.Subproject),
-		render.Style("  Package manager: ", render.Dim) + valueOrDash(c.manifest.PackageManager),
+		render.Style("  Package manager: ", render.Dim) + valueOrDash(c.manifest.PackageManager.Name()),
 		render.Style("  Manifest status: ", render.Dim) + statusText(c.manifest.Status),
 	}
 
@@ -1706,7 +1706,7 @@ func renderLicenseList(licenses []output.LicenseRef) []string {
 		}
 		line := render.Style("  - ", render.Dim) + id
 		if lic.Type != "" {
-			line += render.Style("  ["+lic.Type+"]", render.Dim)
+			line += render.Style("  ["+string(lic.Type)+"]", render.Dim)
 		}
 		out = append(out, line)
 	}
@@ -1754,12 +1754,12 @@ func renderVulnList(vulns []output.VulnerabilityRef) []string {
 		return out
 	}
 	for _, v := range vulns {
-		out = append(out, render.Style("  - ", render.Dim)+severityText(v.Severity)+" "+valueOrDash(v.ID))
+		out = append(out, render.Style("  - ", render.Dim)+severityText(string(v.Severity))+" "+valueOrDash(v.ID))
 		if v.FixedIn != "" {
 			out = append(out, render.Style("      fixed in: ", render.Dim)+v.FixedIn)
 		}
 		if v.FixState != "" {
-			out = append(out, render.Style("      fix state: ", render.Dim)+v.FixState)
+			out = append(out, render.Style("      fix state: ", render.Dim)+string(v.FixState))
 		}
 		if exploitability := exploitabilityLine(v.KEVExploited, v.KnownExploited, v.RiskScore); exploitability != "" {
 			out = append(out, render.Style("      exploitability: ", render.Dim)+exploitability)
@@ -1778,14 +1778,14 @@ func renderVulnDelta(before, after []output.VulnerabilityRef) []string {
 	for id, v := range afterSet {
 		switch {
 		case beforeSet[id] != nil:
-			out = append(out, render.Style("  = ", render.Dim)+severityText(v.Severity)+" "+id+render.Style("  (old)", render.Dim))
+			out = append(out, render.Style("  = ", render.Dim)+severityText(string(v.Severity))+" "+id+render.Style("  (old)", render.Dim))
 		default:
-			out = append(out, render.Style("  + ", render.Red, render.Bold)+severityText(v.Severity)+" "+id+render.Style("  (new)", render.Dim))
+			out = append(out, render.Style("  + ", render.Red, render.Bold)+severityText(string(v.Severity))+" "+id+render.Style("  (new)", render.Dim))
 		}
 	}
 	for id, v := range beforeSet {
 		if afterSet[id] == nil {
-			out = append(out, render.Style("  - ", render.Green, render.Bold)+severityText(v.Severity)+" "+id+render.Style("  (fixed)", render.Dim))
+			out = append(out, render.Style("  - ", render.Green, render.Bold)+severityText(string(v.Severity))+" "+id+render.Style("  (fixed)", render.Dim))
 		}
 	}
 	return out
@@ -1804,7 +1804,7 @@ func vulnIDSet(vulns []output.VulnerabilityRef) map[string]*output.Vulnerability
 }
 
 func diffManifestKey(mf output.DiffManifestResult) string {
-	return mf.Path + "|" + mf.Subproject + "|" + mf.PackageManager
+	return mf.Path + "|" + mf.Subproject + "|" + mf.PackageManager.Name()
 }
 
 // --- Vulnerabilities / Findings tab ---------------------------------------
@@ -1829,7 +1829,7 @@ func (m *DiffModel) auditDeltas(keep func(output.AuditFinding) bool) []auditDelt
 			if keep != nil && !keep(f) {
 				continue
 			}
-			out = append(out, auditDelta{status: status, finding: f, severity: f.Severity})
+			out = append(out, auditDelta{status: status, finding: f, severity: string(f.Severity)})
 		}
 	}
 	collect("introduced", m.payload.Audit.Introduced)
@@ -1847,7 +1847,7 @@ func isVulnerabilityFinding(f output.AuditFinding) bool {
 	case "license", "package":
 		return false
 	}
-	kind := strings.ToLower(strings.TrimSpace(f.Kind))
+	kind := strings.ToLower(strings.TrimSpace(string(f.Kind)))
 	if kind == "" {
 		// Fallback: presence of a CVE/GHSA-shaped ID or a Source like
 		// "osv"/"grype" implies a vulnerability finding.
@@ -1989,14 +1989,14 @@ func (m *DiffModel) auditVerdict() auditVerdict {
 	// stays consistent with the rows it's actually showing.
 	for _, f := range m.payload.Audit.Introduced {
 		switch f.Disposition {
-		case "", string(sdk.FindingDispositionFail):
+		case "", sdk.FindingDispositionFail:
 			v.FailingIntroduced++
 			if isVulnerabilityFinding(f) {
 				v.FailingIntroducedVuln++
 			} else {
 				v.FailingIntroducedNonVuln++
 			}
-		case string(sdk.FindingDispositionWarn):
+		case sdk.FindingDispositionWarn:
 			v.WarnIntroduced++
 		}
 	}
@@ -2179,7 +2179,7 @@ func (m *DiffModel) vulnsOutcomePanels() []listPanel {
 			if !isVulnerabilityFinding(f) {
 				continue
 			}
-			sev := strings.ToLower(strings.TrimSpace(f.Severity))
+			sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
 			if sev == "" {
 				sev = "unknown"
 			}
@@ -2442,11 +2442,11 @@ func auditDeltaDetails(d auditDelta) []string {
 		"",
 		render.Style("Status", render.Bold, render.Cyan),
 		render.Style("  Delta status: ", render.Dim)+statusText(auditStatusLabel(d.status)),
-		render.Style("  Disposition: ", render.Dim)+valueOrDash(f.Disposition),
-		render.Style("  Severity: ", render.Dim)+severityText(f.Severity),
+		render.Style("  Disposition: ", render.Dim)+valueOrDash(string(f.Disposition)),
+		render.Style("  Severity: ", render.Dim)+severityText(string(f.Severity)),
 		"",
 		render.Style("Classification", render.Bold, render.Magenta),
-		render.Style("  Kind: ", render.Dim)+valueOrDash(f.Kind),
+		render.Style("  Kind: ", render.Dim)+valueOrDash(string(f.Kind)),
 		render.Style("  Auditor: ", render.Dim)+valueOrDash(f.Auditor),
 		render.Style("  Source: ", render.Dim)+valueOrDash(f.Source),
 		"",

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -52,14 +52,14 @@ func fixtureDiffPayload() output.DiffResponse {
 		}},
 		Audit: &output.DiffAudit{
 			Introduced: []output.AuditFinding{
-				{ID: "CVE-2024-0001", Kind: "vulnerability", Severity: "high", Source: "osv", Package: output.PackageRef{Name: "react", Version: "19.0.0"}},
-				{ID: "license:unknown-license:zod@3.23.0", Kind: string(sdk.FindingKindLicense), Severity: "n/a", Auditor: "license", Source: "license", Package: output.PackageRef{Name: "zod", Version: "3.23.0"}},
+				{ID: "CVE-2024-0001", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityHigh, Source: "osv", Package: output.PackageRef{Name: "react", Version: "19.0.0"}},
+				{ID: "license:unknown-license:zod@3.23.0", Kind: sdk.FindingKindLicense, Severity: "n/a", Auditor: "license", Source: "license", Package: output.PackageRef{Name: "zod", Version: "3.23.0"}},
 			},
 			Persisted: []output.AuditFinding{
-				{ID: "CVE-2023-9999", Kind: "vulnerability", Severity: "medium", Source: "osv", Package: output.PackageRef{Name: "lodash", Version: "4.17.20"}},
+				{ID: "CVE-2023-9999", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityMedium, Source: "osv", Package: output.PackageRef{Name: "lodash", Version: "4.17.20"}},
 			},
 			Resolved: []output.AuditFinding{
-				{ID: "CVE-2022-1111", Kind: "vulnerability", Severity: "low", Source: "osv", Package: output.PackageRef{Name: "dropped", Version: "0.1.0"}},
+				{ID: "CVE-2022-1111", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityLow, Source: "osv", Package: output.PackageRef{Name: "dropped", Version: "0.1.0"}},
 			},
 			// AuditSummary.Total now reflects Introduced + Persisted only
 			// (scan_output.go no longer appends Resolved). For this fixture
@@ -356,21 +356,21 @@ func TestComputeOverviewStats_LicenseAndPackageByStatus(t *testing.T) {
 	// when the rule keyword isn't one we know about.
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "license:unknown-license:pkg@1", Kind: "license", Auditor: "license"},
-			{ID: "license:invalid-license:pkg@2", Kind: "license", Auditor: "license"},
-			{ID: "license:denied-license:pkg@3", Kind: "license", Auditor: "license"},
-			{ID: "package:denied-package:pkg@4", Kind: "package", Auditor: "package"},
-			{ID: "package:denied-group:pkg@5", Kind: "package", Auditor: "package"},
-			{ID: "package:suspicious-package:pkg@6", Kind: "package", Auditor: "package"},
+			{ID: "license:unknown-license:pkg@1", Kind: sdk.FindingKindLicense, Auditor: "license"},
+			{ID: "license:invalid-license:pkg@2", Kind: sdk.FindingKindLicense, Auditor: "license"},
+			{ID: "license:denied-license:pkg@3", Kind: sdk.FindingKindLicense, Auditor: "license"},
+			{ID: "package:denied-package:pkg@4", Kind: sdk.FindingKindPackage, Auditor: "package"},
+			{ID: "package:denied-group:pkg@5", Kind: sdk.FindingKindPackage, Auditor: "package"},
+			{ID: "package:suspicious-package:pkg@6", Kind: sdk.FindingKindPackage, Auditor: "package"},
 		},
 		Persisted: []output.AuditFinding{
-			{ID: "license:unknown-license:pkg@7", Kind: "license", Auditor: "license"},
+			{ID: "license:unknown-license:pkg@7", Kind: sdk.FindingKindLicense, Auditor: "license"},
 			// External plugin emitting a kind we don't know — must land
 			// in the "other" row.
-			{ID: "ext:weird-rule:pkg@8", Kind: "package", Auditor: "external"},
+			{ID: "ext:weird-rule:pkg@8", Kind: sdk.FindingKindPackage, Auditor: "external"},
 		},
 		Resolved: []output.AuditFinding{
-			{ID: "license:denied-license:pkg@9", Kind: "license", Auditor: "license"},
+			{ID: "license:denied-license:pkg@9", Kind: sdk.FindingKindLicense, Auditor: "license"},
 		},
 	}}
 	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -412,9 +412,9 @@ func TestFindingKindOf_ClassifiesBuiltinAuditors(t *testing.T) {
 		f    output.AuditFinding
 		want string
 	}{
-		{output.AuditFinding{Kind: "vulnerability"}, "vulnerability"},
-		{output.AuditFinding{Kind: "license"}, "license"},
-		{output.AuditFinding{Kind: "package"}, "package"},
+		{output.AuditFinding{Kind: sdk.FindingKindVulnerability}, "vulnerability"},
+		{output.AuditFinding{Kind: sdk.FindingKindLicense}, "license"},
+		{output.AuditFinding{Kind: sdk.FindingKindPackage}, "package"},
 		{output.AuditFinding{Kind: "vuln"}, "vulnerability"},     // alias
 		{output.AuditFinding{Kind: "advisory"}, "vulnerability"}, // alias
 		{output.AuditFinding{Kind: "cve"}, "vulnerability"},      // alias
@@ -504,7 +504,7 @@ func TestAuditVerdict_PassWhenNoIntroduced(t *testing.T) {
 // A diff that resolves findings — even high-severity ones — must NOT FAIL.
 func TestAuditVerdict_ResolvedOnlyIsPass(t *testing.T) {
 	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
-		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: "vulnerability", Severity: "high", Source: "osv"}},
+		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityHigh, Source: "osv"}},
 		AuditSummary: &output.AuditSummary{},
 	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 	v := m.auditVerdict()
@@ -523,7 +523,7 @@ func TestAuditVerdict_ResolvedOnlyIsPass(t *testing.T) {
 // runs on Introduced only.
 func TestAuditVerdict_PersistedOnlyIsPass(t *testing.T) {
 	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
-		Persisted:    []output.AuditFinding{{ID: "CVE-2023-X", Kind: "vulnerability", Severity: "critical", Source: "osv"}},
+		Persisted:    []output.AuditFinding{{ID: "CVE-2023-X", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityCritical, Source: "osv"}},
 		AuditSummary: &output.AuditSummary{Critical: 1, Total: 1},
 	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
 	if got := m.auditVerdict().Verdict(); got != "PASS" {
@@ -537,19 +537,19 @@ func TestAuditVerdict_PersistedOnlyIsPass(t *testing.T) {
 func TestAuditVerdict_DispositionGate(t *testing.T) {
 	cases := []struct {
 		name        string
-		disposition string
+		disposition sdk.FindingDisposition
 		wantFail    bool
 	}{
 		{"empty disposition (legacy default = fail)", "", true},
-		{"explicit fail", string(sdk.FindingDispositionFail), true},
-		{"warn does not gate exit code", string(sdk.FindingDispositionWarn), false},
-		{"unknown disposition treated as non-failing", "informational", false},
+		{"explicit fail", sdk.FindingDispositionFail, true},
+		{"warn does not gate exit code", sdk.FindingDispositionWarn, false},
+		{"unknown disposition treated as non-failing", sdk.FindingDisposition("informational"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
 				Introduced: []output.AuditFinding{{
-					ID: "X-1", Kind: "vulnerability", Severity: "high", Source: "osv",
+					ID: "X-1", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityHigh, Source: "osv",
 					Disposition: tc.disposition,
 				}},
 				AuditSummary: &output.AuditSummary{High: 1, Total: 1},
@@ -570,8 +570,8 @@ func TestAuditVerdict_DispositionGate(t *testing.T) {
 func TestAuditVerdict_WarnOnlyIntroducedYieldsPassWithCount(t *testing.T) {
 	m := NewDiff(output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "W-1", Disposition: string(sdk.FindingDispositionWarn)},
-			{ID: "W-2", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "W-1", Disposition: sdk.FindingDispositionWarn},
+			{ID: "W-2", Disposition: sdk.FindingDispositionWarn},
 		},
 		AuditSummary: &output.AuditSummary{Total: 2},
 	}}, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -680,13 +680,13 @@ func TestIsVulnerabilityFinding_KindFirstThenFallback(t *testing.T) {
 		f    output.AuditFinding
 		want bool
 	}{
-		{"Kind=vulnerability", output.AuditFinding{Kind: "vulnerability"}, true},
+		{"Kind=vulnerability", output.AuditFinding{Kind: sdk.FindingKindVulnerability}, true},
 		{"Kind=vuln", output.AuditFinding{Kind: "vuln"}, true},
 		{"Kind=advisory", output.AuditFinding{Kind: "advisory"}, true},
 		{"Kind=cve", output.AuditFinding{Kind: "cve"}, true},
 		{"Kind=policy", output.AuditFinding{Kind: "policy"}, false},
 		{"Kind=risk", output.AuditFinding{Kind: "risk"}, false},
-		{"Kind=license", output.AuditFinding{Kind: "license"}, false},
+		{"Kind=license", output.AuditFinding{Kind: sdk.FindingKindLicense}, false},
 		// Fallback path when Kind is empty:
 		{"empty Kind, CVE id", output.AuditFinding{ID: "CVE-2024-0001"}, true},
 		{"empty Kind, GHSA id", output.AuditFinding{ID: "GHSA-abcd"}, true},
@@ -812,9 +812,9 @@ func TestCollectComponentChanges_MaxSeverityFromInlineVulns(t *testing.T) {
 		Added: []output.DiffPackageChange{{Package: output.PackageRef{
 			Name: "vulny", Version: "1",
 			Vulnerabilities: []output.VulnerabilityRef{
-				{ID: "X-1", Severity: "low"},
-				{ID: "X-2", Severity: "critical"},
-				{ID: "X-3", Severity: "high"},
+				{ID: "X-1", Severity: sdk.SeverityLow},
+				{ID: "X-2", Severity: sdk.SeverityCritical},
+				{ID: "X-3", Severity: sdk.SeverityHigh},
 			},
 		}}},
 	}}}}
@@ -876,7 +876,7 @@ func TestFindingsTableLines_PackageOtherRowAbsorbsUnknownRules(t *testing.T) {
 	// row so the pre-seeded table stays exhaustive.
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "ext:mystery:pkg@1", Kind: "package", Auditor: "external"},
+			{ID: "ext:mystery:pkg@1", Kind: sdk.FindingKindPackage, Auditor: "external"},
 		},
 	}}
 	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -926,7 +926,7 @@ func TestOverviewHeadline_PassWhenNoIntroduced(t *testing.T) {
 // regression for diff_cmd.go's new gate (Introduced only).
 func TestOverviewHeadline_ResolvedOnlyIsPass(t *testing.T) {
 	p := output.DiffResponse{Audit: &output.DiffAudit{
-		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: "vulnerability", Severity: "high"}},
+		Resolved:     []output.AuditFinding{{ID: "CVE-2022-X", Kind: sdk.FindingKindVulnerability, Severity: sdk.SeverityHigh}},
 		AuditSummary: &output.AuditSummary{},
 	}}
 	m := NewDiff(p, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -944,8 +944,8 @@ func TestOverviewHeadline_ResolvedOnlyIsPass(t *testing.T) {
 func TestOverviewHeadline_WarnOnlyIntroducedIsPassWithCount(t *testing.T) {
 	p := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "W-1", Disposition: string(sdk.FindingDispositionWarn)},
-			{ID: "W-2", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "W-1", Disposition: sdk.FindingDispositionWarn},
+			{ID: "W-2", Disposition: sdk.FindingDispositionWarn},
 		},
 		AuditSummary: &output.AuditSummary{Total: 2},
 	}}
@@ -1000,7 +1000,7 @@ func TestAuditStatusLabel(t *testing.T) {
 func TestComponentChangeBadges_NoDuplicateStatus(t *testing.T) {
 	c := flatComponentChange{
 		status:       "changed",
-		maxSeverity:  "high",
+		maxSeverity:  string(sdk.SeverityHigh),
 		relationship: "direct",
 	}
 	for _, b := range componentChangeBadges(c) {
@@ -1139,17 +1139,17 @@ func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		intro = append(intro, output.AuditFinding{
 			ID:       "CVE-X-" + string(rune('A'+i)),
-			Kind:     "vulnerability",
+			Kind:     sdk.FindingKindVulnerability,
 			Auditor:  "vulnerability",
 			Source:   "osv",
-			Severity: "high",
+			Severity: sdk.SeverityHigh,
 		})
 	}
 	var persisted []output.AuditFinding
 	for i := 0; i < 6; i++ {
 		persisted = append(persisted, output.AuditFinding{
 			ID:       "license:unknown-license:pkg-" + string(rune('A'+i)),
-			Kind:     string(sdk.FindingKindLicense),
+			Kind:     sdk.FindingKindLicense,
 			Auditor:  "license",
 			Source:   "license",
 			Severity: "n/a",
@@ -1193,10 +1193,10 @@ func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
 func TestFindingsOutcomePanels_PassWhenNoIntroduced(t *testing.T) {
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Persisted: []output.AuditFinding{
-			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability"},
+			{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability"},
 		},
 		Resolved: []output.AuditFinding{
-			{ID: "license:denied-license:pkg@1", Kind: "license", Auditor: "license"},
+			{ID: "license:denied-license:pkg@1", Kind: sdk.FindingKindLicense, Auditor: "license"},
 		},
 	}}
 	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -1215,11 +1215,11 @@ func TestFindingsOutcomePanels_PassWhenNoIntroduced(t *testing.T) {
 func TestVulnsOutcomePanels_ScopedToVulns(t *testing.T) {
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "critical"},
-			{ID: "license:unknown-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license", Source: "license", Severity: "n/a"},
+			{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability", Source: "osv", Severity: sdk.SeverityCritical},
+			{ID: "license:unknown-license:pkg@1", Kind: sdk.FindingKindLicense, Auditor: "license", Source: "license", Severity: "n/a"},
 		},
 		Persisted: []output.AuditFinding{
-			{ID: "CVE-2", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv", Severity: "medium"},
+			{ID: "CVE-2", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability", Source: "osv", Severity: sdk.SeverityMedium},
 		},
 		AuditSummary: &output.AuditSummary{Critical: 1, Medium: 1, Total: 3},
 	}}
@@ -1274,14 +1274,14 @@ func TestAuditVerdict_FailingSplitByKind(t *testing.T) {
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
 			// 2 failing vulns (empty Disposition = fail).
-			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability"},
-			{ID: "CVE-2", Kind: "vulnerability", Auditor: "vulnerability", Disposition: string(sdk.FindingDispositionFail)},
+			{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability"},
+			{ID: "CVE-2", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability", Disposition: sdk.FindingDispositionFail},
 			// 1 warn vuln — counted in WarnIntroduced, not FailingIntroduced*.
-			{ID: "CVE-3", Kind: "vulnerability", Auditor: "vulnerability", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "CVE-3", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability", Disposition: sdk.FindingDispositionWarn},
 			// 1 failing license-kind finding.
-			{ID: "license:denied-license:pkg@1", Kind: string(sdk.FindingKindLicense), Auditor: "license"},
+			{ID: "license:denied-license:pkg@1", Kind: sdk.FindingKindLicense, Auditor: "license"},
 			// 1 warn license-kind finding.
-			{ID: "license:unknown-license:pkg@2", Kind: string(sdk.FindingKindLicense), Auditor: "license", Disposition: string(sdk.FindingDispositionWarn)},
+			{ID: "license:unknown-license:pkg@2", Kind: sdk.FindingKindLicense, Auditor: "license", Disposition: sdk.FindingDispositionWarn},
 		},
 	}}
 	m := NewDiff(payload, sdk.ConsolidatedGraph{}, sdk.ConsolidatedGraph{})
@@ -1306,10 +1306,10 @@ func TestFindingsOutcomePanels_ByKindReadsFindingKind(t *testing.T) {
 	// every kind so we can see all three rows.
 	payload := output.DiffResponse{Audit: &output.DiffAudit{
 		Introduced: []output.AuditFinding{
-			{ID: "CVE-1", Kind: "vulnerability", Auditor: "vulnerability", Source: "osv"},
-			{ID: "license:unknown-license:pkg@1", Kind: "license", Auditor: "license", Source: "license"},
-			{ID: "license:invalid-license:pkg@2", Kind: "license", Auditor: "license", Source: "license"},
-			{ID: "package:denied-package:pkg@3", Kind: "package", Auditor: "package", Source: "package"},
+			{ID: "CVE-1", Kind: sdk.FindingKindVulnerability, Auditor: "vulnerability", Source: "osv"},
+			{ID: "license:unknown-license:pkg@1", Kind: sdk.FindingKindLicense, Auditor: "license", Source: "license"},
+			{ID: "license:invalid-license:pkg@2", Kind: sdk.FindingKindLicense, Auditor: "license", Source: "license"},
+			{ID: "package:denied-package:pkg@3", Kind: sdk.FindingKindPackage, Auditor: "package", Source: "package"},
 		},
 		AuditSummary: &output.AuditSummary{Total: 4},
 	}}
@@ -1447,12 +1447,12 @@ func TestComponentChangeDetails_ChangedShowsLicenseAndVulnDelta(t *testing.T) {
 		beforePkg: output.PackageRef{
 			Name: "react", Version: "18.2.0",
 			Licenses:        []output.LicenseRef{{SPDXExpression: "MIT"}, {SPDXExpression: "BSD-2-Clause"}},
-			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-OLD", Severity: "high"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-OLD", Severity: sdk.SeverityHigh}},
 		},
 		pkgRef: output.PackageRef{
 			Name: "react", Version: "19.0.0",
 			Licenses:        []output.LicenseRef{{SPDXExpression: "MIT"}, {SPDXExpression: "Apache-2.0"}},
-			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-NEW", Severity: "critical"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-NEW", Severity: sdk.SeverityCritical}},
 		},
 	}
 	plain := render.StripANSI(strings.Join(componentChangeDetails(c), "\n"))
@@ -1498,7 +1498,7 @@ func TestComponentChangeDetails_AddedRemovedShowsPlainLists(t *testing.T) {
 		pkgRef: output.PackageRef{
 			Name: "new-thing", Version: "1",
 			Licenses:        []output.LicenseRef{{SPDXExpression: "ISC"}},
-			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-X", Severity: "low"}},
+			Vulnerabilities: []output.VulnerabilityRef{{ID: "CVE-X", Severity: sdk.SeverityLow}},
 		},
 	}
 	plain := render.StripANSI(strings.Join(componentChangeDetails(added), "\n"))

--- a/internal/tui/focus_test.go
+++ b/internal/tui/focus_test.go
@@ -16,7 +16,7 @@ func newScanModelWithPosture(t *testing.T, repo string, score float64) *ScanMode
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
 	const libPURL = "pkg:npm/lib@1.0.0"
-	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", PURL: libPURL})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lib", Version: "1.0.0", PURL: libPURL}})
 	registry := sdk.NewPackageRegistry()
 	regLib := registry.Ensure(libPURL)
 	regLib.Name = "lib"
@@ -153,8 +153,8 @@ func TestPostureGrouping_ByCheckRendersFailingFirst(t *testing.T) {
 	rootA := sdk.NewDependencyRef("app", "1.0.0")
 	const aPURL = "pkg:npm/a@1"
 	const bPURL = "pkg:npm/b@1"
-	a := sdk.NewDependency(sdk.Dependency{Name: "a", Version: "1", PURL: aPURL})
-	b := sdk.NewDependency(sdk.Dependency{Name: "b", Version: "1", PURL: bPURL})
+	a := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "a", Version: "1", PURL: aPURL}})
+	b := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "b", Version: "1", PURL: bPURL}})
 	registry := sdk.NewPackageRegistry()
 	regA := registry.Ensure(aPURL)
 	regA.Name = "a"

--- a/internal/tui/posture_test.go
+++ b/internal/tui/posture_test.go
@@ -27,7 +27,7 @@ func TestPostureTab_ScanRendersList(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
 	const libPURL = "pkg:npm/lib@1.0.0"
-	dep := sdk.NewDependency(sdk.Dependency{Name: "lib", Version: "1.0.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime), PURL: libPURL})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lib", Version: "1.0.0", PURL: libPURL}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	registry := sdk.NewPackageRegistry()
 	regLib := registry.Ensure(libPURL)
 	regLib.Name = "lib"
@@ -114,7 +114,7 @@ func TestPostureTab_CheckNotesFitSplitPane(t *testing.T) {
 	g := sdk.New()
 	registry := sdk.NewPackageRegistry()
 	const purl = "pkg:golang/github.com/anchore/go-struct-converter@1.0.0"
-	dep := sdk.NewDependency(sdk.Dependency{Name: "go-struct-converter", Version: "1.0.0", PURL: purl})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "go-struct-converter", Version: "1.0.0", PURL: purl}})
 	regPkg := registry.Ensure(purl)
 	regPkg.Name = "go-struct-converter"
 	regPkg.Version = "1.0.0"
@@ -153,10 +153,8 @@ func TestPostureTab_CheckNotesFitSplitPane(t *testing.T) {
 }
 
 func TestTopAffectedLines_FitBoxBudget(t *testing.T) {
-	pkg := sdk.NewDependency(sdk.Dependency{
-		Name:    "org.springframework:spring-web",
-		Version: "6.0.0",
-		Scopes:  sdk.ScopesOf(sdk.ScopeRuntime),
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "org.springframework:spring-web",
+		Version: "6.0.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime),
 	})
 	rows := make([]packageVulnerabilityRow, 0, 12)
 	for i := 0; i < 12; i++ {
@@ -185,7 +183,7 @@ func TestPostureRowsFromGraph_DedupesAndSortsWorstFirst(t *testing.T) {
 	g := sdk.New()
 	registry := sdk.NewPackageRegistry()
 	add := func(name, purl, repo string, score float64) *sdk.Dependency {
-		dep := sdk.NewDependencyWithID(purl, sdk.Dependency{Name: name, Version: "1", PURL: purl})
+		dep := sdk.NewDependencyWithID(purl, sdk.Dependency{Coordinates: sdk.Coordinates{Name: name, Version: "1", PURL: purl}})
 		regPkg := registry.Ensure(purl)
 		regPkg.Name = name
 		regPkg.Version = "1"

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -361,7 +361,7 @@ func (m *ScanModel) componentEcosystemValues() []string {
 		if pkg == nil {
 			continue
 		}
-		values[valueOrDefault(pkg.Ecosystem, "unknown")] = struct{}{}
+		values[valueOrDefault(string(pkg.Ecosystem), "unknown")] = struct{}{}
 	}
 	out := make([]string, 0, len(values))
 	for value := range values {
@@ -798,7 +798,7 @@ func vulnerabilityMatchesSeverityFilter(vulnerability sdk.Vulnerability, filter 
 	case "none":
 		return false
 	default:
-		return strings.EqualFold(vulnerability.ParsedSeverity, filter)
+		return strings.EqualFold(string(vulnerability.ParsedSeverity), filter)
 	}
 }
 
@@ -847,7 +847,7 @@ func manifestEcosystem(graphValue *sdk.Graph, row listPackageRow) string {
 	if !ok || pkg == nil {
 		return "unknown"
 	}
-	return valueOrDefault(pkg.Ecosystem, "unknown")
+	return valueOrDefault(string(pkg.Ecosystem), "unknown")
 }
 
 func (m *ScanModel) buildOverviewListModel() *listModel {
@@ -861,8 +861,8 @@ func (m *ScanModel) buildOverviewListModel() *listModel {
 				render.Style("Target", render.Bold, render.Cyan),
 				render.Style("  Name: ", render.Dim) + valueOrDash(m.project.Name),
 				render.Style("  Path: ", render.Dim) + valueOrDash(m.project.Path),
-				render.Style("  Ecosystem: ", render.Dim) + valueOrDash(m.project.Ecosystem),
-				render.Style("  Package manager: ", render.Dim) + valueOrDash(m.project.PackageManager),
+				render.Style("  Ecosystem: ", render.Dim) + valueOrDash(string(m.project.Ecosystem)),
+				render.Style("  Package manager: ", render.Dim) + valueOrDash(m.project.PackageManager.Name()),
 				render.Style("  Manifests: ", render.Dim) + fmt.Sprintf("%d", len(m.manifests)),
 			},
 		},
@@ -955,8 +955,8 @@ func (m *ScanModel) overviewDashboardView(width, height int) string {
 			render.Style("Type: ", render.Dim) + targetKindLabel(m.project),
 			render.Style("Ref: ", render.Dim) + valueOrDash(m.project.TargetRef),
 			render.Style("Path: ", render.Dim) + valueOrDash(m.project.Path),
-			render.Style("Ecosystem: ", render.Dim) + valueOrDash(m.project.Ecosystem),
-			render.Style("Package manager: ", render.Dim) + valueOrDash(m.project.PackageManager),
+			render.Style("Ecosystem: ", render.Dim) + valueOrDash(string(m.project.Ecosystem)),
+			render.Style("Package manager: ", render.Dim) + valueOrDash(m.project.PackageManager.Name()),
 			render.Style("Manifests: ", render.Dim) + fmt.Sprintf("%d", len(m.manifests)),
 		}, targetWidth, cardHeight, render.Green),
 	}
@@ -1021,7 +1021,7 @@ func (m *ScanModel) buildVulnsListModel() *listModel {
 	}
 
 	sort.Slice(filtered, func(i, j int) bool {
-		ri, rj := severityRank(filtered[i].vulnerability.ParsedSeverity), severityRank(filtered[j].vulnerability.ParsedSeverity)
+		ri, rj := severityRank(string(filtered[i].vulnerability.ParsedSeverity)), severityRank(string(filtered[j].vulnerability.ParsedSeverity))
 		if ri != rj {
 			return ri < rj
 		}
@@ -1094,7 +1094,7 @@ func (m *ScanModel) vulnerabilityItems(vulnerabilities []packageVulnerabilityRow
 			}
 			var badges []badge
 			if group != "severity" {
-				badges = append(badges, badge{label: vulnerability.vulnerability.ParsedSeverity, kind: "severity-" + strings.ToLower(vulnerability.vulnerability.ParsedSeverity)})
+				badges = append(badges, badge{label: string(vulnerability.vulnerability.ParsedSeverity), kind: "severity-" + strings.ToLower(string(vulnerability.vulnerability.ParsedSeverity))})
 			}
 			if m.reachabilityEnabled {
 				if reachabilityBadge, ok := vulnerabilityReachabilityBadge(vulnerability.vulnerability); ok {
@@ -1144,10 +1144,10 @@ func sortedFindingGroupKeys(groups map[string][]sdk.Finding) []string {
 func vulnerabilityGroupKey(row packageVulnerabilityRow, group string) string {
 	switch group {
 	case "severity":
-		return titleCase(valueOrDefault(row.vulnerability.ParsedSeverity, "unknown"))
+		return titleCase(valueOrDefault(string(row.vulnerability.ParsedSeverity), "unknown"))
 	case "ecosystem":
 		if row.pkg != nil {
-			return valueOrDefault(row.pkg.Ecosystem, "unknown")
+			return valueOrDefault(string(row.pkg.Ecosystem), "unknown")
 		}
 		return "unknown"
 	default:
@@ -1265,14 +1265,14 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 	if row.pkg != nil {
 		packageID = row.pkg.ID
 		packageVersion = row.pkg.Version
-		packageEcosystem = row.pkg.Ecosystem
+		packageEcosystem = string(row.pkg.Ecosystem)
 		packagePURL = row.pkg.PURL
 	}
 	lines := []string{
 		render.Style("Vulnerability", render.Bold, render.Cyan),
 		"",
 		render.Style("  ID: ", render.Dim) + valueOrDash(vulnerability.ID),
-		render.Style("  Severity: ", render.Dim) + severityText(vulnerability.ParsedSeverity),
+		render.Style("  Severity: ", render.Dim) + severityText(string(vulnerability.ParsedSeverity)),
 		render.Style("  Severity source: ", render.Dim) + valueOrDash(vulnerability.SeveritySource),
 		render.Style("  Source: ", render.Dim) + valueOrDash(vulnerability.Source),
 		render.Style("  Namespace: ", render.Dim) + valueOrDash(vulnerability.Namespace),
@@ -1295,7 +1295,7 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		"",
 		render.Style("  Affected: ", render.Dim) + valueOrDash(vulnerability.AffectedVersionRange),
 		render.Style("  Fixed in: ", render.Dim) + valueOrDash(vulnerability.FixedIn),
-		render.Style("  Fix state: ", render.Dim) + valueOrDash(vulnerability.FixState),
+		render.Style("  Fix state: ", render.Dim) + valueOrDash(string(vulnerability.FixState)),
 		render.Style("  Fixed versions: ", render.Dim) + valueOrDash(strings.Join(vulnerability.FixedVersions, ", ")),
 		"",
 	}
@@ -1370,7 +1370,7 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
 		for _, ref := range vulnerability.References {
-			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{ref.Type, ref.URL}), " | "))
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{string(ref.Type), ref.URL}), " | "))
 		}
 	}
 	lines = append(lines, "", render.Style(fmt.Sprintf("Fix Availability (%d)", len(vulnerability.FixAvailable)), render.Bold, render.Magenta))
@@ -1378,7 +1378,7 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
 		for _, fix := range vulnerability.FixAvailable {
-			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{fix.Version, fix.Date, fix.Kind}), " "))
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{fix.Version, fix.Date, string(fix.Kind)}), " "))
 		}
 	}
 
@@ -1387,7 +1387,7 @@ func vulnerabilityDetails(row packageVulnerabilityRow) []string {
 		lines = append(lines, render.Style("  (none)", render.Dim))
 	} else {
 		for _, symbol := range vulnerability.AffectedSymbols {
-			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{symbol.Symbol, symbol.Kind, symbol.Package, symbol.Module}), " | "))
+			lines = append(lines, render.Style("  - ", render.Dim)+strings.Join(nonEmptyStrings([]string{symbol.Symbol, string(symbol.Kind), symbol.Package, symbol.Module}), " | "))
 		}
 	}
 	lines = append(lines, "")
@@ -1682,7 +1682,7 @@ func (m *ScanModel) findingItems(findings []sdk.Finding) []listItem {
 			items = append(items, listItem{
 				title:    finding.ID,
 				subtitle: string(finding.Kind),
-				badges:   []badge{{label: finding.Severity, kind: "severity-" + strings.ToLower(finding.Severity)}},
+				badges:   []badge{{label: string(finding.Severity), kind: "severity-" + strings.ToLower(string(finding.Severity))}},
 				details:  m.findingDetails(finding),
 				tree:     treePrefix(nil, idx == len(groupFindings)-1, 1),
 				depth:    1,
@@ -1695,13 +1695,13 @@ func (m *ScanModel) findingItems(findings []sdk.Finding) []listItem {
 func (m *ScanModel) findingGroupKey(finding sdk.Finding, group string) string {
 	switch group {
 	case "severity":
-		return titleCase(valueOrDefault(finding.Severity, "n/a"))
+		return titleCase(valueOrDefault(string(finding.Severity), "n/a"))
 	case "component":
 		return valueOrDefault(m.findingPackageName(finding), "unknown component")
 	case "ecosystem":
 		if m != nil && m.registry != nil && finding.PackageRef != "" {
 			if pkg, ok := m.registry.Get(finding.PackageRef); ok && pkg != nil && pkg.Ecosystem != "" {
-				return pkg.Ecosystem
+				return string(pkg.Ecosystem)
 			}
 		}
 		return "unknown"
@@ -1739,7 +1739,7 @@ func (m *ScanModel) findingDetails(finding sdk.Finding) []string {
 		"",
 		render.Style("  ID: ", render.Dim) + valueOrDash(finding.ID),
 		render.Style("  Kind: ", render.Dim) + valueOrDash(string(finding.Kind)),
-		render.Style("  Severity: ", render.Dim) + severityText(finding.Severity),
+		render.Style("  Severity: ", render.Dim) + severityText(string(finding.Severity)),
 		render.Style("  Package: ", render.Dim) + valueOrDash(pkgDisplay),
 		render.Style("  Title: ", render.Dim) + valueOrDash(finding.Title),
 		render.Style("  Source: ", render.Dim) + valueOrDash(finding.Source),
@@ -1768,7 +1768,7 @@ func (m *ScanModel) findingDetails(finding sdk.Finding) []string {
 					details = append(details, render.Style("  Fixed in: ", render.Dim)+v.FixedIn)
 				}
 				if v.FixState != "" {
-					details = append(details, render.Style("  Fix state: ", render.Dim)+v.FixState)
+					details = append(details, render.Style("  Fix state: ", render.Dim)+string(v.FixState))
 				}
 				if v.KEVExploited {
 					details = append(details, render.Style("  KEV: ", render.Dim)+"yes")
@@ -1868,8 +1868,8 @@ func (m *ScanModel) sourceSectionChildren(section, prefix string) []listItem {
 			fmt.Sprintf("name: %q", valueOrDash(m.project.Name)),
 			fmt.Sprintf("path: %q", valueOrDash(m.project.Path)),
 			fmt.Sprintf("type: %q", targetKindLabel(m.project)),
-			fmt.Sprintf("ecosystem: %q", valueOrDash(m.project.Ecosystem)),
-			fmt.Sprintf("packageManager: %q", valueOrDash(m.project.PackageManager)),
+			fmt.Sprintf("ecosystem: %q", valueOrDash(string(m.project.Ecosystem))),
+			fmt.Sprintf("packageManager: %q", valueOrDash(m.project.PackageManager.Name())),
 		}
 		return sourceLeafItems(lines, prefix)
 	case "manifests":
@@ -1928,9 +1928,9 @@ func packageRawLines(pkg *sdk.Dependency, registry *sdk.PackageRegistry) []strin
 	lines := []string{
 		fmt.Sprintf("name: %q", valueOrDash(pkg.Name)),
 		fmt.Sprintf("version: %q", valueOrDash(pkg.Version)),
-		fmt.Sprintf("ecosystem: %q", valueOrDash(pkg.Ecosystem)),
+		fmt.Sprintf("ecosystem: %q", valueOrDash(string(pkg.Ecosystem))),
 		fmt.Sprintf("scope: %q", valueOrDash(string(pkg.PrimaryScope()))),
-		fmt.Sprintf("type: %q", valueOrDash(pkg.Type)),
+		fmt.Sprintf("type: %q", valueOrDash(string(pkg.Type))),
 		fmt.Sprintf("purl: %q", valueOrDash(pkg.PURL)),
 		fmt.Sprintf("licenses: %q", strings.Join(licenseValues, ", ")),
 		fmt.Sprintf("vulnerabilities: %d", len(vulnsForDependency(registry, pkg))),
@@ -2392,7 +2392,7 @@ func packageRowFromGraph(pkg *sdk.Dependency, relationship string) listPackageRo
 		displayName:  displayName,
 		version:      pkg.Version,
 		scope:        string(pkg.PrimaryScope()),
-		ecosystem:    pkg.Ecosystem,
+		ecosystem:    string(pkg.Ecosystem),
 		relationship: relationship,
 		purl:         pkg.PURL,
 	}
@@ -2573,17 +2573,17 @@ func componentDetails(graphValue *sdk.Graph, registry *sdk.PackageRegistry, row 
 	} else {
 		for _, vulnerability := range vulnerabilities {
 			var severityLabel string
-			switch strings.ToLower(vulnerability.ParsedSeverity) {
+			switch strings.ToLower(string(vulnerability.ParsedSeverity)) {
 			case "critical":
-				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(vulnerability.ParsedSeverity))+" ", render.BgRed, render.White, render.Bold)
+				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(string(vulnerability.ParsedSeverity)))+" ", render.BgRed, render.White, render.Bold)
 			case "high":
-				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(vulnerability.ParsedSeverity))+" ", render.BgRed, render.White)
+				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(string(vulnerability.ParsedSeverity)))+" ", render.BgRed, render.White)
 			case "medium":
-				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(vulnerability.ParsedSeverity))+" ", render.BgYellow, render.Bold)
+				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(string(vulnerability.ParsedSeverity)))+" ", render.BgYellow, render.Bold)
 			case "low":
-				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(vulnerability.ParsedSeverity))+" ", render.BgCyan, render.Blue, render.Bold)
+				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(string(vulnerability.ParsedSeverity)))+" ", render.BgCyan, render.Blue, render.Bold)
 			default:
-				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(vulnerability.ParsedSeverity))+" ", render.Dim)
+				severityLabel = render.Style(" "+strings.ToUpper(valueOrDash(string(vulnerability.ParsedSeverity)))+" ", render.Dim)
 			}
 			title := valueOrDash(vulnerability.Title)
 			if title == "-" {
@@ -2608,7 +2608,7 @@ func componentDetails(graphValue *sdk.Graph, registry *sdk.PackageRegistry, row 
 				expr = lic.Value
 			}
 			if lic.Type != "" {
-				expr += " [" + lic.Type + "]"
+				expr += " [" + string(lic.Type) + "]"
 			}
 			lines = append(lines, render.Style("  - ", render.Dim)+valueOrDash(expr))
 		}
@@ -2656,7 +2656,7 @@ func scanStats(graphValue *sdk.Graph, registry *sdk.PackageRegistry) scanOvervie
 				continue
 			}
 			if pkg.Ecosystem != "" {
-				stats.ecosystems[pkg.Ecosystem]++
+				stats.ecosystems[string(pkg.Ecosystem)]++
 			} else {
 				stats.ecosystems["unknown"]++
 			}
@@ -2679,7 +2679,7 @@ func scanStats(graphValue *sdk.Graph, registry *sdk.PackageRegistry) scanOvervie
 func severityDistribution(vulnerabilities []packageVulnerabilityRow) map[string]int {
 	counts := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
 	for _, row := range vulnerabilities {
-		sev := strings.ToLower(strings.TrimSpace(row.vulnerability.ParsedSeverity))
+		sev := strings.ToLower(strings.TrimSpace(string(row.vulnerability.ParsedSeverity)))
 		if _, ok := counts[sev]; !ok {
 			sev = "unknown"
 		}
@@ -2694,7 +2694,7 @@ func reachableSeverityDistribution(vulnerabilities []packageVulnerabilityRow) ma
 		if row.vulnerability.Reachability == nil || row.vulnerability.Reachability.Status != sdk.ReachabilityReachable {
 			continue
 		}
-		severity := strings.ToLower(strings.TrimSpace(row.vulnerability.ParsedSeverity))
+		severity := strings.ToLower(strings.TrimSpace(string(row.vulnerability.ParsedSeverity)))
 		if _, ok := counts[severity]; !ok {
 			severity = "unknown"
 		}
@@ -3009,8 +3009,8 @@ func packageVulnerabilityStats(graphValue *sdk.Graph, registry *sdk.PackageRegis
 			name := packageDisplayName(pkg)
 			counts[name] += len(vulns)
 			for _, vuln := range vulns {
-				if severityRank(vuln.ParsedSeverity) < severityRank(severities[name]) {
-					severities[name] = vuln.ParsedSeverity
+				if severityRank(string(vuln.ParsedSeverity)) < severityRank(severities[name]) {
+					severities[name] = string(vuln.ParsedSeverity)
 				}
 			}
 		}
@@ -3284,9 +3284,9 @@ func targetKindLabel(project output.ProjectDescriptor) string {
 	case strings.TrimSpace(project.TargetType) != "":
 		return project.TargetType
 	case project.PackageManager != "":
-		return project.PackageManager
+		return project.PackageManager.Name()
 	case project.Ecosystem != "":
-		return project.Ecosystem
+		return string(project.Ecosystem)
 	default:
 		return "dependency graph"
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -59,7 +59,7 @@ func TestInteractiveManifestRows_OnlyIncludesManifests(t *testing.T) {
 func TestInteractiveListModel_ViewIncludesDetails(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
-	dep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	if err := g.AddNode(root); err != nil {
 		t.Fatalf("add root: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestNewDiffInteractiveModel_ViewIncludesManifestChanges(t *testing.T) {
 func TestNewScanInteractiveModel_ViewIncludesGraphSummary(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
-	dep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	if err := g.AddNode(root); err != nil {
 		t.Fatalf("add root: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestNewScanInteractiveModel_ViewIncludesGraphSummary(t *testing.T) {
 }
 
 func TestInteractivePackageDisplayName_IncludesScope(t *testing.T) {
-	pkg := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	if got := packageDisplayName(pkg); got != "react@18.2.0 [runtime]" {
 		t.Fatalf("expected scoped display name, got %q", got)
 	}
@@ -624,8 +624,8 @@ func TestInteractiveListModel_HelpWrapsAcrossMultipleLines(t *testing.T) {
 func TestScanInteractiveModel_FiltersAndScopeBadges(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
-	runtimeDep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
-	devDep := sdk.NewDependency(sdk.Dependency{Name: "vitest", Version: "2.0.0", Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
+	runtimeDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	devDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "vitest", Version: "2.0.0"}, Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
 	for _, pkg := range []*sdk.Dependency{root, runtimeDep, devDep} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package: %v", err)
@@ -681,9 +681,9 @@ func TestScanInteractiveModel_FiltersAndScopeBadges(t *testing.T) {
 
 func TestScanInteractiveModel_EcosystemFilterUpdatesComponents(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
-	npmDep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Ecosystem: "npm"})
-	goDep := sdk.NewDependency(sdk.Dependency{Name: "cobra", Version: "1.8.0", Ecosystem: "go"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
+	npmDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0", Ecosystem: "npm"}})
+	goDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "cobra", Version: "1.8.0", Ecosystem: "go"}})
 	for _, pkg := range []*sdk.Dependency{root, npmDep, goDep} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package: %v", err)
@@ -727,7 +727,7 @@ func TestScanInteractiveModel_EcosystemFilterUpdatesComponents(t *testing.T) {
 
 func TestScanInteractiveModel_ManifestDetailsIncludeDetectorMetadata(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
 	if err := g.AddNode(root); err != nil {
 		t.Fatalf("add package: %v", err)
 	}
@@ -783,9 +783,9 @@ func TestScanInteractiveModel_FindingsCanGroupByEcosystem(t *testing.T) {
 
 func TestScanInteractiveModel_UsesEnrichedVulnerabilitiesWithoutFindings(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
 	const reactPURL = "pkg:npm/react@18.2.0"
-	dep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL}})
 	registry := sdk.NewPackageRegistry()
 	regPkg := registry.Ensure(reactPURL)
 	regPkg.Name = "react"
@@ -855,11 +855,11 @@ func TestScanInteractiveModel_UsesEnrichedVulnerabilitiesWithoutFindings(t *test
 
 func TestScanInteractiveModel_VulnerabilityFilterKeepsGlobalSummaries(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
 	const reactPURL = "pkg:npm/react@18.2.0"
 	const lodashPURL = "pkg:npm/lodash@4.17.20"
-	react := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL})
-	lodash := sdk.NewDependency(sdk.Dependency{Name: "lodash", Version: "4.17.20", Ecosystem: "npm", PURL: lodashPURL})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL}})
+	lodash := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash", Version: "4.17.20", Ecosystem: "npm", PURL: lodashPURL}})
 	registry := sdk.NewPackageRegistry()
 	rp := registry.Ensure(reactPURL)
 	rp.Name, rp.Version, rp.Ecosystem = "react", "18.2.0", "npm"
@@ -918,9 +918,9 @@ func TestScanInteractiveModel_VulnerabilityFilterKeepsGlobalSummaries(t *testing
 
 func TestScanInteractiveModel_VulnerabilityFilterEmptyStateDistinguishesNoMatchesFromNoEnrich(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
 	const reactPURL = "pkg:npm/react@18.2.0"
-	dep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0", Ecosystem: "npm", PURL: reactPURL}})
 	registry := sdk.NewPackageRegistry()
 	rp := registry.Ensure(reactPURL)
 	rp.Name, rp.Version, rp.Ecosystem = "react", "18.2.0", "npm"
@@ -1113,14 +1113,14 @@ func newScanReachabilityFilterModel(t *testing.T, enabled bool) *ScanModel {
 	}
 	registry := sdk.NewPackageRegistry()
 	mkDep := func(name, purl string, vulns ...sdk.Vulnerability) *sdk.Dependency {
-		dep := sdk.NewDependency(sdk.Dependency{Name: name, Version: "1.0.0", Ecosystem: "npm", PURL: purl})
+		dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: name, Version: "1.0.0", Ecosystem: "npm", PURL: purl}})
 		regPkg := registry.Ensure(purl)
 		regPkg.Name = name
 		regPkg.Version = "1.0.0"
 		regPkg.Vulnerabilities = vulns
 		return dep
 	}
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
 	reachable := mkDep("reachable-lib", "pkg:npm/reachable-lib@1.0.0",
 		vulnerability("CVE-REACHABLE", &sdk.Reachability{Status: sdk.ReachabilityReachable}))
 	unreachable := mkDep("unreachable-lib", "pkg:npm/unreachable-lib@1.0.0",
@@ -1272,8 +1272,8 @@ func TestTopDependedOnComponentStats_UsesTransitiveDependents(t *testing.T) {
 func TestScanInteractiveModel_ComponentTreeExpandsSelectedNode(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
-	direct := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
-	transitive := sdk.NewDependency(sdk.Dependency{Name: "loose-envify", Version: "1.4.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	direct := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	transitive := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "loose-envify", Version: "1.4.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	for _, pkg := range []*sdk.Dependency{root, direct, transitive} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package: %v", err)
@@ -1326,8 +1326,8 @@ func TestScanInteractiveModel_ComponentTreeExpandsSelectedNode(t *testing.T) {
 func TestScanInteractiveModel_ComponentExpandCollapseAllProgressesByLayer(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRef("demo-app", "1.0.0")
-	direct := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0"})
-	transitive := sdk.NewDependency(sdk.Dependency{Name: "loose-envify", Version: "1.4.0"})
+	direct := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}})
+	transitive := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "loose-envify", Version: "1.4.0"}})
 	for _, pkg := range []*sdk.Dependency{root, direct, transitive} {
 		if err := g.AddNode(pkg); err != nil {
 			t.Fatalf("add package: %v", err)
@@ -1395,8 +1395,8 @@ func assertViewContains(t *testing.T, model *ScanModel, contains, excludes []str
 
 func TestScanInteractiveModel_OverviewDashboardUsesBordersAndBars(t *testing.T) {
 	g := sdk.New()
-	root := sdk.NewDependency(sdk.Dependency{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"})
-	dep := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Ecosystem: "npm"})
+	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "demo-app", Version: "1.0.0", Ecosystem: "npm"}})
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0", Ecosystem: "npm"}})
 	sdk.SetDetectionLicenses(dep, []sdk.PackageLicense{{Value: "MIT"}})
 	for _, pkg := range []*sdk.Dependency{root, dep} {
 		if err := g.AddNode(pkg); err != nil {
@@ -1568,9 +1568,9 @@ func TestInteractiveListModel_SearchIgnoresDependencyDetailText(t *testing.T) {
 func TestBuildLicensesListModel_GroupsByUniqueLicense(t *testing.T) {
 	g := sdk.New()
 	app := sdk.NewDependencyRef("demo-app", "1.0.0")
-	react := sdk.NewDependency(sdk.Dependency{Name: "react", Version: "18.2.0", Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
+	react := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "react", Version: "18.2.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime)})
 	sdk.SetDetectionLicenses(react, []sdk.PackageLicense{{Value: "MIT"}})
-	vite := sdk.NewDependency(sdk.Dependency{Name: "vite", Version: "5.4.0", Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
+	vite := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "vite", Version: "5.4.0"}, Scopes: sdk.ScopesOf(sdk.ScopeDevelopment)})
 	sdk.SetDetectionLicenses(vite, []sdk.PackageLicense{{Value: "MIT"}, {Value: "Apache-2.0"}})
 	for _, pkg := range []*sdk.Dependency{app, react, vite} {
 		if err := g.AddNode(pkg); err != nil {

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -331,8 +331,8 @@ func maxVulnerabilitySeverityByPkgID(graphValue *sdk.Graph, registry *sdk.Packag
 		}
 		for _, vulnerability := range vulnsForDependency(registry, pkg) {
 			current := result[pkg.ID]
-			if severityRank(vulnerability.ParsedSeverity) < severityRank(current) {
-				result[pkg.ID] = vulnerability.ParsedSeverity
+			if severityRank(string(vulnerability.ParsedSeverity)) < severityRank(current) {
+				result[pkg.ID] = string(vulnerability.ParsedSeverity)
 			}
 		}
 	}

--- a/sdk/container.go
+++ b/sdk/container.go
@@ -3,7 +3,38 @@ package sdk
 import "errors"
 
 // ManifestKind identifies the manifest family represented by one graph entry.
-type ManifestKind = string
+type ManifestKind string
+
+const (
+	// ManifestKindPackageLockJSON identifies npm package-lock.json manifests.
+	ManifestKindPackageLockJSON ManifestKind = "package-lock.json"
+	// ManifestKindNPMLockfile identifies generic npm lockfile manifests.
+	ManifestKindNPMLockfile ManifestKind = "npm-lockfile"
+	// ManifestKindPackageJSON identifies npm package.json manifests.
+	ManifestKindPackageJSON ManifestKind = "package.json"
+	// ManifestKindGoMod identifies Go module manifests.
+	ManifestKindGoMod ManifestKind = "go.mod"
+	// ManifestKindGoModule identifies normalized Go module manifests.
+	ManifestKindGoModule ManifestKind = "go-module"
+	// ManifestKindPomXML identifies Maven POM manifests.
+	ManifestKindPomXML ManifestKind = "pom.xml"
+	// ManifestKindRequirementsTXT identifies Python requirements manifests.
+	ManifestKindRequirementsTXT ManifestKind = "requirements.txt"
+	// ManifestKindSPDX identifies SPDX SBOM manifests.
+	ManifestKindSPDX ManifestKind = "spdx"
+	// ManifestKindSBOM identifies generic SBOM manifests.
+	ManifestKindSBOM ManifestKind = "sbom"
+	// ManifestKindGitHubSPDX identifies GitHub-produced SPDX SBOM manifests.
+	ManifestKindGitHubSPDX ManifestKind = "github.spdx"
+	// ManifestKindBomlySPDX identifies Bomly-produced SPDX SBOM manifests.
+	ManifestKindBomlySPDX ManifestKind = "bomly.spdx"
+	// ManifestKindGitHubActions identifies GitHub Actions manifests.
+	ManifestKindGitHubActions ManifestKind = "github-actions"
+	// ManifestKindGitHubActionsWorkflow identifies GitHub Actions workflow files.
+	ManifestKindGitHubActionsWorkflow ManifestKind = "github-actions-workflow"
+	// ManifestKindGitHubActionsAction identifies GitHub Actions action metadata files.
+	ManifestKindGitHubActionsAction ManifestKind = "github-actions-action"
+)
 
 // ManifestMetadata describes the manifest or evidence file associated with one graph.
 type ManifestMetadata struct {

--- a/sdk/coordinates.go
+++ b/sdk/coordinates.go
@@ -1,0 +1,41 @@
+package sdk
+
+import "strings"
+
+// Coordinates is the shared coordinates view for manifest dependencies and
+// matched registry packages. It intentionally excludes graph-only fields
+// (scopes, locations, package refs) and enrichment-only fields (licenses,
+// vulnerabilities, scorecard) so Dependency and Package remain distinct
+// domain models.
+type Coordinates struct {
+	PURL           string         `json:"purl,omitempty"`
+	Ecosystem      Ecosystem      `json:"ecosystem,omitempty"`
+	PackageManager PackageManager `json:"package_manager,omitempty"`
+	Type           PackageType    `json:"type,omitempty"`
+	Org            string         `json:"org,omitempty"`
+	Name           string         `json:"name,omitempty"`
+	Version        string         `json:"version,omitempty"`
+	Language       Language       `json:"language,omitempty"`
+}
+
+// QualifiedName returns the package name prefixed with its organization when present.
+func (i Coordinates) QualifiedName() string {
+	return qualifiedName(i.Org, i.Name)
+}
+
+// StableID returns a graph-friendly identifier derived from name and version.
+func (i Coordinates) StableID() string {
+	base := i.QualifiedName()
+	if i.Version == "" {
+		return base
+	}
+	if base == "" {
+		return i.Version
+	}
+	return base + "@" + i.Version
+}
+
+// IdentityKey returns a stable package identity without version information.
+func (i Coordinates) IdentityKey() string {
+	return strings.Join([]string{string(i.Ecosystem), i.PackageManager.Name(), string(i.Type), i.Org, i.Name}, "\x00")
+}

--- a/sdk/coordinates_test.go
+++ b/sdk/coordinates_test.go
@@ -1,0 +1,46 @@
+package sdk
+
+import "testing"
+
+func TestCoordinatesSharedView(t *testing.T) {
+	dep := NewDependency(Dependency{
+		Coordinates: Coordinates{
+			Ecosystem:      EcosystemMaven,
+			PackageManager: PackageManagerGradle,
+			Type:           PackageTypePackage,
+			Org:            "com.example",
+			Name:           "demo",
+			Version:        "1.2.3",
+			Language:       LanguageJava,
+		},
+	})
+	pkg := &Package{
+		Coordinates: dep.Coordinates,
+	}
+
+	if dep.Coordinates != pkg.Coordinates {
+		t.Fatalf("dependency and coordinates differ:\ndep=%#v\npkg=%#v", dep.Coordinates, pkg.Coordinates)
+	}
+	if got, want := dep.Coordinates.QualifiedName(), "com.example:demo"; got != want {
+		t.Fatalf("QualifiedName() = %q, want %q", got, want)
+	}
+	if got, want := dep.Coordinates.StableID(), "com.example:demo@1.2.3"; got != want {
+		t.Fatalf("StableID() = %q, want %q", got, want)
+	}
+	if dep.IdentityKey() != pkg.IdentityKey() {
+		t.Fatalf("identity keys differ: dep=%q pkg=%q", dep.IdentityKey(), pkg.IdentityKey())
+	}
+}
+
+func TestCoordinatesCanonicalPURL(t *testing.T) {
+	identity := Coordinates{
+		Ecosystem:      EcosystemGo,
+		PackageManager: PackageManagerGoMod,
+		Name:           "github.com/Example/Lib/v2",
+		Version:        "v2.1.0",
+	}
+
+	if got, want := identity.CanonicalPURL(), "pkg:golang/github.com/example/lib/v2@v2.1.0"; got != want {
+		t.Fatalf("CanonicalPURL() = %q, want %q", got, want)
+	}
+}

--- a/sdk/dependency.go
+++ b/sdk/dependency.go
@@ -83,23 +83,23 @@ func ScopesOf(scopes ...Scope) []Scope {
 // matching artifact (Package) by PURL. Matching enrichment (licenses,
 // vulnerabilities, scorecard) lives on the referenced Package, not here.
 type Dependency struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name,omitempty"`
-	Version     string            `json:"version,omitempty"`
-	PURL        string            `json:"purl,omitempty"`
-	Ecosystem   string            `json:"ecosystem,omitempty"`
-	Type        string            `json:"type,omitempty"`
-	Org         string            `json:"org,omitempty"`
-	BuildSystem string            `json:"build_system,omitempty"`
-	Language    string            `json:"language,omitempty"`
-	Scopes      []Scope           `json:"scopes,omitempty"`
-	Locations   []PackageLocation `json:"locations,omitempty"`
-	CPEs        []string          `json:"cpes,omitempty"`
-	Digests     []Digest          `json:"digests,omitempty"`
-	Copyright   string            `json:"copyright,omitempty"`
-	FoundBy     string            `json:"found_by,omitempty"`
-	ResolvedURL string            `json:"resolved_url,omitempty"`
-	Metadata    map[string]any    `json:"metadata,omitempty"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name,omitempty"`
+	Version        string            `json:"version,omitempty"`
+	PURL           string            `json:"purl,omitempty"`
+	Ecosystem      Ecosystem         `json:"ecosystem,omitempty"`
+	Type           PackageType       `json:"type,omitempty"`
+	Org            string            `json:"org,omitempty"`
+	PackageManager PackageManager    `json:"package_manager,omitempty"`
+	Language       Language          `json:"language,omitempty"`
+	Scopes         []Scope           `json:"scopes,omitempty"`
+	Locations      []PackageLocation `json:"locations,omitempty"`
+	CPEs           []string          `json:"cpes,omitempty"`
+	Digests        []Digest          `json:"digests,omitempty"`
+	Copyright      string            `json:"copyright,omitempty"`
+	FoundBy        string            `json:"found_by,omitempty"`
+	ResolvedURL    string            `json:"resolved_url,omitempty"`
+	Metadata       map[string]any    `json:"metadata,omitempty"`
 
 	// Matched is true when the referenced package was enriched by a matcher.
 	Matched bool `json:"matched,omitempty"`
@@ -146,7 +146,7 @@ func (d *Dependency) IdentityKey() string {
 	if d == nil {
 		return ""
 	}
-	return strings.Join([]string{d.Ecosystem, d.BuildSystem, d.Type, d.Org, d.Name}, "\x00")
+	return strings.Join([]string{string(d.Ecosystem), d.PackageManager.Name(), string(d.Type), d.Org, d.Name}, "\x00")
 }
 
 // PrimaryScope returns the merged precedence scope across all recorded scopes.

--- a/sdk/dependency.go
+++ b/sdk/dependency.go
@@ -83,23 +83,16 @@ func ScopesOf(scopes ...Scope) []Scope {
 // matching artifact (Package) by PURL. Matching enrichment (licenses,
 // vulnerabilities, scorecard) lives on the referenced Package, not here.
 type Dependency struct {
-	ID             string            `json:"id"`
-	Name           string            `json:"name,omitempty"`
-	Version        string            `json:"version,omitempty"`
-	PURL           string            `json:"purl,omitempty"`
-	Ecosystem      Ecosystem         `json:"ecosystem,omitempty"`
-	Type           PackageType       `json:"type,omitempty"`
-	Org            string            `json:"org,omitempty"`
-	PackageManager PackageManager    `json:"package_manager,omitempty"`
-	Language       Language          `json:"language,omitempty"`
-	Scopes         []Scope           `json:"scopes,omitempty"`
-	Locations      []PackageLocation `json:"locations,omitempty"`
-	CPEs           []string          `json:"cpes,omitempty"`
-	Digests        []Digest          `json:"digests,omitempty"`
-	Copyright      string            `json:"copyright,omitempty"`
-	FoundBy        string            `json:"found_by,omitempty"`
-	ResolvedURL    string            `json:"resolved_url,omitempty"`
-	Metadata       map[string]any    `json:"metadata,omitempty"`
+	Coordinates
+	ID          string            `json:"id"`
+	Scopes      []Scope           `json:"scopes,omitempty"`
+	Locations   []PackageLocation `json:"locations,omitempty"`
+	CPEs        []string          `json:"cpes,omitempty"`
+	Digests     []Digest          `json:"digests,omitempty"`
+	Copyright   string            `json:"copyright,omitempty"`
+	FoundBy     string            `json:"found_by,omitempty"`
+	ResolvedURL string            `json:"resolved_url,omitempty"`
+	Metadata    map[string]any    `json:"metadata,omitempty"`
 
 	// Matched is true when the referenced package was enriched by a matcher.
 	Matched bool `json:"matched,omitempty"`
@@ -112,7 +105,7 @@ func (d *Dependency) QualifiedName() string {
 	if d == nil {
 		return ""
 	}
-	return qualifiedName(d.Org, d.Name)
+	return d.Coordinates.QualifiedName()
 }
 
 // DisplayName returns the most human-friendly identifier available.
@@ -131,14 +124,7 @@ func (d *Dependency) StableID() string {
 	if d == nil {
 		return ""
 	}
-	base := d.QualifiedName()
-	if d.Version == "" {
-		return base
-	}
-	if base == "" {
-		return d.Version
-	}
-	return fmt.Sprintf("%s@%s", base, d.Version)
+	return d.Coordinates.StableID()
 }
 
 // IdentityKey returns a stable identity without version information.
@@ -146,7 +132,7 @@ func (d *Dependency) IdentityKey() string {
 	if d == nil {
 		return ""
 	}
-	return strings.Join([]string{string(d.Ecosystem), d.PackageManager.Name(), string(d.Type), d.Org, d.Name}, "\x00")
+	return d.Coordinates.IdentityKey()
 }
 
 // PrimaryScope returns the merged precedence scope across all recorded scopes.
@@ -234,10 +220,10 @@ func NewDependencyWithID(id string, dep Dependency) *Dependency {
 // NewDependencyRef constructs a dependency from a name and version. If version
 // is set, ID is "name@version"; otherwise ID is "name".
 func NewDependencyRef(name, version string) *Dependency {
-	return NewDependency(Dependency{Name: name, Version: version})
+	return NewDependency(Dependency{Coordinates: Coordinates{Name: name, Version: version}})
 }
 
 // NewDependencyRefWithID constructs a dependency with a custom ID.
 func NewDependencyRefWithID(id, name, version string) *Dependency {
-	return NewDependencyWithID(id, Dependency{Name: name, Version: version})
+	return NewDependencyWithID(id, Dependency{Coordinates: Coordinates{Name: name, Version: version}})
 }

--- a/sdk/ecosystem.go
+++ b/sdk/ecosystem.go
@@ -8,6 +8,9 @@ import (
 // Ecosystem groups package managers under a registry-specific dependency model.
 type Ecosystem string
 
+// String returns the ecosystem value.
+func (e Ecosystem) String() string { return string(e) }
+
 // Keep this list aligned with the Syft-backed support matrix in docs/SUPPORT_MATRIX.md
 // and the Syft manifest mappings in internal/detectors/syft/detector.go.
 const (

--- a/sdk/graph.go
+++ b/sdk/graph.go
@@ -451,8 +451,8 @@ func NodeIsDiffable(node *Dependency) bool {
 	if node == nil || strings.HasPrefix(node.ID, "subproject:") || strings.HasPrefix(node.ID, "manifest:") {
 		return false
 	}
-	switch strings.ToLower(strings.TrimSpace(node.Type)) {
-	case "manifest", "application":
+	switch node.Type {
+	case PackageTypeManifest, PackageTypeApplication:
 		return false
 	}
 	name := strings.ToLower(strings.TrimSpace(node.Name))

--- a/sdk/graph_test.go
+++ b/sdk/graph_test.go
@@ -15,12 +15,11 @@ func TestNewNode_BuildsIDFromNameAndVersion(t *testing.T) {
 }
 
 func TestNewDependencyNode_StoresCoordinatesAndBuildsID(t *testing.T) {
-	n := NewDependency(Dependency{
-		Ecosystem:      EcosystemMaven,
+	n := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemMaven,
 		Name:           "demo-artifact:sources",
 		Version:        "1.0.0",
 		Org:            "com.example",
-		PackageManager: PackageManagerMaven,
+		PackageManager: PackageManagerMaven},
 	})
 
 	if n.ID != "com.example:demo-artifact:sources@1.0.0" {
@@ -435,13 +434,13 @@ func TestCompare_ClassifiesAddedRemovedAndUpdated(t *testing.T) {
 	head := New()
 
 	baseApp := NewDependencyRef("app", "1.0.0")
-	baseKeep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"})
-	baseRemove := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "remove", Version: "1.0.0"})
-	baseUpdate := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "update", Version: "1.0.0"})
+	baseKeep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"}})
+	baseRemove := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "remove", Version: "1.0.0"}})
+	baseUpdate := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "update", Version: "1.0.0"}})
 	headApp := NewDependencyRef("app", "1.0.0")
-	headKeep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"})
-	headAdd := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "add", Version: "2.0.0"})
-	headUpdate := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "update", Version: "2.0.0"})
+	headKeep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"}})
+	headAdd := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "add", Version: "2.0.0"}})
+	headUpdate := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "update", Version: "2.0.0"}})
 
 	for _, node := range []*Dependency{baseApp, baseKeep, baseRemove, baseUpdate} {
 		if err := base.AddNode(node); err != nil {
@@ -475,7 +474,7 @@ func TestCompare_IgnoresSyntheticSubprojectRoots(t *testing.T) {
 	for _, g := range []*Graph{base, head} {
 		for _, node := range []*Dependency{
 			NewDependencyRefWithID("subproject:npm:root", "root", ""),
-			NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "shared", Version: "1.0.0"}),
+			NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "shared", Version: "1.0.0"}}),
 		} {
 			if err := g.AddNode(node); err != nil {
 				t.Fatalf("AddNode(%q): %v", node.ID, err)
@@ -493,15 +492,15 @@ func TestCompareIgnoresManifestAndRootNodes(t *testing.T) {
 	base := New()
 	head := New()
 	for _, node := range []*Dependency{
-		NewDependencyWithID("pkg:generic/root", Dependency{Name: "root", PURL: "pkg:generic/root"}),
-		NewDependencyWithID("pkg:generic/requirements.txt", Dependency{Name: "requirements.txt", PURL: "pkg:generic/requirements.txt"}),
-		NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}),
+		NewDependencyWithID("pkg:generic/root", Dependency{Coordinates: Coordinates{Name: "root", PURL: "pkg:generic/root"}}),
+		NewDependencyWithID("pkg:generic/requirements.txt", Dependency{Coordinates: Coordinates{Name: "requirements.txt", PURL: "pkg:generic/requirements.txt"}}),
+		NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}}),
 	} {
 		if err := head.AddNode(node); err != nil {
 			t.Fatalf("head add node %q: %v", node.ID, err)
 		}
 	}
-	if err := base.AddNode(NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"})); err != nil {
+	if err := base.AddNode(NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}})); err != nil {
 		t.Fatalf("base add node: %v", err)
 	}
 
@@ -514,7 +513,7 @@ func TestCompareIgnoresManifestAndRootNodes(t *testing.T) {
 func TestCompareIgnoresApplicationNodes(t *testing.T) {
 	base := New()
 	head := New()
-	if err := head.AddNode(NewDependencyWithID("pkg:npm/demo@1.0.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "demo", Version: "1.0.0", Type: PackageTypeApplication, PURL: "pkg:npm/demo@1.0.0"})); err != nil {
+	if err := head.AddNode(NewDependencyWithID("pkg:npm/demo@1.0.0", Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "demo", Version: "1.0.0", Type: PackageTypeApplication, PURL: "pkg:npm/demo@1.0.0"}})); err != nil {
 		t.Fatalf("head add application: %v", err)
 	}
 
@@ -525,16 +524,14 @@ func TestCompareIgnoresApplicationNodes(t *testing.T) {
 }
 
 func TestPackageHelpers(t *testing.T) {
-	pkg := &Package{
-		PURL:    "pkg:generic/acme/demo@1.0.0",
+	pkg := &Package{Coordinates: Coordinates{PURL: "pkg:generic/acme/demo@1.0.0",
 		Org:     "acme",
 		Name:    "demo",
-		Version: "1.0.0",
-		Licenses: []PackageLicense{
-			{Value: "MIT"},
-			{SPDXExpression: "Apache-2.0"},
-			{},
-		},
+		Version: "1.0.0"}, Licenses: []PackageLicense{
+		{Value: "MIT"},
+		{SPDXExpression: "Apache-2.0"},
+		{},
+	},
 	}
 
 	if got := pkg.DisplayName(); got != "acme:demo" {

--- a/sdk/graph_test.go
+++ b/sdk/graph_test.go
@@ -16,11 +16,11 @@ func TestNewNode_BuildsIDFromNameAndVersion(t *testing.T) {
 
 func TestNewDependencyNode_StoresCoordinatesAndBuildsID(t *testing.T) {
 	n := NewDependency(Dependency{
-		Ecosystem:   "maven",
-		Name:        "demo-artifact:sources",
-		Version:     "1.0.0",
-		Org:         "com.example",
-		BuildSystem: "maven",
+		Ecosystem:      EcosystemMaven,
+		Name:           "demo-artifact:sources",
+		Version:        "1.0.0",
+		Org:            "com.example",
+		PackageManager: PackageManagerMaven,
 	})
 
 	if n.ID != "com.example:demo-artifact:sources@1.0.0" {
@@ -29,7 +29,7 @@ func TestNewDependencyNode_StoresCoordinatesAndBuildsID(t *testing.T) {
 	if n.QualifiedName() != "com.example:demo-artifact:sources" {
 		t.Fatalf("expected qualified name, got %q", n.QualifiedName())
 	}
-	if n.Ecosystem != "maven" || n.Org != "com.example" || n.BuildSystem != "maven" {
+	if n.Ecosystem != EcosystemMaven || n.Org != "com.example" || n.PackageManager != PackageManagerMaven {
 		t.Fatalf("unexpected coordinates on dependency: %#v", n)
 	}
 }
@@ -435,13 +435,13 @@ func TestCompare_ClassifiesAddedRemovedAndUpdated(t *testing.T) {
 	head := New()
 
 	baseApp := NewDependencyRef("app", "1.0.0")
-	baseKeep := NewDependency(Dependency{Ecosystem: "npm", Name: "keep", Version: "1.0.0"})
-	baseRemove := NewDependency(Dependency{Ecosystem: "npm", Name: "remove", Version: "1.0.0"})
-	baseUpdate := NewDependency(Dependency{Ecosystem: "npm", Name: "update", Version: "1.0.0"})
+	baseKeep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"})
+	baseRemove := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "remove", Version: "1.0.0"})
+	baseUpdate := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "update", Version: "1.0.0"})
 	headApp := NewDependencyRef("app", "1.0.0")
-	headKeep := NewDependency(Dependency{Ecosystem: "npm", Name: "keep", Version: "1.0.0"})
-	headAdd := NewDependency(Dependency{Ecosystem: "npm", Name: "add", Version: "2.0.0"})
-	headUpdate := NewDependency(Dependency{Ecosystem: "npm", Name: "update", Version: "2.0.0"})
+	headKeep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "keep", Version: "1.0.0"})
+	headAdd := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "add", Version: "2.0.0"})
+	headUpdate := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "update", Version: "2.0.0"})
 
 	for _, node := range []*Dependency{baseApp, baseKeep, baseRemove, baseUpdate} {
 		if err := base.AddNode(node); err != nil {
@@ -475,7 +475,7 @@ func TestCompare_IgnoresSyntheticSubprojectRoots(t *testing.T) {
 	for _, g := range []*Graph{base, head} {
 		for _, node := range []*Dependency{
 			NewDependencyRefWithID("subproject:npm:root", "root", ""),
-			NewDependency(Dependency{Ecosystem: "npm", Name: "shared", Version: "1.0.0"}),
+			NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "shared", Version: "1.0.0"}),
 		} {
 			if err := g.AddNode(node); err != nil {
 				t.Fatalf("AddNode(%q): %v", node.ID, err)
@@ -495,13 +495,13 @@ func TestCompareIgnoresManifestAndRootNodes(t *testing.T) {
 	for _, node := range []*Dependency{
 		NewDependencyWithID("pkg:generic/root", Dependency{Name: "root", PURL: "pkg:generic/root"}),
 		NewDependencyWithID("pkg:generic/requirements.txt", Dependency{Name: "requirements.txt", PURL: "pkg:generic/requirements.txt"}),
-		NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}),
+		NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"}),
 	} {
 		if err := head.AddNode(node); err != nil {
 			t.Fatalf("head add node %q: %v", node.ID, err)
 		}
 	}
-	if err := base.AddNode(NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"})); err != nil {
+	if err := base.AddNode(NewDependencyWithID("pkg:npm/react@18.2.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "react", Version: "18.2.0", PURL: "pkg:npm/react@18.2.0"})); err != nil {
 		t.Fatalf("base add node: %v", err)
 	}
 
@@ -514,7 +514,7 @@ func TestCompareIgnoresManifestAndRootNodes(t *testing.T) {
 func TestCompareIgnoresApplicationNodes(t *testing.T) {
 	base := New()
 	head := New()
-	if err := head.AddNode(NewDependencyWithID("pkg:npm/demo@1.0.0", Dependency{Ecosystem: "npm", BuildSystem: "npm", Name: "demo", Version: "1.0.0", Type: "application", PURL: "pkg:npm/demo@1.0.0"})); err != nil {
+	if err := head.AddNode(NewDependencyWithID("pkg:npm/demo@1.0.0", Dependency{Ecosystem: EcosystemNPM, PackageManager: PackageManagerNPM, Name: "demo", Version: "1.0.0", Type: PackageTypeApplication, PURL: "pkg:npm/demo@1.0.0"})); err != nil {
 		t.Fatalf("head add application: %v", err)
 	}
 

--- a/sdk/json_test.go
+++ b/sdk/json_test.go
@@ -46,7 +46,7 @@ func TestPackageRegistryJSONRoundTrip(t *testing.T) {
 	pkg.Name = "react"
 	pkg.Version = "18.2.0"
 	pkg.Licenses = []PackageLicense{{SPDXExpression: "MIT"}}
-	pkg.Vulnerabilities = []Vulnerability{{ID: "GHSA-1", Source: "osv", ParsedSeverity: "high"}}
+	pkg.Vulnerabilities = []Vulnerability{{ID: "GHSA-1", Source: "osv", ParsedSeverity: SeverityHigh}}
 
 	data, err := json.Marshal(registry)
 	if err != nil {

--- a/sdk/language.go
+++ b/sdk/language.go
@@ -98,18 +98,16 @@ func ParseLanguage(value string) Language {
 
 // LanguageFromPackage returns the most specific language for a package. It
 // prefers the package's own Language field, then falls back to the primary
-// language declared by the package's BuildSystem (if recognizable), and
+// language declared by the package's PackageManager (if recognizable), and
 // finally returns LanguageUnknown.
 func LanguageFromPackage(p Package) Language {
-	if l := ParseLanguage(p.Language); l != LanguageUnknown {
-		return l
+	if p.Language != LanguageUnknown {
+		return p.Language
 	}
-	if p.BuildSystem != "" {
-		if pm, err := ParsePackageManager(p.BuildSystem); err == nil {
-			langs := pm.Languages()
-			if len(langs) > 0 {
-				return langs[0]
-			}
+	if p.PackageManager != PackageManagerUnknown {
+		langs := p.PackageManager.Languages()
+		if len(langs) > 0 {
+			return langs[0]
 		}
 	}
 	return LanguageUnknown

--- a/sdk/language_test.go
+++ b/sdk/language_test.go
@@ -63,17 +63,17 @@ func TestLanguageFromPackage(t *testing.T) {
 	}{
 		{
 			name: "explicit Language wins",
-			pkg:  Package{Language: LanguageKotlin, PackageManager: PackageManagerMaven},
+			pkg:  Package{Coordinates: Coordinates{Language: LanguageKotlin, PackageManager: PackageManagerMaven}},
 			want: LanguageKotlin,
 		},
 		{
 			name: "fallback to PackageManager primary",
-			pkg:  Package{PackageManager: PackageManagerMaven},
+			pkg:  Package{Coordinates: Coordinates{PackageManager: PackageManagerMaven}},
 			want: LanguageJava,
 		},
 		{
 			name: "fallback for npm",
-			pkg:  Package{PackageManager: PackageManagerNPM},
+			pkg:  Package{Coordinates: Coordinates{PackageManager: PackageManagerNPM}},
 			want: LanguageJavaScript,
 		},
 		{
@@ -83,7 +83,7 @@ func TestLanguageFromPackage(t *testing.T) {
 		},
 		{
 			name: "OS-level pm has no language",
-			pkg:  Package{PackageManager: PackageManagerAPK},
+			pkg:  Package{Coordinates: Coordinates{PackageManager: PackageManagerAPK}},
 			want: LanguageUnknown,
 		},
 	}
@@ -173,12 +173,10 @@ func TestVulnerabilityCloneCarriesNewFields(t *testing.T) {
 
 func TestDependencyCloneCarriesLocationPosition(t *testing.T) {
 	pos := SourcePosition{File: "package.json", Line: 12, Column: 5}
-	dep := Dependency{
-		Name:    "lodash",
-		Version: "4.17.21",
-		Locations: []PackageLocation{
-			{RealPath: "/abs/package.json", Position: &pos},
-		},
+	dep := Dependency{Coordinates: Coordinates{Name: "lodash",
+		Version: "4.17.21"}, Locations: []PackageLocation{
+		{RealPath: "/abs/package.json", Position: &pos},
+	},
 	}
 	clone := dep.Clone()
 	if clone.Locations[0].Position == dep.Locations[0].Position {

--- a/sdk/language_test.go
+++ b/sdk/language_test.go
@@ -63,17 +63,17 @@ func TestLanguageFromPackage(t *testing.T) {
 	}{
 		{
 			name: "explicit Language wins",
-			pkg:  Package{Language: "kotlin", BuildSystem: "maven"},
+			pkg:  Package{Language: LanguageKotlin, PackageManager: PackageManagerMaven},
 			want: LanguageKotlin,
 		},
 		{
-			name: "fallback to BuildSystem primary",
-			pkg:  Package{BuildSystem: "maven"},
+			name: "fallback to PackageManager primary",
+			pkg:  Package{PackageManager: PackageManagerMaven},
 			want: LanguageJava,
 		},
 		{
 			name: "fallback for npm",
-			pkg:  Package{BuildSystem: "npm"},
+			pkg:  Package{PackageManager: PackageManagerNPM},
 			want: LanguageJavaScript,
 		},
 		{
@@ -83,7 +83,7 @@ func TestLanguageFromPackage(t *testing.T) {
 		},
 		{
 			name: "OS-level pm has no language",
-			pkg:  Package{BuildSystem: "apk"},
+			pkg:  Package{PackageManager: PackageManagerAPK},
 			want: LanguageUnknown,
 		},
 	}

--- a/sdk/normalization.go
+++ b/sdk/normalization.go
@@ -33,17 +33,17 @@ func NormalizeDependencyIdentity(pkg *Dependency) {
 	}
 
 	switch normEffectiveEcosystem(pkg) {
-	case string(EcosystemNPM):
+	case EcosystemNPM:
 		applied = append(applied, normNPM(pkg)...)
-	case string(EcosystemPython):
+	case EcosystemPython:
 		applied = append(applied, normPython(pkg)...)
-	case string(EcosystemRust):
+	case EcosystemRust:
 		applied = append(applied, normRust(pkg)...)
-	case string(EcosystemMaven):
+	case EcosystemMaven:
 		applied = append(applied, normMaven(pkg)...)
-	case string(EcosystemGo):
+	case EcosystemGo:
 		applied = append(applied, normGo(pkg)...)
-	case string(EcosystemPHP):
+	case EcosystemPHP:
 		applied = append(applied, normComposer(pkg)...)
 	}
 
@@ -125,41 +125,41 @@ func normComposer(pkg *Dependency) []string {
 	return nil
 }
 
-func normEffectiveEcosystem(pkg *Dependency) string {
+func normEffectiveEcosystem(pkg *Dependency) Ecosystem {
 	if pkg == nil {
-		return ""
+		return EcosystemUnknown
 	}
-	for _, candidate := range []string{pkg.Ecosystem, pkg.BuildSystem, pkg.Type} {
+	for _, candidate := range []string{string(pkg.Ecosystem), pkg.PackageManager.Name(), string(pkg.Type)} {
 		switch strings.ToLower(strings.TrimSpace(candidate)) {
 		case string(EcosystemNPM), "pnpm", "yarn":
-			return string(EcosystemNPM)
+			return EcosystemNPM
 		case string(EcosystemPython), "pip", "pipenv", "poetry", "uv", "setup.py", "pypi":
-			return string(EcosystemPython)
+			return EcosystemPython
 		case string(EcosystemRust), "cargo":
-			return string(EcosystemRust)
+			return EcosystemRust
 		case string(EcosystemGo), "gomod", "golang":
-			return string(EcosystemGo)
+			return EcosystemGo
 		case string(EcosystemMaven), "gradle":
-			return string(EcosystemMaven)
+			return EcosystemMaven
 		case string(EcosystemDotNet), "nuget":
-			return string(EcosystemDotNet)
+			return EcosystemDotNet
 		case string(EcosystemDart), "pub":
-			return string(EcosystemDart)
+			return EcosystemDart
 		case string(EcosystemSwift), "cocoapods", "swiftpm":
-			return string(EcosystemSwift)
+			return EcosystemSwift
 		case string(EcosystemCPP), "conan":
-			return string(EcosystemCPP)
+			return EcosystemCPP
 		case string(EcosystemElixir), "mix", "hex":
-			return string(EcosystemElixir)
+			return EcosystemElixir
 		case string(EcosystemScala), "sbt":
-			return string(EcosystemScala)
+			return EcosystemScala
 		case string(EcosystemPHP), "composer":
-			return string(EcosystemPHP)
+			return EcosystemPHP
 		case string(EcosystemRuby), "gem", "bundler", "rubygems":
-			return string(EcosystemRuby)
+			return EcosystemRuby
 		}
 	}
-	return ""
+	return EcosystemUnknown
 }
 
 func normSplitScopedNPMName(name string) (string, string, bool) {

--- a/sdk/normalization_test.go
+++ b/sdk/normalization_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNormalizePackageIdentityPython(t *testing.T) {
-	pkg := &Dependency{Ecosystem: EcosystemPython, Name: " Requests_Toolbelt ", Version: "1.0.0RC1"}
+	pkg := &Dependency{Coordinates: Coordinates{Ecosystem: EcosystemPython, Name: " Requests_Toolbelt ", Version: "1.0.0RC1"}}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -20,7 +20,7 @@ func TestNormalizePackageIdentityPython(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityRust(t *testing.T) {
-	pkg := &Dependency{PackageManager: PackageManagerCargo, Name: "Serde_JSON", Version: "1.0.0-RC1"}
+	pkg := &Dependency{Coordinates: Coordinates{PackageManager: PackageManagerCargo, Name: "Serde_JSON", Version: "1.0.0-RC1"}}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -34,7 +34,7 @@ func TestNormalizePackageIdentityRust(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityNPMScopedName(t *testing.T) {
-	pkg := &Dependency{Ecosystem: EcosystemNPM, Name: "@Types/Node", Version: "20.11.30"}
+	pkg := &Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "@Types/Node", Version: "20.11.30"}}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -48,7 +48,7 @@ func TestNormalizePackageIdentityNPMScopedName(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityGoPath(t *testing.T) {
-	pkg := &Dependency{Ecosystem: EcosystemGo, Name: "github.com\\Example\\lib//v2", Version: "V2.1.0-RC1"}
+	pkg := &Dependency{Coordinates: Coordinates{Ecosystem: EcosystemGo, Name: "github.com\\Example\\lib//v2", Version: "V2.1.0-RC1"}}
 
 	NormalizeDependencyIdentity(pkg)
 

--- a/sdk/normalization_test.go
+++ b/sdk/normalization_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNormalizePackageIdentityPython(t *testing.T) {
-	pkg := &Dependency{Ecosystem: string(EcosystemPython), Name: " Requests_Toolbelt ", Version: "1.0.0RC1"}
+	pkg := &Dependency{Ecosystem: EcosystemPython, Name: " Requests_Toolbelt ", Version: "1.0.0RC1"}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -20,7 +20,7 @@ func TestNormalizePackageIdentityPython(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityRust(t *testing.T) {
-	pkg := &Dependency{BuildSystem: "cargo", Name: "Serde_JSON", Version: "1.0.0-RC1"}
+	pkg := &Dependency{PackageManager: PackageManagerCargo, Name: "Serde_JSON", Version: "1.0.0-RC1"}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -34,7 +34,7 @@ func TestNormalizePackageIdentityRust(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityNPMScopedName(t *testing.T) {
-	pkg := &Dependency{Ecosystem: string(EcosystemNPM), Name: "@Types/Node", Version: "20.11.30"}
+	pkg := &Dependency{Ecosystem: EcosystemNPM, Name: "@Types/Node", Version: "20.11.30"}
 
 	NormalizeDependencyIdentity(pkg)
 
@@ -48,7 +48,7 @@ func TestNormalizePackageIdentityNPMScopedName(t *testing.T) {
 }
 
 func TestNormalizePackageIdentityGoPath(t *testing.T) {
-	pkg := &Dependency{Ecosystem: string(EcosystemGo), Name: "github.com\\Example\\lib//v2", Version: "V2.1.0-RC1"}
+	pkg := &Dependency{Ecosystem: EcosystemGo, Name: "github.com\\Example\\lib//v2", Version: "V2.1.0-RC1"}
 
 	NormalizeDependencyIdentity(pkg)
 

--- a/sdk/package.go
+++ b/sdk/package.go
@@ -5,6 +5,48 @@ import (
 	"strings"
 )
 
+// PackageType describes the broad role or artifact kind of a package node.
+type PackageType string
+
+const (
+	PackageTypeUnknown     PackageType = ""
+	PackageTypeApplication PackageType = "application"
+	PackageTypePackage     PackageType = "package"
+	PackageTypeManifest    PackageType = "manifest"
+	PackageTypeWorkflow    PackageType = "workflow"
+	PackageTypeAction      PackageType = "action"
+	PackageTypeTransitive  PackageType = "transitive"
+	PackageTypeProject     PackageType = "project"
+	PackageTypeFile        PackageType = "file"
+)
+
+// ParsePackageType normalizes a package role string.
+func ParsePackageType(value string) PackageType {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return PackageTypeUnknown
+	}
+	return PackageType(normalized)
+}
+
+// String returns the package type value.
+func (t PackageType) String() string { return string(t) }
+
+// LicenseType identifies license provenance.
+type LicenseType string
+
+const (
+	LicenseTypeDeclared LicenseType = "declared"
+)
+
+// DigestAlgorithm identifies an artifact digest algorithm.
+type DigestAlgorithm string
+
+const (
+	DigestAlgorithmSHA1   DigestAlgorithm = "sha1"
+	DigestAlgorithmSHA256 DigestAlgorithm = "sha256"
+)
+
 // PackageLocation captures where a package was discovered.
 type PackageLocation struct {
 	RealPath   string `json:"real_path,omitempty"`
@@ -16,15 +58,15 @@ type PackageLocation struct {
 
 // PackageLicense captures normalized license details for a package.
 type PackageLicense struct {
-	Value          string `json:"value,omitempty"`
-	SPDXExpression string `json:"spdx_expression,omitempty"`
-	Type           string `json:"type,omitempty"`
+	Value          string      `json:"value,omitempty"`
+	SPDXExpression string      `json:"spdx_expression,omitempty"`
+	Type           LicenseType `json:"type,omitempty"`
 }
 
 // Digest captures integrity information for a package artifact.
 type Digest struct {
-	Algorithm string `json:"algorithm,omitempty"`
-	Value     string `json:"value,omitempty"`
+	Algorithm DigestAlgorithm `json:"algorithm,omitempty"`
+	Value     string          `json:"value,omitempty"`
 }
 
 // PackageEOL captures end-of-life enrichment attached by the EOL matcher.
@@ -53,16 +95,16 @@ func (e *PackageEOL) Clone() *PackageEOL {
 // Dependency.
 type Package struct {
 	// PURL is the canonical package URL and the registry primary key.
-	PURL        string `json:"purl"`
-	Ecosystem   string `json:"ecosystem,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Org         string `json:"org,omitempty"`
-	Type        string `json:"type,omitempty"`
-	BuildSystem string `json:"build_system,omitempty"`
-	Language    string `json:"language,omitempty"`
-	Copyright   string `json:"copyright,omitempty"`
-	ResolvedURL string `json:"resolved_url,omitempty"`
+	PURL           string         `json:"purl"`
+	Ecosystem      Ecosystem      `json:"ecosystem,omitempty"`
+	Name           string         `json:"name,omitempty"`
+	Version        string         `json:"version,omitempty"`
+	Org            string         `json:"org,omitempty"`
+	Type           PackageType    `json:"type,omitempty"`
+	PackageManager PackageManager `json:"package_manager,omitempty"`
+	Language       Language       `json:"language,omitempty"`
+	Copyright      string         `json:"copyright,omitempty"`
+	ResolvedURL    string         `json:"resolved_url,omitempty"`
 
 	CPEs            []string          `json:"cpes,omitempty"`
 	Digests         []Digest          `json:"digests,omitempty"`
@@ -117,7 +159,7 @@ func (p *Package) IdentityKey() string {
 	if p == nil {
 		return ""
 	}
-	return strings.Join([]string{p.Ecosystem, p.BuildSystem, p.Type, p.Org, p.Name}, "\x00")
+	return strings.Join([]string{string(p.Ecosystem), p.PackageManager.Name(), string(p.Type), p.Org, p.Name}, "\x00")
 }
 
 // LicenseValues returns normalized package license labels in stable order.
@@ -186,13 +228,13 @@ func (p *Package) MergeFrom(src *Package) {
 	if p.Org == "" {
 		p.Org = src.Org
 	}
-	if p.Type == "" {
+	if p.Type == PackageTypeUnknown {
 		p.Type = src.Type
 	}
-	if p.BuildSystem == "" {
-		p.BuildSystem = src.BuildSystem
+	if p.PackageManager == PackageManagerUnknown {
+		p.PackageManager = src.PackageManager
 	}
-	if p.Language == "" {
+	if p.Language == LanguageUnknown {
 		p.Language = src.Language
 	}
 	if strings.TrimSpace(p.Copyright) == "" {
@@ -292,15 +334,15 @@ func PackageFromDependency(dep *Dependency) *Package {
 	}
 	purl := CanonicalPackageURLFromDependency(dep)
 	return &Package{
-		PURL:        purl,
-		Ecosystem:   dep.Ecosystem,
-		Name:        dep.Name,
-		Version:     dep.Version,
-		Org:         dep.Org,
-		Type:        dep.Type,
-		BuildSystem: dep.BuildSystem,
-		Language:    dep.Language,
-		ResolvedURL: dep.ResolvedURL,
+		PURL:           purl,
+		Ecosystem:      dep.Ecosystem,
+		Name:           dep.Name,
+		Version:        dep.Version,
+		Org:            dep.Org,
+		Type:           dep.Type,
+		PackageManager: dep.PackageManager,
+		Language:       dep.Language,
+		ResolvedURL:    dep.ResolvedURL,
 	}
 }
 

--- a/sdk/package.go
+++ b/sdk/package.go
@@ -94,17 +94,12 @@ func (e *PackageEOL) Clone() *PackageEOL {
 // matching-stage enrichment; detection-time identity and relationships live on
 // Dependency.
 type Package struct {
-	// PURL is the canonical package URL and the registry primary key.
-	PURL           string         `json:"purl"`
-	Ecosystem      Ecosystem      `json:"ecosystem,omitempty"`
-	Name           string         `json:"name,omitempty"`
-	Version        string         `json:"version,omitempty"`
-	Org            string         `json:"org,omitempty"`
-	Type           PackageType    `json:"type,omitempty"`
-	PackageManager PackageManager `json:"package_manager,omitempty"`
-	Language       Language       `json:"language,omitempty"`
-	Copyright      string         `json:"copyright,omitempty"`
-	ResolvedURL    string         `json:"resolved_url,omitempty"`
+	Coordinates
+	// ID is the package registry identifier. It may be a database ID, PURL, or
+	// another stable key chosen by the package registry.
+	ID          string `json:"id,omitempty"`
+	Copyright   string `json:"copyright,omitempty"`
+	ResolvedURL string `json:"resolved_url,omitempty"`
 
 	CPEs            []string          `json:"cpes,omitempty"`
 	Digests         []Digest          `json:"digests,omitempty"`
@@ -143,11 +138,17 @@ type NPMPackageMetadata struct {
 
 // QualifiedName returns the package name prefixed with its organization when present.
 func (p *Package) QualifiedName() string {
-	return qualifiedName(p.Org, p.Name)
+	if p == nil {
+		return ""
+	}
+	return p.Coordinates.QualifiedName()
 }
 
 // DisplayName returns the most human-friendly identifier available.
 func (p *Package) DisplayName() string {
+	if p == nil {
+		return ""
+	}
 	if name := p.QualifiedName(); name != "" {
 		return name
 	}
@@ -159,7 +160,7 @@ func (p *Package) IdentityKey() string {
 	if p == nil {
 		return ""
 	}
-	return strings.Join([]string{string(p.Ecosystem), p.PackageManager.Name(), string(p.Type), p.Org, p.Name}, "\x00")
+	return p.Coordinates.IdentityKey()
 }
 
 // LicenseValues returns normalized package license labels in stable order.
@@ -215,6 +216,9 @@ func (p *Package) Clone() *Package {
 func (p *Package) MergeFrom(src *Package) {
 	if p == nil || src == nil {
 		return
+	}
+	if p.ID == "" {
+		p.ID = src.ID
 	}
 	if p.Ecosystem == "" {
 		p.Ecosystem = src.Ecosystem
@@ -334,15 +338,18 @@ func PackageFromDependency(dep *Dependency) *Package {
 	}
 	purl := CanonicalPackageURLFromDependency(dep)
 	return &Package{
-		PURL:           purl,
-		Ecosystem:      dep.Ecosystem,
-		Name:           dep.Name,
-		Version:        dep.Version,
-		Org:            dep.Org,
-		Type:           dep.Type,
-		PackageManager: dep.PackageManager,
-		Language:       dep.Language,
-		ResolvedURL:    dep.ResolvedURL,
+		Coordinates: Coordinates{
+			PURL:           purl,
+			Ecosystem:      dep.Ecosystem,
+			Name:           dep.Name,
+			Version:        dep.Version,
+			Org:            dep.Org,
+			Type:           dep.Type,
+			PackageManager: dep.PackageManager,
+			Language:       dep.Language,
+		},
+		ID:          purl,
+		ResolvedURL: dep.ResolvedURL,
 	}
 }
 

--- a/sdk/package_manager.go
+++ b/sdk/package_manager.go
@@ -6,57 +6,57 @@ import (
 )
 
 // PackageManager identifies the concrete package manager or manifest family for a target.
-type PackageManager int
+type PackageManager string
 
 const (
-	PackageManagerUnknown PackageManager = iota
-	PackageManagerNPM
-	PackageManagerPNPM
-	PackageManagerYarn
-	PackageManagerGradle
-	PackageManagerMaven
-	PackageManagerGoMod
-	PackageManagerPip
-	PackageManagerPipenv
-	PackageManagerPoetry
-	PackageManagerUV
-	PackageManagerALPM
-	PackageManagerAPK
-	PackageManagerConan
-	PackageManagerConda
-	PackageManagerPub
-	PackageManagerDPKG
-	PackageManagerMix
-	PackageManagerRebar
-	PackageManagerOTP
-	PackageManagerGitHubActions
-	PackageManagerCabal
-	PackageManagerStack
-	PackageManagerHomebrew
-	PackageManagerLuaRocks
-	PackageManagerNuGet
-	PackageManagerNix
-	PackageManagerOpam
-	PackageManagerComposer
-	PackageManagerPear
-	PackageManagerPDM
-	PackageManagerPortage
-	PackageManagerSWIPLPack
-	PackageManagerRPackage
-	PackageManagerRPM
-	PackageManagerBundler
-	PackageManagerGemspec
-	PackageManagerCargo
-	PackageManagerSBOM
-	PackageManagerSnap
-	PackageManagerCocoaPods
-	PackageManagerSwiftPM
-	PackageManagerTerraform
-	PackageManagerWordPress
-	PackageManagerSetupPy
-	PackageManagerOther
-	PackageManagerSBT
-	PackageManagerCount
+	PackageManagerUnknown       PackageManager = ""
+	PackageManagerNPM           PackageManager = "npm"
+	PackageManagerPNPM          PackageManager = "pnpm"
+	PackageManagerYarn          PackageManager = "yarn"
+	PackageManagerGradle        PackageManager = "gradle"
+	PackageManagerMaven         PackageManager = "maven"
+	PackageManagerGoMod         PackageManager = "gomod"
+	PackageManagerPip           PackageManager = "pip"
+	PackageManagerPipenv        PackageManager = "pipenv"
+	PackageManagerPoetry        PackageManager = "poetry"
+	PackageManagerUV            PackageManager = "uv"
+	PackageManagerALPM          PackageManager = "alpm"
+	PackageManagerAPK           PackageManager = "apk"
+	PackageManagerConan         PackageManager = "conan"
+	PackageManagerConda         PackageManager = "conda"
+	PackageManagerPub           PackageManager = "pub"
+	PackageManagerDPKG          PackageManager = "dpkg"
+	PackageManagerMix           PackageManager = "mix"
+	PackageManagerRebar         PackageManager = "rebar"
+	PackageManagerOTP           PackageManager = "otp"
+	PackageManagerGitHubActions PackageManager = "github-actions"
+	PackageManagerCabal         PackageManager = "cabal"
+	PackageManagerStack         PackageManager = "stack"
+	PackageManagerHomebrew      PackageManager = "homebrew"
+	PackageManagerLuaRocks      PackageManager = "luarocks"
+	PackageManagerNuGet         PackageManager = "nuget"
+	PackageManagerNix           PackageManager = "nix"
+	PackageManagerOpam          PackageManager = "opam"
+	PackageManagerComposer      PackageManager = "composer"
+	PackageManagerPear          PackageManager = "pear"
+	PackageManagerPDM           PackageManager = "pdm"
+	PackageManagerPortage       PackageManager = "portage"
+	PackageManagerSWIPLPack     PackageManager = "swipl-pack"
+	PackageManagerRPackage      PackageManager = "r-package"
+	PackageManagerRPM           PackageManager = "rpm"
+	PackageManagerBundler       PackageManager = "bundler"
+	PackageManagerGemspec       PackageManager = "gemspec"
+	PackageManagerCargo         PackageManager = "cargo"
+	PackageManagerSBOM          PackageManager = "sbom"
+	PackageManagerSnap          PackageManager = "snap"
+	PackageManagerCocoaPods     PackageManager = "cocoapods"
+	PackageManagerSwiftPM       PackageManager = "swiftpm"
+	PackageManagerTerraform     PackageManager = "terraform"
+	PackageManagerWordPress     PackageManager = "wordpress"
+	PackageManagerSetupPy       PackageManager = "setuppy"
+	PackageManagerOther         PackageManager = "other"
+	PackageManagerSBT           PackageManager = "sbt"
+	PackageManagerMultiple      PackageManager = "multiple"
 )
 
 type packageManagerInfo struct {
@@ -69,7 +69,7 @@ type packageManagerInfo struct {
 	Languages []Language
 }
 
-var packageManagerInfoByID = [...]packageManagerInfo{
+var packageManagerInfoByID = map[PackageManager]packageManagerInfo{
 	PackageManagerUnknown:       {},
 	PackageManagerNPM:           {Name: "npm", Ecosystem: EcosystemNPM, Languages: []Language{LanguageJavaScript, LanguageTypeScript}},
 	PackageManagerPNPM:          {Name: "pnpm", Ecosystem: EcosystemNPM, Languages: []Language{LanguageJavaScript, LanguageTypeScript}},
@@ -117,6 +117,7 @@ var packageManagerInfoByID = [...]packageManagerInfo{
 	PackageManagerSetupPy:       {Name: "setuppy", Ecosystem: EcosystemPython, Languages: []Language{LanguagePython}},
 	PackageManagerOther:         {Name: "other", Ecosystem: EcosystemOther},
 	PackageManagerSBT:           {Name: "sbt", Ecosystem: EcosystemScala, Languages: []Language{LanguageScala, LanguageJava}},
+	PackageManagerMultiple:      {Name: "multiple"},
 }
 
 var allPackageManagers = []PackageManager{
@@ -171,7 +172,7 @@ var allPackageManagers = []PackageManager{
 var packageManagerByName = map[string]PackageManager{}
 
 func init() {
-	for _, manager := range allPackageManagers {
+	for _, manager := range append(append([]PackageManager(nil), allPackageManagers...), PackageManagerMultiple) {
 		info := packageManagerInfoByID[manager]
 		packageManagerByName[info.Name] = manager
 		for _, alias := range info.Aliases {
@@ -181,7 +182,8 @@ func init() {
 }
 
 func (p PackageManager) valid() bool {
-	return p > PackageManagerUnknown && p < PackageManagerCount
+	_, ok := packageManagerInfoByID[p]
+	return ok && p != PackageManagerUnknown
 }
 
 // String returns the canonical package-manager name.
@@ -192,7 +194,7 @@ func (p PackageManager) String() string {
 // Name returns the canonical package-manager name.
 func (p PackageManager) Name() string {
 	if !p.valid() {
-		return ""
+		return string(p)
 	}
 	return packageManagerInfoByID[p].Name
 }

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -37,15 +37,6 @@ func (c FailOnConstraint) String() string {
 	return string(c.Kind) + ":" + c.Value
 }
 
-// Severity values accepted by the severity constraint kind.
-const (
-	SeverityAny      = "any"
-	SeverityLow      = "low"
-	SeverityMedium   = "medium"
-	SeverityHigh     = "high"
-	SeverityCritical = "critical"
-)
-
 // ReachabilityValueReachable constraint values currently supported.
 const (
 	ReachabilityValueReachable = "reachable"
@@ -56,7 +47,7 @@ const (
 	ExploitabilityValueExploitable = "exploitable"
 )
 
-var validSeverityValues = map[string]struct{}{
+var validSeverityValues = map[SeverityLevel]struct{}{
 	SeverityAny:      {},
 	SeverityLow:      {},
 	SeverityMedium:   {},
@@ -78,18 +69,19 @@ var validExploitabilityValues = map[string]struct{}{
 // ExploitabilityConstraint. Empty input returns the zero value with no error
 // so callers can treat empty repeats as no-ops.
 func ParseFailOn(raw string) (FailOnConstraint, error) {
-	normalized := strings.ToLower(strings.TrimSpace(raw))
-	if normalized == "" {
+	normalized := ParseSeverityLevel(raw)
+	if normalized == SeverityUnknown && strings.TrimSpace(raw) == "" {
 		return FailOnConstraint{}, nil
 	}
 	if _, ok := validSeverityValues[normalized]; ok {
-		return FailOnConstraint{Kind: SeverityConstraint, Value: normalized}, nil
+		return FailOnConstraint{Kind: SeverityConstraint, Value: string(normalized)}, nil
 	}
-	if _, ok := validReachabilityValues[normalized]; ok {
-		return FailOnConstraint{Kind: ReachabilityConstraint, Value: normalized}, nil
+	rawNormalized := strings.ToLower(strings.TrimSpace(raw))
+	if _, ok := validReachabilityValues[rawNormalized]; ok {
+		return FailOnConstraint{Kind: ReachabilityConstraint, Value: rawNormalized}, nil
 	}
-	if _, ok := validExploitabilityValues[normalized]; ok {
-		return FailOnConstraint{Kind: ExploitabilityConstraint, Value: normalized}, nil
+	if _, ok := validExploitabilityValues[rawNormalized]; ok {
+		return FailOnConstraint{Kind: ExploitabilityConstraint, Value: rawNormalized}, nil
 	}
 	return FailOnConstraint{}, fmt.Errorf("unsupported --fail-on value %q (accepted: any, low, medium, high, critical, reachable, exploitable)", raw)
 }
@@ -118,15 +110,15 @@ func ParseFailOnList(raws []string) ([]FailOnConstraint, error) {
 
 // SeverityRank returns a comparable rank for a severity string.
 // Unknown / empty values rank below "low".
-func SeverityRank(severity string) int {
-	switch strings.ToLower(strings.TrimSpace(severity)) {
-	case "critical":
+func SeverityRank(severity SeverityLevel) int {
+	switch ParseSeverityLevel(string(severity)) {
+	case SeverityCritical:
 		return 4
-	case "high":
+	case SeverityHigh:
 		return 3
-	case "medium":
+	case SeverityMedium:
 		return 2
-	case "low":
+	case SeverityLow:
 		return 1
 	default:
 		return 0
@@ -135,9 +127,9 @@ func SeverityRank(severity string) int {
 
 // SeverityMeets reports whether candidate's severity is at or above
 // threshold. Threshold "any" matches every candidate, including unknown.
-func SeverityMeets(candidate, threshold string) bool {
-	t := strings.ToLower(strings.TrimSpace(threshold))
-	if t == SeverityAny || t == "" {
+func SeverityMeets(candidate SeverityLevel, threshold string) bool {
+	t := ParseSeverityLevel(threshold)
+	if t == SeverityAny || strings.TrimSpace(threshold) == "" {
 		return true
 	}
 	return SeverityRank(candidate) >= SeverityRank(t)

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -72,7 +72,7 @@ func TestSeverityMeets(t *testing.T) {
 		{"unknown", "low", false},
 	}
 	for _, tc := range cases {
-		if got := SeverityMeets(tc.candidate, tc.threshold); got != tc.want {
+		if got := SeverityMeets(ParseSeverityLevel(tc.candidate), tc.threshold); got != tc.want {
 			t.Errorf("SeverityMeets(%q, %q) = %v, want %v", tc.candidate, tc.threshold, got, tc.want)
 		}
 	}
@@ -80,20 +80,20 @@ func TestSeverityMeets(t *testing.T) {
 
 func TestMatchesConstraints(t *testing.T) {
 	highReachable := Vulnerability{
-		ParsedSeverity: "high",
+		ParsedSeverity: SeverityHigh,
 		Reachability:   &Reachability{Status: ReachabilityReachable},
 	}
 	highUnreachable := Vulnerability{
-		ParsedSeverity: "high",
+		ParsedSeverity: SeverityHigh,
 		Reachability:   &Reachability{Status: ReachabilityUnreachable},
 	}
-	highNoReach := Vulnerability{ParsedSeverity: "high"}
+	highNoReach := Vulnerability{ParsedSeverity: SeverityHigh}
 	lowReachable := Vulnerability{
-		ParsedSeverity: "low",
+		ParsedSeverity: SeverityLow,
 		Reachability:   &Reachability{Status: ReachabilityReachable},
 	}
 	highExploitable := Vulnerability{
-		ParsedSeverity: "high",
+		ParsedSeverity: SeverityHigh,
 		KnownExploited: []KnownExploited{{CVE: "CVE-2024-1234"}},
 	}
 

--- a/sdk/purl.go
+++ b/sdk/purl.go
@@ -82,9 +82,9 @@ func buildPackageURLFallback(purlType, namespace, name, version string) string {
 }
 
 // PackageURLTypeForValues maps ecosystem/build-system values to a package-url type.
-func PackageURLTypeForValues(values ...string) string {
+func PackageURLTypeForValues(values ...any) string {
 	for _, value := range values {
-		normalized := strings.ToLower(strings.TrimSpace(value))
+		normalized := strings.ToLower(strings.TrimSpace(packageURLTypeValue(value)))
 		switch normalized {
 		case "nuget":
 			return "nuget"
@@ -113,7 +113,7 @@ func PackageURLTypeForValues(values ...string) string {
 		}
 	}
 	for _, value := range values {
-		normalized := strings.ToLower(strings.TrimSpace(value))
+		normalized := strings.ToLower(strings.TrimSpace(packageURLTypeValue(value)))
 		if normalized == "" {
 			continue
 		}
@@ -127,13 +127,30 @@ func PackageURLTypeForValues(values ...string) string {
 	return "generic"
 }
 
+func packageURLTypeValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case Ecosystem:
+		return string(v)
+	case PackageManager:
+		return v.Name()
+	case PackageType:
+		return string(v)
+	case Language:
+		return string(v)
+	default:
+		return ""
+	}
+}
+
 // CanonicalPackageURLFromParts returns the canonical package URL derived from
 // raw identity fields. existingPURL takes precedence when it canonicalizes.
-func CanonicalPackageURLFromParts(existingPURL, ecosystem, buildSystem, typ, org, name, version string) string {
+func CanonicalPackageURLFromParts(existingPURL string, ecosystem Ecosystem, packageManager PackageManager, typ PackageType, org, name, version string) string {
 	if canonical := CanonicalizePackageURL(existingPURL); canonical != "" {
 		return canonical
 	}
-	if strings.EqualFold(strings.TrimSpace(typ), "manifest") {
+	if typ == PackageTypeManifest {
 		return ""
 	}
 
@@ -142,7 +159,7 @@ func CanonicalPackageURLFromParts(existingPURL, ecosystem, buildSystem, typ, org
 		return ""
 	}
 
-	purlType := PackageURLTypeForValues(ecosystem, buildSystem, typ)
+	purlType := PackageURLTypeForValues(ecosystem, packageManager, typ)
 	namespace := strings.TrimSpace(org)
 	if purlType == "golang" && namespace == "" {
 		parts := strings.Split(strings.ReplaceAll(name, "\\", "/"), "/")
@@ -160,7 +177,7 @@ func CanonicalPackageURLFromDependency(dep *Dependency) string {
 	if dep == nil {
 		return ""
 	}
-	return CanonicalPackageURLFromParts(dep.PURL, dep.Ecosystem, dep.BuildSystem, dep.Type, dep.Org, dep.Name, dep.Version)
+	return CanonicalPackageURLFromParts(dep.PURL, dep.Ecosystem, dep.PackageManager, dep.Type, dep.Org, dep.Name, dep.Version)
 }
 
 // PackageURLBase strips version and qualifiers from a package URL.

--- a/sdk/purl.go
+++ b/sdk/purl.go
@@ -147,20 +147,33 @@ func packageURLTypeValue(value any) string {
 // CanonicalPackageURLFromParts returns the canonical package URL derived from
 // raw identity fields. existingPURL takes precedence when it canonicalizes.
 func CanonicalPackageURLFromParts(existingPURL string, ecosystem Ecosystem, packageManager PackageManager, typ PackageType, org, name, version string) string {
-	if canonical := CanonicalizePackageURL(existingPURL); canonical != "" {
+	return (Coordinates{
+		PURL:           existingPURL,
+		Ecosystem:      ecosystem,
+		PackageManager: packageManager,
+		Type:           typ,
+		Org:            org,
+		Name:           name,
+		Version:        version,
+	}).CanonicalPURL()
+}
+
+// CanonicalPURL returns the canonical package URL for the identity.
+func (i Coordinates) CanonicalPURL() string {
+	if canonical := CanonicalizePackageURL(i.PURL); canonical != "" {
 		return canonical
 	}
-	if typ == PackageTypeManifest {
+	if i.Type == PackageTypeManifest {
 		return ""
 	}
 
-	name = strings.TrimSpace(name)
+	name := strings.TrimSpace(i.Name)
 	if name == "" {
 		return ""
 	}
 
-	purlType := PackageURLTypeForValues(ecosystem, packageManager, typ)
-	namespace := strings.TrimSpace(org)
+	purlType := PackageURLTypeForValues(i.Ecosystem, i.PackageManager, i.Type)
+	namespace := strings.TrimSpace(i.Org)
 	if purlType == "golang" && namespace == "" {
 		parts := strings.Split(strings.ReplaceAll(name, "\\", "/"), "/")
 		if len(parts) > 1 {
@@ -169,7 +182,7 @@ func CanonicalPackageURLFromParts(existingPURL string, ecosystem Ecosystem, pack
 		}
 	}
 
-	return BuildPackageURL(purlType, namespace, name, version)
+	return BuildPackageURL(purlType, namespace, name, i.Version)
 }
 
 // CanonicalPackageURLFromDependency returns the canonical package URL for dep.
@@ -177,7 +190,7 @@ func CanonicalPackageURLFromDependency(dep *Dependency) string {
 	if dep == nil {
 		return ""
 	}
-	return CanonicalPackageURLFromParts(dep.PURL, dep.Ecosystem, dep.PackageManager, dep.Type, dep.Org, dep.Name, dep.Version)
+	return dep.CanonicalPURL()
 }
 
 // PackageURLBase strips version and qualifiers from a package URL.

--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -25,6 +25,9 @@ func (r *PackageRegistry) Add(pkg *Package) *Package {
 	if r.byPURL == nil {
 		r.byPURL = make(map[string]*Package)
 	}
+	if pkg.ID == "" {
+		pkg.ID = pkg.PURL
+	}
 	if existing, ok := r.byPURL[pkg.PURL]; ok {
 		existing.MergeFrom(pkg)
 		return existing
@@ -47,7 +50,7 @@ func (r *PackageRegistry) Ensure(purl string) *Package {
 	if existing, ok := r.byPURL[purl]; ok {
 		return existing
 	}
-	stored := &Package{PURL: purl}
+	stored := &Package{Coordinates: Coordinates{PURL: purl}, ID: purl}
 	r.byPURL[purl] = stored
 	r.order = append(r.order, purl)
 	return stored

--- a/sdk/registry_test.go
+++ b/sdk/registry_test.go
@@ -1,0 +1,24 @@
+package sdk
+
+import "testing"
+
+func TestPackageRegistryUsesPURLAsDefaultPackageID(t *testing.T) {
+	const purl = "pkg:npm/react@18.2.0"
+	registry := NewPackageRegistry()
+
+	ensured := registry.Ensure(purl)
+	if ensured == nil {
+		t.Fatal("Ensure() returned nil")
+	}
+	if ensured.ID != purl {
+		t.Fatalf("Ensure() package ID = %q, want %q", ensured.ID, purl)
+	}
+
+	added := registry.Add(&Package{Coordinates: Coordinates{PURL: purl}})
+	if added == nil {
+		t.Fatal("Add() returned nil")
+	}
+	if added.ID != purl {
+		t.Fatalf("Add() package ID = %q, want %q", added.ID, purl)
+	}
+}

--- a/sdk/scope_filter_test.go
+++ b/sdk/scope_filter_test.go
@@ -58,8 +58,8 @@ func TestFilterGraphByScope(t *testing.T) {
 func TestFilterDetectionResultByScope_FiltersEntryPackages(t *testing.T) {
 	depsGraph := New()
 	root := NewDependency(Dependency{Name: "app", Version: "1.0.0"})
-	runtimeDep := NewDependency(Dependency{Ecosystem: "npm", Name: "react", Version: "18.2.0", Scopes: ScopesOf(ScopeRuntime)})
-	devDep := NewDependency(Dependency{Ecosystem: "npm", Name: "vitest", Version: "2.0.0", Scopes: ScopesOf(ScopeDevelopment)})
+	runtimeDep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "react", Version: "18.2.0", Scopes: ScopesOf(ScopeRuntime)})
+	devDep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "vitest", Version: "2.0.0", Scopes: ScopesOf(ScopeDevelopment)})
 	for _, pkg := range []*Dependency{root, runtimeDep, devDep} {
 		if err := depsGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -115,7 +115,7 @@ func TestFilterDetectionResultByScope_RepresentativeParserOutputs(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			result := DetectionResult{
 				Graphs: &GraphContainer{Entries: []GraphEntry{{
-					Graph:    representativeScopedGraph(t, tt.ecosystem),
+					Graph:    representativeScopedGraph(t, Ecosystem(tt.ecosystem)),
 					Manifest: ManifestMetadata{Path: tt.manifest},
 				}}},
 			}
@@ -134,12 +134,12 @@ func TestFilterDetectionResultByScope_RepresentativeParserOutputs(t *testing.T) 
 	}
 }
 
-func representativeScopedGraph(t *testing.T, ecosystem string) *Graph {
+func representativeScopedGraph(t *testing.T, ecosystem Ecosystem) *Graph {
 	t.Helper()
 	graph := New()
-	root := NewDependency(Dependency{Ecosystem: ecosystem, Name: ecosystem + "-app", Version: "1.0.0"})
-	runtimeDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: ecosystem + "-runtime", Version: "1.0.0", Scopes: ScopesOf(ScopeRuntime)})
-	devDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: ecosystem + "-dev", Version: "1.0.0", Scopes: ScopesOf(ScopeDevelopment)})
+	root := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-app", Version: "1.0.0"})
+	runtimeDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-runtime", Version: "1.0.0", Scopes: ScopesOf(ScopeRuntime)})
+	devDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-dev", Version: "1.0.0", Scopes: ScopesOf(ScopeDevelopment)})
 	for _, dep := range []*Dependency{root, runtimeDep, devDep} {
 		if err := graph.AddNode(dep); err != nil {
 			t.Fatalf("add %q: %v", dep.ID, err)

--- a/sdk/scope_filter_test.go
+++ b/sdk/scope_filter_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestFilterGraphByScope(t *testing.T) {
 	depsGraph := New()
-	root := NewDependency(Dependency{Name: "app", Version: "1.0.0"})
-	runtimeDep := NewDependency(Dependency{Name: "react", Version: "18.2.0", Scopes: ScopesOf(ScopeRuntime)})
-	devDep := NewDependency(Dependency{Name: "vitest", Version: "2.0.0", Scopes: ScopesOf(ScopeDevelopment)})
-	sharedDep := NewDependency(Dependency{Name: "shared", Version: "1.0.0", Scopes: ScopesOf(ScopeDevelopment, ScopeRuntime)})
+	root := NewDependency(Dependency{Coordinates: Coordinates{Name: "app", Version: "1.0.0"}})
+	runtimeDep := NewDependency(Dependency{Coordinates: Coordinates{Name: "react", Version: "18.2.0"}, Scopes: ScopesOf(ScopeRuntime)})
+	devDep := NewDependency(Dependency{Coordinates: Coordinates{Name: "vitest", Version: "2.0.0"}, Scopes: ScopesOf(ScopeDevelopment)})
+	sharedDep := NewDependency(Dependency{Coordinates: Coordinates{Name: "shared", Version: "1.0.0"}, Scopes: ScopesOf(ScopeDevelopment, ScopeRuntime)})
 	for _, pkg := range []*Dependency{root, runtimeDep, devDep, sharedDep} {
 		if err := depsGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -57,9 +57,9 @@ func TestFilterGraphByScope(t *testing.T) {
 
 func TestFilterDetectionResultByScope_FiltersEntryPackages(t *testing.T) {
 	depsGraph := New()
-	root := NewDependency(Dependency{Name: "app", Version: "1.0.0"})
-	runtimeDep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "react", Version: "18.2.0", Scopes: ScopesOf(ScopeRuntime)})
-	devDep := NewDependency(Dependency{Ecosystem: EcosystemNPM, Name: "vitest", Version: "2.0.0", Scopes: ScopesOf(ScopeDevelopment)})
+	root := NewDependency(Dependency{Coordinates: Coordinates{Name: "app", Version: "1.0.0"}})
+	runtimeDep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "react", Version: "18.2.0"}, Scopes: ScopesOf(ScopeRuntime)})
+	devDep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: EcosystemNPM, Name: "vitest", Version: "2.0.0"}, Scopes: ScopesOf(ScopeDevelopment)})
 	for _, pkg := range []*Dependency{root, runtimeDep, devDep} {
 		if err := depsGraph.AddNode(pkg); err != nil {
 			t.Fatalf("add package %q: %v", pkg.ID, err)
@@ -77,8 +77,8 @@ func TestFilterDetectionResultByScope_FiltersEntryPackages(t *testing.T) {
 			Graph:    depsGraph,
 			Manifest: ManifestMetadata{Path: "package-lock.json"},
 			Packages: []*Package{
-				{PURL: BuildPackageURL("npm", "", "react", "18.2.0")},
-				{PURL: BuildPackageURL("npm", "", "vitest", "2.0.0")},
+				{Coordinates: Coordinates{PURL: BuildPackageURL("npm", "", "react", "18.2.0")}},
+				{Coordinates: Coordinates{PURL: BuildPackageURL("npm", "", "vitest", "2.0.0")}},
 			},
 		}}},
 	}
@@ -137,9 +137,9 @@ func TestFilterDetectionResultByScope_RepresentativeParserOutputs(t *testing.T) 
 func representativeScopedGraph(t *testing.T, ecosystem Ecosystem) *Graph {
 	t.Helper()
 	graph := New()
-	root := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-app", Version: "1.0.0"})
-	runtimeDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-runtime", Version: "1.0.0", Scopes: ScopesOf(ScopeRuntime)})
-	devDep := NewDependency(Dependency{Ecosystem: ecosystem, Name: string(ecosystem) + "-dev", Version: "1.0.0", Scopes: ScopesOf(ScopeDevelopment)})
+	root := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: ecosystem, Name: string(ecosystem) + "-app", Version: "1.0.0"}})
+	runtimeDep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: ecosystem, Name: string(ecosystem) + "-runtime", Version: "1.0.0"}, Scopes: ScopesOf(ScopeRuntime)})
+	devDep := NewDependency(Dependency{Coordinates: Coordinates{Ecosystem: ecosystem, Name: string(ecosystem) + "-dev", Version: "1.0.0"}, Scopes: ScopesOf(ScopeDevelopment)})
 	for _, dep := range []*Dependency{root, runtimeDep, devDep} {
 		if err := graph.AddNode(dep); err != nil {
 			t.Fatalf("add %q: %v", dep.ID, err)

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -1,5 +1,7 @@
 package sdk
 
+import "strings"
+
 // FindingKind categorizes audit findings by the underlying concern the
 // auditor is reporting on. Each built-in auditor emits findings of exactly
 // one kind:
@@ -27,26 +29,141 @@ const (
 	FindingDispositionWarn FindingDisposition = "warn"
 )
 
+// SeverityLevel is Bomly's normalized severity band.
+type SeverityLevel string
+
+const (
+	// SeverityUnknown indicates that no severity could be determined.
+	SeverityUnknown SeverityLevel = "unknown"
+	// SeverityNA indicates that severity does not apply to the finding kind.
+	SeverityNA SeverityLevel = "n/a"
+	// SeverityLow indicates a low-severity issue.
+	SeverityLow SeverityLevel = "low"
+	// SeverityMedium indicates a medium-severity issue.
+	SeverityMedium SeverityLevel = "medium"
+	// SeverityHigh indicates a high-severity issue.
+	SeverityHigh SeverityLevel = "high"
+	// SeverityCritical indicates a critical-severity issue.
+	SeverityCritical SeverityLevel = "critical"
+	// SeverityAny is a policy threshold that matches every severity.
+	SeverityAny SeverityLevel = "any"
+)
+
+// ParseSeverityLevel normalizes a severity string into a SeverityLevel.
+func ParseSeverityLevel(value string) SeverityLevel {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(SeverityCritical):
+		return SeverityCritical
+	case string(SeverityHigh):
+		return SeverityHigh
+	case string(SeverityMedium):
+		return SeverityMedium
+	case string(SeverityLow):
+		return SeverityLow
+	case string(SeverityNA):
+		return SeverityNA
+	case string(SeverityAny):
+		return SeverityAny
+	case "", string(SeverityUnknown):
+		return SeverityUnknown
+	default:
+		return SeverityLevel(strings.ToLower(strings.TrimSpace(value)))
+	}
+}
+
+// SeverityType identifies the OSV severity vector family.
+type SeverityType string
+
+const (
+	SeverityTypeCVSSV2  SeverityType = "CVSS_V2"
+	SeverityTypeCVSSV3  SeverityType = "CVSS_V3"
+	SeverityTypeCVSSV31 SeverityType = "CVSS_V31"
+	SeverityTypeCVSSV4  SeverityType = "CVSS_V4"
+)
+
+// ReferenceType identifies the role of a vulnerability reference URL.
+type ReferenceType string
+
+const (
+	ReferenceTypeAdvisory   ReferenceType = "advisory"
+	ReferenceTypeDataSource ReferenceType = "data_source"
+)
+
+// FixState identifies whether a vulnerability has a known fix.
+type FixState string
+
+const (
+	FixStateUnknown  FixState = "unknown"
+	FixStateFixed    FixState = "fixed"
+	FixStateNotFixed FixState = "not-fixed"
+	FixStateWontFix  FixState = "wont-fix"
+)
+
+// FixAvailableKind identifies why a fix version was selected.
+type FixAvailableKind string
+
+const (
+	FixAvailableFirstObserved FixAvailableKind = "first-observed"
+)
+
+// VEXStatus identifies a finding's VEX disposition.
+type VEXStatus string
+
+const (
+	VEXStatusAffected           VEXStatus = "affected"
+	VEXStatusNotAffected        VEXStatus = "not_affected"
+	VEXStatusFixed              VEXStatus = "fixed"
+	VEXStatusUnderInvestigation VEXStatus = "under_investigation"
+)
+
+// RiskBand is the normalized label for a risk score range.
+type RiskBand string
+
+const (
+	RiskBandUnknown  RiskBand = "unknown"
+	RiskBandLow      RiskBand = "low"
+	RiskBandMedium   RiskBand = "medium"
+	RiskBandHigh     RiskBand = "high"
+	RiskBandCritical RiskBand = "critical"
+)
+
+// SymbolKind identifies a vulnerable or reachable code symbol kind.
+type SymbolKind string
+
+const (
+	SymbolKindFunction SymbolKind = "function"
+	SymbolKindMethod   SymbolKind = "method"
+)
+
 // CVSSScore captures one CVSS vector and score.
 type CVSSScore struct {
-	Vector  string  `json:"vector,omitempty"`
-	Score   float64 `json:"score,omitempty"`
-	Version string  `json:"version,omitempty"`
-	Source  string  `json:"source,omitempty"`
+	Vector  string       `json:"vector,omitempty"`
+	Score   float64      `json:"score,omitempty"`
+	Version SeverityType `json:"version,omitempty"`
+	Source  string       `json:"source,omitempty"`
 }
 
 // Reference is a URL and type pair.
 type Reference struct {
-	URL  string `json:"url,omitempty"`
-	Type string `json:"type,omitempty"`
+	URL  string        `json:"url,omitempty"`
+	Type ReferenceType `json:"type,omitempty"`
 }
 
 // FixAvailable captures one version/date/kind tuple for an available fix.
 type FixAvailable struct {
-	Version string `json:"version,omitempty"`
-	Date    string `json:"date,omitempty"`
-	Kind    string `json:"kind,omitempty"`
+	Version string           `json:"version,omitempty"`
+	Date    string           `json:"date,omitempty"`
+	Kind    FixAvailableKind `json:"kind,omitempty"`
 }
+
+// VersionRangeType identifies the OSV affected range scheme.
+type VersionRangeType string
+
+const (
+	VersionRangeTypeSemver    VersionRangeType = "SEMVER"
+	VersionRangeTypeEcosystem VersionRangeType = "ECOSYSTEM"
+	VersionRangeTypeGit       VersionRangeType = "GIT"
+)
 
 // EPSSScore captures Exploit Prediction Scoring System data for a vulnerability.
 type EPSSScore struct {
@@ -101,7 +218,7 @@ func (p SourcePosition) IsZero() bool {
 // analyzers use it to know which symbols to look for in app code.
 type AffectedSymbol struct {
 	Symbol     string          `json:"symbol,omitempty"`
-	Kind       string          `json:"kind,omitempty"`
+	Kind       SymbolKind      `json:"kind,omitempty"`
 	Package    string          `json:"package,omitempty"`
 	Module     string          `json:"module,omitempty"`
 	Definition *SourcePosition `json:"definition,omitempty"`
@@ -230,7 +347,7 @@ func (r *Reachability) Clone() *Reachability {
 // Severity is one OSV-format severity entry (a CVSS type + vector/score).
 type Severity struct {
 	// Type is the OSV severity type, e.g. "CVSS_V3", "CVSS_V4".
-	Type string `json:"type,omitempty"`
+	Type SeverityType `json:"type,omitempty"`
 	// Score is the vector string or numeric score for Type.
 	Score string `json:"score,omitempty"`
 }
@@ -246,9 +363,9 @@ type RangeEvent struct {
 // VersionRange is one OSV affected version range.
 type VersionRange struct {
 	// Type is the OSV range type: "SEMVER", "ECOSYSTEM", or "GIT".
-	Type   string       `json:"type,omitempty"`
-	Repo   string       `json:"repo,omitempty"`
-	Events []RangeEvent `json:"events,omitempty"`
+	Type   VersionRangeType `json:"type,omitempty"`
+	Repo   string           `json:"repo,omitempty"`
+	Events []RangeEvent     `json:"events,omitempty"`
 }
 
 // Affected describes one OSV affected entry: the version ranges and explicit
@@ -288,7 +405,7 @@ type Vulnerability struct {
 	Namespace            string           `json:"namespace,omitempty"`
 	Title                string           `json:"title,omitempty"`
 	Reasons              []string         `json:"reasons,omitempty"`
-	ParsedSeverity       string           `json:"parsed_severity,omitempty"`
+	ParsedSeverity       SeverityLevel    `json:"parsed_severity,omitempty"`
 	SeveritySource       string           `json:"severity_source,omitempty"`
 	CVSS                 []CVSSScore      `json:"cvss,omitempty"`
 	EPSS                 []EPSSScore      `json:"epss,omitempty"`
@@ -296,7 +413,7 @@ type Vulnerability struct {
 	KEVExploited         bool             `json:"kev_exploited,omitempty"`
 	KnownExploited       []KnownExploited `json:"known_exploited,omitempty"`
 	RiskScore            float64          `json:"risk_score,omitempty"`
-	FixState             string           `json:"fix_state,omitempty"`
+	FixState             FixState         `json:"fix_state,omitempty"`
 	FixedIn              string           `json:"fixed_in,omitempty"`
 	FixedVersions        []string         `json:"fixed_versions,omitempty"`
 	FixAvailable         []FixAvailable   `json:"fix_available,omitempty"`
@@ -385,12 +502,12 @@ type Finding struct {
 	ID               string             `json:"id"`
 	Kind             FindingKind        `json:"kind"`
 	Title            string             `json:"title,omitempty"`
-	Severity         string             `json:"severity,omitempty"`
+	Severity         SeverityLevel      `json:"severity,omitempty"`
 	Disposition      FindingDisposition `json:"disposition,omitempty"`
 	Reasons          []string           `json:"reasons,omitempty"`
 	Source           string             `json:"source,omitempty"`
 	Auditor          string             `json:"auditor,omitempty"`
-	VexStatus        string             `json:"vex_status,omitempty"`
+	VexStatus        VEXStatus          `json:"vex_status,omitempty"`
 	VEXJustification string             `json:"vex_justification,omitempty"`
 	// PackageRef is the PURL of the offending package in the registry.
 	PackageRef string `json:"package_ref,omitempty"`
@@ -414,7 +531,7 @@ func (f Finding) Clone() Finding {
 type RiskScore struct {
 	PackageRef string         `json:"package_ref,omitempty"`
 	Score      int            `json:"score"`
-	Band       string         `json:"band,omitempty"`
+	Band       RiskBand       `json:"band,omitempty"`
 	Signals    map[string]any `json:"signals,omitempty"`
 }
 

--- a/test/smoke/fixture_compile_test.go
+++ b/test/smoke/fixture_compile_test.go
@@ -57,11 +57,13 @@ func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.Det
 		return nil, err
 	}
 	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: sdk.EcosystemGo,
-		Name:      moduleName,
-		Version:   "v0.0.0",
-		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
-		FoundBy:   pluginID,
+		Coordinates: sdk.Coordinates{
+			Ecosystem: sdk.EcosystemGo,
+			Name:      moduleName,
+			Version:   "v0.0.0",
+			PURL:      "pkg:golang/" + moduleName + "@v0.0.0",
+		},
+		FoundBy: pluginID,
 	})
 	graph := sdk.New()
 	if err := graph.AddNode(pkg); err != nil {

--- a/test/smoke/fixture_compile_test.go
+++ b/test/smoke/fixture_compile_test.go
@@ -57,7 +57,7 @@ func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.Det
 		return nil, err
 	}
 	pkg := sdk.NewDependency(sdk.Dependency{
-		Ecosystem: string(sdk.EcosystemGo),
+		Ecosystem: sdk.EcosystemGo,
 		Name:      moduleName,
 		Version:   "v0.0.0",
 		PURL:      "pkg:golang/" + moduleName + "@v0.0.0",


### PR DESCRIPTION
## Summary

- Add string-backed SDK enum types for finite/semi-finite fields such as severity, OSV range/reference metadata, fix state, VEX status, risk bands, package identity metadata, license/digest provenance, and manifest kinds.
- Rename SDK `BuildSystem` fields to `PackageManager`, including the JSON field change from `build_system` to `package_manager`.
- Keep enum definitions with their owning SDK domain files instead of a catch-all `types.go` file.
- Convert `PackageManager` to a string-backed typed value while keeping package-manager values readable and stable.
- Propagate typed fields through detectors, analyzers, matchers, SBOM transforms, engine consolidation/diff, command output DTOs, SARIF, TUI, MCP fix targets, plugin payload tests, and smoke fixtures.
- Add a separate second commit that embeds shared `Coordinates` in `Dependency` and `Package`, keeping the model cleanup easy to revert independently from the enum sweep.
- Add `Package.ID` for registry/database identifiers and default registry-created package IDs to their PURL when no explicit ID is provided.

## Model note

`Dependency` and `Package` remain distinct types. They intentionally represent different lifecycle stages: manifest-scoped graph nodes versus matched registry records. Both now embed the same `Coordinates` value for shared coordinate fields (`purl`, `ecosystem`, `package_manager`, `type`, `org`, `name`, `version`, and `language`), which keeps JSON output flat while centralizing coordinate behavior such as qualified names, stable IDs, identity keys, and canonical PURLs.

`Dependency.ID` continues to identify graph nodes. `Package.ID` identifies package registry records and may be a database ID, a PURL, or another stable registry key. The in-memory `PackageRegistry` still keys by PURL and backfills `Package.ID` from `Package.PURL` when callers do not provide a more specific ID.

## Impact

The SDK now catches many formerly raw string assignments/comparisons at compile time. External/open vocabularies remain supported through explicit typed casts or parser/normalization boundaries, so serialized enum values stay readable and stable. The `BuildSystem` rename and embedded coordinates model are intentionally breaking per the SDK cleanup goal.

## Validation

- `make fmt-check`
- `go test ./...`
- `make generate`
- `make test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adopted a unified coordinates model and strongly-typed enums for ecosystems, package managers, severities, license/types and related metadata — resulting in more consistent IDs, PURL handling, and normalized labels across reports, UI, and exports.
* **Bug Fixes**
  * Improved pyproject detection to recognize PDM when Poetry/uv tables are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->