### PR TITLE
Annotate SARIF diff output and GitHub Actions locations

### DIFF
--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -182,7 +182,7 @@ func newDiffCmd() *cobra.Command {
 				Text:     textRenderer,
 			}
 			sarifRenderer := func(w io.Writer) error {
-				return output.WriteSARIF(w, diffResult.Findings, diffResult.Head.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Analyze, LocationGraphs: []*sdk.Graph{diffResult.Head.Graph, diffResult.Base.Graph}})
+				return output.WriteSARIF(w, diffSARIFFindings(diffResult.Audit), diffResult.Head.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Analyze, LocationGraphs: []*sdk.Graph{diffResult.Head.Graph}, BaselineState: "new"})
 			}
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
@@ -224,6 +224,13 @@ func newDiffCmd() *cobra.Command {
 	cmd.Flags().StringVar(&baseRef, "base", "", "Base git reference to compare (or SBOM file path when --sbom is set)")
 	cmd.Flags().StringVar(&headRef, "head", "", "Head git reference to compare (or SBOM file path when --sbom is set)")
 	return cmd
+}
+
+func diffSARIFFindings(audit *diffengine.Audit) []sdk.Finding {
+	if audit == nil || len(audit.Introduced) == 0 {
+		return nil
+	}
+	return append([]sdk.Finding(nil), audit.Introduced...)
 }
 
 func diffPolicyExit(auditEnabled bool, audit *diffengine.Audit) error {

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
 	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
 func TestRenderDiffTextShowsFindingsSummaryLine(t *testing.T) {
@@ -44,6 +46,25 @@ func TestRenderDiffTextShowsFindingsSummaryLine(t *testing.T) {
 		if strings.Contains(report, absent) {
 			t.Fatalf("expected %q to be absent from compact diff output, got:\n%s", absent, report)
 		}
+	}
+}
+
+func TestDiffSARIFFindingsOnlyIncludesIntroduced(t *testing.T) {
+	introduced := sdk.Finding{ID: "new", PackageRef: "pkg:npm/new@1.0.0"}
+	resolved := sdk.Finding{ID: "old", PackageRef: "pkg:npm/old@1.0.0"}
+	persisted := sdk.Finding{ID: "kept", PackageRef: "pkg:npm/kept@1.0.0"}
+
+	got := diffSARIFFindings(&diffengine.Audit{
+		Introduced: []sdk.Finding{introduced},
+		Resolved:   []sdk.Finding{resolved},
+		Persisted:  []sdk.Finding{persisted},
+	})
+	if len(got) != 1 || got[0].ID != introduced.ID {
+		t.Fatalf("diffSARIFFindings() = %#v, want only introduced finding", got)
+	}
+
+	if got := diffSARIFFindings(&diffengine.Audit{Resolved: []sdk.Finding{resolved}}); len(got) != 0 {
+		t.Fatalf("resolved-only SARIF findings = %#v, want none", got)
 	}
 }
 

--- a/internal/detectors/githubactions/detector_test.go
+++ b/internal/detectors/githubactions/detector_test.go
@@ -95,3 +95,52 @@ func TestDepGraphFromRepository(t *testing.T) {
 		t.Fatalf("expected 3 workflow dependencies, got %d", len(workflowDeps))
 	}
 }
