### PR TITLE
feat(cli/diff): emphasize invalid licenses + exit 5 when no targets resolve

### DIFF
--- a/docs/EXIT_CODES.md
+++ b/docs/EXIT_CODES.md
@@ -9,6 +9,7 @@ Bomly uses a small, stable set of exit codes so scripts and CI pipelines can bra
 | 2 | Policy violation | At least one finding matched `--fail-on` |
 | 3 | Resolution failure | A required detector could not produce a graph (e.g. missing lockfile, malformed manifest) |
 | 4 | Invalid input | A flag value, target, or config setting is invalid |
+| 5 | Nothing to evaluate | No subprojects/manifests were discovered for the target (often because an `--ecosystems`/`--detectors` filter matched nothing) |
 
 ## When each code is returned
 
@@ -56,6 +57,15 @@ A flag, target, or config value is malformed. Examples:
 
 Exit-4 errors describe the offending flag in the message and never produce partial output.
 
+### `5` — Nothing to evaluate
+
+No subprojects were discovered for the target, so there was nothing to scan, diff, or audit. This is distinct from `3`: exit `3` means Bomly *found* a subproject but a detector could not turn it into a graph (a real failure), whereas exit `5` means none were found in the first place. Typical causes:
+
+- An `--ecosystems` / `--detectors` filter that doesn't match anything in the target (e.g. `--ecosystems maven` against a pure-npm repo). The message lists the active filters.
+- A target (directory, ref, or image) that contains no supported manifests at all.
+
+No partial output is produced. CI wrappers that should pass when there is simply nothing applicable to evaluate can treat `5` as a neutral, non-failing outcome while still failing on `1`/`3`/`4`.
+
 ## Recipes
 
 ### GitHub Actions — fail on high vulnerabilities
@@ -80,6 +90,7 @@ code=$?
 case $code in
   0) echo "clean" ;;
   2) echo "policy violation"; exit 2 ;;
