### PR TITLE
docs(release): lead with What's Changed, demote artifacts to a footnote

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,10 +98,10 @@ release:
     name: bomly-cli
   draft: false
   prerelease: auto
-  header: |
-    Bomly release {{ .Tag }}
+  footer: |
+    ---
+    ### Release artifacts
 
-    Included artifacts:
     - Full builtin `bomly` archives for Linux, macOS, and Windows.
     - Alternate `bomly-lite` archives for users who prefer external Syft and Grype binaries.
     - Linux packages for Debian, RPM, Alpine, and Arch-compatible package managers.


### PR DESCRIPTION
## What

Restructures GitHub release notes so the per-release **What's Changed** leads, and the unchanging packaging boilerplate becomes a footnote.

- Removes `release.header` (the `Bomly release {{ .Tag }}` line + `Included artifacts:` block). The version is already the release title, so the header was redundant and pushed What's Changed below the fold.
- Adds `release.footer` with the same artifact list under a `### Release artifacts` heading, separated by a horizontal rule — so it reads as a footnote *after* What's Changed / Full Changelog.

`changelog.use: github-native` already generates the What's Changed / Full Changelog body, so with no header the notes now start with `## What's Changed`.

## Why

Every release opened with identical boilerplate before the one thing that varies release-to-release. This also flows through to the landing-page changelog blog, which ingests the release body verbatim.

## Verification

- `goreleaser check` ✅ (config validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub release notes formatting and templating to improve presentation and organization of release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->