### PR TITLE
Fix dogfood detector edge cases

### DIFF
--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -158,7 +159,7 @@ func (d Detector) runDependencies(stderr io.Writer, workingDir string, verbose b
 		return nil, fmt.Errorf("run gradle dependencies: %w", err)
 	}
 
-	depsGraph, err := depGraphFromGradleOutput(gradleOut.Bytes(), filepath.Base(workingDir))
+	depsGraph, err := depGraphFromGradleOutput(gradleOut.Bytes(), gradleRootName(workingDir))
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to map Gradle output to a dependency graph: %v", err))
 		logger.Debug("gradle output mapping failed", zap.Error(err))
@@ -304,6 +305,24 @@ func depGraphFromGradleOutput(raw []byte, rootName string) (*sdk.Graph, error) {
 	}
 
 	return depsGraph, nil
+}
+
+var gradleRootProjectNamePattern = regexp.MustCompile(`(?m)\brootProject\.name\s*=\s*["']([^"']+)["']`)
+
+func gradleRootName(workingDir string) string {
+	for _, name := range []string{"settings.gradle", "settings.gradle.kts"} {
+		raw, err := os.ReadFile(filepath.Join(workingDir, name))
+		if err != nil {
+			continue
+		}
+		matches := gradleRootProjectNamePattern.FindSubmatch(raw)
+		if len(matches) == 2 {
+			if value := strings.TrimSpace(string(matches[1])); value != "" {
+				return value
+			}
+		}
+	}
+	return filepath.Base(workingDir)
 }
 
 func isGradleConfigurationHeader(line string) bool {

--- a/internal/detectors/gradle/detector_test.go
+++ b/internal/detectors/gradle/detector_test.go
@@ -1,6 +1,7 @@
 package gradle
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -195,5 +196,54 @@ func TestDepGraphFromGradleOutput_UsesResolvedVersion(t *testing.T) {
 
 	if _, ok := g.Node("org.slf4j:slf4j-api@2.0.12"); !ok {
 		t.Fatalf("expected resolved version package to exist")
+	}
+}
+
+func TestGradleRootName_ReadsSettingsGradle(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "settings.gradle"), []byte("rootProject.name = 'example-java-gradle'\n"), 0o644); err != nil {
+		t.Fatalf("write settings.gradle: %v", err)
+	}
+
+	if got := gradleRootName(projectDir); got != "example-java-gradle" {
+		t.Fatalf("gradleRootName() = %q, want example-java-gradle", got)
+	}
+}
+
+func TestGradleRootName_ReadsSettingsGradleKts(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "settings.gradle.kts"), []byte("rootProject.name = \"example-kts\"\n"), 0o644); err != nil {
+		t.Fatalf("write settings.gradle.kts: %v", err)
+	}
+
+	if got := gradleRootName(projectDir); got != "example-kts" {
+		t.Fatalf("gradleRootName() = %q, want example-kts", got)
+	}
+}
+
+func TestRunDependencies_UsesSettingsGradleRootName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is unix-only")
+	}
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "settings.gradle"), []byte("rootProject.name = 'example-java-gradle'\n"), 0o644); err != nil {
+		t.Fatalf("write settings.gradle: %v", err)
+	}
+	gradlePath := filepath.Join(projectDir, "gradle-fixture")
+	script := "#!/bin/sh\ncat <<'OUT'\nruntimeClasspath - Runtime classpath of source set 'main'.\n\\--- org.springframework:spring-core:6.1.1\nOUT\n"
+	if err := os.WriteFile(gradlePath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gradle fixture: %v", err)
+	}
+
+	g, err := (Detector{}).runDependencies(&bytes.Buffer{}, projectDir, false, gradlePath, nil)
+	if err != nil {
+		t.Fatalf("runDependencies() error = %v", err)
+	}
+	if _, ok := g.Node("example-java-gradle"); !ok {
+		t.Fatalf("expected settings.gradle root node")
+	}
+	if _, ok := g.Node(filepath.Base(projectDir)); ok {
+		t.Fatalf("did not expect temp directory root node")
 	}
 }

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -182,7 +183,28 @@ func wrapCommand(path string) (string, []string, error) {
 	if runtime.GOOS == "windows" && (ext == ".cmd" || ext == ".bat") {
 		return "cmd", []string{"/c", path}, nil
 	}
+	if err := ensureExecutableMavenWrapper(path); err != nil {
+		return "", nil, err
+	}
 	return path, nil, nil
+}
+
+func ensureExecutableMavenWrapper(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat maven wrapper: %w", err)
+	}
+	mode := info.Mode()
+	if mode&0o111 != 0 {
+		return nil
+	}
+	if err := os.Chmod(path, mode|0o755); err != nil {
+		return fmt.Errorf("chmod maven wrapper executable: %w", err)
+	}
+	return nil
 }
 
 func findWrapper(workingDir string) (string, bool, error) {

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -210,6 +210,36 @@ func TestMavenDetectorResolveRunner_PrefersWrapper(t *testing.T) {
 	}
 }
 
