### PR TITLE
feat(sdk): GitHub-aligned severities for non-CVSS findings + compact license IDs

### DIFF
--- a/dev-docs/MODELS.md
+++ b/dev-docs/MODELS.md
@@ -133,7 +133,10 @@ type Finding struct {
     // Identity + policy
     ID          string             // CVE / GHSA / policy ID
     Kind        FindingKind        // vulnerability | license | package | ...
-    Severity    string
+    Severity    string             // CVSS band (critical|high|medium|low) for
+                                   // vulnerabilities; GitHub-aligned level
+                                   // (error|warning|note) for findings without
+                                   // a CVSS score (license, package)
     Title       string
     Reasons     []string
     Source      string             // osv | grype | license | package | ...

--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -12,9 +12,13 @@ import (
 )
 
 const (
-	auditorName             = "license"
+	auditorName = "license"
+	// Finding-ID prefixes. The remainder is a compact base32 SHA256 of the PURL
+	// so IDs stay stable, short, and free of package coordinates (which can leak
+	// internal paths and break SARIF rule-ID expectations).
 	unknownLicenseFindingID = "UNKNOWN"
-	licenseSeverityNA       = "n/a"
+	invalidLicenseFindingID = "INVALID"
+	deniedLicenseFindingID  = "DENIED"
 )
 
 // Auditor evaluates package licenses against allow/deny SPDX policy.
@@ -137,15 +141,12 @@ func registryLicenseValues(registry *sdk.PackageRegistry, purl string) []string 
 }
 
 func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) sdk.Finding {
-	findingID := fmt.Sprintf("%s:%s:%s", auditorName, id, purl)
-	if id == "unknown-license" {
-		findingID = unknownLicenseID(purl)
-	}
+	prefix, severity := licenseFindingClass(id)
 	f := sdk.Finding{
-		ID:          findingID,
+		ID:          licenseFindingID(prefix, purl),
 		Kind:        sdk.FindingKindLicense,
 		Title:       title,
-		Severity:    licenseSeverityNA,
+		Severity:    severity,
 		Source:      auditorName,
 		Auditor:     auditorName,
 		Disposition: disposition,
@@ -157,16 +158,34 @@ func finding(purl, depID, id, title string, disposition sdk.FindingDisposition) 
 	return f
 }
 
-func unknownLicenseID(purl string) string {
+// licenseFindingClass maps a license check id to its finding-ID prefix and
+// GitHub-aligned severity. Invalid and unknown licenses are advisory (Warning);
+// a denylisted/not-allowlisted license is a policy failure (Error).
+func licenseFindingClass(id string) (prefix string, severity sdk.SeverityLevel) {
+	switch id {
+	case "unknown-license":
+		return unknownLicenseFindingID, sdk.SeverityWarning
+	case "invalid-license":
+		return invalidLicenseFindingID, sdk.SeverityWarning
+	case "denied-license":
+		return deniedLicenseFindingID, sdk.SeverityError
+	default:
+		return strings.ToUpper(id), sdk.SeverityWarning
+	}
+}
+
+// licenseFindingID builds a compact, stable finding ID of the form
+// "PREFIX-xxxx-xxxx-xxxx" from a base32 SHA256 of the PURL.
+func licenseFindingID(prefix, purl string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(purl)))
 	encoded := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(sum[:]))
 	if len(encoded) > 12 {
 		encoded = encoded[:12]
 	}
 	if len(encoded) < 12 {
-		return unknownLicenseFindingID + "-" + encoded
+		return prefix + "-" + encoded
 	}
