### PR TITLE
Add support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ See [Plugins](docs/PLUGINS.md) for install, trust, and authoring guidance.
 
 Contributor setup lives in [CONTRIBUTING.md](CONTRIBUTING.md). Architecture details live in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+## Support
+
+Bomly is an open-source project. If you find it useful, you can support the project by starring the repository, sharing feedback, opening issues, contributing improvements, or sponsoring ongoing maintenance.
+
+See [Support Bomly](https://bomly.dev/support).
+
 ## License
 
 Bomly CLI is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Adds a short support section near the bottom of the Bomly CLI README. The section points readers to ways they can support the open-source project, including feedback, issues, contributions, and sponsorship.

## Validation

- `git diff --check -- README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Support section to the README documenting multiple ways to support the project, including starring the repository, sharing feedback, opening issues, contributing improvements, and sponsoring maintenance efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->