+  5) echo "nothing to evaluate"; exit 0 ;;  # no applicable manifests — treat as a pass
   *) echo "scan failed with $code"; exit 1 ;;
 esac
 ```

--- a/internal/cli/exit/errors.go
+++ b/internal/cli/exit/errors.go
@@ -13,6 +13,7 @@ const (
 	exitCodePolicyViolation   = 2
 	exitCodeResolutionFailure = 3
 	exitCodeInvalidInput      = 4
+	exitCodeNothingToEvaluate = 5
 )
 
 type exitError struct {
@@ -44,6 +45,10 @@ func ErrorPrefix(err error) string {
 	switch Code(err) {
 	case exitCodePolicyViolation:
 		return "Policy violation"
+	case exitCodeNothingToEvaluate:
+		// Exit 5 is a benign "no resolvable targets" outcome, not a failure;
+		// print it as an informational notice rather than an error.
+		return "Nothing to evaluate"
 	default:
 		return "Error"
 	}
@@ -55,6 +60,16 @@ func InvalidInputError(format string, args ...any) error {
 
 func ResolutionFailureError(err error) error {
 	return &exitError{code: exitCodeResolutionFailure, err: err}
+}
+
+// NothingToEvaluateError marks the benign "no resolvable targets" outcome —
+// no subprojects/manifests were discovered for the target (with the applied
+// filters). It is deliberately distinct from ResolutionFailureError (exit 3,
+// a real error where a discovered subproject could not be turned into a
+// graph) so CI wrappers can treat "nothing to scan" as a neutral pass without
+// masking genuine resolution failures.
+func NothingToEvaluateError(err error) error {
+	return &exitError{code: exitCodeNothingToEvaluate, err: err}
 }
 
 // InteractiveResult wraps the error returned by tui.Run so that a missing

--- a/internal/cli/opts/planning.go
+++ b/internal/cli/opts/planning.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/cli/exit"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	"github.com/bomly-dev/bomly-cli/internal/registry"
 	"github.com/bomly-dev/bomly-cli/internal/system"
@@ -572,10 +573,14 @@ func noSubprojectsError(req Request) error {
 		hints = append(hints, fmt.Sprintf("--ecosystems %s", strings.Join(names, ",")))
 	}
 
+	// Wrap as a "nothing to evaluate" exit (5), distinct from a resolution
+	// failure (3): no subprojects were discovered at all, which CI wrappers can
+	// treat as a neutral pass. ErrNoSubprojects stays the inner sentinel so
+	// errors.Is(err, ErrNoSubprojects) callers keep working.
 	if len(hints) > 0 {
-		return fmt.Errorf("%w (active filters: %s)", ErrNoSubprojects, strings.Join(hints, ", "))
+		return exit.NothingToEvaluateError(fmt.Errorf("%w (active filters: %s)", ErrNoSubprojects, strings.Join(hints, ", ")))
 	}
-	return ErrNoSubprojects
+	return exit.NothingToEvaluateError(ErrNoSubprojects)
 }
 
 func pathMatchesPatterns(candidatePath string, patterns []string) bool {

--- a/internal/cli/opts/planning_test.go
+++ b/internal/cli/opts/planning_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bomly-dev/bomly-cli/internal/cli/exit"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
@@ -43,6 +44,28 @@ func TestPlanSubprojectsReportsActiveFilters(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNoSubprojects) {
 		t.Fatalf("expected ErrNoSubprojects, got %v", err)
+	}
+	// "Nothing to evaluate" (5), not a generic execution error (1) or a
+	// resolution failure (3): no subprojects were discovered at all.
+	if got := exit.Code(err); got != 5 {
+		t.Fatalf("expected exit code 5 for no subprojects, got %d", got)
+	}
+}
+
+func TestPlanSubprojectsNoFilterStillReportsNothingToEvaluate(t *testing.T) {
+	reg := engine.NewRegistry(engine.RegistryConfigs{}, *zap.NewNop())
+	reg.Build()
+
+	// Empty directory, no filter: still "nothing to evaluate" (exit 5), per the
+	// with-or-without-filter scope.
+	_, err := PlanSubprojects(reg, Request{
+		ExecutionTarget: sdk.ExecutionTarget{Kind: sdk.ExecutionTargetFilesystem, Location: t.TempDir()},
+	})
+	if !errors.Is(err, ErrNoSubprojects) {
+		t.Fatalf("expected ErrNoSubprojects, got %v", err)
+	}
+	if got := exit.Code(err); got != 5 {
+		t.Fatalf("expected exit code 5 for an empty target, got %d", got)
 	}
 }
 

--- a/internal/cli/render/diff_markdown.go
+++ b/internal/cli/render/diff_markdown.go
@@ -323,7 +323,7 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding,
 		}
 		row = append(row,
 			valueOrDash(fixedVersionSummary(finding.FixedIn, finding.FixedVersions)),
-			firstNonEmpty(finding.Title, strings.Join(finding.Reasons, "; ")),
+			emphasizeFindingTitle(finding),
 		)
 		rows = append(rows, row)
 	}
@@ -333,6 +333,25 @@ func diffAuditFindingTable(title, status string, findings []output.AuditFinding,
 	}
 	header = append(header, "Fixed In", "Title")
 	return append([]string{"### " + title, ""}, append(markdownTable(header, rows), "")...)
+}
+
+// emphasizeFindingTitle bolds the salient trailing value of a license
+// finding's title — e.g. the offending expression in "Package has invalid
+// SPDX license: non-standard" → "...license: **non-standard**" — so it stands
+// out in the Policy Findings table. Non-license findings, and license titles
+// with no "<label>: <value>" shape (e.g. "Package license is unknown"), are
+// returned unchanged. Markdown-only: the underlying finding.Title (shared by
+// the text/JSON/SARIF outputs) is not modified.
+func emphasizeFindingTitle(finding output.AuditFinding) string {
+	title := firstNonEmpty(finding.Title, strings.Join(finding.Reasons, "; "))
+	if finding.Kind != sdk.FindingKindLicense {
+		return title
+	}
+	prefix, value, found := strings.Cut(title, ": ")
+	if !found || strings.TrimSpace(value) == "" {
+		return title
+	}
+	return prefix + ": **" + value + "**"
 }
 
 // findingIconLegend explains the leading status icon used in the findings

--- a/internal/cli/render/diff_markdown_test.go
+++ b/internal/cli/render/diff_markdown_test.go
@@ -171,4 +171,43 @@ func TestDiffMarkdownFindingsTableHasLegendNoDisposition(t *testing.T) {
 	if strings.Contains(report, "Disposition") || strings.Contains(report, "Exploitability") {
 		t.Errorf("findings table should not have Disposition/Exploitability columns, got:\n%s", report)
 	}
+	if !strings.Contains(report, "Package has invalid SPDX license: **non-standard**") {
+		t.Errorf("expected the offending license to be bolded in the findings table, got:\n%s", report)
+	}
+}
+
+func TestEmphasizeFindingTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		finding output.AuditFinding
+		want    string
+	}{
+		{
+			name:    "invalid license bolds the offending expression",
+			finding: output.AuditFinding{Kind: sdk.FindingKindLicense, Title: "Package has invalid SPDX license: non-standard"},
+			want:    "Package has invalid SPDX license: **non-standard**",
+		},
+		{
+			name:    "invalid license with multiple expressions bolds all of them",
+			finding: output.AuditFinding{Kind: sdk.FindingKindLicense, Title: "Package has invalid SPDX license: foo, bar"},
+			want:    "Package has invalid SPDX license: **foo, bar**",
+		},
+		{
+			name:    "license title without a colon value is unchanged",
+			finding: output.AuditFinding{Kind: sdk.FindingKindLicense, Title: "Package license is unknown"},
+			want:    "Package license is unknown",
+		},
+		{
+			name:    "non-license finding is never emphasized",
+			finding: output.AuditFinding{Kind: sdk.FindingKindVulnerability, Title: "Prototype pollution: critical impact"},
+			want:    "Prototype pollution: critical impact",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := emphasizeFindingTitle(tt.finding); got != tt.want {
+				t.Errorf("emphasizeFindingTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -586,6 +586,44 @@ func TestRoot_DiffCommand_JSONOutput(t *testing.T) {
 	}
 }
 
+// TestRoot_DiffCommand_NoMatchingEcosystemExitsNothingToEvaluate verifies that
+// pointing diff at a repo with an ecosystem filter that matches nothing exits
+// with the dedicated "nothing to evaluate" code (5) and produces no partial
+// output, rather than the generic execution-error code (1).
+func TestRoot_DiffCommand_NoMatchingEcosystemExitsNothingToEvaluate(t *testing.T) {
+	requireGit(t)
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	setDynamicFakeNPMOnPath(t)
+	repoDir, baseSHA, headSHA := createGitNPMRepoHistory(t)
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"diff", "--path", repoDir, "--ecosystems", "maven", "--base", baseSHA, "--head", headSHA, "--format", "json"})
+
+	err = root.Execute()
+	if err == nil {
+		t.Fatalf("expected an error when no manifests match the ecosystem filter; stdout=%s", stdout.String())
+	}
+	if got := exit.Code(err); got != 5 {
+		t.Fatalf("expected exit code 5 (nothing to evaluate), got %d (err=%v)", got, err)
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("expected no partial output on the nothing-to-evaluate path, got:\n%s", stdout.String())
+	}
+}
+
 func TestRoot_DiffCommand_JSONOutputWithMarkdownOutputFile(t *testing.T) {
 	requireGit(t)
 	tempHome := t.TempDir()


### PR DESCRIPTION
Follow-up polish from dogfooding Bomly Guard on the example repos. Two independent changes.

## 1. Emphasize the offending license in the markdown findings table

The Policy Findings table rendered `Package has invalid SPDX license: non-standard` as plain text. Now the offending expression is bolded → `Package has invalid SPDX license: **non-standard**` via a small markdown-only helper (`emphasizeFindingTitle`). License titles without a `<label>: <value>` shape ("Package license is unknown") and non-license findings are unchanged; the shared `finding.Title` used by text/JSON/SARIF is untouched.

## 2. Exit code 5 — "nothing to evaluate"

When an `--ecosystems`/`--detectors` filter (or an empty/unsupported target) yields no subprojects, bomly returned `ErrNoSubprojects` as a plain error → generic **exit 1**, indistinguishable from a crash. Bomly Guard aborts on it, so a repo whose content doesn't match the configured ecosystem fails the whole check.

This introduces a dedicated **exit code `5` = "nothing to evaluate"**, deliberately distinct from `3` (resolution failure — a discovered subproject couldn't be turned into a graph, a real error that must keep failing). `noSubprojectsError` now wraps via `exit.NothingToEvaluateError`, keeping `ErrNoSubprojects` as the inner sentinel (so `errors.Is` checks still hold), and scan/diff/explain all surface it unwrapped. `ErrorPrefix` prints code 5 as a `Nothing to evaluate` notice rather than an error. Documented in `docs/EXIT_CODES.md` with the 3-vs-5 distinction.

A companion **bomly-guard** PR will treat exit 5 as a neutral pass (notice + skip SARIF upload + a short neutral comment); the two can merge independently — older CLIs never emit 5, and the new CLI emitting 5 against an un-updated Guard simply fails as it does today until Guard ships.

## Test

`make test`, `make generate` (no drift), `gofmt`, `go vet`, and `golangci-lint run ./internal/...` all clean. Added: `emphasizeFindingTitle` unit + table-render assertion; `exit.Code(noSubprojectsError(...)) == 5` (with and without a filter) keeping `errors.Is(..., ErrNoSubprojects)`; and an end-to-end `root_cmd` test running `diff --ecosystems maven` on the npm fixture asserting exit 5 with no partial output.

Note: the third dogfooding item (SARIF level showing severity instead of policy) was already fixed in #199/v0.14.13 — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Nothing to evaluate” exit outcome when no applicable manifests or subprojects are found.
  * Improved diff output so license-related finding titles highlight the problematic part more clearly.

* **Bug Fixes**
  * `diff` now exits cleanly with the new neutral code when filters match no results, avoiding confusing error handling.

* **Documentation**
  * Updated exit-code docs with the new code and an example for handling no-result cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->