-	return fmt.Sprintf("%s-%s-%s-%s", unknownLicenseFindingID, encoded[:4], encoded[4:8], encoded[8:12])
+	return fmt.Sprintf("%s-%s-%s-%s", prefix, encoded[:4], encoded[4:8], encoded[8:12])
 }
 
 func packageExempt(dep *sdk.Dependency, exemptions []string) bool {

--- a/internal/auditors/license/auditor_test.go
+++ b/internal/auditors/license/auditor_test.go
@@ -98,12 +98,12 @@ func TestLicenseAuditorUnknownLicenseUsesCompactFindingID(t *testing.T) {
 	if finding.PackageRef != purl {
 		t.Fatalf("finding package ref = %q, want %q", finding.PackageRef, purl)
 	}
-	if finding.Severity != licenseSeverityNA {
-		t.Fatalf("finding severity = %q, want %q", finding.Severity, licenseSeverityNA)
+	if finding.Severity != sdk.SeverityWarning {
+		t.Fatalf("finding severity = %q, want %q", finding.Severity, sdk.SeverityWarning)
 	}
 }
 
-func TestLicenseAuditorDeniedLicensesUseNASeverity(t *testing.T) {
+func TestLicenseAuditorDeniedLicensesUseErrorSeverity(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependencyRefWithID("app@1.0.0", "app", "1.0.0")
 	_ = g.AddNode(root)
@@ -126,8 +126,11 @@ func TestLicenseAuditorDeniedLicensesUseNASeverity(t *testing.T) {
 	if len(result.Findings) != 1 {
 		t.Fatalf("expected 1 finding, got %#v", result.Findings)
 	}
-	if got := result.Findings[0].Severity; got != licenseSeverityNA {
-		t.Fatalf("finding severity = %q, want %q", got, licenseSeverityNA)
+	if got := result.Findings[0].Severity; got != sdk.SeverityError {
+		t.Fatalf("finding severity = %q, want %q", got, sdk.SeverityError)
+	}
+	if got := result.Findings[0].ID; !strings.HasPrefix(got, deniedLicenseFindingID+"-") {
+		t.Fatalf("finding ID = %q, want %q prefix", got, deniedLicenseFindingID+"-")
 	}
 }
 

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -9,10 +9,7 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-const (
-	auditorName       = "package"
-	packageSeverityNA = "n/a"
-)
+const auditorName = "package"
 
 // Auditor protects against denied packages and suspiciously similar package names.
 type Auditor struct {
@@ -104,13 +101,22 @@ func finding(pkg *sdk.Dependency, id, title string, disposition sdk.FindingDispo
 		ID:             fmt.Sprintf("%s:%s:%s", auditorName, id, pkg.ID),
 		Kind:           sdk.FindingKindPackage,
 		Title:          title,
-		Severity:       packageSeverityNA,
+		Severity:       packageFindingSeverity(disposition),
 		Source:         auditorName,
 		Auditor:        auditorName,
 		Disposition:    disposition,
 		PackageRef:     purl,
 		DependencyRefs: []string{pkg.ID},
 	}
+}
+
+// packageFindingSeverity maps a finding's disposition to a GitHub-aligned
+// severity: a policy failure is an Error, an advisory finding is a Warning.
+func packageFindingSeverity(disposition sdk.FindingDisposition) sdk.SeverityLevel {
+	if disposition == sdk.FindingDispositionWarn {
+		return sdk.SeverityWarning
+	}
+	return sdk.SeverityError
 }
 
 func packageIDs(graph *sdk.Graph) map[string]struct{} {

--- a/internal/auditors/package/auditor_test.go
+++ b/internal/auditors/package/auditor_test.go
@@ -224,8 +224,12 @@ func TestAudit(t *testing.T) {
 				t.Errorf("finding count = %d, want %d; findings: %v", got, tc.wantFindingCount, findingIDs(result.Findings))
 			}
 			for _, finding := range result.Findings {
-				if finding.Severity != packageSeverityNA {
-					t.Errorf("finding %q severity = %q, want %q", finding.ID, finding.Severity, packageSeverityNA)
+				wantSeverity := sdk.SeverityError
+				if finding.Disposition == sdk.FindingDispositionWarn {
+					wantSeverity = sdk.SeverityWarning
+				}
+				if finding.Severity != wantSeverity {
+					t.Errorf("finding %q severity = %q, want %q (disposition %q)", finding.ID, finding.Severity, wantSeverity, finding.Disposition)
 				}
 			}
 			for _, wantID := range tc.wantFindingIDs {

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -109,16 +109,17 @@ func ParseFailOnList(raws []string) ([]FailOnConstraint, error) {
 }
 
 // SeverityRank returns a comparable rank for a severity string.
-// Unknown / empty values rank below "low".
+// Unknown / empty values rank below "low". The GitHub-aligned levels share the
+// ladder with the CVSS bands: error ≡ high, warning ≡ medium, note ≡ low.
 func SeverityRank(severity SeverityLevel) int {
 	switch ParseSeverityLevel(string(severity)) {
 	case SeverityCritical:
 		return 4
-	case SeverityHigh:
+	case SeverityHigh, SeverityError:
 		return 3
-	case SeverityMedium:
+	case SeverityMedium, SeverityWarning:
 		return 2
-	case SeverityLow:
+	case SeverityLow, SeverityNote:
 		return 1
 	default:
 		return 0

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -70,10 +70,35 @@ func TestSeverityMeets(t *testing.T) {
 		{"", "any", true},
 		{"", "low", false},
 		{"unknown", "low", false},
+		// GitHub-aligned levels share the rank ladder: error≡high, warning≡medium, note≡low.
+		{"error", "high", true},
+		{"warning", "medium", true},
+		{"warning", "high", false},
+		{"note", "low", true},
+		{"note", "medium", false},
 	}
 	for _, tc := range cases {
 		if got := SeverityMeets(ParseSeverityLevel(tc.candidate), tc.threshold); got != tc.want {
 			t.Errorf("SeverityMeets(%q, %q) = %v, want %v", tc.candidate, tc.threshold, got, tc.want)
+		}
+	}
+}
+
+func TestSeverityRankGitHubLevels(t *testing.T) {
+	cases := []struct {
+		severity SeverityLevel
+		want     int
+	}{
+		{SeverityError, 3},
+		{SeverityWarning, 2},
+		{SeverityNote, 1},
+		{SeverityError, SeverityRank(SeverityHigh)},
+		{SeverityWarning, SeverityRank(SeverityMedium)},
+		{SeverityNote, SeverityRank(SeverityLow)},
+	}
+	for _, tc := range cases {
+		if got := SeverityRank(tc.severity); got != tc.want {
+			t.Errorf("SeverityRank(%q) = %d, want %d", tc.severity, got, tc.want)
 		}
 	}
 }

--- a/sdk/vulnerability.go
+++ b/sdk/vulnerability.go
@@ -30,12 +30,28 @@ const (
 )
 
 // SeverityLevel is Bomly's normalized severity band.
+//
+// It carries two parallel vocabularies over one ordered scale, mirroring how
+// GitHub presents code-scanning results:
+//
+//   - CVSS bands (critical/high/medium/low) are used for vulnerabilities, which
+//     also drive SARIF `security-severity`; GitHub renders them as
+//     Critical/High/Medium/Low.
+//   - GitHub levels (error/warning/note) are used for findings that have no
+//     CVSS score (license, package); GitHub renders the SARIF `level` directly
+//     as Error/Warning/Note.
+//
+// The two vocabularies share a single rank ladder (see SeverityRank): error ≡
+// high tier, warning ≡ medium tier, note ≡ low tier.
 type SeverityLevel string
 
 const (
 	// SeverityUnknown indicates that no severity could be determined.
 	SeverityUnknown SeverityLevel = "unknown"
 	// SeverityNA indicates that severity does not apply to the finding kind.
+	//
+	// Deprecated: kept for backward-compatible parsing only. New findings that
+	// lack a CVSS score should use SeverityError/SeverityWarning/SeverityNote.
 	SeverityNA SeverityLevel = "n/a"
 	// SeverityLow indicates a low-severity issue.
 	SeverityLow SeverityLevel = "low"
@@ -47,6 +63,16 @@ const (
 	SeverityCritical SeverityLevel = "critical"
 	// SeverityAny is a policy threshold that matches every severity.
 	SeverityAny SeverityLevel = "any"
+
+	// SeverityNote is the GitHub-aligned level for low-impact findings without a
+	// CVSS score. Ranks alongside SeverityLow.
+	SeverityNote SeverityLevel = "note"
+	// SeverityWarning is the GitHub-aligned level for findings without a CVSS
+	// score that warrant attention. Ranks alongside SeverityMedium.
+	SeverityWarning SeverityLevel = "warning"
+	// SeverityError is the GitHub-aligned level for high-impact findings without
+	// a CVSS score. Ranks alongside SeverityHigh.
+	SeverityError SeverityLevel = "error"
 )
 
 // ParseSeverityLevel normalizes a severity string into a SeverityLevel.
@@ -60,6 +86,12 @@ func ParseSeverityLevel(value string) SeverityLevel {
 		return SeverityMedium
 	case string(SeverityLow):
 		return SeverityLow
+	case string(SeverityError):
+		return SeverityError
+	case string(SeverityWarning):
+		return SeverityWarning
+	case string(SeverityNote):
+		return SeverityNote
 	case string(SeverityNA):
 		return SeverityNA
 	case string(SeverityAny):


### PR DESCRIPTION
## Why

While dogfooding Bomly Guard, license findings showed up with severity **N/A** (SARIF `Note`) and verbose IDs like `license:invalid-license:pkg:maven/junit/junit@4.12`. Reviewers got no severity signal, and the IDs leaked package coordinates.

## What

Adopt GitHub's severity vocabulary for findings that have **no CVSS score**, while keeping CVSS bands canonical for vulnerabilities (GitHub itself shows security alerts as Critical/High/Medium/Low from `security-severity`, and non-security alerts as Error/Warning/Note from `level`).

- **SDK** (`sdk/vulnerability.go`, `sdk/policy.go`): add `SeverityError`/`SeverityWarning`/`SeverityNote`, sharing one rank ladder with the bands — `error ≡ high`, `warning ≡ medium`, `note ≡ low`. `ParseSeverityLevel`/`SeverityRank` updated; `SeverityNA` kept for backward-compatible parsing only.
- **License auditor**: `invalid` + `unknown` license → **Warning**, `denied` → **Error**. Finding IDs are now compact and stable — `INVALID-xxxx-xxxx-xxxx`, `DENIED-…`, `UNKNOWN-…` — built from a base32 SHA256 of the PURL (shared helper), no longer embedding the coordinate.
- **Package auditor**: severity now follows disposition (`fail → Error`, `warn → Warning`).

## Safety

Finding severity does **not** gate pass/fail for license/package findings — that is driven by `Disposition` — and `MatchesConstraints`/`SeverityMeets` only applies to vulnerabilities. So `--fail-on` behavior is unchanged.

## Follow-ups (separate PRs)

- SARIF emits `security-severity` + maps the new levels (so GitHub renders Medium/High instead of Warning).

## Test

`make test` green; `make generate` produces no doc diffs (severity is a free-form string in the schemas). Added SDK rank/parse cases and updated auditor expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer severity labels for non-CVSS findings, including `error`, `warning`, and `note`.
  * Finding severity now better reflects the type of issue, with more consistent ranking across reports.

* **Bug Fixes**
  * License findings now use more consistent severity levels, distinguishing advisory issues from policy failures.
  * Package findings now report severity based on their disposition instead of a generic neutral value.

* **Documentation**
  * Expanded guidance on how severity levels are interpreted for different kinds of findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->