+
+func TestDetectorResolveGraphAttachesUsesLineLocations(t *testing.T) {
+	projectDir := t.TempDir()
+	workflowDir := filepath.Join(projectDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("create workflow dir: %v", err)
+	}
+	workflow := []byte("name: CI\njobs:\n  build:\n    steps:\n      - name: Review dependencies\n        uses: actions/dependency-review-action@v5\n      - uses: github/codeql-action/upload-sarif@v4\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "guard.yml"), workflow, 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	result, err := (Detector{}).ResolveGraph(context.Background(), sdk.DetectionRequest{
+		ProjectPath:     projectDir,
+		PackageManager:  sdk.PackageManagerGitHubActions,
+		Ecosystem:       sdk.EcosystemGitHub,
+		ExecutionTarget: sdk.ExecutionTarget{Location: projectDir},
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+	g, err := result.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+
+	dependencyReview, ok := g.Node("actions:dependency-review-action@v5")
+	if !ok {
+		t.Fatal("expected actions/dependency-review-action package")
+	}
+	if len(dependencyReview.Locations) != 1 {
+		t.Fatalf("dependency-review-action locations = %#v, want one location", dependencyReview.Locations)
+	}
+	loc := dependencyReview.Locations[0]
+	if loc.RealPath != ".github/workflows/guard.yml" || loc.AccessPath != ".github/workflows/guard.yml" {
+		t.Fatalf("location path = %#v, want workflow manifest path", loc)
+	}
+	if loc.Position == nil || loc.Position.File != ".github/workflows/guard.yml" || loc.Position.Line != 6 || loc.Position.Column == 0 {
+		t.Fatalf("location position = %#v, want workflow uses line with column", loc.Position)
+	}
+
+	codeql, ok := g.Node("github:codeql-action/upload-sarif@v4")
+	if !ok {
+		t.Fatal("expected github/codeql-action/upload-sarif package")
+	}
+	if len(codeql.Locations) != 1 || codeql.Locations[0].Position == nil || codeql.Locations[0].Position.Line != 7 {
+		t.Fatalf("codeql action locations = %#v, want line 7", codeql.Locations)
+	}
+}

--- a/internal/detectors/githubactions/positions.go
+++ b/internal/detectors/githubactions/positions.go
@@ -10,9 +10,8 @@ import (
 )
 
 // usesLine matches `uses: owner/repo[/path]@ref` entries in workflow
-// YAML. The captured value is the owner/repo coordinate (excluding
-// path and ref).
-var usesLine = regexp.MustCompile(`^\s*-?\s*uses\s*:\s*['"]?([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*)(?:/[^@'"\s]*)?@[^'"\s]+['"]?\s*$`)
+// YAML. The captured value is the action coordinate excluding the ref.
+var usesLine = regexp.MustCompile(`^\s*-?\s*uses\s*:\s*['"]?([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*(?:/[^@'"\s]*)?)@[^'"\s]+['"]?\s*$`)
 
 // workflowPositions walks .github/workflows/*.yml + .github/actions/*/action.yml
 // and returns a map from owner/repo coordinate to the line where the
@@ -34,18 +33,18 @@ func workflowPositions(projectDir string) map[string]*sdk.SourcePosition {
 			}
 			rel = filepath.ToSlash(rel)
 			_ = detectors.ScanLines(file, func(line int, text string) {
-				m := usesLine.FindStringSubmatch(text)
-				if m == nil {
+				matches := usesLine.FindStringSubmatchIndex(text)
+				if matches == nil || len(matches) < 4 {
 					return
 				}
-				coord := strings.TrimSpace(m[1])
+				coord := strings.TrimSpace(text[matches[2]:matches[3]])
 				if coord == "" {
 					return
 				}
 				if _, exists := out[coord]; exists {
 					return
 				}
-				out[coord] = &sdk.SourcePosition{File: rel, Line: line}
+				out[coord] = &sdk.SourcePosition{File: rel, Line: line, Column: matches[2] + 1, EndLine: line}
 			})
 		}
 	}
@@ -66,7 +65,11 @@ func AttachWorkflowPositions(g *sdk.Graph, projectDir string) {
 		if pkg == nil {
 			return ""
 		}
-		// GitHub Actions packages have Name=owner/repo.
+		// External GitHub Actions packages store owner and repository
+		// separately, while workflow manifests spell them as owner/repo.
+		if strings.TrimSpace(pkg.Org) != "" && strings.TrimSpace(pkg.Name) != "" {
+			return strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + strings.Trim(strings.TrimSpace(pkg.Name), "/")
+		}
 		return strings.TrimSpace(pkg.Name)
 	})
 }

