### PR TITLE
Keep release notes outside release checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Write release notes
         shell: bash
         run: |
-          cat > RELEASE_NOTES.md <<'EOF'
+          cat > "$RUNNER_TEMP/RELEASE_NOTES.md" <<'EOF'
           Bomly release ${{ github.ref_name }}
 
           Assets in this draft release include:
@@ -90,7 +90,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v2.16.0
-          args: release --clean --release-notes=RELEASE_NOTES.md
+          args: release --clean --release-notes=${{ runner.temp }}/RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TAP_GITHUB_TOKEN: ${{ steps.package-token.outputs.token }}


### PR DESCRIPTION
## Summary

- write generated release notes to the runner temp directory instead of the repository checkout
- pass GoReleaser the temp-file path so its dirty-tree check no longer sees an untracked `RELEASE_NOTES.md`

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml OK"'`
- `git diff --check`
- `/Users/ahmed/go/bin/goreleaser check`
- `make test`
- `go vet ./...`
- `/Users/ahmed/go/bin/goreleaser release --snapshot --clean --skip=publish --release-notes=<tmp>/RELEASE_NOTES.md`