### PR TITLE
Avoid fork sync for Bomly package repos

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -157,10 +157,6 @@ homebrew_casks:
       pull_request:
         enabled: true
         draft: false
-        base:
-          owner: bomly-dev
-          name: homebrew-tap
-          branch: main
 
 scoops:
   - name: bomly
@@ -178,10 +174,6 @@ scoops:
       pull_request:
         enabled: true
         draft: false
-        base:
-          owner: bomly-dev
-          name: scoop-bucket
-          branch: main
 
 winget:
   - name: bomly


### PR DESCRIPTION
## Summary

- remove the explicit same-repo `pull_request.base` blocks for Homebrew and Scoop publishing
- keep the WinGet cross-repo base untouched, since that PR targets `microsoft/winget-pkgs`

This should stop GoReleaser from trying GitHub's fork-sync API for `bomly-dev/homebrew-tap` and `bomly-dev/scoop-bucket`, which are standalone Bomly-owned repos rather than forks.

## Validation

- `/Users/ahmed/go/bin/goreleaser check`
- `git diff --check`
- `make test`
- `/Users/ahmed/go/bin/goreleaser release --snapshot --clean --skip=publish --release-notes=<tmp>/RELEASE_NOTES.md`

Note: the snapshot release completed successfully; the local shell wrapper then exited non-zero while cleaning up because `status` is a readonly zsh variable. Generated `dist/` artifacts were removed afterwards.