### PR TITLE
docs(guard): clarify that Bomly Guard installs CLI only, not package managers

### DIFF
--- a/docs/BOMLY_GUARD.md
+++ b/docs/BOMLY_GUARD.md
@@ -38,6 +38,55 @@ jobs:
 
 Pin to a major tag (`@v1`) for automatic patch and minor updates, or to an exact release (`@v1.2.3`) for fully reproducible builds.
 
+## Package Manager Setup
+
+Bomly Guard installs the Bomly CLI. It does not install project package managers.
+
+Package-manager tools such as npm, pnpm, Yarn, Dart pub, SwiftPM, SBT, Composer, Bundler, and Conan should be installed by earlier workflow steps when your project needs them. Many repositories can be reviewed from committed lockfiles alone. Build-tool-backed detectors — currently Dart pub, SwiftPM, and SBT — produce richer dependency graphs when their build tool is available; any detector may also need its package manager when lockfile parsing is not enough or when `install-first` is enabled.
+
+Use the normal ecosystem setup action before Bomly Guard:
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+    with:
+      fetch-depth: 0
+
+  # Node.js, npm, pnpm, and Yarn
+  - uses: actions/setup-node@v6
+    with:
+      node-version: 22
+      cache: npm
+  - run: corepack enable
+
+  # Java, Maven, Gradle, Scala, and SBT
+  - uses: actions/setup-java@v5
+    with:
+      distribution: temurin
+      java-version: 21
+
+  # Go modules
+  - uses: actions/setup-go@v6
+    with:
+      go-version: stable
+
+  # Python, pip, pipenv, poetry, and uv
+  - uses: actions/setup-python@v6
+    with:
+      python-version: "3.12"
+
+  # Dart pub
+  - uses: dart-lang/setup-dart@v1
+
+  - uses: bomly-dev/bomly-guard@v1
+    with:
+      fail-on: high
+```
+
+See the [Bomly Guard README](https://github.com/bomly-dev/bomly-guard) for the full per-ecosystem setup reference.
+
+The `install-first` input passes `--install-first` to `bomly diff`, telling CLI detectors that support it to install project dependencies before resolving graphs. It does not install the package-manager binary itself.
+
 ## How it works
 
 On a `pull_request` event the action:
@@ -84,7 +133,7 @@ Inputs map directly onto CLI flags. Comma-separated values become repeated flags
 | `matchers` | | `--matchers` selector. |
 | `auditors` | | `--auditors` selector. |
 | `analyzers` | | `--analyzers` selector. |
-| `install-first` | `false` | `--install-first` — run detector installs before resolving. |
+| `install-first` | `false` | `--install-first` — ask CLI detectors that support install-first behavior to install project dependencies before resolving graphs. Does not install package-manager binaries. |
 | `install-args` | | repeated `--install-arg`. |
 | `comment-summary-in-pr` | `never` | PR comment mode: `never`, `always`, `on-failure`. |
 | `upload-sarif` | `auto` | SARIF upload: `auto`, `true`, `false`. |

--- a/docs/BOMLY_GUARD.md
+++ b/docs/BOMLY_GUARD.md
@@ -38,6 +38,19 @@ jobs:
 
 Pin to a major tag (`@v1`) for automatic patch and minor updates, or to an exact release (`@v1.2.3`) for fully reproducible builds.
 
+## How it works
+
+On a `pull_request` event the action:
+
+1. Installs the Bomly CLI (`version` input, defaults to `latest`).
+2. Resolves the base and head refs. Pull requests default to the PR merge base for the base and the PR head SHA for the head, so review focuses only on what the PR changes — pre-existing findings on the target branch are ignored.
+3. Runs `bomly diff --format json` with the enrich/audit/analyze and policy flags mapped from the action inputs.
+4. Renders the Markdown summary and SARIF side outputs.
+5. Writes the job summary, optionally posts (or updates) a PR comment, and optionally uploads SARIF.
+6. Exits non-zero when policy fails the review, failing the job.
+
+Because the engine is the same `bomly diff` you run locally, the policy you enforce on your machine is the policy the action enforces on PRs.
+
 ## Package Manager Setup
 
 Bomly Guard installs the Bomly CLI. It does not install project package managers.
@@ -52,53 +65,20 @@ steps:
     with:
       fetch-depth: 0
 
-  # Node.js, npm, pnpm, and Yarn
   - uses: actions/setup-node@v6
     with:
       node-version: 22
       cache: npm
-  - run: corepack enable
-
-  # Java, Maven, Gradle, Scala, and SBT
-  - uses: actions/setup-java@v5
-    with:
-      distribution: temurin
-      java-version: 21
-
-  # Go modules
-  - uses: actions/setup-go@v6
-    with:
-      go-version: stable
-
-  # Python, pip, pipenv, poetry, and uv
-  - uses: actions/setup-python@v6
-    with:
-      python-version: "3.12"
-
-  # Dart pub
-  - uses: dart-lang/setup-dart@v1
 
   - uses: bomly-dev/bomly-guard@v1
     with:
       fail-on: high
+      install-first: true
 ```
 
 See the [Bomly Guard README](https://github.com/bomly-dev/bomly-guard) for the full per-ecosystem setup reference.
 
 The `install-first` input passes `--install-first` to `bomly diff`, telling CLI detectors that support it to install project dependencies before resolving graphs. It does not install the package-manager binary itself.
-
-## How it works
-
-On a `pull_request` event the action:
-
-1. Installs the Bomly CLI (`version` input, defaults to `latest`).
-2. Resolves the base and head refs. Pull requests default to the PR merge base for the base and the PR head SHA for the head, so review focuses only on what the PR changes — pre-existing findings on the target branch are ignored.
-3. Runs `bomly diff --format json` with the enrich/audit/analyze and policy flags mapped from the action inputs.
-4. Renders the Markdown summary and SARIF side outputs.
-5. Writes the job summary, optionally posts (or updates) a PR comment, and optionally uploads SARIF.
-6. Exits non-zero when policy fails the review, failing the job.
-
-Because the engine is the same `bomly diff` you run locally, the policy you enforce on your machine is the policy the action enforces on PRs.
 
 ## Inputs
 

--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -117,6 +117,8 @@ jobs:
 
 The action's inputs map onto the CLI policy flags. See [Bomly Guard](BOMLY_GUARD.md) for the full input and output reference.
 
+The action installs the Bomly CLI — not project package managers. Add ecosystem setup steps (e.g. `actions/setup-node`, `actions/setup-java`) before Bomly Guard when your project uses build-tool-backed detectors or `install-first`. See [Package Manager Setup](BOMLY_GUARD.md#package-manager-setup).
+
 ## GitLab CI
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add a **Package Manager Setup** section to `docs/BOMLY_GUARD.md` explaining the action installs the Bomly CLI but not project package-manager toolchains
- Show per-ecosystem setup action examples (Node, Java, Go, Python, Dart) and note that the full reference lives in the bomly-guard README
- Clarify the `install-first` inputs table row to say it triggers detector installs, not PM binary installation
- Add a one-line note to the Bomly Guard subsection in `docs/CI_INTEGRATION.md` pointing readers to the new section

Mirrors the clarification landed in [bomly-dev/bomly-guard#17](https://github.com/bomly-dev/bomly-guard/pull/17).

## Test plan

- [ ] Docs render correctly (markdown links resolve, code blocks display)
- [ ] `install-first` table description is accurate and non-ambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Bomly Guard installs only the Bomly CLI, and that ecosystem tooling (e.g., npm/pnpm/Yarn, Java/Maven/Gradle/SBT, Go modules, Python tooling, Dart pub) must be set up separately in workflows when needed.
  * Expanded the `install-first` parameter description to specify it prompts detectors to install project dependencies before graph resolution, and that it does not install package-manager binaries.
  * Added CI-focused clarification on when to perform ecosystem setup prior to running Bomly Guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->