--- a/internal/detectors/githubactions/positions.go
+++ b/internal/detectors/githubactions/positions.go
@@ -34,7 +34,7 @@ func workflowPositions(projectDir string) map[string]*sdk.SourcePosition {
 			rel = filepath.ToSlash(rel)
 			_ = detectors.ScanLines(file, func(line int, text string) {
 				matches := usesLine.FindStringSubmatchIndex(text)
-				if matches == nil || len(matches) < 4 {
+				if len(matches) < 4 {
 					return
 				}
 				coord := strings.TrimSpace(text[matches[2]:matches[3]])

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -78,11 +78,13 @@ type checkStats struct {
 	requested          int
 	unsupported        int
 	cacheHits          int
+	cacheEmpty         int
 	cacheMisses        int
 	cacheApplied       int
 	cacheLicenses      int
 	apiRequests        int
 	apiEnriched        int
+	apiEmpty           int
 	apiLicenses        int
 	cacheWriteFailures int
 	responseMisses     int
@@ -167,6 +169,11 @@ func (c *Checker) Match(ctx context.Context, req sdk.MatchRequest) (sdk.MatchRes
 		}
 		if cached, hit := cache.Get[[]string](c.cache, cacheKey); hit {
 			stats.cacheHits++
+			if len(cached) == 0 {
+				stats.cacheEmpty++
+				pendingItems = append(pendingItems, pending{pkg: pkg, key: cacheKey, req: versionReq})
+				continue
+			}
 			if count := applyLicenses(pkg, cached); count > 0 {
 				stats.cacheApplied++
 				stats.cacheLicenses += count
@@ -191,11 +198,13 @@ func (c *Checker) Match(ctx context.Context, req sdk.MatchRequest) (sdk.MatchRes
 		"deps.dev: license matcher summary",
 		zap.Int("requested", stats.requested),
 		zap.Int("cache_hits", stats.cacheHits),
+		zap.Int("cache_empty", stats.cacheEmpty),
 		zap.Int("cache_misses", stats.cacheMisses),
 		zap.Int("cache_applied", stats.cacheApplied),
 		zap.Int("cache_licenses", stats.cacheLicenses),
 		zap.Int("api_requests", stats.apiRequests),
 		zap.Int("api_enriched", stats.apiEnriched),
+		zap.Int("api_empty", stats.apiEmpty),
 		zap.Int("api_licenses", stats.apiLicenses),
 		zap.Int("response_misses", stats.responseMisses),
 		zap.Int("cache_write_failures", stats.cacheWriteFailures),
@@ -270,11 +279,17 @@ func (c *Checker) fetchBatch(ctx context.Context, items []pending, stats *checkS
 			break
 		}
 		values := licenseValuesFromResponse(result.Version)
-		if err := cache.Set(c.cache, items[idx].key, values); err != nil {
+		if len(values) == 0 {
 			if stats != nil {
-				stats.cacheWriteFailures++
+				stats.apiEmpty++
 			}
-			c.logger.Warn("deps.dev: cache write failed", zap.Error(err))
+		} else {
+			if err := cache.Set(c.cache, items[idx].key, values); err != nil {
+				if stats != nil {
+					stats.cacheWriteFailures++
+				}
+				c.logger.Warn("deps.dev: cache write failed", zap.Error(err))
+			}
 		}
 		if count := applyLicenses(items[idx].pkg, values); count > 0 {
 			enriched++

--- a/internal/matchers/depsdev/matcher_test.go
+++ b/internal/matchers/depsdev/matcher_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/logging"
+	"github.com/bomly-dev/bomly-cli/internal/matchers/cache"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -40,6 +41,30 @@ func TestVersionRequestFromPackage(t *testing.T) {
 		}
 	})
 
+	t.Run("go purl esbuild", func(t *testing.T) {
+		req, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/github.com/evanw/esbuild@v0.28.0",
+			Version: "v0.28.0"},
+		})
+		if !ok {
+			t.Fatal("expected go purl to map to deps.dev request")
+		}
+		if req.VersionKey.System != "GO" || req.VersionKey.Name != "github.com/evanw/esbuild" || req.VersionKey.Version != "v0.28.0" {
+			t.Fatalf("unexpected request: %#v", req)
+		}
+	})
+
+	t.Run("go purl golang x module", func(t *testing.T) {
+		req, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/golang.org/x/net@v0.55.0",
+			Version: "v0.55.0"},
+		})
+		if !ok {
+			t.Fatal("expected golang.org/x purl to map to deps.dev request")
+		}
+		if req.VersionKey.System != "GO" || req.VersionKey.Name != "golang.org/x/net" || req.VersionKey.Version != "v0.55.0" {
+			t.Fatalf("unexpected request: %#v", req)
+		}
+	})
+
 	t.Run("unsupported ecosystem", func(t *testing.T) {
 		if _, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: sdk.Coordinates{Ecosystem: "conan",
 			Name:    "openssl",
@@ -48,6 +73,113 @@ func TestVersionRequestFromPackage(t *testing.T) {
 			t.Fatal("expected unsupported ecosystem to be rejected")
 		}
 	})
+}
+
+func TestCheckerMatch_RefetchesCachedEmptyLicenseSet(t *testing.T) {
+	var hits int
+	var stderr bytes.Buffer
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.Method != http.MethodPost || r.URL.Path != "/versionbatch" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		response := versionBatchResponse{
+			Responses: []versionBatchResult{{
+				Version: depsDevVersion{
+					LicenseDetails: []depsDevLicenseRef{{SPDX: "BSD-3-Clause", License: "BSD-3-Clause"}},
+				},
+			}},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	fileCache, err := cache.NewFileCache(cacheDir, defaultCacheTTL)
+	if err != nil {
+		t.Fatalf("NewFileCache() error = %v", err)
+	}
+	pkg := &sdk.Package{Coordinates: sdk.Coordinates{PURL: "pkg:golang/golang.org/x/net@v0.55.0", Version: "v0.55.0"}}
+	_, cacheKey, ok := versionRequestFromPackage(pkg)
+	if !ok {
+		t.Fatal("expected package to produce cache key")
+	}
+	if err := cache.Set(fileCache, cacheKey, []string{}); err != nil {
+		t.Fatalf("seed empty cache entry: %v", err)
+	}
+
+	checker, err := New(Config{
+		APIBase:  server.URL,
+		CacheDir: cacheDir,
+		Client:   server.Client(),
+		Logger:   logging.NewConsole(&stderr, 2, false),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	g := sdk.New()
+	dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGo, Name: "golang.org/x/net", Version: "v0.55.0"}})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+	registry := sdk.NewPackageRegistry()
+
+	result, err := checker.Match(context.Background(), sdk.MatchRequest{Graph: g, Registry: registry})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	gotPkg, _ := result.Registry.Get("pkg:golang/golang.org/x/net@v0.55.0")
+	if gotPkg == nil || len(gotPkg.LicenseValues()) != 1 || gotPkg.LicenseValues()[0] != "BSD-3-Clause" {
+		t.Fatalf("expected API license after empty cache refetch, got %#v", gotPkg)
+	}
+	if hits != 1 {
+		t.Fatalf("expected one API hit after cached empty value, got %d", hits)
+	}
+	logOutput := stderr.String()
+	for _, want := range []string{`"cache_hits": 1`, `"cache_empty": 1`, `"api_enriched": 1`} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("expected log output to contain %q, got:\n%s", want, logOutput)
+		}
+	}
+}
+
+func TestCheckerMatch_DoesNotCacheEmptyAPIResponse(t *testing.T) {
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if err := json.NewEncoder(w).Encode(versionBatchResponse{
+			Responses: []versionBatchResult{{Version: depsDevVersion{}}},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	checker, err := New(Config{
+		APIBase:  server.URL,
+		CacheDir: t.TempDir(),
+		Client:   server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		g := sdk.New()
+		dep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemGo, Name: "golang.org/x/net", Version: "v0.55.0"}})
+		if err := g.AddNode(dep); err != nil {
+			t.Fatalf("add dependency: %v", err)
+		}
+		if _, err := checker.Match(context.Background(), sdk.MatchRequest{Graph: g, Registry: sdk.NewPackageRegistry()}); err != nil {
+			t.Fatalf("Match() run %d error = %v", i+1, err)
+		}
+	}
+	if hits != 2 {
+		t.Fatalf("expected empty API response not to be cached; hits = %d, want 2", hits)
+	}
 }
 
 func TestCheckerMatch_EnrichesMissingOnly(t *testing.T) {

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -52,12 +52,14 @@ type sarifRuleConfig struct {
 }
 
 type sarifResult struct {
-	RuleID     string           `json:"ruleId"`
-	Level      string           `json:"level"`
-	Message    sarifMessage     `json:"message"`
-	Locations  []sarifLocation  `json:"locations"`
-	CodeFlows  []sarifCodeFlow  `json:"codeFlows,omitempty"`
-	Properties *sarifProperties `json:"properties,omitempty"`
+	RuleID              string            `json:"ruleId"`
+	Level               string            `json:"level"`
+	Message             sarifMessage      `json:"message"`
+	Locations           []sarifLocation   `json:"locations"`
+	BaselineState       string            `json:"baselineState,omitempty"`
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+	CodeFlows           []sarifCodeFlow   `json:"codeFlows,omitempty"`
+	Properties          *sarifProperties  `json:"properties,omitempty"`
 }
 
 type sarifLocation struct {
@@ -142,6 +144,7 @@ type sarifProperties struct {
 type SARIFOptions struct {
 	IncludeReachability bool
 	LocationGraphs      []*sdk.Graph
+	BaselineState       string
 }
 
 // WriteSARIF writes findings as a SARIF 2.1.0 document to w.
@@ -186,10 +189,12 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, registry *sdk.PackageRegist
 		}
 		locations, locationURIs := sarifLocationsForFinding(f, includeReachability, options)
 		result := sarifResult{
-			RuleID:    f.ID,
-			Level:     severityToSARIFLevel(string(f.Severity)),
-			Message:   sarifMessage{Text: msgText},
-			Locations: locations,
+			RuleID:              f.ID,
+			Level:               severityToSARIFLevel(string(f.Severity)),
+			Message:             sarifMessage{Text: msgText},
+			Locations:           locations,
+			BaselineState:       sarifBaselineState(options),
+			PartialFingerprints: sarifPartialFingerprints(f, locationURIs, locations),
 		}
 		props := sarifPropertiesFromFinding(f, locationURIs)
 		if vuln != nil {
@@ -255,6 +260,42 @@ func sarifPropertiesEmpty(props sarifProperties) bool {
 		props.ReachabilityConfidence == "" &&
 		props.ReachabilityHops == nil &&
 		!props.DynamicImportsDetected
+}
+
+func sarifBaselineState(options []SARIFOptions) string {
+	if len(options) == 0 {
+		return ""
+	}
+	switch options[0].BaselineState {
+	case "new", "unchanged", "updated", "absent":
+		return options[0].BaselineState
+	default:
+		return ""
+	}
+}
+
+func sarifPartialFingerprints(f sdk.Finding, locationURIs []string, locations []sarifLocation) map[string]string {
+	parts := []string{
+		strings.TrimSpace(f.ID),
+		strings.TrimSpace(string(f.Kind)),
+		strings.TrimSpace(f.Source),
+		strings.TrimSpace(f.PackageRef),
+	}
+	if f.VulnerabilityID != "" {
+		parts = append(parts, strings.TrimSpace(f.VulnerabilityID))
+	}
+	if len(locationURIs) > 0 {
+		parts = append(parts, strings.TrimSpace(locationURIs[0]))
+	}
+	if len(locations) > 0 {
+		loc := locations[0].PhysicalLocation
+		parts = append(parts,
+			strings.TrimSpace(loc.ArtifactLocation.URI),
+			fmt.Sprintf("%d", regionStartLine(loc.Region)),
+			fmt.Sprintf("%d", regionStartColumn(loc.Region)),
+		)
+	}
+	return map[string]string{"bomlyStableId/v1": strings.Join(parts, "|")}
 }
 
 // buildSARIFCodeFlows converts reachability call paths into SARIF

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -166,6 +166,28 @@ func TestWriteSARIF_OSVHelpURI(t *testing.T) {
 	}
 }
 
+func TestWriteSARIF_EmitsBaselineStateAndStableFingerprint(t *testing.T) {
+	findings := []sdk.Finding{
+		{ID: "BOMLY-LIC-UNKNOWN", Kind: sdk.FindingKindLicense, PackageRef: sarifTestPURL, Title: "Package license is unknown", Severity: sdk.SeverityLow, Source: "license"},
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, findings, nil, "bomly", "0.1.0", SARIFOptions{BaselineState: "new"}); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	result := doc["runs"].([]any)[0].(map[string]any)["results"].([]any)[0].(map[string]any)
+	if got := result["baselineState"]; got != "new" {
+		t.Fatalf("baselineState = %v, want new", got)
+	}
+	fingerprints := result["partialFingerprints"].(map[string]any)
+	if got := fingerprints["bomlyStableId/v1"]; got == "" {
+		t.Fatalf("expected stable fingerprint, got %#v", fingerprints)
+	}
+}
+
 // TestWriteSARIF_LocationsFallBackToRepoFile verifies the writer uses a
 // GitHub-compatible repository file when no richer dependency location is
 // available. Package identity stays in the SARIF properties bag.


### PR DESCRIPTION
## Summary
- Emit SARIF baseline metadata and stable fingerprints for diff output.
- Include only introduced findings in diff SARIF results.
- Attach line and column locations to GitHub Actions workflow `uses` entries.
- Tighten deps.dev matcher handling for empty cached and API license sets.

## Testing
- Added unit coverage for SARIF diff filtering and baseline annotations.
- Added detector coverage for workflow `uses` line and column positions.
- Added matcher coverage for refetching cached empty license sets and skipping empty API responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SARIF output now includes baseline state tracking and stable fingerprints to improve finding identification and deduplication.
  * `bomly diff` SARIF output now focuses on introduced findings with updated baseline behavior.

* **Bug Fixes**
  * License matching now correctly handles empty cache/API responses and triggers API enrichment when needed.
  * GitHub Actions workflow analysis records more precise `uses:` source locations and supports owner/repo coordinates.

* **Tests**
  * Added unit tests for diff SARIF “introduced-only” behavior, SARIF baseline/stable fingerprints, and improved GitHub Actions location tracking.
  * Added tests covering license matcher caching/enrichment for empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->