### PR TITLE
feat: compact, colorful text output for scan, explain, diff, and mcp serve

### DIFF
--- a/cmd/bomly/main.go
+++ b/cmd/bomly/main.go
@@ -12,7 +12,7 @@ var version = "0.13.0"
 
 func main() {
 	if err := cli.Execute(version); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "\n\n%s: %v", exit.ErrorPrefix(err), err)
+		_, _ = fmt.Fprintf(os.Stderr, "\n\n%s: %v\n", exit.ErrorPrefix(err), err)
 		os.Exit(exit.Code(err))
 	}
 }

--- a/docs/schemas/explain.md
+++ b/docs/schemas/explain.md
@@ -138,6 +138,7 @@ Complete reference for the `bomly explain` JSON output.
 |-------|------|-------------|
 | `project` | [`ProjectDescriptor`](#projectdescriptor) | |
 | `detector` | `string` | |
+| `package_manager` | `string` | |
 | `dependency` | [`PackageRef`](#packageref) | |
 | `paths` | Array<[`DependencyPath`](#dependencypath)> | |
 | `findings` | Array<[`AuditFinding`](#auditfinding)> | |

--- a/docs/schemas/explain.schema.json
+++ b/docs/schemas/explain.schema.json
@@ -3558,6 +3558,9 @@
             },
             "type": "array"
           },
+          "package_manager": {
+            "type": "string"
+          },
           "paths": {
             "items": {
               "properties": {

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/output"
 )
 
-func TestRenderDiffTextIncludesAuditOutcomeWithoutChanges(t *testing.T) {
+func TestRenderDiffTextShowsFindingsSummaryLine(t *testing.T) {
 	payload := output.DiffResponse{
 		Comparison: output.DiffComparison{Base: "main", Head: "feature"},
 		Summary: output.DiffSummary{
@@ -30,17 +30,39 @@ func TestRenderDiffTextIncludesAuditOutcomeWithoutChanges(t *testing.T) {
 		t.Fatalf("renderDiffText() error = %v", err)
 	}
 
-	report := out.String()
-	for _, want := range []string{
-		"Dependency diff main -> feature",
+	report := render.StripANSI(out.String())
+	if !strings.Contains(report, "No new findings introduced.") {
+		t.Fatalf("expected findings summary line, got:\n%s", report)
+	}
+	// Removed sections should not appear
+	for _, absent := range []string{
+		"Dependency diff",
 		"Policy Evaluation",
-		"Current findings: 1 total (1 high).",
-		"Change summary: 0 introduced, 0 persisted, and 0 resolved findings.",
-		"No policy differences were identified between the base and head dependency sets.",
+		"Current findings:",
+		"Change summary:",
 	} {
-		if !strings.Contains(report, want) {
-			t.Fatalf("expected diff report to contain %q, got:\n%s", want, report)
+		if strings.Contains(report, absent) {
+			t.Fatalf("expected %q to be absent from compact diff output, got:\n%s", absent, report)
 		}
+	}
+}
+
+func TestRenderDiffTextShowsHighFindingsWhenIntroduced(t *testing.T) {
+	payload := output.DiffResponse{
+		Audit: &output.DiffAudit{
+			Introduced: []output.AuditFinding{
+				{ID: "CVE-2024-1234", Severity: "high"},
+				{ID: "CVE-2024-5678", Severity: "critical"},
+			},
+		},
+	}
+	var out bytes.Buffer
+	if err := render.Diff(&out, payload); err != nil {
+		t.Fatalf("render.Diff() error = %v", err)
+	}
+	report := render.StripANSI(out.String())
+	if !strings.Contains(report, "2 new finding(s) introduced.") {
+		t.Fatalf("expected high-severity count line, got:\n%s", report)
 	}
 }
 
@@ -176,34 +198,16 @@ func TestWriteRenderedOutputCreatesParentDirectory(t *testing.T) {
 	}
 }
 
-func TestRenderDiffTextIncludesAuditSections(t *testing.T) {
+func TestRenderDiffTextShowsHighFindingCountWhenIntroducedFindings(t *testing.T) {
 	payload := output.DiffResponse{
 		Comparison: output.DiffComparison{Base: "base.spdx", Head: "head.spdx"},
-		Summary: output.DiffSummary{
-			ChangedManifestCount: 1,
-			AddedPackageCount:    1,
-			RemovedPackageCount:  1,
-		},
 		Audit: &output.DiffAudit{
-			Introduced: []output.AuditFinding{{
-				ID:       "OSV-123",
-				Severity: "high",
-				Package:  output.PackageRef{Name: "react", Version: "18.2.0"},
-				Title:    "Prototype pollution in react",
-				Source:   "osv",
-			}},
-			Persisted: []output.AuditFinding{{
-				ID:       "OSV-234",
-				Severity: "medium",
-				Package:  output.PackageRef{Name: "lodash", Version: "4.17.20"},
-				Source:   "osv",
-			}},
-			Resolved: []output.AuditFinding{{
-				ID:       "OSV-345",
-				Severity: "low",
-				Package:  output.PackageRef{Name: "minimist", Version: "1.2.5"},
-				Source:   "osv",
-			}},
+			Introduced: []output.AuditFinding{
+				{ID: "OSV-123", Severity: "high", Package: output.PackageRef{Name: "react", Version: "18.2.0"}, Title: "Prototype pollution in react"},
+			},
+			Resolved: []output.AuditFinding{
+				{ID: "OSV-345", Severity: "low", Package: output.PackageRef{Name: "minimist", Version: "1.2.5"}},
+			},
 			AuditSummary: &output.AuditSummary{High: 1, Medium: 1, Total: 2},
 		},
 	}
@@ -213,24 +217,14 @@ func TestRenderDiffTextIncludesAuditSections(t *testing.T) {
 		t.Fatalf("renderDiffText() error = %v", err)
 	}
 
-	report := out.String()
-	for _, want := range []string{
-		"Policy Evaluation",
-		"Current findings: 2 total (1 high, 1 medium).",
-		"Change summary: 1 introduced, 1 persisted, and 1 resolved findings.",
-		"Introduced Findings",
-		"Resolved Findings",
-		"OSV-123 react@18.2.0: Prototype pollution in react",
-		"OSV-345 minimist@1.2.5",
-	} {
-		if !strings.Contains(report, want) {
-			t.Fatalf("expected diff report to contain %q, got:\n%s", want, report)
+	report := render.StripANSI(out.String())
+	if !strings.Contains(report, "1 new finding(s) introduced.") {
+		t.Fatalf("expected high-severity summary line, got:\n%s", report)
+	}
+	// Verbose policy sections are not shown in the compact text format.
+	for _, absent := range []string{"Policy Evaluation", "Introduced Findings", "Resolved Findings", "Change summary:"} {
+		if strings.Contains(report, absent) {
+			t.Fatalf("expected %q absent from compact diff output, got:\n%s", absent, report)
 		}
-	}
-	if strings.Contains(report, "Persisted Findings") {
-		t.Fatalf("did not expect persisted findings subsection, got:\n%s", report)
-	}
-	if !strings.Contains(report, "Prototype pollution in react\x1b[0m\n\nResolved Findings") {
-		t.Fatalf("expected a blank line after introduced findings, got:\n%s", report)
 	}
 }

--- a/internal/cli/explain_cmd.go
+++ b/internal/cli/explain_cmd.go
@@ -102,12 +102,13 @@ func newExplainCmd() *cobra.Command {
 			targets := make([]output.ExplainTargetResponse, 0, len(explainResult.Targets))
 			for _, target := range explainResult.Targets {
 				targets = append(targets, output.ExplainTargetResponse{
-					Project:      context.ProjectDescriptorForSubproject(target.Manifest.Subproject),
-					Detector:     target.Manifest.DetectorName,
-					Dependency:   explainPackageRef(target.Dependency),
-					Paths:        explainPathsWithStableIDs(target.Paths),
-					Findings:     output.FindingsFromScan(target.Findings, explainResult.Registry),
-					AuditSummary: output.SummaryFromFindings(target.Findings),
+					Project:        context.ProjectDescriptorForSubproject(target.Manifest.Subproject),
+					Detector:       target.Manifest.DetectorName,
+					PackageManager: target.Manifest.Subproject.PrimaryPackageManager(),
+					Dependency:     explainPackageRef(target.Dependency, explainResult.Registry),
+					Paths:          explainPathsWithStableIDs(target.Paths),
+					Findings:       output.FindingsFromScan(target.Findings, explainResult.Registry),
+					AuditSummary:   output.SummaryFromFindings(target.Findings),
 				})
 			}
 			if context.ResolvedConfig.Audit {

--- a/internal/cli/explain_cmd_test.go
+++ b/internal/cli/explain_cmd_test.go
@@ -32,10 +32,10 @@ func TestWhyTreeLines_RendersBranchingPaths(t *testing.T) {
 	got := strings.Join(render.WhyTreeLines(paths), "\n")
 	want := strings.Join([]string{
 		"app",
-		"|- react",
-		"|  \\- loose-envify (transitive)",
-		"\\- zod",
-		"   \\- loose-envify (transitive)",
+		"├─ react",
+		"│  └─ loose-envify (transitive)",
+		"└─ zod",
+		"   └─ loose-envify (transitive)",
 	}, "\n")
 	if got != want {
 		t.Fatalf("whyTreeLines() mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
@@ -67,9 +67,9 @@ func TestWhyTreeLines_PreservesLeafAnnotationsOnSharedPrefix(t *testing.T) {
 	got := strings.Join(render.WhyTreeLines(paths), "\n")
 	want := strings.Join([]string{
 		"app",
-		"\\- b (direct)",
-		"   \\- c",
-		"      \\- b (transitive, cycle to b)",
+		"└─ b (direct)",
+		"   └─ c",
+		"      └─ b (transitive, cycle to b)",
 	}, "\n")
 	if got != want {
 		t.Fatalf("whyTreeLines() mismatch\nwant:\n%s\n\ngot:\n%s", want, got)

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/bomly-dev/bomly-cli/internal/cli/opts"
+	"github.com/bomly-dev/bomly-cli/internal/cli/render"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
 	"github.com/bomly-dev/bomly-cli/internal/engine/explain"
@@ -53,9 +54,44 @@ func newMcpServeCmd() *cobra.Command {
 				Adapter: adapter,
 				Version: cmd.Root().Version,
 			})
+			printMCPBanner(cmd.ErrOrStderr())
 			return mcpserver.ServeStdio(s)
 		},
 	}
+}
+
+// printMCPBanner writes a brief startup notice to w (stderr) before the MCP
+// stdio protocol begins. Output goes to stderr so it doesn't interfere with
+// the JSON-RPC stream on stdout.
+func printMCPBanner(w io.Writer) {
+	type tool struct {
+		name string
+		desc string
+	}
+	tools := []tool{
+		{"bomly_scan", "Scan a path, image, Git URL, or SBOM."},
+		{"bomly_explain", "Show the dependency path for a package."},
+		{"bomly_diff", "Compare dependency state across refs or SBOMs."},
+		{"bomly_vuln_fix_context", "Get fix context for a vulnerability."},
+		{"bomly_plugins", "List registered Bomly plugins."},
+	}
+
+	nameWidth := 0
+	for _, t := range tools {
+		if len(t.name) > nameWidth {
+			nameWidth = len(t.name)
+		}
+	}
+
+	fmt.Fprintf(w, "%s\n", render.Style("Starting Bomly MCP server (stdio) ...", render.Dim))
+	fmt.Fprintf(w, "%s\n", render.Style("Registered tools:", render.Bold))
+	for _, t := range tools {
+		fmt.Fprintf(w, "  %s  %s\n",
+			render.Style(fmt.Sprintf("%-*s", nameWidth, t.name), render.Cyan),
+			render.Style(t.desc, render.Dim),
+		)
+	}
+	fmt.Fprintf(w, "%s\n", render.Style("Awaiting client on stdio ...", render.Dim))
 }
 
 // mcpOptionsAdapter implements bomcp.OptionsAdapter.
@@ -257,12 +293,13 @@ func (a *mcpOptionsAdapter) RunExplain(ctx context.Context, req mcp.ExplainReque
 	targets := make([]output.ExplainTargetResponse, 0, len(explainResult.Targets))
 	for _, target := range explainResult.Targets {
 		targets = append(targets, output.ExplainTargetResponse{
-			Project:      cmdCtx.ProjectDescriptorForSubproject(target.Manifest.Subproject),
-			Detector:     target.Manifest.DetectorName,
-			Dependency:   explainPackageRef(target.Dependency),
-			Paths:        explainPathsWithStableIDs(target.Paths),
-			Findings:     output.FindingsFromScan(target.Findings, explainResult.Registry),
-			AuditSummary: output.SummaryFromFindings(target.Findings),
+			Project:        cmdCtx.ProjectDescriptorForSubproject(target.Manifest.Subproject),
+			Detector:       target.Manifest.DetectorName,
+			PackageManager: target.Manifest.Subproject.PrimaryPackageManager(),
+			Dependency:     explainPackageRef(target.Dependency, explainResult.Registry),
+			Paths:          explainPathsWithStableIDs(target.Paths),
+			Findings:       output.FindingsFromScan(target.Findings, explainResult.Registry),
+			AuditSummary:   output.SummaryFromFindings(target.Findings),
 		})
 	}
 	return output.BuildExplainResponse(

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -7,29 +7,14 @@ import (
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-// Diff writes the human-readable diff report for the diff command.
+// Diff writes the compact human-readable diff report for the diff command.
 func Diff(w io.Writer, payload output.DiffResponse) error {
-	lines := []string{
-		fmt.Sprintf("Dependency diff %s -> %s", payload.Comparison.Base, payload.Comparison.Head),
-		fmt.Sprintf(
-			"Matches: %d exact, %d fuzzy, %d unmatched",
-			payload.Summary.ExactMatchCount,
-			payload.Summary.FuzzyMatchCount,
-			payload.Summary.UnmatchedPackageCount,
-		),
-		"",
-	}
+	var lines []string
 	lines = append(lines, dependencyTextSections(payload.Results.Dependencies)...)
-	lines = append(lines, licenseTextSections(payload.Results.Licenses)...)
-	lines = append(lines, vulnerabilityTextSections(payload.Results.Vulnerabilities, payload.Metadata.ReachabilityEnabled)...)
-	if section := postureTextSections(payload.Results.Dependencies); len(section) > 0 {
-		lines = append(lines, section...)
-	}
-	if payload.Audit != nil {
-		lines = append(lines, policyTextSections(*payload.Audit, payload.Metadata.ReachabilityEnabled)...)
-	}
+	lines = append(lines, findingsSummaryLine(payload.Audit)...)
 	for _, line := range lines {
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err
@@ -39,16 +24,17 @@ func Diff(w io.Writer, payload output.DiffResponse) error {
 }
 
 func dependencyTextSections(results output.DiffDependencyResults) []string {
-	lines := []string{"Dependencies"}
+	var lines []string
 	nameWidth := dependencyNameWidth(results)
 	appendAdded := func() {
 		if len(results.Added) == 0 {
 			return
 		}
-		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
+		lines = append(lines, Style(fmt.Sprintf("Added (%d)", len(results.Added)), Bold))
 		for _, change := range results.Added {
 			pkg := change.Package
-			line := fmt.Sprintf("  + %-*s  %-8s %s", nameWidth, DiffPackageDisplayName(pkg), primaryLicense(pkg), displayScope(pkg.Scope))
+			vulns := vulnCountsForPackageRef(pkg)
+			line := fmt.Sprintf("  + %-*s  %-8s %s%s", nameWidth, DiffPackageDisplayName(pkg), primaryLicense(pkg), displayScope(pkg.Scope), vulns)
 			lines = append(lines, Wrap(strings.TrimRight(line, " "), Green))
 		}
 	}
@@ -56,7 +42,7 @@ func dependencyTextSections(results output.DiffDependencyResults) []string {
 		if len(results.Removed) == 0 {
 			return
 		}
-		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
+		lines = append(lines, Style(fmt.Sprintf("Removed (%d)", len(results.Removed)), Bold))
 		for _, change := range results.Removed {
 			line := fmt.Sprintf("  - %s", DiffPackageDisplayName(change.Package))
 			lines = append(lines, Wrap(line, Red))
@@ -66,127 +52,105 @@ func dependencyTextSections(results output.DiffDependencyResults) []string {
 		if len(results.Changed) == 0 {
 			return
 		}
-		lines = append(lines, fmt.Sprintf("Changed (%d)", len(results.Changed)))
+		lines = append(lines, Style(fmt.Sprintf("Changed (%d)", len(results.Changed)), Bold))
 		for _, change := range results.Changed {
 			name := change.After.Name
 			if strings.TrimSpace(name) == "" {
 				name = change.After.ID
 			}
-			line := fmt.Sprintf("  ~ %-*s  %s -> %s", changedNameWidth(results), name, change.Before.Version, change.After.Version)
+			line := fmt.Sprintf("  ~ %-*s  %s → %s", changedNameWidth(results), name, change.Before.Version, change.After.Version)
 			lines = append(lines, Wrap(line, Yellow))
 		}
 	}
 	appendAdded()
 	appendRemoved()
 	appendChanged()
-	if len(lines) == 1 {
-		lines = append(lines, "  No dependency changes.")
-	}
-	lines = append(lines, "")
-	return lines
-}
-
-func licenseTextSections(results output.DiffLicenseResults) []string {
-	lines := []string{"Licenses"}
-	if len(results.Added) == 0 && len(results.Removed) == 0 && len(results.Changed) == 0 {
-		return append(lines, "  No license changes.", "")
-	}
-	if len(results.Added) > 0 {
-		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
-		for _, change := range results.Added {
-			lines = append(lines, Wrap(fmt.Sprintf("  + %s  %s", DiffPackageDisplayName(change.Package), licenseList(change.Licenses)), Green))
-		}
-	}
-	if len(results.Removed) > 0 {
-		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
-		for _, change := range results.Removed {
-			lines = append(lines, Wrap(fmt.Sprintf("  - %s  %s", DiffPackageDisplayName(change.Package), licenseList(change.Licenses)), Red))
-		}
-	}
-	if len(results.Changed) > 0 {
-		lines = append(lines, fmt.Sprintf("Changed (%d)", len(results.Changed)))
-		for _, change := range results.Changed {
-			lines = append(lines, Wrap(fmt.Sprintf("  ~ %s  %s -> %s", DiffPackageDisplayName(change.Package), licenseList(change.Before), licenseList(change.After)), Yellow))
-		}
-	}
-	return append(lines, "")
-}
-
-func vulnerabilityTextSections(results output.DiffVulnerabilityResults, includeReachability bool) []string {
-	lines := []string{"Vulnerabilities"}
-	if len(results.Added) == 0 && len(results.Removed) == 0 {
-		return append(lines, "  No vulnerability changes.", "")
-	}
-	if len(results.Added) > 0 {
-		lines = append(lines, fmt.Sprintf("Added (%d)", len(results.Added)))
-		for _, change := range results.Added {
-			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
-			lines = append(lines, Wrap(fmt.Sprintf("  + [%s] %s  %s%s", strings.ToUpper(ValueOrDash(string(change.Vulnerability.Severity))), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Red))
-		}
-	}
-	if len(results.Removed) > 0 {
-		lines = append(lines, fmt.Sprintf("Removed (%d)", len(results.Removed)))
-		for _, change := range results.Removed {
-			details := diffVulnerabilityDetails(change.Vulnerability, includeReachability)
-			lines = append(lines, Wrap(fmt.Sprintf("  - [%s] %s  %s%s", strings.ToUpper(ValueOrDash(string(change.Vulnerability.Severity))), change.Vulnerability.ID, DiffPackageDisplayName(change.Package), details), Green))
-		}
-	}
-	return append(lines, "")
-}
-
-func policyTextSections(audit output.DiffAudit, includeReachability bool) []string {
-	lines := []string{
-		"Policy Evaluation",
-		fmt.Sprintf("  Current findings: %s.", diffAuditFindingsSummary(audit.AuditSummary)),
-		fmt.Sprintf("  Change summary: %d introduced, %d persisted, and %d resolved findings.", len(audit.Introduced), len(audit.Persisted), len(audit.Resolved)),
-	}
-	appendSection := func(title string, findings []output.AuditFinding, color string) {
-		if len(findings) == 0 {
-			return
-		}
-		lines = append(lines, title)
-		for _, finding := range sortDiffAuditFindings(findings) {
-			disposition := strings.ToUpper(ValueOrDash(string(finding.Disposition)))
-			line := fmt.Sprintf("  - [%s/%s] %s", strings.ToUpper(ValueOrDash(string(finding.Severity))), disposition, ValueOrDash(finding.ID))
-			if pkgLabel := DiffPackageDisplayName(finding.Package); pkgLabel != "" {
-				line += " " + pkgLabel
-			}
-			if strings.TrimSpace(finding.Title) != "" && finding.Title != finding.ID {
-				line += ": " + finding.Title
-			}
-			var details []string
-			if fixed := fixedVersionSummary(finding.FixedIn, finding.FixedVersions); fixed != "" {
-				details = append(details, "fixed in "+fixed)
-			}
-			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
-				details = append(details, exploitability)
-			}
-			if includeReachability {
-				details = append(details, "reachability "+formatReachabilityCell(finding.Reachability))
-			}
-			if len(details) > 0 {
-				line += " [" + strings.Join(details, "; ") + "]"
-			}
-			if color != "" {
-				line = Wrap(line, color)
-			}
-			lines = append(lines, line)
-		}
-		lines = append(lines, "")
-	}
-	appendSection("Introduced Findings", audit.Introduced, Red)
-	appendSection("Resolved Findings", audit.Resolved, Green)
-	if len(audit.Introduced) == 0 && len(audit.Persisted) == 0 && len(audit.Resolved) == 0 {
-		lines = append(lines, "  No policy differences were identified between the base and head dependency sets.")
+	if len(lines) == 0 {
+		lines = append(lines, Style("No dependency changes.", Dim))
 	}
 	return lines
 }
 
-func diffVulnerabilityDetails(vulnerability output.VulnerabilityRef, includeReachability bool) string {
-	if !includeReachability {
+// findingsSummaryLine produces a summary line plus a list of each introduced
+// finding when audit data is present. N/A-severity findings (e.g. unknown
+// license) are omitted — they belong in the policy section, not the compact
+// summary. The summary intentionally omits a severity qualifier so it stays
+// accurate when only low/medium findings are introduced.
+func findingsSummaryLine(audit *output.DiffAudit) []string {
+	if audit == nil {
+		return nil
+	}
+	var introduced []output.AuditFinding
+	for _, f := range audit.Introduced {
+		sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
+		if sev == "n/a" || sev == "" {
+			continue
+		}
+		introduced = append(introduced, f)
+	}
+	if len(introduced) == 0 {
+		return []string{"", Style("No new findings introduced.", Gray)}
+	}
+	sort.Slice(introduced, func(i, j int) bool {
+		si := severityRankTable(string(introduced[i].Severity))
+		sj := severityRankTable(string(introduced[j].Severity))
+		if si != sj {
+			return si < sj
+		}
+		return introduced[i].ID < introduced[j].ID
+	})
+
+	maxIDWidth := 0
+	for _, f := range introduced {
+		if l := len(f.ID); l > maxIDWidth {
+			maxIDWidth = l
+		}
+	}
+
+	lines := []string{"", Style(fmt.Sprintf("%d new finding(s) introduced.", len(introduced)), Red)}
+	for _, f := range introduced {
+		pkg := DiffPackageDisplayName(f.Package)
+		if pkg == "" {
+			pkg = "-"
+		}
+		lines = append(lines, fmt.Sprintf("  %s  %-*s  %s", severityLabelFixed(string(f.Severity)), maxIDWidth, f.ID, pkg))
+	}
+	return lines
+}
+
+// vulnCountsForPackageRef returns a compact coloured vuln-count string like " 1H 2M"
+// from an output.PackageRef's pre-populated Vulnerabilities slice. Returns "" when empty.
+func vulnCountsForPackageRef(pkg output.PackageRef) string {
+	var critical, high, medium, low int
+	for _, v := range pkg.Vulnerabilities {
+		switch strings.ToLower(string(v.Severity)) {
+		case "critical":
+			critical++
+		case "high":
+			high++
+		case "medium":
+			medium++
+		case "low":
+			low++
+		}
+	}
+	var parts []string
+	if critical > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dC", critical), Red, Bold))
+	}
+	if high > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dH", high), Red))
+	}
+	if medium > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dM", medium), Yellow, Bold))
+	}
+	if low > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dL", low), Cyan))
+	}
+	if len(parts) == 0 {
 		return ""
 	}
-	return " [" + "reachability " + formatReachabilityCell(vulnerability.Reachability) + "]"
+	return "  " + strings.Join(parts, " ")
 }
 
 func dependencyNameWidth(results output.DiffDependencyResults) int {
@@ -296,3 +260,15 @@ func DiffManifestDisplayLabel(manifest output.DiffManifestResult) string {
 	}
 	return label
 }
+
+// fixedVersionSummary and exploitabilitySummary are retained for markdown
+// renderers that still use them.
+func diffVulnerabilityDetails(vulnerability output.VulnerabilityRef, includeReachability bool) string {
+	if !includeReachability {
+		return ""
+	}
+	return " [" + "reachability " + formatReachabilityCell(vulnerability.Reachability) + "]"
+}
+
+// Ensure sdk import is used (formatReachabilityCell references sdk.Reachability).
+var _ = sdk.Reachability{}

--- a/internal/cli/render/explain.go
+++ b/internal/cli/render/explain.go
@@ -8,186 +8,119 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/output"
 )
 
-// Explain writes the human-readable explain report for one target dependency.
+// Explain writes the compact human-readable explain report for one target dependency.
 func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabilityValue ...bool) error {
 	includeReachability := len(includeReachabilityValue) > 0 && includeReachabilityValue[0]
-	divider := Style(strings.Repeat("=", 72), Dim)
-	section := Style(strings.Repeat("-", 72), Dim)
+	_ = includeReachability
 
-	if _, err := fmt.Fprintln(w, divider); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(w, Style("Dependency Explanation", Bold, Cyan)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(w, section); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "%s %s\n", Style("Component:", Dim), explainPackageDisplayName(target.Dependency)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "%s %s\n", Style("Project:  ", Dim), ValueOrDash(target.Project.Name)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "%s %s\n", Style("Detector: ", Dim), ValueOrDash(target.Detector)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "%s %d\n", Style("Path count:", Dim), len(target.Paths)); err != nil {
-		return err
+	// Key-value header block
+	ecosystem := ecosystemFromPURL(target.Dependency.Purl)
+	pkgLabel := explainPackageDisplayName(target.Dependency)
+	scope := ValueOrDash(target.Dependency.Scope)
+	directLabel := "no"
+	for _, path := range target.Paths {
+		if len(path.Packages) == 2 {
+			directLabel = "yes"
+			break
+		}
 	}
 
-	if _, err := fmt.Fprintln(w); err != nil {
+	// Bold keys: pad the key text to a fixed visible width BEFORE styling so
+	// ANSI bytes don't affect the value column alignment.
+	const kvKeyWidth = 10
+	boldKey := func(k string) string {
+		return Style(fmt.Sprintf("%-*s", kvKeyWidth, k), Bold)
+	}
+	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("ecosystem"), ecosystem); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(w, Style("Dependency Paths", Bold)); err != nil {
-		return err
-	}
-	for _, line := range whyTreeLinesForTarget(target.Paths, target.Dependency.ID) {
-		if _, err := fmt.Fprintln(w, line); err != nil {
+	if pm := strings.TrimSpace(target.PackageManager.Name()); pm != "" {
+		if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("manager"), pm); err != nil {
 			return err
 		}
 	}
-
-	if len(target.Findings) > 0 || len(target.Dependency.Licenses) > 0 || len(target.Dependency.Vulnerabilities) > 0 || target.Dependency.Scorecard != nil {
-		if _, err := fmt.Fprintln(w); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintln(w, Style("Impact Assessment", Bold)); err != nil {
-			return err
-		}
+	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("package"), pkgLabel); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("scope"), scope); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("direct"), directLabel); err != nil {
+		return err
 	}
 
-	if len(target.Dependency.Vulnerabilities) > 0 {
-		if _, err := fmt.Fprintf(w, "%s %d matched\n", Style("Vulnerability enrichment:", Dim), len(target.Dependency.Vulnerabilities)); err != nil {
-			return err
-		}
-		for _, vulnerability := range target.Dependency.Vulnerabilities {
-			if _, err := fmt.Fprintf(w, "- %s %s (%s)\n", explainSeverityLabel(string(vulnerability.Severity)), vulnerability.ID, ValueOrDash(vulnerability.Source)); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Title:   ", Dim), ValueOrDash(vulnerability.Title)); err != nil {
-				return err
-			}
-			if fixed := fixedVersionSummary(vulnerability.FixedIn, vulnerability.FixedVersions); fixed != "" {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Fixed in:", Dim), fixed); err != nil {
-					return err
-				}
-			}
-			if exploitability := exploitabilitySummary(vulnerability.KEVExploited, vulnerability.KnownExploited, vulnerability.RiskScore); exploitability != "" {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Exploit: ", Dim), exploitability); err != nil {
-					return err
-				}
-			}
-			if epss := epssSummary(vulnerability.EPSS); epss != "" {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("EPSS:    ", Dim), epss); err != nil {
-					return err
-				}
-			}
-			if includeReachability {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Reach:   ", Dim), formatReachabilityCell(vulnerability.Reachability)); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	if len(target.Findings) > 0 {
-		if len(target.Dependency.Vulnerabilities) > 0 {
-			if _, err := fmt.Fprintln(w); err != nil {
-				return err
-			}
-		}
-		if _, err := fmt.Fprintf(w, "%s %s\n", Style("Policy findings:", Dim), formatExplainAuditSummary(target.AuditSummary)); err != nil {
-			return err
-		}
-		for _, finding := range target.Findings {
-			if _, err := fmt.Fprintf(w, "- %s %s\n", explainSeverityLabel(string(finding.Severity)), finding.ID); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Title:   ", Dim), ValueOrDash(finding.Title)); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Source:  ", Dim), ValueOrDash(finding.Source)); err != nil {
-				return err
-			}
-			if fixed := fixedVersionSummary(finding.FixedIn, finding.FixedVersions); fixed != "" {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Fixed in:", Dim), fixed); err != nil {
-					return err
-				}
-			}
-			if exploitability := exploitabilitySummary(finding.KEVExploited, finding.KnownExploited, finding.RiskScore); exploitability != "" {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Exploit: ", Dim), exploitability); err != nil {
-					return err
-				}
-			}
-			if includeReachability {
-				if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Reach:   ", Dim), formatReachabilityCell(finding.Reachability)); err != nil {
-					return err
-				}
-			}
-			if _, err := fmt.Fprintf(w, "  %s %s\n", Style("Package: ", Dim), explainPackageDisplayName(finding.Package)); err != nil {
-				return err
-			}
-			if len(finding.Reasons) > 0 {
-				if _, err := fmt.Fprintln(w, "  "+Style("Details: ", Dim)+finding.Reasons[0]); err != nil {
-					return err
-				}
-				for _, reason := range finding.Reasons[1:] {
-					if _, err := fmt.Fprintln(w, "           "+reason); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	if scorecard := target.Dependency.Scorecard; scorecard != nil {
-		if len(target.Dependency.Vulnerabilities) > 0 || len(target.Findings) > 0 {
-			if _, err := fmt.Fprintln(w); err != nil {
-				return err
-			}
-		}
-		if _, err := fmt.Fprintf(w, "%s %s\n", Style("Project posture:", Dim), explainScorecardHeadline(scorecard)); err != nil {
-			return err
-		}
-		for _, check := range topScorecardChecks(scorecard.Checks, 5) {
-			if _, err := fmt.Fprintf(w, "  %s %s/%d  %s\n",
-				Style(scorecardCheckBadge(check.Score), Dim),
-				explainScorecardCheckScore(check.Score),
-				10,
-				explainScorecardCheckLine(check)); err != nil {
-				return err
-			}
-		}
-	}
-
+	// Licenses section — shown before the tree so the reader has context before
+	// following the dependency chain.
 	if len(target.Dependency.Licenses) > 0 {
-		if len(target.Findings) > 0 || target.Dependency.Scorecard != nil {
-			if _, err := fmt.Fprintln(w); err != nil {
-				return err
-			}
-		}
-		if _, err := fmt.Fprintf(w, "%s %d detected\n", Style("Licenses:", Dim), len(target.Dependency.Licenses)); err != nil {
+		if _, err := fmt.Fprintln(w, Style("licenses", Bold)); err != nil {
 			return err
 		}
-		for idx, license := range target.Dependency.Licenses {
+		for _, license := range target.Dependency.Licenses {
 			label := license.Identifier()
+			if label == "" {
+				continue
+			}
 			if license.Type != "" {
 				label += " [" + string(license.Type) + "]"
 			}
-			if _, err := fmt.Fprintf(w, "- License %d: %s\n", idx+1, ValueOrDash(label)); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(w, "  %s applicable to %s\n", Style("Scope:   ", Dim), explainPackageDisplayName(target.Dependency)); err != nil {
+			if _, err := fmt.Fprintln(w, "  "+label); err != nil {
 				return err
 			}
 		}
 	}
 
-	if _, err := fmt.Fprintln(w, divider); err != nil {
-		return err
+	// Dependency tree
+	if len(target.Paths) > 0 {
+		if _, err := fmt.Fprintln(w, Style("introduced by:", Bold)); err != nil {
+			return err
+		}
+		for _, line := range whyTreeLinesForTarget(target.Paths, target.Dependency.ID) {
+			if _, err := fmt.Fprintln(w, "  "+line); err != nil {
+				return err
+			}
+		}
 	}
+
+	// Vulnerabilities section — shown after the tree so the reader sees the dep
+	// chain before the security findings.
+	if len(target.Dependency.Vulnerabilities) > 0 {
+		if _, err := fmt.Fprintln(w, Style("vulnerabilities", Bold)); err != nil {
+			return err
+		}
+		maxIDWidth := 0
+		for _, vuln := range target.Dependency.Vulnerabilities {
+			if l := len(vuln.ID); l > maxIDWidth {
+				maxIDWidth = l
+			}
+		}
+		for _, vuln := range target.Dependency.Vulnerabilities {
+			title := strings.TrimSpace(vuln.Title)
+			if len(title) > 50 {
+				title = title[:47] + "..."
+			}
+			line := fmt.Sprintf("  %-*s  %s  %s", maxIDWidth, vuln.ID, severityLabelFixed(string(vuln.Severity)), title)
+			if _, err := fmt.Fprintln(w, strings.TrimRight(line, " ")); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
+}
+
+// ecosystemFromPURL extracts the package type (e.g. "npm", "go") from a PURL
+// of the form "pkg:TYPE/...". Returns "-" when the PURL is absent or malformed.
+func ecosystemFromPURL(purl string) string {
+	const prefix = "pkg:"
+	if !strings.HasPrefix(purl, prefix) {
+		return "-"
+	}
+	rest := strings.TrimPrefix(purl, prefix)
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "-"
+	}
+	return parts[0]
 }
 
 func formatExplainAuditSummary(summary *output.AuditSummary) string {
@@ -226,5 +159,27 @@ func explainSeverityLabel(severity string) string {
 		return Style("["+label+"]", Cyan)
 	default:
 		return Style("["+label+"]", Dim)
+	}
+}
+
+// severityLabelFixed is like explainSeverityLabel but pads the visible text to
+// a fixed width (that of "[CRITICAL]") before applying ANSI styling. This keeps
+// tabular findings rows aligned even when ANSI escape sequences vary in length
+// across severity levels — the invisible bytes are added after the padding, so
+// all cells occupy the same number of visible terminal columns.
+func severityLabelFixed(severity string) string {
+	const width = 10 // len("[CRITICAL]")
+	label := fmt.Sprintf("%-*s", width, "["+strings.ToUpper(ValueOrDash(severity))+"]")
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return Style(label, Red, Bold)
+	case "high":
+		return Style(label, Red)
+	case "medium":
+		return Style(label, Yellow, Bold)
+	case "low":
+		return Style(label, Cyan)
+	default:
+		return Style(label, Dim)
 	}
 }

--- a/internal/cli/render/explain.go
+++ b/internal/cli/render/explain.go
@@ -32,28 +32,28 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 		return Style(fmt.Sprintf("%-*s", kvKeyWidth, k), Bold)
 	}
 	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("ecosystem"), ecosystem); err != nil {
-		return err
+		return fmt.Errorf("write explain ecosystem: %w", err)
 	}
 	if pm := strings.TrimSpace(target.PackageManager.Name()); pm != "" {
 		if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("manager"), pm); err != nil {
-			return err
+			return fmt.Errorf("write explain manager: %w", err)
 		}
 	}
 	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("package"), pkgLabel); err != nil {
-		return err
+		return fmt.Errorf("write explain package: %w", err)
 	}
 	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("scope"), scope); err != nil {
-		return err
+		return fmt.Errorf("write explain scope: %w", err)
 	}
 	if _, err := fmt.Fprintf(w, "%s %s\n", boldKey("direct"), directLabel); err != nil {
-		return err
+		return fmt.Errorf("write explain direct: %w", err)
 	}
 
 	// Licenses section — shown before the tree so the reader has context before
 	// following the dependency chain.
 	if len(target.Dependency.Licenses) > 0 {
 		if _, err := fmt.Fprintln(w, Style("licenses", Bold)); err != nil {
-			return err
+			return fmt.Errorf("write explain licenses header: %w", err)
 		}
 		for _, license := range target.Dependency.Licenses {
 			label := license.Identifier()
@@ -64,7 +64,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 				label += " [" + string(license.Type) + "]"
 			}
 			if _, err := fmt.Fprintln(w, "  "+label); err != nil {
-				return err
+				return fmt.Errorf("write explain license entry: %w", err)
 			}
 		}
 	}
@@ -72,11 +72,11 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 	// Dependency tree
 	if len(target.Paths) > 0 {
 		if _, err := fmt.Fprintln(w, Style("introduced by:", Bold)); err != nil {
-			return err
+			return fmt.Errorf("write explain introduced-by header: %w", err)
 		}
 		for _, line := range whyTreeLinesForTarget(target.Paths, target.Dependency.ID) {
 			if _, err := fmt.Fprintln(w, "  "+line); err != nil {
-				return err
+				return fmt.Errorf("write explain tree line: %w", err)
 			}
 		}
 	}
@@ -85,7 +85,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 	// chain before the security findings.
 	if len(target.Dependency.Vulnerabilities) > 0 {
 		if _, err := fmt.Fprintln(w, Style("vulnerabilities", Bold)); err != nil {
-			return err
+			return fmt.Errorf("write explain vulnerabilities header: %w", err)
 		}
 		maxIDWidth := 0
 		for _, vuln := range target.Dependency.Vulnerabilities {
@@ -100,7 +100,7 @@ func Explain(w io.Writer, target output.ExplainTargetResponse, includeReachabili
 			}
 			line := fmt.Sprintf("  %-*s  %s  %s", maxIDWidth, vuln.ID, severityLabelFixed(string(vuln.Severity)), title)
 			if _, err := fmt.Fprintln(w, strings.TrimRight(line, " ")); err != nil {
-				return err
+				return fmt.Errorf("write explain vulnerability entry: %w", err)
 			}
 		}
 	}

--- a/internal/cli/render/explain_tree.go
+++ b/internal/cli/render/explain_tree.go
@@ -50,9 +50,9 @@ func appendWhyTreeLines(lines []string, node *whyTreeNode, prefix string, isLast
 	if root {
 		lines = append(lines, line)
 	} else {
-		connector := "|- "
+		connector := "├─ "
 		if isLast {
-			connector = "\\- "
+			connector = "└─ "
 		}
 		lines = append(lines, prefix+connector+line)
 	}
@@ -62,7 +62,7 @@ func appendWhyTreeLines(lines []string, node *whyTreeNode, prefix string, isLast
 		if isLast {
 			childPrefix += "   "
 		} else {
-			childPrefix += "|  "
+			childPrefix += "│  "
 		}
 	}
 	for i, key := range node.childOrder {

--- a/internal/cli/render/reachability_test.go
+++ b/internal/cli/render/reachability_test.go
@@ -9,7 +9,6 @@ import (
 	model "github.com/bomly-dev/bomly-cli/sdk"
 )
 
-
 func TestScanRendersReachabilityColumnWhenEnabled(t *testing.T) {
 	g := model.New()
 	const libPURL = "pkg:go/lib@1.0.0"

--- a/internal/cli/render/reachability_test.go
+++ b/internal/cli/render/reachability_test.go
@@ -9,6 +9,7 @@ import (
 	model "github.com/bomly-dev/bomly-cli/sdk"
 )
 
+
 func TestScanRendersReachabilityColumnWhenEnabled(t *testing.T) {
 	g := model.New()
 	const libPURL = "pkg:go/lib@1.0.0"
@@ -41,15 +42,14 @@ func TestScanRendersReachabilityColumnWhenEnabled(t *testing.T) {
 			Source:          "osv",
 		},
 	}
-	out := Scan([]output.ScanManifest{}, g, registry, findings, true /*enrich*/, true /*audit*/, true /*reachability*/)
-	if !strings.Contains(out, "REACHABILITY") {
-		t.Fatalf("expected REACHABILITY column when reachabilityEnabled=true; got:\n%s", out)
+	out := Scan(g, registry, findings, nil /*matcherStats*/, true /*enrich*/, true /*audit*/, true /*reachability*/, nil /*failOn*/, "" /*subprojectSummary*/)
+	// The compact text format shows the finding CVE ID and package name; detailed
+	// reachability info is available in the JSON and Markdown output formats.
+	if !strings.Contains(StripANSI(out), "CVE-2024-0001") {
+		t.Fatalf("expected finding ID in compact scan output; got:\n%s", out)
 	}
-	if !strings.Contains(out, "reachable (symbol)") {
-		t.Fatalf("expected reachable (symbol) cell in findings table; got:\n%s", out)
-	}
-	if !strings.Contains(out, "Reachability:") {
-		t.Fatalf("expected Reachability summary line; got:\n%s", out)
+	if !strings.Contains(StripANSI(out), "Findings") {
+		t.Fatalf("expected Findings section in compact scan output; got:\n%s", out)
 	}
 }
 
@@ -114,13 +114,20 @@ func TestDiffTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
 			}},
 		},
 	}
+	// Compact text diff shows only a findings summary; reachability detail is
+	// available in JSON and Markdown formats.
 	var text bytes.Buffer
 	if err := Diff(&text, payload); err != nil {
 		t.Fatalf("Diff() error = %v", err)
 	}
-	if !strings.Contains(text.String(), "reachability reachable (package)") {
-		t.Fatalf("expected reachability in enabled diff text; got:\n%s", text.String())
+	plainText := StripANSI(text.String())
+	if strings.Contains(plainText, "reachability reachable") {
+		t.Fatalf("reachability detail should not appear in compact diff text; got:\n%s", text.String())
 	}
+	if !strings.Contains(plainText, "finding") {
+		t.Fatalf("expected findings summary in diff text; got:\n%s", text.String())
+	}
+
 	var markdown bytes.Buffer
 	if err := DiffMarkdown(&markdown, payload); err != nil {
 		t.Fatalf("DiffMarkdown() error = %v", err)
@@ -130,13 +137,6 @@ func TestDiffTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
 	}
 
 	payload.Metadata.ReachabilityEnabled = false
-	text.Reset()
-	if err := Diff(&text, payload); err != nil {
-		t.Fatalf("Diff() error = %v", err)
-	}
-	if strings.Contains(text.String(), "reachability reachable") {
-		t.Fatalf("reachability should be absent from disabled diff text; got:\n%s", text.String())
-	}
 	markdown.Reset()
 	if err := DiffMarkdown(&markdown, payload); err != nil {
 		t.Fatalf("DiffMarkdown() error = %v", err)
@@ -165,19 +165,18 @@ func TestExplainTextAndMarkdownRenderReachabilityOnlyWhenEnabled(t *testing.T) {
 			Reachability: &model.Reachability{Status: model.ReachabilityReachable, Tier: model.TierPackage},
 		}},
 	}
+	// Compact text explain shows the CVE ID and severity but not the reachability
+	// detail; that is available in JSON and Markdown formats.
 	var text bytes.Buffer
 	if err := Explain(&text, target, true); err != nil {
 		t.Fatalf("Explain() error = %v", err)
 	}
-	if !strings.Contains(text.String(), "Reach:") || !strings.Contains(text.String(), "reachable (package)") {
-		t.Fatalf("expected reachability in enabled explain text; got:\n%s", text.String())
+	plainText := StripANSI(text.String())
+	if !strings.Contains(plainText, "CVE-2024-0001") {
+		t.Fatalf("expected CVE ID in compact explain text; got:\n%s", text.String())
 	}
-	text.Reset()
-	if err := Explain(&text, target, false); err != nil {
-		t.Fatalf("Explain() error = %v", err)
-	}
-	if strings.Contains(text.String(), "Reach:") || strings.Contains(text.String(), "reachable (package)") {
-		t.Fatalf("reachability should be absent from disabled explain text; got:\n%s", text.String())
+	if strings.Contains(plainText, "Reach:") || strings.Contains(plainText, "reachable (package)") {
+		t.Fatalf("reachability detail should not appear in compact explain text; got:\n%s", text.String())
 	}
 
 	payload := output.ExplainResponse{
@@ -211,12 +210,13 @@ func TestScanOmitsReachabilityColumnWhenDisabled(t *testing.T) {
 	findings := []model.Finding{
 		{ID: "CVE-2024-0001", Kind: model.FindingKindVulnerability, PackageRef: pkg.PURL, Severity: "high", Title: "x", Source: "osv"},
 	}
-	out := Scan([]output.ScanManifest{}, g, nil, findings, true, true, false)
-	if strings.Contains(out, "REACHABILITY") {
-		t.Fatalf("REACHABILITY column should not appear when reachabilityEnabled=false; got:\n%s", out)
+	out := Scan(g, nil, findings, nil, true, true, false, nil, "")
+	// Compact text format never shows a REACHABILITY column; detailed info is in JSON/Markdown.
+	if strings.Contains(StripANSI(out), "REACHABILITY") {
+		t.Fatalf("REACHABILITY column should not appear in compact text output; got:\n%s", out)
 	}
-	if strings.Contains(out, "Reachability:") {
-		t.Fatalf("Reachability summary should not appear when disabled; got:\n%s", out)
+	if strings.Contains(StripANSI(out), "Reachability:") {
+		t.Fatalf("Reachability summary should not appear in compact text output; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/render/scan.go
+++ b/internal/cli/render/scan.go
@@ -226,10 +226,10 @@ func renderDirectDepsTable(g *sdk.Graph, registry *sdk.PackageRegistry) string {
 	})
 
 	const maxRows = 20
-	truncated := false
+	overflow := 0
 	if len(rows) > maxRows {
+		overflow = len(rows) - maxRows
 		rows = rows[:maxRows]
-		truncated = true
 	}
 
 	var b strings.Builder
@@ -243,8 +243,8 @@ func renderDirectDepsTable(g *sdk.Graph, registry *sdk.PackageRegistry) string {
 		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n", r.name, r.version, r.license, r.scope, r.vulns)
 	}
 	_ = tw.Flush()
-	if truncated {
-		fmt.Fprintf(&b, "  %s\n", Style(fmt.Sprintf("… and %d more (use --json for full list)", len(rows)), Dim))
+	if overflow > 0 {
+		fmt.Fprintf(&b, "  %s\n", Style(fmt.Sprintf("… and %d more (use --json for full list)", overflow), Dim))
 	}
 	return b.String()
 }

--- a/internal/cli/render/scan.go
+++ b/internal/cli/render/scan.go
@@ -29,131 +29,292 @@ func ScanGraphDisplayName(g *sdk.Graph, fallback string) string {
 	return fallback
 }
 
-// Scan returns the human-readable text report for a scan command.
-// registry, when non-nil, supplies matching-stage enrichment (vulnerabilities,
-// scorecards, licenses learned during matching) which is folded into the
-// rendered summaries and tables. Pass nil for a detection-only render.
-func Scan(manifests []output.ScanManifest, g *sdk.Graph, registry *sdk.PackageRegistry, findings []sdk.Finding, enrichEnabled, auditEnabled, reachabilityEnabled bool) string {
+// Scan returns the compact human-readable text report for a scan command.
+// failOn is the active fail-on constraint list from config; N/A-severity
+// findings (e.g. unknown-license) are suppressed unless "any" is present.
+// subprojectSummary is an optional pre-computed line like "Discovered 2
+// subprojects: web (npm), api (go)" shown before the package count.
+func Scan(g *sdk.Graph, registry *sdk.PackageRegistry, findings []sdk.Finding, matcherStats []sdk.MatcherStats, enrichEnabled, auditEnabled, reachabilityEnabled bool, failOn []string, subprojectSummary string) string {
 	var b strings.Builder
 
 	if g == nil {
 		return "(empty graph)"
 	}
 
-	summary := output.SummaryFromFindings(findings)
+	if subprojectSummary != "" {
+		fmt.Fprintf(&b, "%s\n", Style(subprojectSummary, Dim))
+	}
+
 	roots, direct, transitive := scanRelationshipCounts(g)
-	runtimeCount, developmentCount, unknownScopeCount := scanScopeCounts(g)
-	_, _ = fmt.Fprintf(&b, "Executive Summary\n")
-	_, _ = fmt.Fprintf(&b, "  Packages: %d total\n", g.Size())
-	_, _ = fmt.Fprintf(&b, "  Relationships: %d root, %d direct, %d transitive\n", roots, direct, transitive)
-	_, _ = fmt.Fprintf(&b, "  Scopes: %d runtime, %d development, %d unspecified\n", runtimeCount, developmentCount, unknownScopeCount)
-	_, _ = fmt.Fprintf(&b, "  Vulnerability enrichment: %s\n", formatEnrichmentSummary(registry, enrichEnabled))
-	_, _ = fmt.Fprintf(&b, "  Policy findings: %s\n", formatAuditSummary(summary, auditEnabled))
-	if reachabilityEnabled {
-		_, _ = fmt.Fprintf(&b, "  Reachability: %s\n", formatReachabilitySummary(registry))
+	runtimeCount, developmentCount, _ := scanScopeCounts(g)
+
+	// Package count line: ✓ N packages in M manifests  (D direct, T transitive)
+	checkmark := Style("✓", Green)
+	countPart := Style(fmt.Sprintf("%d", g.Size()), Cyan, Bold)
+	manifestWord := "manifest"
+	if roots != 1 {
+		manifestWord = "manifests"
 	}
-	_, _ = fmt.Fprintf(&b, "  Unique licenses: %d\n", scanUniqueLicenseCount(g, registry))
-	if scoredCount, totalRepos := scorecardCounts(registry); totalRepos > 0 {
-		_, _ = fmt.Fprintf(&b, "  Project posture: %d Scorecard run(s) across %d package(s)\n", totalRepos, scoredCount)
-	}
+	manifestPart := Style(fmt.Sprintf("in %d %s", roots, manifestWord), Dim)
+	detailPart := Style(fmt.Sprintf("(%d direct, %d transitive)", direct, transitive), Dim)
+	fmt.Fprintf(&b, "%s %s packages %s   %s\n", checkmark, countPart, manifestPart, detailPart)
 
-	b.WriteString("\nManifests\n")
-	b.WriteString(renderScanManifestTable(manifests))
+	// Scopes line
+	fmt.Fprintf(&b, "  %s\n", Style(fmt.Sprintf("scopes: runtime %d · dev %d", runtimeCount, developmentCount), Dim))
 
-	b.WriteString("\nDependency Inventory\n")
-	b.WriteString(renderScanGraphTable(g, registry))
-
-	b.WriteString("\n\nPolicy Findings\n")
-	if len(findings) == 0 {
-		if auditEnabled {
-			b.WriteString("No policy findings.\n")
-		} else {
-			b.WriteString("Policy evaluation not enabled. Run with --audit to create findings.\n")
+	// Enrichment line
+	if enrichEnabled && len(matcherStats) > 0 {
+		sources := make([]string, 0, len(matcherStats))
+		seen := make(map[string]struct{})
+		for _, stat := range matcherStats {
+			label := strings.TrimSpace(stat.DisplayName)
+			if label == "" {
+				label = strings.TrimSpace(stat.Name)
+			}
+			if label != "" {
+				if _, ok := seen[label]; !ok {
+					seen[label] = struct{}{}
+					sources = append(sources, label)
+				}
+			}
 		}
-	} else {
-		sorted := make([]sdk.Finding, len(findings))
-		copy(sorted, findings)
-		sort.Slice(sorted, func(i, j int) bool {
-			si := severityRankTable(string(sorted[i].Severity))
-			sj := severityRankTable(string(sorted[j].Severity))
-			if si != sj {
-				return si < sj
+		if len(sources) > 0 {
+			fmt.Fprintf(&b, "%s %s\n", checkmark, Style("Enriched via "+strings.Join(sources, ", "), Green))
+		}
+	}
+
+	// Top-level dependencies (direct only) — blank line before the section.
+	if table := renderDirectDepsTable(g, registry); table != "" {
+		b.WriteString("\n")
+		b.WriteString(table)
+	}
+
+	// Findings section — blank line before it; N/A-severity findings (e.g.
+	// unknown-license policy results) are hidden unless fail-on is "any",
+	// matching the principle that display follows enforcement policy.
+	if len(findings) > 0 {
+		if section := renderCompactFindings(findings, registry, reachabilityEnabled, failOnIncludesAny(failOn)); section != "" {
+			b.WriteString("\n")
+			b.WriteString(section)
+		}
+	}
+
+	return b.String()
+}
+
+// BuildSubprojectSummary returns a human-readable line like
+// "Discovered 2 subprojects: web (npm), api (go)" from the scan manifests.
+// Returns "" when no named subprojects are present (e.g. single-root repos).
+func BuildSubprojectSummary(manifests []output.ScanManifest) string {
+	type entry struct {
+		name string
+		pm   string
+	}
+	seen := make(map[string]struct{})
+	var entries []entry
+	for _, m := range manifests {
+		name := strings.TrimSpace(m.Subproject)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		pm := strings.TrimSpace(m.PackageManager.Name())
+		entries = append(entries, entry{name: name, pm: pm})
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	word := "subproject"
+	if len(entries) > 1 {
+		word = "subprojects"
+	}
+	labels := make([]string, 0, len(entries))
+	for _, e := range entries {
+		label := e.name
+		if e.pm != "" {
+			label += " (" + e.pm + ")"
+		}
+		labels = append(labels, label)
+	}
+	return fmt.Sprintf("Discovered %d %s: %s", len(entries), word, strings.Join(labels, ", "))
+}
+
+// renderDirectDepsTable renders the "Top-level dependencies" section showing
+// only packages that are direct dependents of a root node.
+func renderDirectDepsTable(g *sdk.Graph, registry *sdk.PackageRegistry) string {
+	if g == nil || g.Size() == 0 {
+		return ""
+	}
+
+	rootIDs := make(map[string]struct{})
+	for _, root := range g.Roots() {
+		if root != nil {
+			rootIDs[root.ID] = struct{}{}
+		}
+	}
+
+	type row struct {
+		name    string
+		version string
+		license string
+		scope   string
+		vulns   string
+	}
+	var rows []row
+	for _, pkg := range g.Nodes() {
+		if pkg == nil {
+			continue
+		}
+		if _, isRoot := rootIDs[pkg.ID]; isRoot {
+			continue
+		}
+		dependents, err := g.Dependents(pkg.ID)
+		if err != nil {
+			continue
+		}
+		isDirect := false
+		for _, dep := range dependents {
+			if dep != nil {
+				if _, isRoot := rootIDs[dep.ID]; isRoot {
+					isDirect = true
+					break
+				}
 			}
-			if sorted[i].ID != sorted[j].ID {
-				return sorted[i].ID < sorted[j].ID
+		}
+		if !isDirect {
+			continue
+		}
+
+		licenseIdents := make([]string, 0, 2)
+		for _, lic := range licensesForDependency(pkg, registry) {
+			if id := graphLicenseIdentifier(lic); id != "" {
+				licenseIdents = append(licenseIdents, id)
+				break // show only the primary license
 			}
-			// Sort by PackageRef (PURL) when severity and ID match — keeps
-			// ordering stable across runs without an extra registry lookup.
-			return sorted[i].PackageRef < sorted[j].PackageRef
+		}
+		license := "-"
+		if len(licenseIdents) > 0 {
+			license = licenseIdents[0]
+		}
+
+		scope := string(pkg.PrimaryScope())
+		if scope == "" {
+			scope = "-"
+		}
+		version := pkg.Version
+		if version == "" {
+			version = "-"
+		}
+		rows = append(rows, row{
+			name:    pkg.DisplayName(),
+			version: version,
+			license: license,
+			scope:   scope,
+			vulns:   formatDepVulnCounts(pkg, registry),
 		})
-		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-		if reachabilityEnabled {
-			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tREACHABILITY\tFIXED IN\tEXPLOITABILITY\tTITLE\tSOURCE")
-		} else {
-			_, _ = fmt.Fprintln(tw, "SEVERITY\tID\tPACKAGE\tFIXED IN\tEXPLOITABILITY\tTITLE\tSOURCE")
+	}
+
+	if len(rows) == 0 {
+		return ""
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].name < rows[j].name
+	})
+
+	const maxRows = 20
+	truncated := false
+	if len(rows) > maxRows {
+		rows = rows[:maxRows]
+		truncated = true
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", Style("Top-level dependencies", Bold))
+	tw := tabwriter.NewWriter(&b, 0, 0, 3, ' ', 0)
+	// Headers are written without ANSI codes so tabwriter measures visible
+	// widths correctly; the column values in data rows are also plain text
+	// except for the VULNS column which uses colour only on the counts.
+	fmt.Fprintf(tw, "  NAME\tVERSION\tLICENSE\tSCOPE\tVULNS\n")
+	for _, r := range rows {
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n", r.name, r.version, r.license, r.scope, r.vulns)
+	}
+	_ = tw.Flush()
+	if truncated {
+		fmt.Fprintf(&b, "  %s\n", Style(fmt.Sprintf("… and %d more (use --json for full list)", len(rows)), Dim))
+	}
+	return b.String()
+}
+
+// failOnIncludesAny reports whether the fail-on constraint list contains "any",
+// which means every severity level (including N/A) should be enforced.
+func failOnIncludesAny(failOn []string) bool {
+	for _, v := range failOn {
+		if strings.ToLower(strings.TrimSpace(v)) == "any" {
+			return true
 		}
-		for _, f := range sorted {
-			pkg, vuln := lookupFindingPkgAndVuln(registry, f)
-			pkgName := f.PackageRef
-			if pkg != nil && pkg.Name != "" {
-				if pkg.Version != "" {
-					pkgName = pkg.Name + "@" + pkg.Version
-				} else {
-					pkgName = pkg.Name
-				}
-			}
-			if pkgName == "" {
-				pkgName = "-"
-			}
-			title := f.Title
-			if title == "" && vuln != nil {
-				title = vuln.Title
-			}
-			if title == "" {
-				title = f.ID
-			}
-			if len(title) > 60 {
-				title = title[:57] + "..."
-			}
-			fixedIn := "-"
-			exploitability := "-"
-			reachCell := "-"
-			if vuln != nil {
-				if vuln.FixedIn != "" {
-					fixedIn = vuln.FixedIn
-				} else if len(vuln.FixedVersions) > 0 {
-					fixedIn = vuln.FixedVersions[0]
-				}
-				if vuln.KEVExploited {
-					exploitability = "KEV"
-				} else if len(vuln.EPSS) > 0 {
-					exploitability = fmt.Sprintf("EPSS %.2f", vuln.EPSS[0].EPSS)
-				}
-				if reachabilityEnabled {
-					reachCell = formatReachabilityCell(vuln.Reachability)
-				}
-			}
-			if reachabilityEnabled {
-				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					f.Severity, f.ID, pkgName, reachCell, fixedIn, exploitability, title, f.Source)
+	}
+	return false
+}
+
+// renderCompactFindings renders the "Findings" section with aligned columns.
+// When showNASeverity is false, findings with N/A or empty severity are omitted.
+func renderCompactFindings(findings []sdk.Finding, registry *sdk.PackageRegistry, reachabilityEnabled bool, showNASeverity bool) string {
+	type findingRow struct {
+		severity string
+		id       string
+		pkg      string
+	}
+
+	rows := make([]findingRow, 0, len(findings))
+	maxIDWidth := 0
+	for _, f := range findings {
+		sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
+		if !showNASeverity && (sev == "n/a" || sev == "") {
+			continue
+		}
+		regPkg, _ := lookupFindingPkgAndVuln(registry, f)
+		pkgName := f.PackageRef
+		if regPkg != nil && regPkg.Name != "" {
+			if regPkg.Version != "" {
+				pkgName = regPkg.Name + "@" + regPkg.Version
 			} else {
-				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					f.Severity, f.ID, pkgName, fixedIn, exploitability, title, f.Source)
+				pkgName = regPkg.Name
 			}
 		}
-		_ = tw.Flush()
+		if pkgName == "" {
+			pkgName = "-"
+		}
+		rows = append(rows, findingRow{severity: string(f.Severity), id: f.ID, pkg: pkgName})
+		if l := len(f.ID); l > maxIDWidth {
+			maxIDWidth = l
+		}
+	}
+	if len(rows) == 0 {
+		return ""
 	}
 
-	b.WriteString("\nLicense Overview\n")
-	b.WriteString(renderUniqueLicensesTable(g, registry))
+	sort.Slice(rows, func(i, j int) bool {
+		si := severityRankTable(rows[i].severity)
+		sj := severityRankTable(rows[j].severity)
+		if si != sj {
+			return si < sj
+		}
+		if rows[i].id != rows[j].id {
+			return rows[i].id < rows[j].id
+		}
+		return rows[i].pkg < rows[j].pkg
+	})
 
-	if posture := renderScorecardTable(registry); posture != "" {
-		b.WriteString("\n\nProject Posture\n")
-		b.WriteString(posture)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", Style("Findings", Bold))
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %s  %-*s  %s\n", severityLabelFixed(r.severity), maxIDWidth, r.id, r.pkg)
 	}
-
-	report := strings.TrimRight(b.String(), "\n")
-	return report
+	return b.String()
 }
 
 func severityRankTable(s string) int {
@@ -215,83 +376,6 @@ func licensesForDependency(dep *sdk.Dependency, registry *sdk.PackageRegistry) [
 	return sdk.DetectionLicenses(dep)
 }
 
-func renderUniqueLicensesTable(g *sdk.Graph, registry *sdk.PackageRegistry) string {
-	if g == nil || g.Size() == 0 {
-		return "(no packages)\n"
-	}
-
-	type licenseSummaryRow struct {
-		identifier string
-		spdx       string
-		value      string
-		sourceType string
-		packages   map[string]struct{}
-	}
-	rowsByIdentifier := make(map[string]*licenseSummaryRow)
-	for _, pkg := range g.Nodes() {
-		if pkg == nil {
-			continue
-		}
-		for _, license := range licensesForDependency(pkg, registry) {
-			identifier := graphLicenseIdentifier(license)
-			if identifier == "" {
-				continue
-			}
-			row, ok := rowsByIdentifier[identifier]
-			if !ok {
-				row = &licenseSummaryRow{
-					identifier: identifier,
-					packages:   make(map[string]struct{}),
-				}
-				rowsByIdentifier[identifier] = row
-			}
-			if row.spdx == "" {
-				row.spdx = strings.TrimSpace(license.SPDXExpression)
-			}
-			if row.value == "" {
-				row.value = strings.TrimSpace(license.Value)
-			}
-			if row.sourceType == "" {
-				row.sourceType = strings.TrimSpace(string(license.Type))
-			}
-			row.packages[pkg.ID] = struct{}{}
-		}
-	}
-	if len(rowsByIdentifier) == 0 {
-		return "(no license information available)\n"
-	}
-
-	rows := make([]licenseSummaryRow, 0, len(rowsByIdentifier))
-	for _, row := range rowsByIdentifier {
-		rows = append(rows, *row)
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].identifier != rows[j].identifier {
-			return rows[i].identifier < rows[j].identifier
-		}
-		if len(rows[i].packages) != len(rows[j].packages) {
-			return len(rows[i].packages) > len(rows[j].packages)
-		}
-		return rows[i].sourceType < rows[j].sourceType
-	})
-	var b strings.Builder
-	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "IDENTIFIER\tSPDX\tVALUE\tSOURCE\tPACKAGES")
-	for _, row := range rows {
-		_, _ = fmt.Fprintf(
-			tw,
-			"%s\t%s\t%s\t%s\t%d\n",
-			ValueOrDash(row.identifier),
-			ValueOrDash(row.spdx),
-			ValueOrDash(row.value),
-			ValueOrDash(row.sourceType),
-			len(row.packages),
-		)
-	}
-	_ = tw.Flush()
-	return strings.TrimRight(b.String(), "\n") + "\n"
-}
-
 func formatAuditSummary(summary *output.AuditSummary, auditEnabled bool) string {
 	if summary == nil || summary.Total == 0 {
 		if auditEnabled {
@@ -329,89 +413,6 @@ func formatReachabilityCell(r *sdk.Reachability) string {
 		return string(r.Status)
 	}
 	return fmt.Sprintf("%s (%s)", r.Status, r.Tier)
-}
-
-// formatReachabilitySummary tallies reachability outcomes across the
-// registry's vulnerabilities for the executive summary.
-func formatReachabilitySummary(registry *sdk.PackageRegistry) string {
-	if registry == nil || registry.Len() == 0 {
-		return "no vulnerabilities analyzed"
-	}
-	var reachable, unreachable, unknown int
-	for _, pkg := range registry.All() {
-		if pkg == nil {
-			continue
-		}
-		for _, v := range pkg.Vulnerabilities {
-			if v.Reachability == nil {
-				continue
-			}
-			switch v.Reachability.Status {
-			case sdk.ReachabilityReachable:
-				reachable++
-			case sdk.ReachabilityUnreachable:
-				unreachable++
-			default:
-				unknown++
-			}
-		}
-	}
-	total := reachable + unreachable + unknown
-	if total == 0 {
-		return "no vulnerabilities analyzed"
-	}
-	return fmt.Sprintf("%d reachable, %d unreachable, %d unknown", reachable, unreachable, unknown)
-}
-
-func formatEnrichmentSummary(registry *sdk.PackageRegistry, enrichEnabled bool) string {
-	if !enrichEnabled {
-		return "disabled"
-	}
-	if registry == nil {
-		return "enabled (no enrichment data available)"
-	}
-	var packages, vulns int
-	for _, pkg := range registry.All() {
-		if pkg == nil {
-			continue
-		}
-		if len(pkg.Vulnerabilities) > 0 || pkg.Matched {
-			packages++
-		}
-		vulns += len(pkg.Vulnerabilities)
-	}
-	return fmt.Sprintf("enabled (%d packages enriched, %d vulnerabilities)", packages, vulns)
-}
-
-func renderScanManifestTable(manifests []output.ScanManifest) string {
-	if len(manifests) == 0 {
-		return "(no manifests)\n"
-	}
-
-	var b strings.Builder
-	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "SUBPROJECT\tMANIFEST\tKIND\tMANAGER\tPACKAGES")
-	for _, manifest := range manifests {
-		subproject := manifest.Subproject
-		if subproject == "" {
-			subproject = "."
-		}
-		pathValue := manifest.Path
-		if pathValue == "" {
-			pathValue = "-"
-		}
-		kind := manifest.Kind
-		if kind == "" {
-			kind = "-"
-		}
-		manager := manifest.PackageManager
-		if manager == "" {
-			manager = "-"
-		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", subproject, pathValue, kind, manager, len(manifest.Dependencies))
-	}
-	_ = tw.Flush()
-	return strings.TrimRight(b.String(), "\n") + "\n"
 }
 
 func scanRelationshipCounts(g *sdk.Graph) (roots, direct, transitive int) {
@@ -492,170 +493,46 @@ func scanUniqueLicenseCount(g *sdk.Graph, registry *sdk.PackageRegistry) int {
 	return len(licenseSet)
 }
 
-func renderScanGraphTable(g *sdk.Graph, registry *sdk.PackageRegistry) string {
-	if g == nil || g.Size() == 0 {
-		return "(empty graph)"
+// formatDepVulnCounts returns a compact coloured vuln-count string like "1C 2H" for a
+// direct dependency. Returns "-" when the registry has no vulnerability data.
+func formatDepVulnCounts(dep *sdk.Dependency, registry *sdk.PackageRegistry) string {
+	if registry == nil || dep == nil || dep.PURL == "" {
+		return "-"
 	}
-
-	rootIDs := make(map[string]struct{})
-	for _, root := range g.Roots() {
-		rootIDs[root.ID] = struct{}{}
+	regPkg, ok := registry.Get(dep.PURL)
+	if !ok || regPkg == nil || len(regPkg.Vulnerabilities) == 0 {
+		return "-"
 	}
-
-	type row struct {
-		name         string
-		version      string
-		scope        string
-		relationship string
-		licenses     string
-		id           string
-	}
-
-	rows := make([]row, 0, g.Size())
-	for _, pkg := range g.Nodes() {
-		relationship := "transitive"
-		if _, isRoot := rootIDs[pkg.ID]; isRoot {
-			relationship = "root"
-		} else if dependents, err := g.Dependents(pkg.ID); err == nil {
-			for _, dependent := range dependents {
-				if _, isRoot := rootIDs[dependent.ID]; isRoot {
-					relationship = "direct"
-					break
-				}
-			}
-		}
-
-		licenseIdents := make([]string, 0, 4)
-		for _, lic := range licensesForDependency(pkg, registry) {
-			if id := graphLicenseIdentifier(lic); id != "" {
-				licenseIdents = append(licenseIdents, id)
-			}
-		}
-		rows = append(rows, row{
-			name:         pkg.DisplayName(),
-			version:      pkg.Version,
-			scope:        string(pkg.PrimaryScope()),
-			relationship: relationship,
-			licenses:     strings.Join(licenseIdents, ", "),
-			id:           pkg.ID,
-		})
-	}
-
-	if len(rows) == 0 {
-		return "(no dependencies)"
-	}
-
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].relationship != rows[j].relationship {
-			return RelationshipOrder(rows[i].relationship) < RelationshipOrder(rows[j].relationship)
-		}
-		return rows[i].id < rows[j].id
-	})
-
-	var b strings.Builder
-	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "PACKAGE\tVERSION\tSCOPE\tRELATIONSHIP\tLICENSES")
-	for _, row := range rows {
-		version := row.version
-		if version == "" {
-			version = "-"
-		}
-		scope := row.scope
-		if scope == "" {
-			scope = "-"
-		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", row.name, version, scope, row.relationship, ValueOrDash(row.licenses))
-	}
-	_ = tw.Flush()
-	return strings.TrimRight(b.String(), "\n")
-}
-
-// scorecardCounts returns (packagesEnriched, uniqueRepos) over the registry.
-func scorecardCounts(registry *sdk.PackageRegistry) (int, int) {
-	if registry == nil {
-		return 0, 0
-	}
-	packages := 0
-	repos := make(map[string]struct{})
-	for _, pkg := range registry.All() {
-		if pkg == nil || pkg.Scorecard == nil {
-			continue
-		}
-		packages++
-		if pkg.Scorecard.Repository != "" {
-			repos[pkg.Scorecard.Repository] = struct{}{}
+	var critical, high, medium, low int
+	for _, v := range regPkg.Vulnerabilities {
+		switch strings.ToLower(string(v.ParsedSeverity)) {
+		case "critical":
+			critical++
+		case "high":
+			high++
+		case "medium":
+			medium++
+		case "low":
+			low++
 		}
 	}
-	return packages, len(repos)
-}
-
-// renderScorecardTable renders one row per unique source repo enriched by the
-// scorecard matcher. Returns the empty string when no packages carry a
-// Scorecard run, so callers can skip the section header entirely.
-func renderScorecardTable(registry *sdk.PackageRegistry) string {
-	if registry == nil || registry.Len() == 0 {
-		return ""
+	var parts []string
+	if critical > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dC", critical), Red, Bold))
 	}
-	type row struct {
-		repo     string
-		score    float64
-		runDate  string
-		version  string
-		packages int
+	if high > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dH", high), Red))
 	}
-	byRepo := make(map[string]*row)
-	for _, pkg := range registry.All() {
-		if pkg == nil || pkg.Scorecard == nil {
-			continue
-		}
-		sc := pkg.Scorecard
-		key := sc.Repository
-		if key == "" {
-			key = pkg.PURL
-		}
-		r, ok := byRepo[key]
-		if !ok {
-			r = &row{repo: key, score: -1}
-			byRepo[key] = r
-		}
-		r.packages++
-		if sc.AggregateScore > r.score {
-			r.score = sc.AggregateScore
-		}
-		if !sc.RunDate.IsZero() && r.runDate == "" {
-			r.runDate = sc.RunDate.Format("2006-01-02")
-		}
-		if sc.ScorecardVersion != "" && r.version == "" {
-			r.version = sc.ScorecardVersion
-		}
+	if medium > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dM", medium), Yellow, Bold))
 	}
-	if len(byRepo) == 0 {
-		return ""
+	if low > 0 {
+		parts = append(parts, Style(fmt.Sprintf("%dL", low), Cyan))
 	}
-	rows := make([]*row, 0, len(byRepo))
-	for _, r := range byRepo {
-		rows = append(rows, r)
+	if len(parts) == 0 {
+		return "-"
 	}
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].score != rows[j].score {
-			return rows[i].score < rows[j].score
-		}
-		return rows[i].repo < rows[j].repo
-	})
-
-	var b strings.Builder
-	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "REPOSITORY\tSCORE\tRUN DATE\tVERSION\tPACKAGES")
-	for _, r := range rows {
-		score := "n/a"
-		if r.score >= 0 {
-			score = fmt.Sprintf("%.1f/10", r.score)
-		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n",
-			r.repo, score, ValueOrDash(r.runDate), ValueOrDash(r.version), r.packages)
-	}
-	_ = tw.Flush()
-	return strings.TrimRight(b.String(), "\n")
+	return strings.Join(parts, " ")
 }
 
 func graphLicenseIdentifier(license sdk.PackageLicense) string {

--- a/internal/cli/render/scorecard_render_test.go
+++ b/internal/cli/render/scorecard_render_test.go
@@ -22,8 +22,10 @@ func newTestScorecard(repo string, score float64, checks ...sdk.PackageScorecard
 	}
 }
 
-func TestExplain_RendersScorecardBlock(t *testing.T) {
+func TestExplain_OmitsScorecardFromCompactText(t *testing.T) {
 	t.Parallel()
+	// The compact text format does not include scorecard blocks; that detail
+	// is available in JSON and Markdown output formats.
 	target := output.ExplainTargetResponse{
 		Dependency: output.PackageRef{
 			Name:    "logrus",
@@ -31,7 +33,6 @@ func TestExplain_RendersScorecardBlock(t *testing.T) {
 			Scorecard: newTestScorecard("github.com/sirupsen/logrus", 8.2,
 				sdk.PackageScorecardCheck{Name: "Branch-Protection", Score: 9, Reason: "branch protection enabled"},
 				sdk.PackageScorecardCheck{Name: "Code-Review", Score: 2, Reason: "missing reviews"},
-				sdk.PackageScorecardCheck{Name: "Fuzzing", Score: -1, Reason: "no fuzzing detected"},
 			),
 		},
 	}
@@ -40,17 +41,12 @@ func TestExplain_RendersScorecardBlock(t *testing.T) {
 		t.Fatalf("Explain: %v", err)
 	}
 	out := StripANSI(buf.String())
-	want := []string{
-		"Project posture:",
-		"8.2/10",
-		"github.com/sirupsen/logrus",
-		"updated 2026-05-18",
-		"Code-Review", // lowest-scoring check should appear in top-N
+	if strings.Contains(out, "Project posture:") {
+		t.Errorf("compact explain text should not include scorecard block; got:\n%s", out)
 	}
-	for _, sub := range want {
-		if !strings.Contains(out, sub) {
-			t.Errorf("explain output missing %q\n---\n%s", sub, out)
-		}
+	// Package metadata (name/version) still appears.
+	if !strings.Contains(out, "logrus@v1.9.0") {
+		t.Errorf("expected package name in explain output; got:\n%s", out)
 	}
 }
 
@@ -117,8 +113,10 @@ func TestBuildPostureDelta_DedupesByRepo(t *testing.T) {
 	}
 }
 
-func TestDiff_RendersPostureSection(t *testing.T) {
+func TestDiff_OmitsPostureSectionFromCompactText(t *testing.T) {
 	t.Parallel()
+	// The compact text format does not include a Project Posture section; that
+	// detail is available in the Markdown output format.
 	payload := output.DiffResponse{
 		Comparison: output.DiffComparison{Base: "main", Head: "HEAD"},
 		Results: output.DiffResults{
@@ -138,15 +136,12 @@ func TestDiff_RendersPostureSection(t *testing.T) {
 		t.Fatalf("Diff: %v", err)
 	}
 	out := StripANSI(buf.String())
-	for _, sub := range []string{
-		"Project Posture",
-		"github.com/new/repo",
-		"github.com/shared/repo",
-		"5.0/10 -> 8.0/10",
-	} {
-		if !strings.Contains(out, sub) {
-			t.Errorf("diff output missing %q\n---\n%s", sub, out)
-		}
+	if strings.Contains(out, "Project Posture") {
+		t.Errorf("compact diff text should not include Project Posture section; got:\n%s", out)
+	}
+	// Dep changes still appear.
+	if !strings.Contains(out, "Added") && !strings.Contains(out, "Changed") {
+		t.Errorf("expected dep change sections in compact diff; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -657,7 +657,9 @@ func TestRoot_DiffCommand_TextOutputWithJSONOutputFile(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("root.Execute() error = %v; stderr=%s", err, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Dependency diff") {
+	// Compact diff output shows Added/Removed/Changed sections.
+	plainOut := render.StripANSI(stdout.String())
+	if !strings.Contains(plainOut, "Added") && !strings.Contains(plainOut, "Changed") && !strings.Contains(plainOut, "Removed") && !strings.Contains(plainOut, "No dependency changes.") {
 		t.Fatalf("expected primary text diff output, got:\n%s", stdout.String())
 	}
 
@@ -851,7 +853,9 @@ func TestRoot_ScanCommand_MarkdownOutputWithJSONAndTextOutputFiles(t *testing.T)
 	if err != nil {
 		t.Fatalf("read text report: %v", err)
 	}
-	if !strings.Contains(string(textData), "Dependency report for demo-app") || !strings.Contains(string(textData), "react") {
+	// Compact text report shows package count and top-level deps.
+	plainText := render.StripANSI(string(textData))
+	if !strings.Contains(plainText, "packages") || !strings.Contains(plainText, "react") {
 		t.Fatalf("unexpected text report:\n%s", textData)
 	}
 }
@@ -1502,17 +1506,14 @@ func TestRoot_WhyCommand_DefaultTextOutputUsesTree(t *testing.T) {
 
 	out := stdout.String()
 	plainOut := render.StripANSI(out)
-	projectName := filepath.Base(projectDir)
 	for _, want := range []string{
-		"Dependency Explanation",
-		"Component:",
+		"ecosystem",
+		"package",
 		"loose-envify@1.4.0",
-		"Project:",
-		projectName,
-		"Path count:",
+		"introduced by:",
 		"demo-app@1.0.0",
-		"\\- react@18.2.0",
-		"   \\- loose-envify@1.4.0 [analyzed] (transitive)",
+		"└─ react@18.2.0",
+		"└─ loose-envify@1.4.0",
 	} {
 		if !strings.Contains(plainOut, want) {
 			t.Fatalf("expected text output to contain %q, got:\n%s", want, out)
@@ -2281,43 +2282,35 @@ func TestRoot_ScanCommand_TextReportOutput(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !strings.Contains(out, "Dependency report for demo-app") {
-		t.Fatalf("expected scan header, got: %s", out)
-	}
+	plain := render.StripANSI(out)
+	// Compact text output shows package count + top-level deps (direct only).
 	for _, want := range []string{
-		"Executive Summary",
-		"Manifests",
-		"package.json",
-		"Dependency Inventory",
-		"License Overview",
-		"PACKAGE",
-		"VERSION",
-		"SCOPE",
-		"RELATIONSHIP",
-		"demo-app",
-		"1.0.0",
-		"root",
+		"packages",
+		"direct",
+		"transitive",
+		"scopes:",
+		"Top-level dependencies",
 		"react",
 		"18.2.0",
-		"direct",
 		"zod",
 		"3.23.0",
-		"loose-envify",
-		"1.4.0",
-		"transitive",
 	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("expected text report output to contain %q, got: %s", want, out)
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected compact text report to contain %q, got: %s", want, out)
 		}
 	}
-	rootIdx := strings.Index(out, "demo-app")
-	directIdx := strings.Index(out, "react")
-	transitiveIdx := strings.Index(out, "loose-envify")
-	if rootIdx == -1 || directIdx == -1 || transitiveIdx == -1 {
-		t.Fatalf("expected root, direct, and transitive rows in output, got: %s", out)
+	// Direct deps appear before transitive in the Top-level section.
+	reactIdx := strings.Index(plain, "react")
+	envifyIdx := strings.Index(plain, "loose-envify")
+	if reactIdx == -1 {
+		t.Fatalf("expected react in output, got: %s", out)
 	}
-	if rootIdx >= directIdx || directIdx >= transitiveIdx {
-		t.Fatalf("expected root/direct/transitive order, got: %s", out)
+	// loose-envify is transitive and should NOT appear in Top-level dependencies.
+	if envifyIdx != -1 && strings.Contains(plain, "Top-level dependencies") {
+		topIdx := strings.Index(plain, "Top-level dependencies")
+		if envifyIdx > topIdx {
+			t.Fatalf("transitive package loose-envify should not appear in Top-level dependencies section, got: %s", out)
+		}
 	}
 }
 

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -109,8 +109,10 @@ func newScanCmd() *cobra.Command {
 			}
 			subprojectSummary := render.BuildSubprojectSummary(output.ScanManifestsFromConsolidated(consolidated, pipeResult.Registry))
 			textRenderer := func(w io.Writer) error {
-				_, err := io.WriteString(w, render.Scan(selectedGraph, pipeResult.Registry, findings, pipeResult.MatcherStats, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Analyze, commandCtx.ResolvedConfig.FailOn, subprojectSummary))
-				return err
+				if _, err := io.WriteString(w, render.Scan(selectedGraph, pipeResult.Registry, findings, pipeResult.MatcherStats, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Analyze, commandCtx.ResolvedConfig.FailOn, subprojectSummary)); err != nil {
+					return fmt.Errorf("write scan text output: %w", err)
+				}
+				return nil
 			}
 			reportRenderers := output.Renderers{
 				Markdown: markdownRenderer,

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -107,17 +107,9 @@ func newScanCmd() *cobra.Command {
 			markdownRenderer := func(w io.Writer) error {
 				return render.ScanMarkdown(w, payload)
 			}
+			subprojectSummary := render.BuildSubprojectSummary(output.ScanManifestsFromConsolidated(consolidated, pipeResult.Registry))
 			textRenderer := func(w io.Writer) error {
-				if len(resolved) == 1 {
-					if _, err := fmt.Fprintf(w, "Dependency report for %s\n\n", render.ScanGraphDisplayName(selectedGraph, payload.Project.Name)); err != nil {
-						return err
-					}
-				} else {
-					if _, err := fmt.Fprintf(w, "Dependency report for %d subprojects\n\n", len(resolved)); err != nil {
-						return err
-					}
-				}
-				_, err := io.WriteString(w, render.Scan(payload.Manifests, selectedGraph, pipeResult.Registry, findings, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Analyze))
+				_, err := io.WriteString(w, render.Scan(selectedGraph, pipeResult.Registry, findings, pipeResult.MatcherStats, commandCtx.ResolvedConfig.Enrich, commandCtx.ResolvedConfig.Audit, commandCtx.ResolvedConfig.Analyze, commandCtx.ResolvedConfig.FailOn, subprojectSummary))
 				return err
 			}
 			reportRenderers := output.Renderers{

--- a/internal/cli/scan_cmd_test.go
+++ b/internal/cli/scan_cmd_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
-	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-func TestRenderScanReportIncludesProfessionalSections(t *testing.T) {
+func TestRenderScanReportShowsPackageCountAndDirectDeps(t *testing.T) {
 	g, registry := newScanTestGraph(t)
 	findings := []sdk.Finding{{
 		ID:         "OSV-123",
@@ -19,51 +18,48 @@ func TestRenderScanReportIncludesProfessionalSections(t *testing.T) {
 		Title:      "Prototype pollution in react",
 		Source:     "osv",
 	}}
-	manifests := []output.ScanManifest{{
-		Path:           "package-lock.json",
-		Kind:           "package-lock.json",
-		Subproject:     ".",
-		PackageManager: "npm",
-		Dependencies:   output.DependenciesFromGraph(g, registry),
-	}}
 
-	report := render.Scan(manifests, g, registry, findings, true, true, false)
+	report := render.Scan(g, registry, findings, nil, true, true, false, nil, "")
+
 	for _, want := range []string{
-		"Executive Summary",
-		"Manifests",
-		"package-lock.json",
-		"Dependency Inventory",
-		"Policy Findings",
-		"License Overview",
-		"LICENSES",
-		"IDENTIFIER",
+		"packages",
+		"direct",
+		"transitive",
+		"scopes:",
+		"Top-level dependencies",
 		"react",
-		"loose-envify",
-		"1 total (1 high)",
+		"Findings",
+		"OSV-123",
+		"HIGH",
 	} {
-		if !strings.Contains(report, want) {
+		if !strings.Contains(render.StripANSI(report), want) {
 			t.Fatalf("expected report to contain %q, got:\n%s", want, report)
 		}
 	}
-	if strings.Contains(report, "-> [") {
-		t.Fatalf("expected report output instead of tree output, got:\n%s", report)
+}
+
+func TestRenderScanReportWithEnrichmentShowsEnrichmentLine(t *testing.T) {
+	g, registry := newScanTestGraph(t)
+	stats := []sdk.MatcherStats{
+		{Name: "osv", DisplayName: "OSV"},
+		{Name: "deps.dev", DisplayName: "deps.dev"},
+	}
+	report := render.Scan(g, registry, nil, stats, true, false, false, nil, "")
+	stripped := render.StripANSI(report)
+	if !strings.Contains(stripped, "Enriched via OSV") {
+		t.Fatalf("expected enrichment line, got:\n%s", report)
 	}
 }
 
-func TestRenderScanReportWithoutFindingsUsesCleanMessage(t *testing.T) {
+func TestRenderScanReportWithoutEnrichmentSkipsEnrichmentLine(t *testing.T) {
 	g, registry := newScanTestGraph(t)
-	report := render.Scan([]output.ScanManifest{{
-		Path:           "package-lock.json",
-		Kind:           "package-lock.json",
-		Subproject:     ".",
-		PackageManager: "npm",
-		Dependencies:   output.DependenciesFromGraph(g, registry),
-	}}, g, registry, nil, false, false, false)
-	if !strings.Contains(report, "Policy evaluation not enabled") {
-		t.Fatalf("expected not-audited message, got:\n%s", report)
+	report := render.Scan(g, registry, nil, nil, false, false, false, nil, "")
+	stripped := render.StripANSI(report)
+	if strings.Contains(stripped, "Enriched via") {
+		t.Fatalf("unexpected enrichment line when not enriched, got:\n%s", report)
 	}
-	if strings.Contains(report, "\u00c3\u00a2\u20ac\u201d") || strings.Contains(report, "\u00c3\u201a\u00c3\u00a2\u20ac\u009d") {
-		t.Fatalf("expected mojibake to be removed, got:\n%s", report)
+	if strings.Contains(stripped, "Findings") {
+		t.Fatalf("unexpected findings section when no findings, got:\n%s", report)
 	}
 }
 

--- a/internal/cli/scan_output.go
+++ b/internal/cli/scan_output.go
@@ -56,8 +56,8 @@ func reportOptionsFromPipelineResults(enabled bool, results ...engine.PipelineRe
 	}
 }
 
-func explainPackageRef(pkg *sdk.Dependency) output.PackageRef {
-	ref := output.PackageFromGraphPackage(pkg)
+func explainPackageRef(pkg *sdk.Dependency, registry *sdk.PackageRegistry) output.PackageRef {
+	ref := output.PackageFromDependencyAndRegistry(pkg, registry)
 	if pkg == nil {
 		return ref
 	}

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -169,12 +169,13 @@ type ExplainQuery struct {
 
 // ExplainTargetResponse represents explain output for one resolved target.
 type ExplainTargetResponse struct {
-	Project      ProjectDescriptor `json:"project"`
-	Detector     string            `json:"detector,omitempty"`
-	Dependency   PackageRef        `json:"dependency"`
-	Paths        []DependencyPath  `json:"paths"`
-	Findings     []AuditFinding    `json:"findings,omitempty"`
-	AuditSummary *AuditSummary     `json:"audit_summary,omitempty"`
+	Project        ProjectDescriptor  `json:"project"`
+	Detector       string             `json:"detector,omitempty"`
+	PackageManager sdk.PackageManager `json:"package_manager,omitempty"`
+	Dependency     PackageRef         `json:"dependency"`
+	Paths          []DependencyPath   `json:"paths"`
+	Findings       []AuditFinding     `json:"findings,omitempty"`
+	AuditSummary   *AuditSummary      `json:"audit_summary,omitempty"`
 }
 
 // BuildScanResponse constructs the structured scan payload from consolidated


### PR DESCRIPTION
## Summary

Replaces the verbose multi-section text reports with concise, colorful, terminal-friendly output across all commands. Full structured detail remains available via `--json` or `--markdown`.

### scan
- Subproject discovery line before package count: `Discovered N subprojects: web (npm)`
- Package count line: `✓ N packages in M manifests (D direct, T transitive)`
- Scope breakdown and enrichment sources on follow-up lines
- **Top-level dependencies** table with NAME / VERSION / LICENSE / SCOPE / VULNS columns (capped at 20 rows)
- **Findings** section with severity-aligned columns; N/A-severity findings (unknown-license) suppressed unless `--fail-on any`
- Blank lines before each section for breathing room

### explain
- Bold key-value header: `ecosystem`, `manager`, `package`, `scope`, `direct`
- Licenses section before the dependency tree
- `introduced by:` tree with Unicode connectors (`├─`, `└─`, `│`)
- Vulnerabilities section after the tree with aligned severity / ID / title columns

### diff
- Added / Removed / Changed sections with colored prefixes (`+` green, `-` red, `~` yellow)
- Vuln counts (`1C 2H`) on added packages
- Findings summary at the bottom listing each introduced finding (N/A filtered, sorted by severity)
- Blank line before the findings summary

### mcp serve
- Startup banner printed to stderr listing registered tools (doesn't interfere with stdio protocol)

### fixes
- Trailing `%` in ZSH (`PROMPT_SP`) — `main.go` error format was missing a trailing `\n`
- Explain output was missing vulnerabilities and licenses — `explainPackageRef` now passes the registry
- Header/column misalignment in tabwriter — ANSI codes applied after padding via `severityLabelFixed()`
- `PackageManager` field added to `ExplainTargetResponse` (JSON: `package_manager`)

## Test plan

- [x] `make test` passes (all 16 changed files compile and all tests green)
- [ ] `bomly scan --enrich --audit` — verify compact output with subproject line, table, findings
- [ ] `bomly explain <pkg>` — verify key-value header, licenses, tree, vulns
- [ ] `bomly diff --base main --head HEAD` — verify dep sections and findings summary
- [ ] `bomly mcp serve` — verify banner on stderr without corrupting MCP stdio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP `serve` now shows a styled startup banner with available tools
  * Dependency diff includes a compact findings summary line for introduced findings
* **Improvements**
  * Scan, explain, and diff text outputs redesigned to be more compact and readable
  * Dependency tree now uses Unicode box-drawing connectors
  * Diff output now clearly shows version transitions for changed dependencies
  * Improved registry-aware package reference context and more compact explain presentation
  * Compact views omit verbose posture/scorecard sections
* **Bug Fixes**
  * CLI error output formatting now includes spacing before the error message
<!-- end of auto-generated comment: release notes by coderabbit.ai -->