+func TestMavenDetectorResolveRunner_MakesUnixWrapperExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only executable-bit behavior")
+	}
+
+	projectDir := t.TempDir()
+	wrapperPath := filepath.Join(projectDir, "mvnw")
+	if err := os.WriteFile(wrapperPath, []byte("wrapper\n"), 0o644); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	t.Setenv("PATH", "")
+
+	detector := Detector{WorkingDir: projectDir}
+	executable, _, err := detector.resolveRunner()
+	if err != nil {
+		t.Fatalf("resolveRunner() error = %v", err)
+	}
+	if executable != wrapperPath {
+		t.Fatalf("expected wrapper executable %q, got %q", wrapperPath, executable)
+	}
+
+	info, err := os.Stat(wrapperPath)
+	if err != nil {
+		t.Fatalf("stat wrapper: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("expected wrapper to be executable, mode=%#o", info.Mode().Perm())
+	}
+}
+
 func TestMavenDetectorResolveRunner_FallsBackToInstalledMaven(t *testing.T) {
 	originalLookPath := execLookPath
 	t.Cleanup(func() { execLookPath = originalLookPath })

--- a/internal/detectors/sbt/detector_test.go
+++ b/internal/detectors/sbt/detector_test.go
@@ -2,6 +2,7 @@ package sbt
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -62,5 +63,71 @@ func TestDepGraphFromSBTDependencyTreePreservesScalaArtifactSuffix(t *testing.T)
 	}
 	if len(children) != 1 || children[0].Name != "cats-kernel_2.13" {
 		t.Fatalf("expected cats-kernel_2.13 child, got %#v", children)
+	}
+}
+
+func TestNativeDetectorApplicable_SkipsOldSBTWithoutDependencyGraphPlugin(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "build.sbt"), []byte(`libraryDependencies += "org.mindrot" % "jbcrypt" % "0.3m"`), 0o644); err != nil {
+		t.Fatalf("write build.sbt: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "project"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "project", "build.properties"), []byte("sbt.version = 0.13.16\n"), 0o644); err != nil {
+		t.Fatalf("write build.properties: %v", err)
+	}
+
+	applicable, err := (NativeDetector{WorkingDir: projectDir}).Applicable(context.Background(), sdk.DetectionRequest{ProjectPath: projectDir})
+	if err != nil {
+		t.Fatalf("Applicable() error = %v", err)
+	}
+	if applicable {
+		t.Fatalf("expected old sbt project without dependency graph plugin to skip native detector")
+	}
+}
+
+func TestNativeDetectorApplicable_AllowsOldSBTWithDependencyGraphPlugin(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "build.sbt"), []byte(`libraryDependencies += "org.mindrot" % "jbcrypt" % "0.3m"`), 0o644); err != nil {
+		t.Fatalf("write build.sbt: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "project"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "project", "build.properties"), []byte("sbt.version = 0.13.16\n"), 0o644); err != nil {
+		t.Fatalf("write build.properties: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "project", "plugins.sbt"), []byte(`addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")`), 0o644); err != nil {
+		t.Fatalf("write plugins.sbt: %v", err)
+	}
+
+	applicable, err := (NativeDetector{WorkingDir: projectDir}).Applicable(context.Background(), sdk.DetectionRequest{ProjectPath: projectDir})
+	if err != nil {
+		t.Fatalf("Applicable() error = %v", err)
+	}
+	if !applicable {
+		t.Fatalf("expected old sbt project with dependency graph plugin to use native detector")
+	}
+}
+
+func TestNativeDetectorApplicable_AllowsModernSBT(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "build.sbt"), []byte(`libraryDependencies += "org.mindrot" % "jbcrypt" % "0.3m"`), 0o644); err != nil {
+		t.Fatalf("write build.sbt: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "project"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "project", "build.properties"), []byte("sbt.version = 1.10.0\n"), 0o644); err != nil {
+		t.Fatalf("write build.properties: %v", err)
+	}
+
+	applicable, err := (NativeDetector{WorkingDir: projectDir}).Applicable(context.Background(), sdk.DetectionRequest{ProjectPath: projectDir})
+	if err != nil {
+		t.Fatalf("Applicable() error = %v", err)
+	}
+	if !applicable {
+		t.Fatalf("expected modern sbt project to use native detector")
 	}
 }

--- a/internal/detectors/sbt/sbt_native.go
+++ b/internal/detectors/sbt/sbt_native.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,7 +40,19 @@ func (d NativeDetector) Ready() bool {
 
 // Applicable reports whether sbt build files are present.
 func (d NativeDetector) Applicable(ctx context.Context, req sdk.DetectionRequest) (bool, error) {
-	return (Detector{WorkingDir: d.workingDir(req.ProjectPath)}).Applicable(ctx, req)
+	workingDir := d.workingDir(req.ProjectPath)
+	applicable, err := (Detector{WorkingDir: workingDir}).Applicable(ctx, req)
+	if err != nil || !applicable {
+		return applicable, err
+	}
+	if requiresDependencyGraphPlugin(workingDir) && !hasDependencyGraphPlugin(workingDir) {
+		d.logger().Debug("sbt native detector skipped: dependencyTree task is unavailable for this sbt version",
+			zap.String("working_dir", workingDir),
+			zap.String("sbt_version", sbtVersion(workingDir)),
+		)
+		return false, nil
+	}
+	return true, nil
 }
 
 // Descriptor describes the sbt native detector.
@@ -97,6 +112,68 @@ func (d NativeDetector) logger() *zap.Logger {
 		return d.Logger
 	}
 	return zap.NewNop()
+}
+
+func requiresDependencyGraphPlugin(workingDir string) bool {
+	version := sbtVersion(workingDir)
+	if version == "" {
+		return false
+	}
+	major, minor, ok := parseSBTMajorMinor(version)
+	if !ok {
+		return false
+	}
+	return major == 0 || (major == 1 && minor < 4)
+}
+
+func sbtVersion(workingDir string) string {
+	raw, err := os.ReadFile(filepath.Join(workingDir, "project", "build.properties"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "sbt.version" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func parseSBTMajorMinor(version string) (int, int, bool) {
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+func hasDependencyGraphPlugin(workingDir string) bool {
+	for _, name := range []string{
+		filepath.Join("project", "plugins.sbt"),
+		filepath.Join("project", "build.sbt"),
+		"build.sbt",
+	} {
+		raw, err := os.ReadFile(filepath.Join(workingDir, name))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(raw), "sbt-dependency-graph") {
+			return true
+		}
+	}
+	return false
 }
 
 // sbtDepTreeLinePattern matches a dependency line from sbt dependencyTree.


### PR DESCRIPTION
## Summary

- make the Maven detector chmod Unix `mvnw` wrappers before execution, matching Gradle wrapper handling
- use `rootProject.name` from Gradle settings files for the root package instead of Bomly temporary checkout directory names
- skip the native SBT detector for old sbt projects where `dependencyTree` is unavailable unless `sbt-dependency-graph` is configured

## Validation

- go test ./internal/detectors/maven ./internal/detectors/gradle ./internal/detectors/sbt
- go build -o /tmp/bomly-detectors-patched ./cmd/bomly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maven wrapper scripts now correctly receive executable permissions on Unix systems when detected.

* **Improvements**
  * Gradle detector now accurately identifies root project names by reading configuration from `settings.gradle` or `settings.gradle.kts`, improving dependency graph representation.
  * SBT detector enhanced to verify native analysis plugin availability before attempting native dependency detection.

* **Tests**
  * Added comprehensive test coverage for Gradle root name detection, Maven wrapper permissions, and SBT plugin availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->