### PR TITLE
fix(diff/sarif): restore fail-on gating for persisted findings, fix severity badges, decouple icons from severity

### DIFF
--- a/internal/cli/cmd_progress.go
+++ b/internal/cli/cmd_progress.go
@@ -286,8 +286,9 @@ func analyzerProgressDetail(stats sdk.ReachabilityStats) string {
 	return "[" + strings.Join(parts, ", ") + "]"
 }
 
-// diffPolicyOutcomeProgressChild summarizes introduced diff findings using
-// the same introduced-only failure semantics as `bomly diff --audit`.
+// diffPolicyOutcomeProgressChild summarizes the diff findings that gate the
+// run, using the same blocking semantics as `bomly diff --audit` (introduced
+// plus persisted — see auditBlockingFindings).
 func diffPolicyOutcomeProgressChild(audit *diffengine.Audit) progress.Child {
 	if audit == nil {
 		return progress.Child{
@@ -296,8 +297,9 @@ func diffPolicyOutcomeProgressChild(audit *diffengine.Audit) progress.Child {
 			Detail: "[no audit delta]",
 		}
 	}
-	failing := output.FailingFindingCount(audit.Introduced)
-	warnings := len(audit.Introduced) - failing
+	blocking := auditBlockingFindings(audit)
+	failing := output.FailingFindingCount(blocking)
+	warnings := len(blocking) - failing
 	child := progress.Child{
 		Icon:  progress.CheckMark,
 		Label: "Policy Outcome",
@@ -305,12 +307,12 @@ func diffPolicyOutcomeProgressChild(audit *diffengine.Audit) progress.Child {
 	switch {
 	case failing > 0:
 		child.Icon = progress.CrossMark
-		child.Detail = fmt.Sprintf("[%d introduced failing, %d warnings]", failing, warnings)
+		child.Detail = fmt.Sprintf("[%d failing, %d warnings]", failing, warnings)
 	case warnings > 0:
 		child.Icon = progress.WarningMark
-		child.Detail = fmt.Sprintf("[passed, %d introduced warnings]", warnings)
+		child.Detail = fmt.Sprintf("[passed, %d warnings]", warnings)
 	default:
-		child.Detail = "[passed, no introduced findings]"
+		child.Detail = "[passed, no findings]"
 	}
 	return child
 }

--- a/internal/cli/cmd_progress_test.go
+++ b/internal/cli/cmd_progress_test.go
@@ -92,7 +92,23 @@ func TestDiffPolicyOutcomeProgressChild_ReportsIntroducedOutcome(t *testing.T) {
 	if child.Icon != progress.CrossMark {
 		t.Fatalf("expected failing outcome icon, got %#v", child)
 	}
-	if child.Detail != "[1 introduced failing, 1 warnings]" {
+	if child.Detail != "[1 failing, 1 warnings]" {
+		t.Fatalf("unexpected policy outcome detail: %#v", child)
+	}
+}
+
+func TestDiffPolicyOutcomeProgressChild_PersistedFindingsAlsoFail(t *testing.T) {
+	// A persisted finding is tied to a package the diff actually changed, so
+	// it must gate the run exactly like an introduced one.
+	child := diffPolicyOutcomeProgressChild(&diffengine.Audit{
+		Persisted: []sdk.Finding{
+			{Disposition: sdk.FindingDispositionFail},
+		},
+	})
+	if child.Icon != progress.CrossMark {
+		t.Fatalf("expected failing outcome icon for a persisted failing finding, got %#v", child)
+	}
+	if child.Detail != "[1 failing, 0 warnings]" {
 		t.Fatalf("unexpected policy outcome detail: %#v", child)
 	}
 }

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -199,7 +199,10 @@ func newDiffCmd() *cobra.Command {
 			}
 			if outputFormat == output.FormatSARIF {
 				prog.Success("Resolved Graph")
-				return sarifRenderer(streams.reportWriter())
+				if err := sarifRenderer(streams.reportWriter()); err != nil {
+					return err
+				}
+				return diffPolicyExit(current.Audit, diffResult.Audit)
 			}
 			if current.Interactive {
 				prog.Stop()

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -211,9 +211,9 @@ func newDiffCmd() *cobra.Command {
 				prog.SeparateReport()
 			}
 			err = output.Write(streams.reportWriter(), outputFormat, payload, reportRenderers)
-			if err == nil && current.Audit && diffResult.Audit != nil {
-				if failing := output.FailingFindingCount(diffResult.Audit.Introduced); failing > 0 {
-					return exit.PolicyViolationFindings(failing)
+			if err == nil {
+				if exitErr := diffPolicyExit(current.Audit, diffResult.Audit); exitErr != nil {
+					return exitErr
 				}
 			}
 			return err
@@ -227,16 +227,33 @@ func newDiffCmd() *cobra.Command {
 	return cmd
 }
 
-func diffSARIFFindings(audit *diffengine.Audit) []sdk.Finding {
-	if audit == nil || len(audit.Introduced) == 0 {
+// auditBlockingFindings returns the findings that must keep gating this diff
+// and remain open code-scanning alerts: newly introduced findings, plus
+// persisted ones.
+//
+// Every Persisted finding is, by construction, tied to a package the diff
+// actually changed: the focused audit graph built in engine/diff.Run only
+// ever audits added, removed, or version-changed packages (see
+// focusedAuditGraphs), so a finding can only be classified "persisted" when
+// the same finding key survives a real change to that package. In other
+// words, "persisted" never means unrelated pre-existing debt — it always
+// means "this exact version bump still ships a known issue" — so it must
+// fail the job under --fail-on just like an introduced finding, and must stay
+// in the uploaded SARIF so GitHub doesn't close its alert.
+func auditBlockingFindings(audit *diffengine.Audit) []sdk.Finding {
+	if audit == nil {
 		return nil
 	}
-	return append([]sdk.Finding(nil), audit.Introduced...)
+	return append(append([]sdk.Finding(nil), audit.Introduced...), audit.Persisted...)
+}
+
+func diffSARIFFindings(audit *diffengine.Audit) []sdk.Finding {
+	return auditBlockingFindings(audit)
 }
 
 func diffPolicyExit(auditEnabled bool, audit *diffengine.Audit) error {
 	if auditEnabled && audit != nil {
-		if failing := output.FailingFindingCount(audit.Introduced); failing > 0 {
+		if failing := output.FailingFindingCount(auditBlockingFindings(audit)); failing > 0 {
 			return exit.PolicyViolationFindings(failing)
 		}
 	}

--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -49,7 +49,10 @@ func TestRenderDiffTextShowsFindingsSummaryLine(t *testing.T) {
 	}
 }
 
-func TestDiffSARIFFindingsOnlyIncludesIntroduced(t *testing.T) {
+func TestDiffSARIFFindingsIncludesIntroducedAndPersisted(t *testing.T) {
+	// Persisted findings are always tied to a package the diff changed, so
+	// they must stay in the SARIF output or GitHub closes their alert as if
+	// the issue had been resolved.
 	introduced := sdk.Finding{ID: "new", PackageRef: "pkg:npm/new@1.0.0"}
 	resolved := sdk.Finding{ID: "old", PackageRef: "pkg:npm/old@1.0.0"}
 	persisted := sdk.Finding{ID: "kept", PackageRef: "pkg:npm/kept@1.0.0"}
@@ -59,12 +62,46 @@ func TestDiffSARIFFindingsOnlyIncludesIntroduced(t *testing.T) {
 		Resolved:   []sdk.Finding{resolved},
 		Persisted:  []sdk.Finding{persisted},
 	})
-	if len(got) != 1 || got[0].ID != introduced.ID {
-		t.Fatalf("diffSARIFFindings() = %#v, want only introduced finding", got)
+	gotIDs := make(map[string]bool, len(got))
+	for _, f := range got {
+		gotIDs[f.ID] = true
+	}
+	if len(got) != 2 || !gotIDs[introduced.ID] || !gotIDs[persisted.ID] {
+		t.Fatalf("diffSARIFFindings() = %#v, want introduced + persisted, excluding resolved", got)
 	}
 
 	if got := diffSARIFFindings(&diffengine.Audit{Resolved: []sdk.Finding{resolved}}); len(got) != 0 {
 		t.Fatalf("resolved-only SARIF findings = %#v, want none", got)
+	}
+}
+
+func TestDiffPolicyExit_PersistedFailingFindingsAlsoFailTheJob(t *testing.T) {
+	// Regression: a version bump that doesn't remediate an advisory classifies
+	// as persisted (see PR fixing diff section agreement), and that must still
+	// fail --fail-on any, since the finding is tied to a package this diff
+	// actually changed.
+	err := diffPolicyExit(true, &diffengine.Audit{
+		Persisted: []sdk.Finding{{ID: "CVE-PERSISTS", Disposition: sdk.FindingDispositionFail}},
+	})
+	if err == nil {
+		t.Fatal("expected a policy violation error for a failing persisted finding")
+	}
+}
+
+func TestDiffPolicyExit_PersistedWarningsDoNotFailTheJob(t *testing.T) {
+	err := diffPolicyExit(true, &diffengine.Audit{
+		Persisted: []sdk.Finding{{ID: "license:warn", Disposition: sdk.FindingDispositionWarn}},
+	})
+	if err != nil {
+		t.Fatalf("expected no policy violation for a warning-only persisted finding, got %v", err)
+	}
+}
+
+func TestDiffPolicyExit_NoAuditNoExit(t *testing.T) {
+	if err := diffPolicyExit(false, &diffengine.Audit{
+		Persisted: []sdk.Finding{{ID: "x", Disposition: sdk.FindingDispositionFail}},
+	}); err != nil {
+		t.Fatalf("expected no exit error when audit is disabled, got %v", err)
 	}
 }
 
@@ -134,7 +171,7 @@ func TestRenderDiffMarkdownIncludesPatchedVersionsByDefault(t *testing.T) {
 		"| added | react@18.2.0 | 18.2.0 | - | unknown | - |",
 		"| changed | zod | 3.22.0 → 3.23.0 | - | unknown | - |",
 		"## Vulnerabilities",
-		"| ❌ | introduced | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | osv | Prototype pollution in react |",
+		"| introduced | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | osv | Prototype pollution in react |",
 		"## Policy Findings",
 		"| ❌ | introduced | vulnerability | HIGH | OSV-123 | react@18.2.0 | 18.2.1 | Prototype pollution in react |",
 	} {

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -35,13 +35,18 @@ func diffOverviewMarkdown(payload output.DiffResponse) []string {
 		persisted = len(payload.Audit.Persisted)
 		resolved = len(payload.Audit.Resolved)
 	}
+	// A persisted finding is always tied to a package this diff actually
+	// changed (see auditBlockingFindings in internal/cli/diff_cmd.go), so it
+	// gates the run exactly like an introduced one.
 	status := "✅ Pass"
-	if payload.Audit != nil && outputAuditFailingCount(payload.Audit.Introduced) > 0 {
-		status = "❌ Failing findings introduced"
-	} else if payload.Audit != nil && introduced > 0 {
-		status = "⚠️ Warnings introduced"
-	} else if payload.Audit != nil && outputAuditFailingCount(payload.Audit.Persisted) > 0 {
-		status = "⚠️ Pre-existing findings unresolved"
+	if payload.Audit != nil {
+		failing := outputAuditFailingCount(payload.Audit.Introduced) + outputAuditFailingCount(payload.Audit.Persisted)
+		switch {
+		case failing > 0:
+			status = "❌ Failing findings"
+		case introduced > 0 || persisted > 0:
+			status = "⚠️ Warnings"
+		}
 	}
 	return markdownTable(
 		[]string{"Status", "Manifests", "Dependencies", "Findings", "Duration"},
@@ -169,7 +174,6 @@ func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabi
 	for _, change := range sortVulnerabilityChanges(changes) {
 		vuln := change.Vulnerability
 		row := []string{
-			findingIcon(status, string(vuln.Severity), ""),
 			status,
 			strings.ToUpper(valueOrDash(string(vuln.Severity))),
 			vuln.ID,
@@ -185,7 +189,7 @@ func diffVulnerabilityTable(title, status string, changes []output.DiffVulnerabi
 		)
 		rows = append(rows, row)
 	}
-	header := []string{"", "Change", "Severity", "ID", "Package"}
+	header := []string{"Change", "Severity", "ID", "Package"}
 	if includeReachability {
 		header = append(header, "Reachability")
 	}
@@ -307,7 +311,7 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding,
 	rows := make([][]string, 0, len(findings))
 	for _, finding := range sortDiffAuditFindings(findings) {
 		row := []string{
-			findingIcon(status, string(finding.Severity), string(finding.Disposition)),
+			findingIcon(status, string(finding.Disposition)),
 			status,
 			valueOrDash(finding.Auditor),
 			strings.ToUpper(valueOrDash(string(finding.Severity))),
@@ -338,19 +342,18 @@ func findingIconLegend() []string {
 	return []string{"> **Legend:** ✅ resolved · ❌ failing · ⚠️ warning"}
 }
 
-func findingIcon(status, severity, disposition string) string {
+// findingIcon represents whether a Policy Findings row will fail the run
+// (❌), only warn (⚠️), or has been resolved (✅) — purely a function of
+// status/disposition, never of severity. A Low-severity failing finding still
+// gets ❌; a Critical-severity warning still gets ⚠️.
+func findingIcon(status, disposition string) string {
 	if status == "resolved" {
 		return "✅"
 	}
 	if strings.EqualFold(disposition, "warn") {
 		return "⚠️"
 	}
-	switch strings.ToLower(strings.TrimSpace(severity)) {
-	case "critical", "high":
-		return "❌"
-	default:
-		return "⚠️"
-	}
+	return "❌"
 }
 
 func outputAuditFailingCount(findings []output.AuditFinding) int {

--- a/internal/cli/render/diff_markdown_test.go
+++ b/internal/cli/render/diff_markdown_test.go
@@ -9,6 +9,35 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
+func TestDiffOverviewMarkdownPersistedFailingCountsAsFailing(t *testing.T) {
+	// A persisted finding is tied to a package the diff actually changed, so
+	// the Overview status must reflect it as a failure, not a softer warning.
+	payload := output.DiffResponse{
+		Audit: &output.DiffAudit{
+			Persisted: []output.AuditFinding{{ID: "CVE-PERSISTS", Disposition: sdk.FindingDispositionFail}},
+		},
+	}
+	got := strings.Join(diffOverviewMarkdown(payload), "\n")
+	if !strings.Contains(got, "❌ Failing findings") {
+		t.Errorf("expected failing status for a failing persisted finding, got %q", got)
+	}
+}
+
+func TestDiffOverviewMarkdownPersistedWarningsAreWarnings(t *testing.T) {
+	payload := output.DiffResponse{
+		Audit: &output.DiffAudit{
+			Persisted: []output.AuditFinding{{ID: "license:warn", Disposition: sdk.FindingDispositionWarn}},
+		},
+	}
+	got := strings.Join(diffOverviewMarkdown(payload), "\n")
+	if !strings.Contains(got, "⚠️ Warnings") {
+		t.Errorf("expected a warning status for a warn-only persisted finding, got %q", got)
+	}
+	if strings.Contains(got, "❌") {
+		t.Errorf("did not expect a failing status, got %q", got)
+	}
+}
+
 func TestHumanizeDurationMS(t *testing.T) {
 	cases := []struct {
 		ms   int64

--- a/internal/matchers/osv/mapper.go
+++ b/internal/matchers/osv/mapper.go
@@ -31,7 +31,7 @@ func MapVulnerability(v Vulnerability) sdk.Vulnerability {
 		// Bomly extensions
 		Source:         "osv",
 		Title:          firstNonEmpty(v.Summary, v.ID),
-		ParsedSeverity: extractSeverity(v.Severity),
+		ParsedSeverity: extractSeverity(v.Severity, v.DatabaseSpecific),
 		Reasons:        buildReasons(v),
 		CVSS:           buildCVSS(v.Severity),
 		CWEs:           mapCWEs(v),
@@ -74,10 +74,20 @@ func mapAffected(affected []Affected) []sdk.Affected {
 }
 
 func mapDatabaseSpecific(ds *DatabaseSpecific) map[string]any {
-	if ds == nil || len(ds.CweIDs) == 0 {
+	if ds == nil {
 		return nil
 	}
-	return map[string]any{"cwe_ids": append([]string(nil), ds.CweIDs...)}
+	out := map[string]any{}
+	if len(ds.CweIDs) > 0 {
+		out["cwe_ids"] = append([]string(nil), ds.CweIDs...)
+	}
+	if ds.Severity != "" {
+		out["severity"] = ds.Severity
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func mapCWEs(v Vulnerability) []sdk.CWE {
@@ -101,7 +111,7 @@ func firstNonEmpty(a, b string) string {
 
 // extractSeverity derives a normalized severity band from OSV severity entries.
 // Prefers CVSS v4 > v3.1 > v3 > v2 > unknown.
-func extractSeverity(severities []Severity) sdk.SeverityLevel {
+func extractSeverity(severities []Severity, ds *DatabaseSpecific) sdk.SeverityLevel {
 	scores := map[string]float64{}
 	for _, s := range severities {
 		if score := parseCVSSScore(s.Type, s.Score); score > 0 {
@@ -113,7 +123,34 @@ func extractSeverity(severities []Severity) sdk.SeverityLevel {
 			return cvssScoreToBand(score)
 		}
 	}
+	// GHSA-sourced advisories (e.g. many Apache project CVEs) frequently
+	// publish no CVSS vector at all, only a textual database_specific.severity
+	// rating. Without this fallback those findings carry SeverityUnknown,
+	// which drops the SARIF security-severity property entirely and leaves
+	// GitHub showing a generic "Warning" badge instead of Low/Medium/High.
+	if ds != nil {
+		if band := severityFromGHSAText(ds.Severity); band != sdk.SeverityUnknown {
+			return band
+		}
+	}
 	return sdk.SeverityUnknown
+}
+
+// severityFromGHSAText maps GitHub Security Advisory's textual severity
+// rating to Bomly's CVSS band vocabulary.
+func severityFromGHSAText(raw string) sdk.SeverityLevel {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "CRITICAL":
+		return sdk.SeverityCritical
+	case "HIGH":
+		return sdk.SeverityHigh
+	case "MODERATE", "MEDIUM":
+		return sdk.SeverityMedium
+	case "LOW":
+		return sdk.SeverityLow
+	default:
+		return sdk.SeverityUnknown
+	}
 }
 
 func parseCVSSScore(kind, raw string) float64 {

--- a/internal/matchers/osv/matcher_test.go
+++ b/internal/matchers/osv/matcher_test.go
@@ -338,7 +338,7 @@ func TestExtractSeverity_CalculatesFromVector(t *testing.T) {
 	got := extractSeverity([]Severity{{
 		Type:  "CVSS_V3",
 		Score: "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:L",
-	}})
+	}}, nil)
 
 	if got != "low" {
 		t.Fatalf("extractSeverity() = %q, want %q", got, "low")
@@ -349,9 +349,46 @@ func TestExtractSeverity_PrefersHigherVersion(t *testing.T) {
 	got := extractSeverity([]Severity{
 		{Type: "CVSS_V2", Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"},
 		{Type: "CVSS_V4", Score: "AV:L/AC:H/AT:N/PR:N/UI:P/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"},
-	})
+	}, nil)
 
 	if got != "low" {
 		t.Fatalf("extractSeverity() = %q, want %q", got, "low")
+	}
+}
+
+func TestExtractSeverity_FallsBackToGHSATextWhenNoCVSSVector(t *testing.T) {
+	// Mirrors GHSA-sourced OSV entries (e.g. many Apache project CVEs) that
+	// publish database_specific.severity but no CVSS vector at all.
+	tests := []struct {
+		text string
+		want sdk.SeverityLevel
+	}{
+		{"CRITICAL", sdk.SeverityCritical},
+		{"HIGH", sdk.SeverityHigh},
+		{"MODERATE", sdk.SeverityMedium},
+		{"MEDIUM", sdk.SeverityMedium},
+		{"LOW", sdk.SeverityLow},
+		{"low", sdk.SeverityLow},
+		{"", sdk.SeverityUnknown},
+		{"UNKNOWN", sdk.SeverityUnknown},
+	}
+	for _, tt := range tests {
+		got := extractSeverity(nil, &DatabaseSpecific{Severity: tt.text})
+		if got != tt.want {
+			t.Errorf("extractSeverity(nil, {Severity: %q}) = %q, want %q", tt.text, got, tt.want)
+		}
+	}
+}
+
+func TestExtractSeverity_CVSSVectorTakesPrecedenceOverGHSAText(t *testing.T) {
+	// A real CVSS vector is more precise than the coarse GHSA text rating, so
+	// it must win when both are present.
+	got := extractSeverity([]Severity{{
+		Type:  "CVSS_V3",
+		Score: "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:L", // low
+	}}, &DatabaseSpecific{Severity: "CRITICAL"})
+
+	if got != sdk.SeverityLow {
+		t.Fatalf("extractSeverity() = %q, want %q (CVSS should win)", got, sdk.SeverityLow)
 	}
 }

--- a/internal/matchers/osv/response.go
+++ b/internal/matchers/osv/response.go
@@ -84,4 +84,9 @@ type Event struct {
 // DatabaseSpecific holds ecosystem-specific metadata (e.g., CWE IDs from GitHub).
 type DatabaseSpecific struct {
 	CweIDs []string `json:"cwe_ids,omitempty"`
+	// Severity is GitHub Security Advisory's textual rating (LOW / MODERATE /
+	// HIGH / CRITICAL). GHSA-sourced OSV entries frequently omit a CVSS vector
+	// in the top-level `severity` array, so this is the only severity signal
+	// available for them.
+	Severity string `json:"severity,omitempty"`
 }

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -188,7 +188,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, registry *sdk.PackageRegist
 			ID:               f.ID,
 			ShortDescription: sarifMessage{Text: f.Title},
 			FullDescription:  sarifReasonsMessage(f.Reasons),
-			DefaultConfig:    sarifRuleConfig{Level: severityToSARIFLevel(string(f.Severity))},
+			DefaultConfig:    sarifRuleConfig{Level: dispositionToSARIFLevel(f.Disposition)},
 			HelpURI:          helpURI,
 		}
 		if help := sarifHelpMessage(f.Reasons, helpURI); help != nil {
@@ -209,7 +209,7 @@ func WriteSARIF(w io.Writer, findings []sdk.Finding, registry *sdk.PackageRegist
 		locations, locationURIs := sarifLocationsForFinding(f, includeReachability, options)
 		result := sarifResult{
 			RuleID:              f.ID,
-			Level:               severityToSARIFLevel(string(f.Severity)),
+			Level:               dispositionToSARIFLevel(f.Disposition),
 			Message:             sarifMessage{Text: msgText},
 			Locations:           locations,
 			BaselineState:       sarifBaselineState(options),
@@ -624,19 +624,22 @@ func sarifPropertiesFromVulnerability(v *sdk.Vulnerability, includeReachability 
 	return props
 }
 
-// severityToSARIFLevel maps an SDK severity to a SARIF level. The CVSS bands
-// and the GitHub-aligned levels share one ladder: critical/high/error → error,
-// medium/warning → warning, low/note → note. Unknown/N-A degrade to note.
-func severityToSARIFLevel(severity string) string {
-	switch sdk.ParseSeverityLevel(severity) {
-	case sdk.SeverityCritical, sdk.SeverityHigh, sdk.SeverityError:
-		return "error"
-	case sdk.SeverityMedium, sdk.SeverityWarning:
+// dispositionToSARIFLevel maps a finding's disposition to a SARIF level. The
+// level reflects whether the finding blocks the job — error for a failing
+// finding, warning for an advisory one — never the underlying severity band.
+// Severity is reported separately via security-severity for vulnerabilities
+// (see sarifRulePropertiesForFinding), so a Low-severity finding that fails
+// the build still surfaces as "error" here, and a Critical one that's merely
+// a warning still surfaces as "warning": job impact and severity are
+// orthogonal, and GitHub's level/badge should track the former.
+func dispositionToSARIFLevel(disposition sdk.FindingDisposition) string {
+	switch disposition {
+	case sdk.FindingDispositionWarn:
 		return "warning"
-	case sdk.SeverityLow, sdk.SeverityNote:
-		return "note"
 	default:
-		return "note"
+		// FindingDispositionFail, and "" (findings with no explicit
+		// disposition are treated as failing — see FailingFindingCount).
+		return "error"
 	}
 }
 

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -133,27 +133,48 @@ func TestWriteSARIF_EmptyFindingsEncodeArrayFields(t *testing.T) {
 	}
 }
 
-func TestSeverityToSARIFLevel(t *testing.T) {
+func TestDispositionToSARIFLevel(t *testing.T) {
 	tests := []struct {
-		sev   string
-		level string
+		disposition sdk.FindingDisposition
+		level       string
 	}{
-		{"critical", "error"},
-		{"high", "error"},
-		{"medium", "warning"},
-		{"low", "note"},
-		{"unknown", "note"},
-		{"", "note"},
-		{"error", "error"},
-		{"warning", "warning"},
-		{"note", "note"},
-		{"n/a", "note"},
+		{sdk.FindingDispositionFail, "error"},
+		{sdk.FindingDispositionWarn, "warning"},
+		{"", "error"}, // unset disposition is treated as failing, like FailingFindingCount
 	}
 	for _, tt := range tests {
-		got := severityToSARIFLevel(tt.sev)
+		got := dispositionToSARIFLevel(tt.disposition)
 		if got != tt.level {
-			t.Errorf("severityToSARIFLevel(%q) = %q, want %q", tt.sev, got, tt.level)
+			t.Errorf("dispositionToSARIFLevel(%q) = %q, want %q", tt.disposition, got, tt.level)
 		}
+	}
+}
+
+// TestSARIFLevelIgnoresSeverity locks in the point that job impact and
+// severity are orthogonal: a Low-severity finding that fails the build is
+// still "error", and a Critical one that's only a warning is still "warning".
+func TestSARIFLevelIgnoresSeverity(t *testing.T) {
+	findings := []sdk.Finding{
+		{ID: "fail-low", PackageRef: sarifTestPURL, Title: "x", Severity: sdk.SeverityLow, Disposition: sdk.FindingDispositionFail},
+		{ID: "warn-critical", PackageRef: sarifTestPURL, Title: "y", Severity: sdk.SeverityCritical, Disposition: sdk.FindingDispositionWarn},
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, findings, nil, "bomly", "0.1.0"); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("decode SARIF: %v\n%s", err, buf.String())
+	}
+	byID := map[string]sarifRule{}
+	for _, r := range doc.Runs[0].Tool.Driver.Rules {
+		byID[r.ID] = r
+	}
+	if got := byID["fail-low"].DefaultConfig.Level; got != "error" {
+		t.Errorf("low-severity failing finding level = %q, want error", got)
+	}
+	if got := byID["warn-critical"].DefaultConfig.Level; got != "warning" {
+		t.Errorf("critical-severity warning finding level = %q, want warning", got)
 	}
 }
 
@@ -173,12 +194,13 @@ func TestWriteSARIF_SecuritySeverityAndFormattedHelp(t *testing.T) {
 			},
 		},
 		{
-			ID:         "INVALID-abcd-efgh-ijkl",
-			Kind:       sdk.FindingKindLicense,
-			PackageRef: sarifTestPURL,
-			Title:      "Package has invalid SPDX license: non-standard",
-			Severity:   sdk.SeverityWarning,
-			Source:     "license",
+			ID:          "INVALID-abcd-efgh-ijkl",
+			Kind:        sdk.FindingKindLicense,
+			PackageRef:  sarifTestPURL,
+			Title:       "Package has invalid SPDX license: non-standard",
+			Severity:    sdk.SeverityWarning,
+			Disposition: sdk.FindingDispositionWarn,
+			Source:      "license",
 		},
 	}
 


### PR DESCRIPTION
## Why

Three regressions/bugs surfaced after dogfooding the previous batch of fixes (#195–#198):

1. **`--fail-on any` no longer fails the job, and code-scanning alerts all show as closed.** Classifying a same-CVE version bump as "persisted" (instead of one introduced + one resolved) fixed the markdown summary's section agreement, but `diffPolicyExit`/`diffSARIFFindings` only ever looked at `audit.Introduced`. A persisted-but-still-failing finding stopped failing the build, and dropped out of the uploaded SARIF entirely — so GitHub closed its alert as if the issue had been resolved.
2. **Code-scanning alerts still don't show Low/Medium/High/Critical.** Root cause: GHSA-sourced OSV entries (common for Apache project CVEs, e.g. the WebGoat commons-lang advisory) frequently publish only a textual `database_specific.severity` rating with **no CVSS vector at all**. `extractSeverity` returned `unknown` for these, which drops the SARIF `security-severity` property entirely, so GitHub falls back to showing the literal level word ("Warning") instead of a mapped severity.
3. **The ✅/❌/⚠️ icons were confusing.** They appeared in both the Vulnerabilities table (severity-driven) and the Policy Findings table (a severity/disposition mix), so a Low-severity *failing* finding and a Critical-severity *warning* could both render misleadingly.

## What

- **`internal/cli/diff_cmd.go` / `cmd_progress.go`**: add `auditBlockingFindings` (Introduced + Persisted) and use it for the `--fail-on` exit code (both output paths), the uploaded SARIF, and the "Evaluated policy" progress summary. Every `Persisted` finding is, by construction, tied to a package the diff actually changed — `engine/diff.Run`'s focused audit graph only ever audits added/removed/version-changed packages — so persisted is never unrelated pre-existing debt.
- **`internal/matchers/osv/`**: `extractSeverity` falls back to the GHSA text rating (LOW/MODERATE/HIGH/CRITICAL) when no CVSS vector is present; a real CVSS vector still wins when both exist.
- **`internal/output/sarif.go`**: `severityToSARIFLevel` → `dispositionToSARIFLevel`. SARIF `level` (error/warning/note) is now purely a function of whether the finding fails the job, never of severity — severity continues to display separately via `security-severity` for vulnerabilities.
- **`internal/cli/render/diff_markdown.go`**: removed the icon column from the Vulnerabilities table (reserved for Policy Findings only); `findingIcon` no longer branches on severity — purely disposition-based; Overview status combines Introduced + Persisted failing counts.

## Test

`make test`, `make generate` (no drift), `gofmt -l`, and `golangci-lint run ./...` all clean. Added/updated tests covering: persisted findings failing `--fail-on` and staying in SARIF, the OSV textual-severity fallback (including CVSS-takes-precedence), SARIF level ignoring severity, and the Overview status reflecting persisted failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SARIF and markdown outputs now more accurately show whether results are failing vs warnings, including effects from persisted findings.
  * Severity parsing now falls back to advisory text when CVSS score/vector data is unavailable.

* **Bug Fixes**
  * Diff and policy exit behavior now treat both introduced and persisted blocking findings as actionable.
  * Progress indicators and summary counts align with the updated blocking-finding semantics.

* **Documentation**
  * Updated user-facing status text, labels, and vulnerability/policy table formatting to reflect the new failing/warning outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->