### PR TITLE
fix(maven): raise TGF scanner buffer to handle large dependency trees

### DIFF
--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -22,6 +22,11 @@ import (
 
 var execLookPath = system.LookPath
 
+// maxTGFTokenSize caps the per-line buffer the TGF scanner will grow to. It is
+// far above any realistic single line of `mvn dependency:tree` TGF output while
+// still bounding memory use on pathological input.
+const maxTGFTokenSize = 10 << 20 // 10 MiB
+
 var mavenScopes = map[string]struct{}{
 	"compile":  {},
 	"provided": {},
@@ -230,6 +235,10 @@ func wrapperCandidates() []string {
 
 func depGraphFromMavenTGF(raw []byte) (*sdk.Graph, error) {
 	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
+	// bufio.Scanner defaults to a 64KB max token size. Large multi-module
+	// dependency trees (or single nodes with very long coordinate strings)
+	// routinely exceed that and fail with "token too long", so raise the cap.
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTGFTokenSize)
 	inEdges := false
 
 	tgfPackages := make(map[string]*sdk.Dependency)

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -48,6 +49,38 @@ func TestDepGraphFromMavenTGF(t *testing.T) {
 	}
 	if logbackDeps[0].ID != "ch.qos.logback:logback-core@1.5.6" || logbackDeps[1].ID != "org.slf4j:slf4j-api@2.0.13" {
 		t.Fatalf("unexpected logback deps: %#v", logbackDeps)
+	}
+}
+
+func TestDepGraphFromMavenTGF_LongLineExceedsDefaultBuffer(t *testing.T) {
+	// Maven's transfer-progress output is carriage-return delimited, so when it
+	// is captured alongside stdout it can collapse into a single newline-delimited
+	// line far larger than bufio.Scanner's default 64KB token cap. The scanner
+	// must tolerate such a line (and skip it) rather than fail with
+	// "token too long".
+	hugeLine := strings.Repeat("Progress (1): demo-app-1.0.0.jar (1.2 MB) ", 4000)
+	if len(hugeLine) <= 64*1024 {
+		t.Fatalf("test setup: expected a line larger than 64KB, got %d bytes", len(hugeLine))
+	}
+	raw := []byte(hugeLine + "\n" + `1 com.example:demo-app:jar:1.0.0
+2 org.slf4j:slf4j-api:jar:2.0.13:compile
+#
+1 2 compile
+`)
+
+	g, err := depGraphFromMavenTGF(raw)
+	if err != nil {
+		t.Fatalf("depGraphFromMavenTGF() error = %v", err)
+	}
+	if g.Size() != 2 {
+		t.Fatalf("expected 2 packages, got %d", g.Size())
+	}
+	rootDeps, err := g.DirectDependencies("com.example:demo-app@1.0.0")
+	if err != nil {
+		t.Fatalf("dependencies(root) error = %v", err)
+	}
+	if len(rootDeps) != 1 || rootDeps[0].ID != "org.slf4j:slf4j-api@2.0.13" {
+		t.Fatalf("unexpected root deps: %#v", rootDeps)
 	}
 }
 


### PR DESCRIPTION
## What

`mvn dependency:tree -DoutputType=tgf` output can collapse into a single newline-delimited line far larger than `bufio.Scanner`'s default 64KB token cap — most commonly because Maven's transfer-progress output is carriage-return (`\r`) delimited and, when captured alongside stdout, never produces a `\n` until the build finishes. The scanner then fails with:

```
ERROR Failed to map Maven output to a dependency graph: scan maven tgf: bufio.Scanner: token too long
```

This aborted the Maven graph mapping entirely and, in **Bomly Guard**, also prevented the SARIF file from being produced/uploaded (observed on [example-java-maven#4](https://github.com/bomly-dev/example-java-maven/pull/4)).

## Change

- Raise the TGF scanner's per-line buffer to 10 MiB (`scanner.Buffer(...)`) in `depGraphFromMavenTGF`.
- Add a regression test that feeds a >64KB line ahead of valid TGF content and asserts the graph still parses.

## Test

`go test ./internal/detectors/maven/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven dependency scanning so very large dependency trees and long coordinate lines no longer fail with “token too long” errors.
  * Dependency graphs now load more reliably when Maven output includes oversized progress lines.
  
* **Tests**
  * Added coverage for parsing Maven output with lines larger than the previous default buffer size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->