### PR TITLE
Skip unsupported deps.dev package systems

### DIFF
--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -369,14 +369,6 @@ func depsDevSystem(ecosystem string) (string, bool) {
 		return "RUBYGEMS", true
 	case "rust", "cargo":
 		return "CARGO", true
-	case "php", "composer":
-		return "PACKAGIST", true
-	case "elixir", "mix", "hex":
-		return "HEXPM", true
-	case "dart", "pub":
-		return "PUB", true
-	case "swift", "cocoapods":
-		return "COCOAPODS", true
 	default:
 		return "", false
 	}
@@ -521,18 +513,6 @@ func versionKeyFromParsedPURL(p parsedPURL) (versionKey, bool) {
 		return versionKey{System: "RUBYGEMS", Name: p.Name, Version: version}, true
 	case "cargo":
 		return versionKey{System: "CARGO", Name: p.Name, Version: version}, true
-	case "composer":
-		name := p.Name
-		if p.Namespace != "" {
-			name = p.Namespace + "/" + p.Name
-		}
-		return versionKey{System: "PACKAGIST", Name: name, Version: version}, true
-	case "hex":
-		return versionKey{System: "HEXPM", Name: strings.ToLower(p.Name), Version: version}, true
-	case "pub":
-		return versionKey{System: "PUB", Name: p.Name, Version: version}, true
-	case "cocoapods":
-		return versionKey{System: "COCOAPODS", Name: p.Name, Version: version}, true
 	default:
 		return versionKey{}, false
 	}

--- a/internal/matchers/depsdev/matcher_test.go
+++ b/internal/matchers/depsdev/matcher_test.go
@@ -74,6 +74,24 @@ func TestVersionRequestFromPackage(t *testing.T) {
 			t.Fatal("expected unsupported ecosystem to be rejected")
 		}
 	})
+
+	t.Run("deps.dev unsupported systems are rejected", func(t *testing.T) {
+		cases := []sdk.Coordinates{
+			{Ecosystem: "php", Name: "guzzlehttp/guzzle", Version: "6.2.3"},
+			{Ecosystem: "elixir", Name: "plug", Version: "1.16.1"},
+			{Ecosystem: "dart", Name: "http", Version: "1.2.0"},
+			{Ecosystem: "swift", Name: "github.com/apple:swift-log", Version: "1.5.4"},
+			{PURL: "pkg:composer/guzzlehttp/guzzle@6.2.3", Version: "6.2.3"},
+			{PURL: "pkg:hex/plug@1.16.1", Version: "1.16.1"},
+			{PURL: "pkg:pub/http@1.2.0", Version: "1.2.0"},
+			{PURL: "pkg:cocoapods/Alamofire@5.8.1", Version: "5.8.1"},
+		}
+		for _, tc := range cases {
+			if req, _, ok := versionRequestFromPackage(&sdk.Package{Coordinates: tc}); ok {
+				t.Fatalf("expected unsupported package to be rejected, got %#v", req)
+			}
+		}
+	})
 }
 
 func TestCheckerMatch_RefetchesCachedEmptyLicenseSet(t *testing.T) {


### PR DESCRIPTION
## Summary

- stop sending deps.dev versionbatch requests for package systems the live API rejects
- treat Composer, Hex, Pub, CocoaPods, and SwiftPM packages as unsupported for deps.dev license enrichment
- add regression coverage for unsupported ecosystem and PURL inputs

## Validation

- go test ./internal/matchers/depsdev
- built a patched CLI and reproduced the Composer and SwiftPM enriched dogfood diffs without deps.dev 400 warnings
- probed deps.dev versionbatch support directly: NPM/MAVEN/GO/PYPI/NUGET/RUBYGEMS/CARGO return 200; PACKAGIST/HEXPM/PUB/COCOAPODS return 400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package ecosystem detection to properly recognize Ruby and Rust packages.
  * Removed support for PHP, Elixir, Dart, and Swift ecosystems.

* **Tests**
  * Added test coverage verifying that unsupported package ecosystems are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->