### PR TITLE
ci(release): publish release with app token so the docs-sync dispatch fires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,23 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: Mint release token
+        # Used as GoReleaser's GITHUB_TOKEN to publish the release to this repo.
+        # The default GITHUB_TOKEN cannot be used here: GitHub does not start new
+        # workflow runs from events triggered by the default token, so a release
+        # published with it would never fire the `release: published` trigger on
+        # "Release lifecycle sync" (notify-landing-yank.yml) — and the
+        # landing-page docs sync (repository_dispatch) would silently never run.
+        # An app token is attributed to the app, so the publish event cascades.
+        uses: actions/create-github-app-token@v3
+        id: release-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bomly-dev
+          repositories: bomly-cli
+          permission-contents: write
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -76,7 +93,7 @@ jobs:
           version: v2.16.0
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
           TAP_GITHUB_TOKEN: ${{ steps.package-token.outputs.token }}
           SCOOP_GITHUB_TOKEN: ${{ steps.package-token.outputs.token }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

A CLI release (v0.14.9) synced the landing-page changelog but **not** the docs.

Both `sync-changelog` and `sync-docs` on the landing page are driven by the same `bomly-release` `repository_dispatch`, which is POSTed by [`notify-landing-yank.yml`](.github/workflows/notify-landing-yank.yml) ("Release lifecycle sync") on `release: published`. That workflow **hasn't run since v0.14.0** — its `release: published` trigger no longer fires.

Root cause: since #175 flipped GoReleaser to `draft: false`, GoReleaser publishes the release directly using `GITHUB_TOKEN: ${{ github.token }}`. **GitHub does not start new workflow runs from events triggered by the default `GITHUB_TOKEN`** (anti-recursion). So the publish event is dropped, no dispatch is sent, and `sync-docs` never runs. `sync-changelog` only kept working because it has a daily cron backstop that `sync-docs` lacks.

## What

Mint a Bomly Release **app token** scoped to `bomly-cli` (`contents:write`) and pass it as GoReleaser's `GITHUB_TOKEN`. Events attributed to a GitHub App **do** cascade, so the publish once again fires "Release lifecycle sync" → `repository_dispatch` → landing-page `sync-docs`.

The app credentials (`RELEASE_BOT_CLIENT_ID` / `RELEASE_BOT_PRIVATE_KEY`) are already used elsewhere in this workflow and in `auto-version.yml`, so no new secrets are needed. The package-manager (tap/scoop/winget) tokens are untouched.

A defense-in-depth daily backstop is added to `sync-docs` separately in [bomly-landing-page#66](https://github.com/bomly-dev/bomly-landing-page/pull/66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication to use a dedicated GitHub App token, improving the reliability of the release process and ensuring proper execution of downstream automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->