### PR TITLE
Preserve diff line locations in SARIF output

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -120,6 +120,10 @@ Reachability data lives on `sdk.Vulnerability.Reachability` rather than on `Find
 
 Pipeline plumbing: `engine.PipelineResult` exposes `Graph`, `Registry`, `Findings`, and `RiskScores`. The registry is built right after consolidation (`consolidation.BuildPackageRegistry`) and threaded through match/analyze/audit requests; output helpers (`BuildScanResponse`, `WriteSARIF`, `FindingsFromScan`, `PackagesFromGraph`) all accept `*sdk.PackageRegistry` and re-enrich their projections by resolving `PackageRef` and `VulnerabilityID`. See [`MODELS.md`](MODELS.md) for the full schema reference.
 
+### Decision: Package locations are detector-relative today
+
+`PackageLocation.Position.File` is emitted by detectors in the coordinate space of the detector working directory. For single-root projects that is already repository-relative, which lets `bomly diff` compare SARIF locations with repo-relative changed-line ranges. In subproject and monorepo scans, detector positions such as `package-lock.json` may need to be rebased with the subproject `RelativePath` during consolidation before diff-aware SARIF can reliably match changed lines. Until that rebasing exists, location extraction remains best effort and the output layer only prefers changed lines when the detector path already matches the git diff path.
+
 ### Decision: Reachability analyzers derive local hierarchy closures
 
 Tier-3 source analyzers discover local workspace and module hierarchies from declarative project files while the consolidated detector graph remains the source of truth for external package edges. `jsreach` follows package-name imports across npm, Yarn, and pnpm workspace members. `jvmreach` follows source namespace imports across Maven `<modules>` and standard Gradle `include` declarations. This keeps hierarchy traversal automatic, avoids package-manager installation or network activity during reachability analysis, and prevents unused sibling projects from widening the reachable set.

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -122,7 +122,9 @@ Pipeline plumbing: `engine.PipelineResult` exposes `Graph`, `Registry`, `Finding
 
 ### Decision: Package locations are detector-relative today
 
-`PackageLocation.Position.File` is emitted by detectors in the coordinate space of the detector working directory. For single-root projects that is already repository-relative, which lets `bomly diff` compare SARIF locations with repo-relative changed-line ranges. In subproject and monorepo scans, detector positions such as `package-lock.json` may need to be rebased with the subproject `RelativePath` during consolidation before diff-aware SARIF can reliably match changed lines. Until that rebasing exists, location extraction remains best effort and the output layer only prefers changed lines when the detector path already matches the git diff path.
+`PackageLocation.Position.File` is emitted by detectors in the coordinate space of the detector working directory. For single-root projects that is already repository-relative, which lets `bomly diff` compare SARIF locations with repo-relative changed-line ranges.
+
+Subproject discovery does **not** recurse into subdirectories today (`planFilesystemSubprojects` only inspects the execution-target root), so every subproject currently resolves with `RelativePath` `"."` and detector positions are already repository-relative. To future-proof a recursive scan mode, consolidation rebases core-detector location paths onto the subproject root via `rebaseGraphLocations` (`internal/engine/consolidation/locations.go`): a subproject discovered at `apps/web` reporting `package-lock.json` is rewritten to `apps/web/package-lock.json`. This mirrors the existing manifest-path rebasing (`normalizeNativeManifestPath`) and is a deliberate no-op while `RelativePath` is `"."`. Absolute and already-prefixed paths are left untouched, so the rewrite is idempotent. Until a recursive mode actually produces non-root subprojects, location extraction remains best effort and the output layer only prefers changed lines when the detector path matches the git diff path.
 
 ### Decision: Reachability analyzers derive local hierarchy closures
 

--- a/internal/cli/diff_cmd.go
+++ b/internal/cli/diff_cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
 	"github.com/bomly-dev/bomly-cli/internal/engine"
 	diffengine "github.com/bomly-dev/bomly-cli/internal/engine/diff"
+	"github.com/bomly-dev/bomly-cli/internal/git"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/internal/tui"
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -107,6 +108,7 @@ func newDiffCmd() *cobra.Command {
 			compBase := baseRef
 			compHead := headRef
 			var resolutionWarnings []engine.PipelineWarning
+			var changedLines map[string][]output.SARIFLineRange
 
 			switch {
 			case current.SBOM:
@@ -114,7 +116,9 @@ func newDiffCmd() *cobra.Command {
 			case current.Container != "":
 				baseTarget, headTarget, projectIdentifier, resolutionWarnings, err = resolveContainerDiffGraphs(cmd.Context(), options, prog, logger, baseRef, headRef)
 			default:
-				baseTarget, headTarget, projectIdentifier, resolutionWarnings, err = resolveGitDiffGraphs(cmd.Context(), options, prog, logger, baseRef, headRef)
+				var gitChangedLines map[string][]git.LineRange
+				baseTarget, headTarget, projectIdentifier, resolutionWarnings, gitChangedLines, err = resolveGitDiffGraphs(cmd.Context(), options, prog, logger, baseRef, headRef)
+				changedLines = sarifChangedLinesFromGit(gitChangedLines)
 			}
 			if err != nil {
 				return err
@@ -183,7 +187,7 @@ func newDiffCmd() *cobra.Command {
 				Text:     textRenderer,
 			}
 			sarifRenderer := func(w io.Writer) error {
-				return output.WriteSARIF(w, diffSARIFFindings(diffResult.Audit), diffResult.Head.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Analyze, LocationGraphs: []*sdk.Graph{diffResult.Head.Graph}, BaselineState: "new"})
+				return output.WriteSARIF(w, diffSARIFFindings(diffResult.Audit), diffResult.Head.Registry, "bomly", cmd.Root().Version, output.SARIFOptions{IncludeReachability: current.Analyze, LocationGraphs: []*sdk.Graph{diffResult.Head.Graph}, BaselineState: "new", ChangedLines: changedLines})
 			}
 			if len(outputSpecs) > 0 {
 				prog.Advance("Writing additional output")
@@ -261,6 +265,19 @@ func diffPolicyExit(auditEnabled bool, audit *diffengine.Audit) error {
 		}
 	}
 	return nil
+}
+
+func sarifChangedLinesFromGit(ranges map[string][]git.LineRange) map[string][]output.SARIFLineRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+	out := make(map[string][]output.SARIFLineRange, len(ranges))
+	for file, fileRanges := range ranges {
+		for _, r := range fileRanges {
+			out[file] = append(out[file], output.SARIFLineRange{Start: r.Start, End: r.End})
+		}
+	}
+	return out
 }
 
 func uniqueStrings(groups ...[]string) []string {

--- a/internal/cli/diff_resolve.go
+++ b/internal/cli/diff_resolve.go
@@ -17,19 +17,23 @@ import (
 	"go.uber.org/zap"
 )
 
-func resolveGitDiffGraphs(ctx context.Context, options *opts.Options, prog *progress.Progress, logger *zap.Logger, baseRef, headRef string) (diffResolvedTarget, diffResolvedTarget, string, []engine.PipelineWarning, error) {
+func resolveGitDiffGraphs(ctx context.Context, options *opts.Options, prog *progress.Progress, logger *zap.Logger, baseRef, headRef string) (diffResolvedTarget, diffResolvedTarget, string, []engine.PipelineWarning, map[string][]git.LineRange, error) {
 	repoRoot, repoCleanup, projectIdentifier, err := resolveDiffRepo(options, prog, logger)
 	if err != nil {
-		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, err
+		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, nil, err
 	}
 	if repoCleanup != nil {
 		defer func() { _ = repoCleanup() }()
 	}
 	if err := git.VerifyRef(repoRoot, baseRef); err != nil {
-		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, exit.InvalidInputError("verify --base %q: %v", baseRef, err)
+		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, nil, exit.InvalidInputError("verify --base %q: %v", baseRef, err)
 	}
 	if err := git.VerifyRef(repoRoot, headRef); err != nil {
-		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, exit.InvalidInputError("verify --head %q: %v", headRef, err)
+		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, nil, exit.InvalidInputError("verify --head %q: %v", headRef, err)
+	}
+	changedLines, err := git.ChangedLineRanges(repoRoot, baseRef, headRef)
+	if err != nil && logger != nil {
+		logger.Warn("diff: changed line ranges unavailable", zap.Error(err))
 	}
 
 	// Single indexing step covering both refs' Prepare phases.
@@ -38,18 +42,18 @@ func resolveGitDiffGraphs(ctx context.Context, options *opts.Options, prog *prog
 	baseTarget, err := resolveDiffResultsForRef(ctx, options, logger, repoRoot, baseRef)
 	if err != nil {
 		indexStep.Fail("Indexing subprojects failed")
-		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, err
+		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, nil, err
 	}
 	headTarget, err := resolveDiffResultsForRef(ctx, options, logger, repoRoot, headRef)
 	if err != nil {
 		indexStep.Fail("Indexing subprojects failed")
 		_ = baseTarget.close()
-		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, err
+		return diffResolvedTarget{}, diffResolvedTarget{}, "", nil, nil, err
 	}
 
 	indexStep.Complete("Indexed subprojects", combinedSubprojectChildren(baseTarget.Context.Subprojects(), headTarget.Context.Subprojects()))
 
-	return baseTarget, headTarget, projectIdentifier, collectPipelineWarnings(baseTarget.Warnings, headTarget.Warnings), nil
+	return baseTarget, headTarget, projectIdentifier, collectPipelineWarnings(baseTarget.Warnings, headTarget.Warnings), changedLines, nil
 }
 
 // resolveDiffRepo finds (or clones) the git repository to diff. When --url is

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -333,7 +333,7 @@ func (a *mcpOptionsAdapter) RunDiff(ctx context.Context, req mcp.DiffRequest) (o
 	})
 	logger := a.logger
 
-	baseTarget, headTarget, projectIdentifier, _, err := resolveGitDiffGraphs(ctx, o, nil, logger, req.Base, req.Head)
+	baseTarget, headTarget, projectIdentifier, _, _, err := resolveGitDiffGraphs(ctx, o, nil, logger, req.Base, req.Head)
 	if err != nil {
 		return output.DiffResponse{}, err
 	}

--- a/internal/detectors/conan/detector_test.go
+++ b/internal/detectors/conan/detector_test.go
@@ -61,7 +61,11 @@ class Demo(ConanFile):
 		t.Fatalf("ResolveGraph returned error: %v", err)
 	}
 	graph := result.Graphs.Entries[0].Graph
-	if _, ok := graph.Node("fmt@10.2.1"); !ok {
+	fmtPkg, ok := graph.Node("fmt@10.2.1")
+	if !ok {
 		t.Fatalf("expected fmt package, got %v", graph.Nodes())
+	}
+	if len(fmtPkg.Locations) != 1 || fmtPkg.Locations[0].Position == nil || fmtPkg.Locations[0].Position.Line != 5 {
+		t.Fatalf("fmt locations = %#v, want conanfile.py line 5", fmtPkg.Locations)
 	}
 }

--- a/internal/detectors/conan/detector_test.go
+++ b/internal/detectors/conan/detector_test.go
@@ -46,6 +46,7 @@ func TestDetectorResolveGraphFromConanfilePy(t *testing.T) {
 
 class Demo(ConanFile):
     def requirements(self):
+        # The docs mention "zlib/1.2.13"; comments should not become locations.
         self.requires("fmt/10.2.1")
 `)
 	if err := os.WriteFile(filepath.Join(projectDir, "conanfile.py"), raw, 0o644); err != nil {
@@ -65,7 +66,7 @@ class Demo(ConanFile):
 	if !ok {
 		t.Fatalf("expected fmt package, got %v", graph.Nodes())
 	}
-	if len(fmtPkg.Locations) != 1 || fmtPkg.Locations[0].Position == nil || fmtPkg.Locations[0].Position.Line != 5 {
-		t.Fatalf("fmt locations = %#v, want conanfile.py line 5", fmtPkg.Locations)
+	if len(fmtPkg.Locations) != 1 || fmtPkg.Locations[0].Position == nil || fmtPkg.Locations[0].Position.Line != 6 {
+		t.Fatalf("fmt locations = %#v, want conanfile.py line 6", fmtPkg.Locations)
 	}
 }

--- a/internal/detectors/conan/positions.go
+++ b/internal/detectors/conan/positions.go
@@ -10,6 +10,7 @@ import (
 )
 
 var conanRefLine = regexp.MustCompile(`([a-zA-Z0-9_][a-zA-Z0-9._+-]*)\s*/\s*([^@'"\s,)]+)`)
+var conanPythonRequireLine = regexp.MustCompile(`(?:self\.)?(?:requires|build_requires|tool_requires|test_requires)\s*\(\s*["']([a-zA-Z0-9_][a-zA-Z0-9._+-]*)\s*/\s*([^@'"\s,)]+)`)
 
 var conanSectionHeader = regexp.MustCompile(`^\s*\[\s*(requires|build_requires|tool_requires|test_requires)\s*\]\s*$`)
 
@@ -33,6 +34,9 @@ func conanPositions(projectDir string) map[string][]*sdk.SourcePosition {
 				return
 			}
 			matches := conanRefLine.FindStringSubmatch(text)
+			if name == "conanfile.py" {
+				matches = conanPythonRequireLine.FindStringSubmatch(text)
+			}
 			if matches == nil {
 				return
 			}
@@ -42,9 +46,9 @@ func conanPositions(projectDir string) map[string][]*sdk.SourcePosition {
 			}
 			version := strings.TrimSpace(matches[2])
 			pos := &sdk.SourcePosition{File: name, Line: line}
-			appendPosition(out, pkgName, pos)
+			detectors.AppendPosition(out, pkgName, pos)
 			if version != "" {
-				appendPosition(out, pkgName+"@"+version, pos)
+				detectors.AppendPosition(out, pkgName+"@"+version, pos)
 			}
 		})
 	}
@@ -70,17 +74,4 @@ func AttachConanPositions(g *sdk.Graph, projectDir string) {
 		}
 		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
-}
-
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
-	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
-		}
-	}
-	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/conan/positions.go
+++ b/internal/detectors/conan/positions.go
@@ -9,20 +9,16 @@ import (
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
-// conanRequireLine matches a Conan require line of the form
-// `name/version[@user/channel]` typically found in conanfile.txt's
-// [requires] / [build_requires] / [tool_requires] sections. The
-// captured value is the package name.
-var conanRequireLine = regexp.MustCompile(`^\s*([a-zA-Z0-9_][a-zA-Z0-9._+-]*)\s*/\s*[^@\s]+`)
+var conanRefLine = regexp.MustCompile(`([a-zA-Z0-9_][a-zA-Z0-9._+-]*)\s*/\s*([^@'"\s,)]+)`)
 
 var conanSectionHeader = regexp.MustCompile(`^\s*\[\s*(requires|build_requires|tool_requires|test_requires)\s*\]\s*$`)
 
-func conanPositions(projectDir string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
-	candidates := []string{"conanfile.txt", "conan.lock", "conaninfo.txt"}
+func conanPositions(projectDir string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
+	candidates := []string{"conanfile.txt", "conanfile.py", "conan.lock", "conaninfo.txt"}
 	for _, name := range candidates {
 		full := filepath.Join(projectDir, name)
-		insideRequires := name == "conan.lock" || name == "conaninfo.txt" // always scan lock/info bodies
+		insideRequires := name == "conan.lock" || name == "conaninfo.txt" || name == "conanfile.py" // always scan lock/info/python bodies
 		_ = detectors.ScanLines(full, func(line int, text string) {
 			trimmed := strings.TrimSpace(text)
 			if conanSectionHeader.MatchString(trimmed) {
@@ -36,7 +32,7 @@ func conanPositions(projectDir string) map[string]*sdk.SourcePosition {
 			if !insideRequires {
 				return
 			}
-			matches := conanRequireLine.FindStringSubmatch(text)
+			matches := conanRefLine.FindStringSubmatch(text)
 			if matches == nil {
 				return
 			}
@@ -44,10 +40,12 @@ func conanPositions(projectDir string) map[string]*sdk.SourcePosition {
 			if pkgName == "" {
 				return
 			}
-			if _, exists := out[pkgName]; exists {
-				return
+			version := strings.TrimSpace(matches[2])
+			pos := &sdk.SourcePosition{File: name, Line: line}
+			appendPosition(out, pkgName, pos)
+			if version != "" {
+				appendPosition(out, pkgName+"@"+version, pos)
 			}
-			out[pkgName] = &sdk.SourcePosition{File: name, Line: line}
 		})
 	}
 	return out
@@ -62,10 +60,27 @@ func AttachConanPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
-		return strings.TrimSpace(pkg.Name)
+		name := strings.TrimSpace(pkg.Name)
+		if name == "" {
+			return nil
+		}
+		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/githubactions/detector_test.go
+++ b/internal/detectors/githubactions/detector_test.go
@@ -144,3 +144,47 @@ func TestDetectorResolveGraphAttachesUsesLineLocations(t *testing.T) {
 		t.Fatalf("codeql action locations = %#v, want line 7", codeql.Locations)
 	}
 }
+
+func TestDetectorResolveGraphPreservesDuplicateUsesLocations(t *testing.T) {
+	projectDir := t.TempDir()
+	workflowDir := filepath.Join(projectDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("create workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte("jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v5\n"), 0o644); err != nil {
+		t.Fatalf("write ci workflow: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "guard.yml"), []byte("jobs:\n  guard:\n    steps:\n      - name: Checkout\n        uses: actions/checkout@v5\n"), 0o644); err != nil {
+		t.Fatalf("write guard workflow: %v", err)
+	}
+
+	result, err := (Detector{}).ResolveGraph(context.Background(), sdk.DetectionRequest{
+		ProjectPath:     projectDir,
+		PackageManager:  sdk.PackageManagerGitHubActions,
+		Ecosystem:       sdk.EcosystemGitHub,
+		ExecutionTarget: sdk.ExecutionTarget{Location: projectDir},
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+	g, err := result.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	checkout, ok := g.Node("actions:checkout@v5")
+	if !ok {
+		t.Fatal("expected actions/checkout package")
+	}
+	if len(checkout.Locations) != 2 {
+		t.Fatalf("checkout locations = %#v, want both workflow locations", checkout.Locations)
+	}
+	got := map[string]int{}
+	for _, loc := range checkout.Locations {
+		if loc.Position != nil {
+			got[loc.Position.File] = loc.Position.Line
+		}
+	}
+	if got[".github/workflows/ci.yml"] != 4 || got[".github/workflows/guard.yml"] != 5 {
+		t.Fatalf("checkout locations = %#v, want ci line 4 and guard line 5", checkout.Locations)
+	}
+}

--- a/internal/detectors/githubactions/positions.go
+++ b/internal/detectors/githubactions/positions.go
@@ -38,10 +38,11 @@ func workflowPositions(projectDir string) map[string][]*sdk.SourcePosition {
 					return
 				}
 				coord := strings.TrimSpace(text[matches[2]:matches[3]])
-				if coord == "" {
+				key := workflowPositionKey(coord)
+				if key == "" {
 					return
 				}
-				appendPosition(out, coord, &sdk.SourcePosition{File: rel, Line: line, Column: matches[2] + 1, EndLine: line})
+				detectors.AppendPosition(out, key, &sdk.SourcePosition{File: rel, Line: line, Column: matches[2] + 1, EndLine: line})
 			})
 		}
 	}
@@ -65,21 +66,30 @@ func AttachWorkflowPositions(g *sdk.Graph, projectDir string) {
 		// External GitHub Actions packages store owner and repository
 		// separately, while workflow manifests spell them as owner/repo.
 		if strings.TrimSpace(pkg.Org) != "" && strings.TrimSpace(pkg.Name) != "" {
-			return []string{strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + strings.Trim(strings.TrimSpace(pkg.Name), "/")}
+			name := strings.Trim(strings.TrimSpace(pkg.Name), "/")
+			keys := []string{strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + workflowRepoName(name)}
+			if repo := workflowPositionKey(strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + name); repo != "" && repo != keys[0] {
+				keys = append(keys, repo)
+			}
+			return keys
 		}
-		return []string{strings.TrimSpace(pkg.Name)}
+		return []string{workflowPositionKey(strings.TrimSpace(pkg.Name))}
 	})
 }
 
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
+func workflowPositionKey(coord string) string {
+	coord = strings.Trim(strings.TrimSpace(coord), "/")
+	parts := strings.Split(coord, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return coord
 	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
-		}
+	return parts[0] + "/" + parts[1]
+}
+
+func workflowRepoName(name string) string {
+	name = strings.Trim(name, "/")
+	if i := strings.Index(name, "/"); i >= 0 {
+		return name[:i]
 	}
-	out[key] = append(out[key], pos)
+	return name
 }

--- a/internal/detectors/githubactions/positions.go
+++ b/internal/detectors/githubactions/positions.go
@@ -14,10 +14,10 @@ import (
 var usesLine = regexp.MustCompile(`^\s*-?\s*uses\s*:\s*['"]?([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*(?:/[^@'"\s]*)?)@[^'"\s]+['"]?\s*$`)
 
 // workflowPositions walks .github/workflows/*.yml + .github/actions/*/action.yml
-// and returns a map from owner/repo coordinate to the line where the
-// `uses:` entry first appears.
-func workflowPositions(projectDir string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
+// and returns every line where a `uses:` entry appears for each owner/repo
+// coordinate.
+func workflowPositions(projectDir string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
 	patterns := []string{
 		filepath.Join(projectDir, ".github", "workflows", "*.yml"),
 		filepath.Join(projectDir, ".github", "workflows", "*.yaml"),
@@ -41,10 +41,7 @@ func workflowPositions(projectDir string) map[string]*sdk.SourcePosition {
 				if coord == "" {
 					return
 				}
-				if _, exists := out[coord]; exists {
-					return
-				}
-				out[coord] = &sdk.SourcePosition{File: rel, Line: line, Column: matches[2] + 1, EndLine: line}
+				appendPosition(out, coord, &sdk.SourcePosition{File: rel, Line: line, Column: matches[2] + 1, EndLine: line})
 			})
 		}
 	}
@@ -61,15 +58,28 @@ func AttachWorkflowPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
 		// External GitHub Actions packages store owner and repository
 		// separately, while workflow manifests spell them as owner/repo.
 		if strings.TrimSpace(pkg.Org) != "" && strings.TrimSpace(pkg.Name) != "" {
-			return strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + strings.Trim(strings.TrimSpace(pkg.Name), "/")
+			return []string{strings.Trim(strings.TrimSpace(pkg.Org), "/") + "/" + strings.Trim(strings.TrimSpace(pkg.Name), "/")}
 		}
-		return strings.TrimSpace(pkg.Name)
+		return []string{strings.TrimSpace(pkg.Name)}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -51,14 +51,14 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 					positionLine = pendingVersionLine
 				}
 				pos := &sdk.SourcePosition{File: relPath, Line: positionLine}
-				appendPosition(out, pendingArtifactName, pos)
+				detectors.AppendPosition(out, pendingArtifactName, pos)
 				if pendingVersion != "" {
-					appendPosition(out, pendingArtifactName+"@"+pendingVersion, pos)
+					detectors.AppendPosition(out, pendingArtifactName+"@"+pendingVersion, pos)
 				}
 				if pendingGroup != "" {
-					appendPosition(out, pendingGroup+":"+pendingArtifactName, pos)
+					detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName, pos)
 					if pendingVersion != "" {
-						appendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+pendingVersion, pos)
+						detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+pendingVersion, pos)
 					}
 				}
 			}
@@ -113,17 +113,4 @@ func AttachPomPositions(g *sdk.Graph, projectDir string) {
 		org := strings.TrimSpace(pkg.Org)
 		return []string{org + ":" + name + "@" + version, name + "@" + version, org + ":" + name, name}
 	})
-}
-
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
-	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
-		}
-	}
-	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -18,6 +18,7 @@ var (
 	pomDependencyClose = regexp.MustCompile(`</dependency>`)
 	pomGroupID         = regexp.MustCompile(`<groupId>([^<]+)</groupId>`)
 	pomArtifactID      = regexp.MustCompile(`<artifactId>([^<]+)</artifactId>`)
+	pomVersion         = regexp.MustCompile(`<version>([^<]+)</version>`)
 )
 
 // pomPositions returns name -> position by scanning every
@@ -25,30 +26,55 @@ var (
 // (matching how the maven detector stores Name on graph packages).
 // In multi-module projects with a single root pom, this is a
 // best-effort attribution to the parent pom.
-func pomPositions(path, relPath string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
+func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
 	insideDep := false
+	pendingGroup := ""
 	pendingArtifactLine := 0
 	pendingArtifactName := ""
+	pendingVersion := ""
+	pendingVersionLine := 0
 	_ = detectors.ScanLines(path, func(line int, text string) {
 		if pomDependencyOpen.MatchString(text) {
 			insideDep = true
+			pendingGroup = ""
 			pendingArtifactLine = 0
 			pendingArtifactName = ""
+			pendingVersion = ""
+			pendingVersionLine = 0
 			return
 		}
 		if pomDependencyClose.MatchString(text) {
 			if pendingArtifactName != "" && pendingArtifactLine > 0 {
-				if _, exists := out[pendingArtifactName]; !exists {
-					out[pendingArtifactName] = &sdk.SourcePosition{File: relPath, Line: pendingArtifactLine}
+				positionLine := pendingArtifactLine
+				if pendingVersionLine > 0 {
+					positionLine = pendingVersionLine
+				}
+				pos := &sdk.SourcePosition{File: relPath, Line: positionLine}
+				appendPosition(out, pendingArtifactName, pos)
+				if pendingVersion != "" {
+					appendPosition(out, pendingArtifactName+"@"+pendingVersion, pos)
+				}
+				if pendingGroup != "" {
+					appendPosition(out, pendingGroup+":"+pendingArtifactName, pos)
+					if pendingVersion != "" {
+						appendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+pendingVersion, pos)
+					}
 				}
 			}
 			insideDep = false
+			pendingGroup = ""
 			pendingArtifactName = ""
 			pendingArtifactLine = 0
+			pendingVersion = ""
+			pendingVersionLine = 0
 			return
 		}
 		if !insideDep {
+			return
+		}
+		if m := pomGroupID.FindStringSubmatch(text); m != nil {
+			pendingGroup = strings.TrimSpace(m[1])
 			return
 		}
 		if m := pomArtifactID.FindStringSubmatch(text); m != nil {
@@ -56,9 +82,10 @@ func pomPositions(path, relPath string) map[string]*sdk.SourcePosition {
 			pendingArtifactLine = line
 			return
 		}
-		// groupId could be useful for disambiguation but we key only on
-		// artifactId to match the graph's Name field.
-		_ = pomGroupID
+		if m := pomVersion.FindStringSubmatch(text); m != nil {
+			pendingVersion = strings.TrimSpace(m[1])
+			pendingVersionLine = line
+		}
 	})
 	return out
 }
@@ -72,16 +99,31 @@ func AttachPomPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
 		// Maven detector stores Name as artifactId (optionally with
 		// :classifier suffix). Strip the suffix to match.
 		name := strings.TrimSpace(pkg.Name)
 		if i := strings.Index(name, ":"); i > 0 {
-			return name[:i]
+			name = name[:i]
 		}
-		return name
+		version := strings.TrimSpace(pkg.Version)
+		org := strings.TrimSpace(pkg.Org)
+		return []string{org + ":" + name + "@" + version, name + "@" + version, org + ":" + name, name}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/node/npm/positions.go
+++ b/internal/detectors/node/npm/positions.go
@@ -40,9 +40,9 @@ func packageLockPositions(path, relPath string) map[string][]*sdk.SourcePosition
 		version := strings.TrimSpace(matches[1])
 		pos := &sdk.SourcePosition{File: relPath, Line: line}
 		if version != "" {
-			appendPosition(out, currentName+"@"+version, pos)
+			detectors.AppendPosition(out, currentName+"@"+version, pos)
 		}
-		appendPosition(out, currentName, &sdk.SourcePosition{File: relPath, Line: currentLine})
+		detectors.AppendPosition(out, currentName, &sdk.SourcePosition{File: relPath, Line: currentLine})
 		currentName = ""
 		currentLine = 0
 	})
@@ -91,19 +91,28 @@ func AttachPackageLockPositions(g *sdk.Graph, projectDir string) {
 		if name == "" {
 			return nil
 		}
-		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
+		return npmPositionKeys(name, strings.TrimSpace(pkg.Version))
 	})
 }
 
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
+func npmPositionKeys(name, version string) []string {
+	names := []string{name}
+	if normalized := npmSlashScopeName(name); normalized != "" && normalized != name {
+		names = append([]string{normalized}, names...)
 	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
+	keys := make([]string, 0, len(names)*2)
+	for _, candidate := range names {
+		if version != "" {
+			keys = append(keys, candidate+"@"+version)
 		}
+		keys = append(keys, candidate)
 	}
-	out[key] = append(out[key], pos)
+	return keys
+}
+
+func npmSlashScopeName(name string) string {
+	if strings.HasPrefix(name, "@") && strings.Contains(name, ":") {
+		return strings.Replace(name, ":", "/", 1)
+	}
+	return name
 }

--- a/internal/detectors/node/npm/positions.go
+++ b/internal/detectors/node/npm/positions.go
@@ -14,26 +14,37 @@ import (
 // `    "node_modules/@scope/pkg": {`. Nested entries
 // (`node_modules/foo/node_modules/bar`) are matched too — we then
 // take the final segment as the package name.
-var npmLockKeyLine = regexp.MustCompile(`^\s*"((?:node_modules/)+(?:@[^/"]+/)?[^"/]+)"\s*:\s*\{?\s*$`)
+var npmLockKeyLine = regexp.MustCompile(`^\s*"((?:.*node_modules/)(?:@[^/"]+/)?[^"/]+)"\s*:\s*\{?\s*$`)
+var npmLockVersionLine = regexp.MustCompile(`^\s*"version"\s*:\s*"([^"]+)"`)
 
-// packageLockPositions returns name -> SourcePosition for every
-// node_modules/... key in package-lock.json. Multiple occurrences
-// (nested installs) keep the first match.
-func packageLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
+// packageLockPositions returns lookup keys for every node_modules/... key in
+// package-lock.json. Exact name@version keys point at the version line, while
+// name-only fallback keys point at the package block key.
+func packageLockPositions(path, relPath string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
+	var currentName string
+	var currentLine int
 	_ = detectors.ScanLines(path, func(line int, text string) {
-		matches := npmLockKeyLine.FindStringSubmatch(text)
+		if matches := npmLockKeyLine.FindStringSubmatch(text); matches != nil {
+			currentName = finalNPMPathSegment(matches[1])
+			currentLine = line
+			return
+		}
+		if currentName == "" {
+			return
+		}
+		matches := npmLockVersionLine.FindStringSubmatch(text)
 		if matches == nil {
 			return
 		}
-		name := finalNPMPathSegment(matches[1])
-		if name == "" {
-			return
+		version := strings.TrimSpace(matches[1])
+		pos := &sdk.SourcePosition{File: relPath, Line: line}
+		if version != "" {
+			appendPosition(out, currentName+"@"+version, pos)
 		}
-		if _, exists := out[name]; exists {
-			return
-		}
-		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+		appendPosition(out, currentName, &sdk.SourcePosition{File: relPath, Line: currentLine})
+		currentName = ""
+		currentLine = 0
 	})
 	return out
 }
@@ -70,12 +81,29 @@ func AttachPackageLockPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
 		// Graph stores npm packages with their QualifiedName
 		// ("@scope:pkg") or bare name. Try both forms.
-		return strings.TrimSpace(pkg.Name)
+		name := strings.TrimSpace(pkg.Name)
+		if name == "" {
+			return nil
+		}
+		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/node/pnpm/positions.go
+++ b/internal/detectors/node/pnpm/positions.go
@@ -16,10 +16,10 @@ import (
 //	/foo/1.0.0:
 //	'/foo@1.0.0(transitivePeer@2.0.0)':
 //	'@scope/pkg@1.0.0':
-var pnpmLockKeyLine = regexp.MustCompile(`^\s*['"]?/?((?:@[^/'"@]+/)?[^/'"@\s]+)[@/][^:'"\s]+['"]?\s*:\s*$`)
+var pnpmLockKeyLine = regexp.MustCompile(`^\s*['"]?/?((?:@[^/'"@]+/)?[^/'"@\s]+)[@/]([^:'"\s(]+)`)
 
-func pnpmLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
+func pnpmLockPositions(path, relPath string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
 	insidePackages := false
 	_ = detectors.ScanLines(path, func(line int, text string) {
 		trimmed := strings.TrimSpace(text)
@@ -43,10 +43,12 @@ func pnpmLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 		if name == "" {
 			return
 		}
-		if _, exists := out[name]; exists {
-			return
+		version := strings.TrimSpace(matches[2])
+		pos := &sdk.SourcePosition{File: relPath, Line: line}
+		if version != "" {
+			appendPosition(out, name+"@"+version, pos)
 		}
-		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+		appendPosition(out, name, pos)
 	})
 	return out
 }
@@ -60,10 +62,27 @@ func AttachPnpmLockPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
-		return strings.TrimSpace(pkg.Name)
+		name := strings.TrimSpace(pkg.Name)
+		if name == "" {
+			return nil
+		}
+		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/node/pnpm/positions.go
+++ b/internal/detectors/node/pnpm/positions.go
@@ -46,9 +46,9 @@ func pnpmLockPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 		version := strings.TrimSpace(matches[2])
 		pos := &sdk.SourcePosition{File: relPath, Line: line}
 		if version != "" {
-			appendPosition(out, name+"@"+version, pos)
+			detectors.AppendPosition(out, name+"@"+version, pos)
 		}
-		appendPosition(out, name, pos)
+		detectors.AppendPosition(out, name, pos)
 	})
 	return out
 }
@@ -70,19 +70,28 @@ func AttachPnpmLockPositions(g *sdk.Graph, projectDir string) {
 		if name == "" {
 			return nil
 		}
-		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
+		return pnpmPositionKeys(name, strings.TrimSpace(pkg.Version))
 	})
 }
 
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
+func pnpmPositionKeys(name, version string) []string {
+	names := []string{name}
+	if normalized := pnpmSlashScopeName(name); normalized != "" && normalized != name {
+		names = append([]string{normalized}, names...)
 	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
+	keys := make([]string, 0, len(names)*2)
+	for _, candidate := range names {
+		if version != "" {
+			keys = append(keys, candidate+"@"+version)
 		}
+		keys = append(keys, candidate)
 	}
-	out[key] = append(out[key], pos)
+	return keys
+}
+
+func pnpmSlashScopeName(name string) string {
+	if strings.HasPrefix(name, "@") && strings.Contains(name, ":") {
+		return strings.Replace(name, ":", "/", 1)
+	}
+	return name
 }

--- a/internal/detectors/nuget/detector_test.go
+++ b/internal/detectors/nuget/detector_test.go
@@ -203,6 +203,27 @@ func TestDetectorResolveGraphAttachesPackagesConfigLocations(t *testing.T) {
 	}
 }
 
+func TestNuGetPositionsRecordSelfClosingReferenceWithoutVersion(t *testing.T) {
+	projectDir := t.TempDir()
+	raw := []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Central.Package" />
+  </ItemGroup>
+</Project>`)
+	if err := os.WriteFile(filepath.Join(projectDir, "example.csproj"), raw, 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	positions := nugetPositions(projectDir)
+	got := positions["central.package"]
+	if len(got) != 1 || got[0].File != "example.csproj" || got[0].Line != 3 {
+		t.Fatalf("central.package positions = %#v, want example.csproj line 3", got)
+	}
+	if got := positions["central.package@"]; len(got) != 0 {
+		t.Fatalf("central.package@ positions = %#v, want none", got)
+	}
+}
+
 func TestDepGraphFromDepsFiles(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "example.deps.json")

--- a/internal/detectors/nuget/detector_test.go
+++ b/internal/detectors/nuget/detector_test.go
@@ -130,6 +130,79 @@ func TestDepGraphFromProjectFiles(t *testing.T) {
 	}
 }
 
+func TestDetectorResolveGraphAttachesProjectAndConfigLocations(t *testing.T) {
+	projectDir := t.TempDir()
+	nestedDir := filepath.Join(projectDir, "src", "app")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	projectPath := filepath.Join(nestedDir, "example.csproj")
+	raw := []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>`)
+	if err := os.WriteFile(projectPath, raw, 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	result, err := (Detector{}).ResolveGraph(context.Background(), sdk.DetectionRequest{
+		ProjectPath:     projectDir,
+		PackageManager:  sdk.PackageManagerNuGet,
+		Ecosystem:       sdk.EcosystemDotNet,
+		ExecutionTarget: sdk.ExecutionTarget{Location: projectDir},
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+	g, err := result.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	systemRuntime, ok := g.Node("System.Runtime.Extensions@4.3.0")
+	if !ok || len(systemRuntime.Locations) == 0 || systemRuntime.Locations[0].Position == nil || systemRuntime.Locations[0].Position.Line != 3 {
+		t.Fatalf("System.Runtime.Extensions locations = %#v, want inline PackageReference line 3", systemRuntime.Locations)
+	}
+	newtonsoft, ok := g.Node("Newtonsoft.Json@13.0.3")
+	if !ok || len(newtonsoft.Locations) == 0 || newtonsoft.Locations[0].Position == nil || newtonsoft.Locations[0].Position.Line != 5 {
+		t.Fatalf("Newtonsoft.Json locations = %#v, want Version element line 5", newtonsoft.Locations)
+	}
+	if newtonsoft.Locations[0].RealPath != "src/app/example.csproj" {
+		t.Fatalf("Newtonsoft.Json location path = %#v, want nested project path", newtonsoft.Locations[0])
+	}
+}
+
+func TestDetectorResolveGraphAttachesPackagesConfigLocations(t *testing.T) {
+	projectDir := t.TempDir()
+	raw := []byte(`<packages>
+  <package id="NUnit" version="4.2.2" targetFramework="net48" />
+</packages>`)
+	if err := os.WriteFile(filepath.Join(projectDir, "packages.config"), raw, 0o644); err != nil {
+		t.Fatalf("write packages.config: %v", err)
+	}
+
+	result, err := (Detector{}).ResolveGraph(context.Background(), sdk.DetectionRequest{
+		ProjectPath:     projectDir,
+		PackageManager:  sdk.PackageManagerNuGet,
+		Ecosystem:       sdk.EcosystemDotNet,
+		ExecutionTarget: sdk.ExecutionTarget{Location: projectDir},
+	})
+	if err != nil {
+		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+	g, err := result.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	nunit, ok := g.Node("NUnit@4.2.2")
+	if !ok || len(nunit.Locations) == 0 || nunit.Locations[0].Position == nil || nunit.Locations[0].Position.Line != 2 {
+		t.Fatalf("NUnit locations = %#v, want packages.config line 2", nunit.Locations)
+	}
+}
+
 func TestDepGraphFromDepsFiles(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "example.deps.json")

--- a/internal/detectors/nuget/positions.go
+++ b/internal/detectors/nuget/positions.go
@@ -48,8 +48,8 @@ func nugetPositions(projectDir string) map[string][]*sdk.SourcePosition {
 		}
 		version := strings.TrimSpace(matches[1])
 		pos := &sdk.SourcePosition{File: "packages.lock.json", Line: line}
-		appendPosition(out, pendingName, &sdk.SourcePosition{File: "packages.lock.json", Line: pendingLine})
-		appendPosition(out, pendingName+"@"+version, pos)
+		detectors.AppendPosition(out, pendingName, &sdk.SourcePosition{File: "packages.lock.json", Line: pendingLine})
+		detectors.AppendPosition(out, pendingName+"@"+version, pos)
 		pendingName = ""
 		pendingLine = 0
 	})
@@ -62,8 +62,8 @@ func nugetPositions(projectDir string) map[string][]*sdk.SourcePosition {
 		name := strings.ToLower(strings.TrimSpace(matches[1]))
 		version := strings.TrimSpace(matches[2])
 		pos := &sdk.SourcePosition{File: "packages.config", Line: line}
-		appendPosition(out, name, pos)
-		appendPosition(out, name+"@"+version, pos)
+		detectors.AppendPosition(out, name, pos)
+		detectors.AppendPosition(out, name+"@"+version, pos)
 	})
 	// 3) Scan project files for PackageReference.
 	projectFiles, _ := nugetProjectFiles(projectDir)
@@ -80,11 +80,15 @@ func nugetPositions(projectDir string) map[string][]*sdk.SourcePosition {
 			if refMatches != nil {
 				pendingName = strings.ToLower(strings.TrimSpace(refMatches[1]))
 				pendingLine = line
+				detectors.AppendPosition(out, pendingName, &sdk.SourcePosition{File: rel, Line: pendingLine})
 				if versionMatches := nugetPackageReferenceVersionAttr.FindStringSubmatch(text); versionMatches != nil {
 					version := strings.TrimSpace(versionMatches[1])
 					pos := &sdk.SourcePosition{File: rel, Line: line}
-					appendPosition(out, pendingName, pos)
-					appendPosition(out, pendingName+"@"+version, pos)
+					detectors.AppendPosition(out, pendingName+"@"+version, pos)
+					pendingName = ""
+					pendingLine = 0
+				}
+				if strings.Contains(text, "/>") {
 					pendingName = ""
 					pendingLine = 0
 				}
@@ -96,14 +100,12 @@ func nugetPositions(projectDir string) map[string][]*sdk.SourcePosition {
 			if versionMatches := nugetVersionElement.FindStringSubmatch(text); versionMatches != nil {
 				version := strings.TrimSpace(versionMatches[1])
 				pos := &sdk.SourcePosition{File: rel, Line: line}
-				appendPosition(out, pendingName, &sdk.SourcePosition{File: rel, Line: pendingLine})
-				appendPosition(out, pendingName+"@"+version, pos)
+				detectors.AppendPosition(out, pendingName+"@"+version, pos)
 				pendingName = ""
 				pendingLine = 0
 				return
 			}
 			if nugetPackageReferenceClose.MatchString(text) {
-				appendPosition(out, pendingName, &sdk.SourcePosition{File: rel, Line: pendingLine})
 				pendingName = ""
 				pendingLine = 0
 			}
@@ -132,17 +134,4 @@ func AttachNugetPositions(g *sdk.Graph, projectDir string) {
 		}
 		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
-}
-
-func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
-	key = strings.TrimSpace(key)
-	if key == "" || pos == nil {
-		return
-	}
-	for _, existing := range out[key] {
-		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
-			return
-		}
-	}
-	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/nuget/positions.go
+++ b/internal/detectors/nuget/positions.go
@@ -14,51 +14,99 @@ import (
 // Captures the Include name. Case-insensitive on the attribute name
 // because some projects use Pascal/Camel.
 var nugetPackageReference = regexp.MustCompile(`(?i)<PackageReference\b[^>]*\bInclude\s*=\s*"([^"]+)"`)
+var nugetPackageReferenceVersionAttr = regexp.MustCompile(`(?i)\bVersion\s*=\s*"([^"]+)"`)
+var nugetVersionElement = regexp.MustCompile(`(?i)<Version>\s*([^<]+)\s*</Version>`)
+var nugetPackageReferenceClose = regexp.MustCompile(`(?i)</PackageReference>`)
+var nugetPackagesConfigPackage = regexp.MustCompile(`(?i)<package\b[^>]*\bid\s*=\s*"([^"]+)"[^>]*\bversion\s*=\s*"([^"]+)"`)
 
 // nugetLockfileEntry matches a `"foo": {` key inside packages.lock.json's
 // dependencies map.
 var nugetLockfileEntry = regexp.MustCompile(`^\s*"([A-Za-z0-9][A-Za-z0-9._-]*)"\s*:\s*\{\s*$`)
+var nugetLockResolvedLine = regexp.MustCompile(`^\s*"resolved"\s*:\s*"([^"]+)"`)
 
-func nugetPositions(projectDir string) map[string]*sdk.SourcePosition {
-	out := make(map[string]*sdk.SourcePosition)
+func nugetPositions(projectDir string) map[string][]*sdk.SourcePosition {
+	out := make(map[string][]*sdk.SourcePosition)
 	// 1) packages.lock.json: top-level dependency map entries.
+	pendingName := ""
+	pendingLine := 0
 	_ = detectors.ScanLines(filepath.Join(projectDir, "packages.lock.json"), func(line int, text string) {
-		matches := nugetLockfileEntry.FindStringSubmatch(text)
+		if matches := nugetLockfileEntry.FindStringSubmatch(text); matches != nil {
+			name := matches[1]
+			if name == "" || name == "type" || name == "dependencies" || name == "contentHash" || name == "resolved" || name == "requested" {
+				return
+			}
+			pendingName = strings.ToLower(name)
+			pendingLine = line
+			return
+		}
+		if pendingName == "" {
+			return
+		}
+		matches := nugetLockResolvedLine.FindStringSubmatch(text)
 		if matches == nil {
 			return
 		}
-		name := matches[1]
-		if name == "" || name == "type" || name == "dependencies" || name == "contentHash" || name == "resolved" || name == "requested" {
-			return
-		}
-		key := strings.ToLower(name)
-		if _, exists := out[key]; exists {
-			return
-		}
-		out[key] = &sdk.SourcePosition{File: "packages.lock.json", Line: line}
+		version := strings.TrimSpace(matches[1])
+		pos := &sdk.SourcePosition{File: "packages.lock.json", Line: line}
+		appendPosition(out, pendingName, &sdk.SourcePosition{File: "packages.lock.json", Line: pendingLine})
+		appendPosition(out, pendingName+"@"+version, pos)
+		pendingName = ""
+		pendingLine = 0
 	})
-	// 2) Scan *.csproj, *.fsproj, *.vbproj for PackageReference.
-	matches, _ := filepath.Glob(filepath.Join(projectDir, "*.csproj"))
-	fs, _ := filepath.Glob(filepath.Join(projectDir, "*.fsproj"))
-	vs, _ := filepath.Glob(filepath.Join(projectDir, "*.vbproj"))
-	matches = append(matches, fs...)
-	matches = append(matches, vs...)
-	for _, projFile := range matches {
-		rel := filepath.Base(projFile)
+	// 2) Scan packages.config.
+	_ = detectors.ScanLines(filepath.Join(projectDir, "packages.config"), func(line int, text string) {
+		matches := nugetPackagesConfigPackage.FindStringSubmatch(text)
+		if matches == nil {
+			return
+		}
+		name := strings.ToLower(strings.TrimSpace(matches[1]))
+		version := strings.TrimSpace(matches[2])
+		pos := &sdk.SourcePosition{File: "packages.config", Line: line}
+		appendPosition(out, name, pos)
+		appendPosition(out, name+"@"+version, pos)
+	})
+	// 3) Scan project files for PackageReference.
+	projectFiles, _ := nugetProjectFiles(projectDir)
+	for _, projFile := range projectFiles {
+		rel, err := filepath.Rel(projectDir, projFile)
+		if err != nil || rel == "" {
+			rel = filepath.Base(projFile)
+		}
+		rel = filepath.ToSlash(rel)
+		pendingName := ""
+		pendingLine := 0
 		_ = detectors.ScanLines(projFile, func(line int, text string) {
 			refMatches := nugetPackageReference.FindStringSubmatch(text)
-			if refMatches == nil {
+			if refMatches != nil {
+				pendingName = strings.ToLower(strings.TrimSpace(refMatches[1]))
+				pendingLine = line
+				if versionMatches := nugetPackageReferenceVersionAttr.FindStringSubmatch(text); versionMatches != nil {
+					version := strings.TrimSpace(versionMatches[1])
+					pos := &sdk.SourcePosition{File: rel, Line: line}
+					appendPosition(out, pendingName, pos)
+					appendPosition(out, pendingName+"@"+version, pos)
+					pendingName = ""
+					pendingLine = 0
+				}
 				return
 			}
-			name := strings.TrimSpace(refMatches[1])
-			if name == "" {
+			if pendingName == "" {
 				return
 			}
-			key := strings.ToLower(name)
-			if _, exists := out[key]; exists {
+			if versionMatches := nugetVersionElement.FindStringSubmatch(text); versionMatches != nil {
+				version := strings.TrimSpace(versionMatches[1])
+				pos := &sdk.SourcePosition{File: rel, Line: line}
+				appendPosition(out, pendingName, &sdk.SourcePosition{File: rel, Line: pendingLine})
+				appendPosition(out, pendingName+"@"+version, pos)
+				pendingName = ""
+				pendingLine = 0
 				return
 			}
-			out[key] = &sdk.SourcePosition{File: rel, Line: line}
+			if nugetPackageReferenceClose.MatchString(text) {
+				appendPosition(out, pendingName, &sdk.SourcePosition{File: rel, Line: pendingLine})
+				pendingName = ""
+				pendingLine = 0
+			}
 		})
 	}
 	return out
@@ -74,10 +122,27 @@ func AttachNugetPositions(g *sdk.Graph, projectDir string) {
 	if len(positions) == 0 {
 		return
 	}
-	detectors.AttachPositions(g, positions, func(pkg *sdk.Dependency) string {
+	detectors.AttachPositionCandidates(g, positions, func(pkg *sdk.Dependency) []string {
 		if pkg == nil {
-			return ""
+			return nil
 		}
-		return strings.ToLower(strings.TrimSpace(pkg.Name))
+		name := strings.ToLower(strings.TrimSpace(pkg.Name))
+		if name == "" {
+			return nil
+		}
+		return []string{name + "@" + strings.TrimSpace(pkg.Version), name}
 	})
+}
+
+func appendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
 }

--- a/internal/detectors/positions.go
+++ b/internal/detectors/positions.go
@@ -39,6 +39,21 @@ func AttachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePo
 	attachPositionCandidates(g, positions, keys, true)
 }
 
+// AppendPosition appends pos under key unless the same file/line/column
+// position was already recorded.
+func AppendPosition(out map[string][]*sdk.SourcePosition, key string, pos *sdk.SourcePosition) {
+	key = strings.TrimSpace(key)
+	if key == "" || pos == nil {
+		return
+	}
+	for _, existing := range out[key] {
+		if existing.File == pos.File && existing.Line == pos.Line && existing.Column == pos.Column {
+			return
+		}
+	}
+	out[key] = append(out[key], pos)
+}
+
 func attachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePosition, keys func(*sdk.Dependency) []string, exactDuplicate bool) {
 	if g == nil || len(positions) == 0 || keys == nil {
 		return
@@ -52,9 +67,13 @@ func attachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePo
 			if key == "" {
 				continue
 			}
-			addedForKey := false
+			matchedKey := false
 			for _, pos := range positions[key] {
-				if pos == nil || hasLocation(pkg.Locations, pos, exactDuplicate) {
+				if pos == nil {
+					continue
+				}
+				matchedKey = true
+				if hasLocation(pkg.Locations, pos, exactDuplicate) {
 					continue
 				}
 				pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
@@ -62,9 +81,8 @@ func attachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePo
 					AccessPath: pos.File,
 					Position:   pos,
 				})
-				addedForKey = true
 			}
-			if addedForKey {
+			if matchedKey {
 				break
 			}
 		}
@@ -80,7 +98,7 @@ func hasLocation(locations []sdk.PackageLocation, pos *sdk.SourcePosition, exact
 			return true
 		}
 		if loc.Position == nil {
-			return true
+			continue
 		}
 		if loc.Position.Line == pos.Line && loc.Position.Column == pos.Column && loc.Position.EndLine == pos.EndLine {
 			return true

--- a/internal/detectors/positions.go
+++ b/internal/detectors/positions.go
@@ -3,6 +3,7 @@ package detectors
 import (
 	"bufio"
 	"os"
+	"strings"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
@@ -16,37 +17,76 @@ import (
 // typically derive it from dep.Name, dep.Org+":"+dep.Name, or a
 // language-specific normalization. Returning "" skips the node.
 func AttachPositions(g *sdk.Graph, positions map[string]*sdk.SourcePosition, nameKey func(*sdk.Dependency) string) {
-	if g == nil || len(positions) == 0 || nameKey == nil {
+	candidates := make(map[string][]*sdk.SourcePosition, len(positions))
+	for key, pos := range positions {
+		if pos == nil {
+			continue
+		}
+		candidates[key] = []*sdk.SourcePosition{pos}
+	}
+	attachPositionCandidates(g, candidates, func(dep *sdk.Dependency) []string {
+		if nameKey == nil {
+			return nil
+		}
+		return []string{nameKey(dep)}
+	}, false)
+}
+
+// AttachPositionCandidates populates PackageLocation.Position on graph nodes
+// using one or more lookup keys per dependency. It preserves multiple
+// declaration sites and skips exact duplicate file/line/column entries.
+func AttachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePosition, keys func(*sdk.Dependency) []string) {
+	attachPositionCandidates(g, positions, keys, true)
+}
+
+func attachPositionCandidates(g *sdk.Graph, positions map[string][]*sdk.SourcePosition, keys func(*sdk.Dependency) []string, exactDuplicate bool) {
+	if g == nil || len(positions) == 0 || keys == nil {
 		return
 	}
 	for _, pkg := range g.Nodes() {
 		if pkg == nil {
 			continue
 		}
-		key := nameKey(pkg)
-		if key == "" {
-			continue
-		}
-		pos, ok := positions[key]
-		if !ok || pos == nil {
-			continue
-		}
-		duplicate := false
-		for _, loc := range pkg.Locations {
-			if loc.RealPath == pos.File {
-				duplicate = true
+		for _, key := range keys(pkg) {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			addedForKey := false
+			for _, pos := range positions[key] {
+				if pos == nil || hasLocation(pkg.Locations, pos, exactDuplicate) {
+					continue
+				}
+				pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
+					RealPath:   pos.File,
+					AccessPath: pos.File,
+					Position:   pos,
+				})
+				addedForKey = true
+			}
+			if addedForKey {
 				break
 			}
 		}
-		if duplicate {
+	}
+}
+
+func hasLocation(locations []sdk.PackageLocation, pos *sdk.SourcePosition, exactDuplicate bool) bool {
+	for _, loc := range locations {
+		if loc.RealPath != pos.File {
 			continue
 		}
-		pkg.Locations = append(pkg.Locations, sdk.PackageLocation{
-			RealPath:   pos.File,
-			AccessPath: pos.File,
-			Position:   pos,
-		})
+		if !exactDuplicate {
+			return true
+		}
+		if loc.Position == nil {
+			return true
+		}
+		if loc.Position.Line == pos.Line && loc.Position.Column == pos.Column && loc.Position.EndLine == pos.EndLine {
+			return true
+		}
 	}
+	return false
 }
 
 // ScanLines invokes fn for every line in the file at path. The

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -109,16 +109,38 @@ func TestNpmPackageLockPositions(t *testing.T) {
 	if lodash == nil || len(lodash.Locations) == 0 {
 		t.Fatal("lodash missing Location")
 	}
-	if lodash.Locations[0].Position.Line != 8 {
-		t.Errorf("lodash line = %d, want 8", lodash.Locations[0].Position.Line)
+	if lodash.Locations[0].Position.Line != 9 {
+		t.Errorf("lodash line = %d, want 9", lodash.Locations[0].Position.Line)
 	}
 
 	scoped, _ := g.Node("@scope/pkg@1.0.0")
 	if scoped == nil || len(scoped.Locations) == 0 {
 		t.Fatal("scoped pkg missing Location")
 	}
-	if scoped.Locations[0].Position.Line != 11 {
-		t.Errorf("scoped pkg line = %d, want 11", scoped.Locations[0].Position.Line)
+	if scoped.Locations[0].Position.Line != 12 {
+		t.Errorf("scoped pkg line = %d, want 12", scoped.Locations[0].Position.Line)
+	}
+}
+
+func TestNpmPackageLockPositionsMatchPackageVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package-lock.json", `{
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.21"
+    },
+    "node_modules/foo/node_modules/lodash": {
+      "version": "3.10.1"
+    }
+  }
+}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "lodash", "3.10.1")
+	npm.AttachPackageLockPositions(g, dir)
+	lodash, _ := g.Node("lodash@3.10.1")
+	if lodash == nil || len(lodash.Locations) == 0 || lodash.Locations[0].Position.Line != 7 {
+		t.Fatalf("lodash@3.10.1 locations = %+v, want version line 7", lodash.Locations)
 	}
 }
 
@@ -154,6 +176,23 @@ packages:
 		if p.Locations[0].Position.Line != c.line {
 			t.Errorf("%s line = %d, want %d", c.name, p.Locations[0].Position.Line, c.line)
 		}
+	}
+}
+
+func TestPnpmLockPositionsMatchPackageVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pnpm-lock.yaml", `packages:
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-new}
+  /lodash@3.10.1:
+    resolution: {integrity: sha512-old}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "lodash", "3.10.1")
+	pnpm.AttachPnpmLockPositions(g, dir)
+	lodash, _ := g.Node("lodash@3.10.1")
+	if lodash == nil || len(lodash.Locations) == 0 || lodash.Locations[0].Position.Line != 4 {
+		t.Fatalf("lodash@3.10.1 locations = %+v, want lock entry line 4", lodash.Locations)
 	}
 }
 
@@ -203,11 +242,11 @@ func TestMavenPomPositions(t *testing.T) {
 	mustPkg(t, g, "junit", "4.13.2", func(p *sdk.Dependency) { p.Org = "junit" })
 	maven.AttachPomPositions(g, dir)
 	jd, _ := g.Node("com.fasterxml.jackson.core:jackson-databind@2.17.0")
-	if jd == nil || len(jd.Locations) == 0 || jd.Locations[0].Position.Line != 5 {
+	if jd == nil || len(jd.Locations) == 0 || jd.Locations[0].Position.Line != 6 {
 		t.Errorf("jackson-databind location wrong: %+v", jd)
 	}
 	ju, _ := g.Node("junit:junit@4.13.2")
-	if ju == nil || len(ju.Locations) == 0 || ju.Locations[0].Position.Line != 10 {
+	if ju == nil || len(ju.Locations) == 0 || ju.Locations[0].Position.Line != 11 {
 		t.Errorf("junit location wrong: %+v", ju)
 	}
 }

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -144,6 +144,28 @@ func TestNpmPackageLockPositionsMatchPackageVersion(t *testing.T) {
 	}
 }
 
+func TestNpmPackageLockPositionsMatchColonScopedGraphName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package-lock.json", `{
+  "packages": {
+    "node_modules/@scope/pkg": {
+      "version": "1.2.3"
+    }
+  }
+}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "@scope:pkg", "1.2.3")
+	npm.AttachPackageLockPositions(g, dir)
+	scoped, _ := g.Node("@scope:pkg@1.2.3")
+	if scoped == nil {
+		t.Fatal("missing @scope:pkg")
+	}
+	if len(scoped.Locations) == 0 || scoped.Locations[0].Position.Line != 4 {
+		t.Fatalf("@scope:pkg locations = %+v, want package-lock version line 4", scoped.Locations)
+	}
+}
+
 func TestPnpmLockPositions(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "pnpm-lock.yaml", `lockfileVersion: '6.0'
@@ -193,6 +215,24 @@ func TestPnpmLockPositionsMatchPackageVersion(t *testing.T) {
 	lodash, _ := g.Node("lodash@3.10.1")
 	if lodash == nil || len(lodash.Locations) == 0 || lodash.Locations[0].Position.Line != 4 {
 		t.Fatalf("lodash@3.10.1 locations = %+v, want lock entry line 4", lodash.Locations)
+	}
+}
+
+func TestPnpmLockPositionsMatchColonScopedGraphName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pnpm-lock.yaml", `packages:
+  /@scope/pkg@1.2.3:
+    resolution: {integrity: sha512-scoped}
+`)
+	g := sdk.New()
+	mustPkg(t, g, "@scope:pkg", "1.2.3")
+	pnpm.AttachPnpmLockPositions(g, dir)
+	scoped, _ := g.Node("@scope:pkg@1.2.3")
+	if scoped == nil {
+		t.Fatal("missing @scope:pkg")
+	}
+	if len(scoped.Locations) == 0 || scoped.Locations[0].Position.Line != 2 {
+		t.Fatalf("@scope:pkg locations = %+v, want pnpm lock entry line 2", scoped.Locations)
 	}
 }
 

--- a/internal/detectors/positions_test.go
+++ b/internal/detectors/positions_test.go
@@ -62,6 +62,49 @@ func TestAttachPositionsHonorsNameKey(t *testing.T) {
 	}
 }
 
+func TestAttachPositionCandidatesExactKeyStopsFallback(t *testing.T) {
+	g := sdk.New()
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "foo", Version: "2.0.0", Ecosystem: "test"}})
+	_ = g.AddNode(pkg)
+
+	AttachPositionCandidates(g, map[string][]*sdk.SourcePosition{
+		"foo@2.0.0": {{File: "lock", Line: 20}},
+		"foo":       {{File: "lock", Line: 10}},
+	}, func(p *sdk.Dependency) []string {
+		return []string{p.Name + "@" + p.Version, p.Name}
+	})
+
+	got, _ := g.Node("foo@2.0.0")
+	if got == nil || len(got.Locations) != 1 {
+		t.Fatalf("Locations = %#v, want one exact-version location", got)
+	}
+	if got.Locations[0].Position == nil || got.Locations[0].Position.Line != 20 {
+		t.Fatalf("Position = %#v, want exact-version line 20", got.Locations[0].Position)
+	}
+}
+
+func TestAttachPositionCandidatesUpgradesFileOnlyLocation(t *testing.T) {
+	g := sdk.New()
+	pkg := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "foo", Version: "1.0.0", Ecosystem: "test"}, Locations: []sdk.PackageLocation{
+		{RealPath: "lock", AccessPath: "lock"},
+	}})
+	_ = g.AddNode(pkg)
+
+	AttachPositionCandidates(g, map[string][]*sdk.SourcePosition{
+		"foo@1.0.0": {{File: "lock", Line: 8}},
+	}, func(p *sdk.Dependency) []string {
+		return []string{p.Name + "@" + p.Version}
+	})
+
+	got, _ := g.Node("foo@1.0.0")
+	if got == nil || len(got.Locations) != 2 {
+		t.Fatalf("Locations = %#v, want file-only plus line-specific location", got)
+	}
+	if got.Locations[1].Position == nil || got.Locations[1].Position.Line != 8 {
+		t.Fatalf("upgraded Position = %#v, want line 8", got.Locations[1].Position)
+	}
+}
+
 func TestScanLinesReportsLineNumbers(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")

--- a/internal/detectors/pub/detector_test.go
+++ b/internal/detectors/pub/detector_test.go
@@ -2,6 +2,8 @@ package pub
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -118,5 +120,42 @@ func TestDepGraphFromPubDepsJSONBuildsTransitiveScopes(t *testing.T) {
 	}
 	if string(testPkg.PrimaryScope()) != string(sdk.ScopeDevelopment) {
 		t.Fatalf("expected dev direct dependency, got %q", string(testPkg.PrimaryScope()))
+	}
+}
+
+func TestPubspecLockPositionsPreferVersionAndFlushFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pubspec.lock")
+	raw := []byte(`packages:
+  collection:
+    dependency: transitive
+    description:
+      name: collection
+    source: hosted
+    version: "1.18.0"
+  no_version:
+    dependency: transitive
+  path:
+    dependency: "direct main"
+    description:
+      name: path
+    source: hosted
+    version: "1.9.0"
+sdks:
+  dart: ">=3.0.0"
+`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write pubspec.lock: %v", err)
+	}
+
+	positions := pubspecLockPositions(path, "pubspec.lock")
+	if got := positions["collection"]; got == nil || got.Line != 7 {
+		t.Fatalf("collection position = %#v, want version line 7", got)
+	}
+	if got := positions["no_version"]; got == nil || got.Line != 8 {
+		t.Fatalf("no_version position = %#v, want package fallback line 8", got)
+	}
+	if got := positions["path"]; got == nil || got.Line != 15 {
+		t.Fatalf("path position = %#v, want version line 15", got)
 	}
 }

--- a/internal/detectors/pub/positions.go
+++ b/internal/detectors/pub/positions.go
@@ -19,13 +19,25 @@ func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 	insidePackages := false
 	pendingName := ""
 	pendingLine := 0
+	flush := func() {
+		if pendingName == "" || pendingLine == 0 {
+			return
+		}
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingLine}
+		}
+		pendingName = ""
+		pendingLine = 0
+	}
 	_ = detectors.ScanLines(path, func(line int, text string) {
 		trimmed := strings.TrimSpace(text)
 		if trimmed == "packages:" {
+			flush()
 			insidePackages = true
 			return
 		}
 		if !strings.HasPrefix(text, " ") && strings.HasSuffix(trimmed, ":") {
+			flush()
 			insidePackages = trimmed == "packages:"
 			return
 		}
@@ -33,6 +45,7 @@ func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 			return
 		}
 		if matches := pubspecLockEntry.FindStringSubmatch(text); matches != nil {
+			flush()
 			pendingName = matches[1]
 			pendingLine = line
 			return
@@ -49,11 +62,7 @@ func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 		pendingName = ""
 		pendingLine = 0
 	})
-	if pendingName != "" {
-		if _, exists := out[pendingName]; !exists {
-			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingLine}
-		}
-	}
+	flush()
 	return out
 }
 

--- a/internal/detectors/pub/positions.go
+++ b/internal/detectors/pub/positions.go
@@ -12,10 +12,13 @@ import (
 // pubspecLockEntry matches a top-level entry under `packages:` in
 // pubspec.lock, indented by two spaces and ending in a colon.
 var pubspecLockEntry = regexp.MustCompile(`^ {2}([A-Za-z_][A-Za-z0-9_]*)\s*:\s*$`)
+var pubspecLockVersion = regexp.MustCompile(`^\s*version\s*:\s*"?([^"\s]+)"?`)
 
 func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 	out := make(map[string]*sdk.SourcePosition)
 	insidePackages := false
+	pendingName := ""
+	pendingLine := 0
 	_ = detectors.ScanLines(path, func(line int, text string) {
 		trimmed := strings.TrimSpace(text)
 		if trimmed == "packages:" {
@@ -29,19 +32,28 @@ func pubspecLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 		if !insidePackages {
 			return
 		}
-		matches := pubspecLockEntry.FindStringSubmatch(text)
-		if matches == nil {
+		if matches := pubspecLockEntry.FindStringSubmatch(text); matches != nil {
+			pendingName = matches[1]
+			pendingLine = line
 			return
 		}
-		name := matches[1]
-		if name == "" {
+		if pendingName == "" {
 			return
 		}
-		if _, exists := out[name]; exists {
+		if pubspecLockVersion.FindStringSubmatch(text) == nil {
 			return
 		}
-		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: line}
+		}
+		pendingName = ""
+		pendingLine = 0
 	})
+	if pendingName != "" {
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingLine}
+		}
+	}
 	return out
 }
 

--- a/internal/detectors/python/pip.go
+++ b/internal/detectors/python/pip.go
@@ -56,6 +56,8 @@ func (d PipDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (
 	// (and inspecting) the ambient Python environment.
 	if lockPath := pipLockFilePath(workingDir); lockPath != "" {
 		if depsGraph, err := depGraphFromRequirementsLock(lockPath, workingDir); err == nil {
+			attachDeclaredPositions(depsGraph, workingDir)
+			attachLoosePythonPositions(depsGraph, workingDir)
 			return sdk.DetectionResult{
 				Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, pipEvidencePatterns)),
 			}, nil

--- a/internal/detectors/python/poetry.go
+++ b/internal/detectors/python/poetry.go
@@ -55,6 +55,8 @@ func (d PoetryDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest
 	// as requested=true (no transitive information).
 	if lockPath := poetryLockFilePath(workingDir); lockPath != "" {
 		if depsGraph, err := depGraphFromPoetryLock(lockPath, workingDir); err == nil {
+			attachDeclaredPositions(depsGraph, workingDir)
+			attachLoosePythonPositions(depsGraph, workingDir)
 			return sdk.DetectionResult{
 				Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, poetryEvidencePatterns)),
 			}, nil

--- a/internal/detectors/python/positions_loose.go
+++ b/internal/detectors/python/positions_loose.go
@@ -16,6 +16,7 @@ var poetryLockPackageHeader = regexp.MustCompile(`^\[\[\s*package\s*\]\]\s*$`)
 // tomlNameLine matches `name = "foo"` within a TOML block. The
 // quotes can be single or double; we accept whitespace either side.
 var tomlNameLine = regexp.MustCompile(`^\s*name\s*=\s*["']([^"']+)["']\s*$`)
+var tomlVersionLine = regexp.MustCompile(`^\s*version\s*=\s*["']([^"']+)["']\s*$`)
 
 // poetryLockPositions returns name -> SourcePosition for every
 // `[[package]]` block in a poetry.lock file. The position points at
@@ -46,10 +47,14 @@ func pdmLockPositions(path, relPath string) map[string]*sdk.SourcePosition {
 // each block it records the line of the `name = "..."` field.
 func collectTOMLPackagePositions(path, relPath string, out map[string]*sdk.SourcePosition, header *regexp.Regexp) {
 	inBlock := false
+	pendingName := ""
+	pendingNameLine := 0
 	scanLinesQuiet(path, func(line int, text string) {
 		switch {
 		case header.MatchString(text):
 			inBlock = true
+			pendingName = ""
+			pendingNameLine = 0
 		case inBlock:
 			matches := tomlNameLine.FindStringSubmatch(text)
 			if matches != nil {
@@ -57,19 +62,37 @@ func collectTOMLPackagePositions(path, relPath string, out map[string]*sdk.Sourc
 				if name == "" {
 					return
 				}
-				if _, exists := out[name]; exists {
-					return
+				pendingName = name
+				pendingNameLine = line
+				return
+			}
+			if matches := tomlVersionLine.FindStringSubmatch(text); matches != nil && pendingName != "" {
+				if _, exists := out[pendingName]; !exists {
+					out[pendingName] = &sdk.SourcePosition{File: relPath, Line: line}
 				}
-				out[name] = &sdk.SourcePosition{File: relPath, Line: line}
 				inBlock = false
+				pendingName = ""
+				pendingNameLine = 0
 				return
 			}
 			// A new top-level table starts a fresh non-package block.
 			if strings.HasPrefix(strings.TrimSpace(text), "[") && !strings.HasPrefix(strings.TrimSpace(text), "[[package]]") {
+				if pendingName != "" {
+					if _, exists := out[pendingName]; !exists {
+						out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingNameLine}
+					}
+				}
 				inBlock = false
+				pendingName = ""
+				pendingNameLine = 0
 			}
 		}
 	})
+	if pendingName != "" {
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingNameLine}
+		}
+	}
 }
 
 // pipfileLockPositions returns positions for Pipfile.lock (JSON).

--- a/internal/detectors/python/uv.go
+++ b/internal/detectors/python/uv.go
@@ -55,6 +55,8 @@ func (d UVDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (s
 	if lockPath := uvLockFilePath(workingDir); lockPath != "" {
 		depsGraph, err := depGraphFromUVLock(lockPath)
 		if err == nil {
+			attachDeclaredPositions(depsGraph, workingDir)
+			attachLoosePythonPositions(depsGraph, workingDir)
 			return sdk.DetectionResult{
 				Graphs: sdk.SingleGraphContainer(depsGraph, detectors.InferManifestMetadata(req, uvEvidencePatterns)),
 			}, nil

--- a/internal/detectors/swiftpm/detector_test.go
+++ b/internal/detectors/swiftpm/detector_test.go
@@ -2,6 +2,7 @@ package swiftpm
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -77,5 +78,45 @@ func TestDepGraphFromSwiftShowDepsBuildsTransitiveGraph(t *testing.T) {
 	}
 	if len(children) != 1 || children[0].ID != "github.com/apple:swift-system@1.2.0" {
 		t.Fatalf("expected swift-system transitive dependency, got %#v", children)
+	}
+}
+
+func TestPackageResolvedPositionsPreferVersionAndFlushFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Package.resolved")
+	raw := []byte(`{
+  "pins": [
+    {
+      "identity": "swift-argument-parser",
+      "state": {
+        "revision": "abc",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "identity": "swift-system",
+      "state": {
+        "revision": "def"
+      }
+    },
+    {
+      "identity": "swift-log"
+    }
+  ]
+}
+`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write Package.resolved: %v", err)
+	}
+
+	positions := packageResolvedPositions(path, "Package.resolved")
+	if got := positions["swift-argument-parser"]; got == nil || got.Line != 7 {
+		t.Fatalf("swift-argument-parser position = %#v, want version line 7", got)
+	}
+	if got := positions["swift-system"]; got == nil || got.Line != 13 {
+		t.Fatalf("swift-system position = %#v, want revision line 13", got)
+	}
+	if got := positions["swift-log"]; got == nil || got.Line != 17 {
+		t.Fatalf("swift-log position = %#v, want identity fallback line 17", got)
 	}
 }

--- a/internal/detectors/swiftpm/positions.go
+++ b/internal/detectors/swiftpm/positions.go
@@ -12,23 +12,35 @@ import (
 // swiftPMIdentity matches an `"identity": "foo"` line in
 // Package.resolved (both v1 and v2 formats use this key).
 var swiftPMIdentity = regexp.MustCompile(`"identity"\s*:\s*"([^"]+)"`)
+var swiftPMVersion = regexp.MustCompile(`"(?:version|revision)"\s*:\s*"([^"]+)"`)
 
 func packageResolvedPositions(path, relPath string) map[string]*sdk.SourcePosition {
 	out := make(map[string]*sdk.SourcePosition)
+	pendingName := ""
+	pendingLine := 0
 	_ = detectors.ScanLines(path, func(line int, text string) {
-		matches := swiftPMIdentity.FindStringSubmatch(text)
-		if matches == nil {
+		if matches := swiftPMIdentity.FindStringSubmatch(text); matches != nil {
+			pendingName = strings.ToLower(strings.TrimSpace(matches[1]))
+			pendingLine = line
 			return
 		}
-		name := strings.ToLower(strings.TrimSpace(matches[1]))
-		if name == "" {
+		if pendingName == "" {
 			return
 		}
-		if _, exists := out[name]; exists {
+		if swiftPMVersion.FindStringSubmatch(text) == nil {
 			return
 		}
-		out[name] = &sdk.SourcePosition{File: relPath, Line: line}
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: line}
+		}
+		pendingName = ""
+		pendingLine = 0
 	})
+	if pendingName != "" {
+		if _, exists := out[pendingName]; !exists {
+			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingLine}
+		}
+	}
 	return out
 }
 

--- a/internal/detectors/swiftpm/positions.go
+++ b/internal/detectors/swiftpm/positions.go
@@ -12,19 +12,43 @@ import (
 // swiftPMIdentity matches an `"identity": "foo"` line in
 // Package.resolved (both v1 and v2 formats use this key).
 var swiftPMIdentity = regexp.MustCompile(`"identity"\s*:\s*"([^"]+)"`)
-var swiftPMVersion = regexp.MustCompile(`"(?:version|revision)"\s*:\s*"([^"]+)"`)
+var swiftPMRevision = regexp.MustCompile(`"revision"\s*:\s*"([^"]+)"`)
+var swiftPMVersion = regexp.MustCompile(`"version"\s*:\s*"([^"]+)"`)
 
 func packageResolvedPositions(path, relPath string) map[string]*sdk.SourcePosition {
 	out := make(map[string]*sdk.SourcePosition)
 	pendingName := ""
-	pendingLine := 0
+	identityLine := 0
+	revisionLine := 0
+	flush := func() {
+		if pendingName == "" {
+			return
+		}
+		positionLine := revisionLine
+		if positionLine == 0 {
+			positionLine = identityLine
+		}
+		if positionLine > 0 {
+			if _, exists := out[pendingName]; !exists {
+				out[pendingName] = &sdk.SourcePosition{File: relPath, Line: positionLine}
+			}
+		}
+		pendingName = ""
+		identityLine = 0
+		revisionLine = 0
+	}
 	_ = detectors.ScanLines(path, func(line int, text string) {
 		if matches := swiftPMIdentity.FindStringSubmatch(text); matches != nil {
+			flush()
 			pendingName = strings.ToLower(strings.TrimSpace(matches[1]))
-			pendingLine = line
+			identityLine = line
 			return
 		}
 		if pendingName == "" {
+			return
+		}
+		if swiftPMRevision.FindStringSubmatch(text) != nil {
+			revisionLine = line
 			return
 		}
 		if swiftPMVersion.FindStringSubmatch(text) == nil {
@@ -34,13 +58,10 @@ func packageResolvedPositions(path, relPath string) map[string]*sdk.SourcePositi
 			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: line}
 		}
 		pendingName = ""
-		pendingLine = 0
+		identityLine = 0
+		revisionLine = 0
 	})
-	if pendingName != "" {
-		if _, exists := out[pendingName]; !exists {
-			out[pendingName] = &sdk.SourcePosition{File: relPath, Line: pendingLine}
-		}
-	}
+	flush()
 	return out
 }
 

--- a/internal/engine/consolidation/consolidation.go
+++ b/internal/engine/consolidation/consolidation.go
@@ -79,6 +79,12 @@ func selectManifestEntries(results []sdk.DetectionResult) (sdk.ExecutionTarget, 
 			if err != nil {
 				return sdk.ExecutionTarget{}, nil, fmt.Errorf("normalize graph identity for %s entry %d: %w", result.SubprojectInfo.RelativePath, idx, err)
 			}
+			if isCoreDetector(result.Origin) {
+				// Rebase detector-relative location paths onto the subproject
+				// root so diff-aware SARIF sees repository-relative paths. A
+				// no-op for today's root-level subprojects (RelativePath ".").
+				rebaseGraphLocations(normalizedGraph, result.SubprojectInfo.RelativePath)
+			}
 			manifest := normalizeSubprojectManifest(result.SubprojectInfo, entry.Manifest, idx, result.Origin)
 			if err := ensureEntryRoot(normalizedGraph, manifest, idx); err != nil {
 				return sdk.ExecutionTarget{}, nil, fmt.Errorf("ensure entry root for %s entry %d: %w", result.SubprojectInfo.RelativePath, idx, err)

--- a/internal/engine/consolidation/locations.go
+++ b/internal/engine/consolidation/locations.go
@@ -1,0 +1,62 @@
+package consolidation
+
+import (
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// rebaseGraphLocations rewrites subproject-relative PackageLocation paths so
+// they are relative to the repository root by prefixing the subproject's
+// RelativePath.
+//
+// Detectors emit location paths in the coordinate space of their own working
+// directory — a subproject discovered at "apps/web" reports a lockfile location
+// of "package-lock.json", not "apps/web/package-lock.json". Diff-aware SARIF and
+// GitHub code scanning expect repository-root-relative paths, so the prefix has
+// to be reattached during consolidation (the same stage that already rebases
+// manifest paths via normalizeNativeManifestPath).
+//
+// This is a deliberate no-op for root-level subprojects (RelativePath "." or
+// ""), which is every subproject today because discovery does not recurse into
+// subdirectories. It exists so a future recursive scan mode reports correct
+// locations without revisiting every detector.
+func rebaseGraphLocations(g *sdk.Graph, relativePath string) {
+	rel := strings.Trim(strings.TrimSpace(toSlashPath(relativePath)), "/")
+	if g == nil || rel == "" || rel == "." {
+		return
+	}
+	for _, pkg := range g.Nodes() {
+		if pkg == nil {
+			continue
+		}
+		for i := range pkg.Locations {
+			pkg.Locations[i].RealPath = rebaseLocationPath(pkg.Locations[i].RealPath, rel)
+			pkg.Locations[i].AccessPath = rebaseLocationPath(pkg.Locations[i].AccessPath, rel)
+			if pos := pkg.Locations[i].Position; pos != nil {
+				pos.File = rebaseLocationPath(pos.File, rel)
+			}
+		}
+	}
+}
+
+// rebaseLocationPath prefixes rel onto a subproject-relative path. Empty,
+// absolute, and already-prefixed paths are returned unchanged so the rewrite is
+// idempotent and never corrupts a path a detector emitted repo-relative.
+func rebaseLocationPath(p, rel string) string {
+	trimmed := strings.TrimSpace(toSlashPath(p))
+	if trimmed == "" {
+		return p
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return trimmed
+	}
+	if trimmed == rel || strings.HasPrefix(trimmed, rel+"/") {
+		return trimmed
+	}
+	return rel + "/" + trimmed
+}
+
+func toSlashPath(p string) string {
+	return strings.ReplaceAll(p, "\\", "/")
+}

--- a/internal/engine/consolidation/locations_test.go
+++ b/internal/engine/consolidation/locations_test.go
@@ -1,0 +1,128 @@
+package consolidation
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestRebaseGraphLocations_PrefixesSubprojectPath(t *testing.T) {
+	g := sdk.New()
+	dep := sdk.NewDependencyWithID("lodash@4.17.21", sdk.Dependency{
+		Coordinates: sdk.Coordinates{Name: "lodash", Version: "4.17.21"},
+		Locations: []sdk.PackageLocation{{
+			RealPath:   "package-lock.json",
+			AccessPath: "package-lock.json",
+			Position:   &sdk.SourcePosition{File: "package-lock.json", Line: 8},
+		}},
+	})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("AddNode: %v", err)
+	}
+
+	rebaseGraphLocations(g, "apps/web")
+
+	node, ok := g.Node("lodash@4.17.21")
+	if !ok {
+		t.Fatal("expected lodash node")
+	}
+	loc := node.Locations[0]
+	if loc.RealPath != "apps/web/package-lock.json" || loc.AccessPath != "apps/web/package-lock.json" {
+		t.Fatalf("rebased paths = %q / %q, want apps/web/package-lock.json", loc.RealPath, loc.AccessPath)
+	}
+	if loc.Position == nil || loc.Position.File != "apps/web/package-lock.json" || loc.Position.Line != 8 {
+		t.Fatalf("rebased position = %#v, want apps/web/package-lock.json line 8", loc.Position)
+	}
+}
+
+func TestRebaseGraphLocations_RootIsNoOp(t *testing.T) {
+	for _, rel := range []string{".", "", "  "} {
+		g := sdk.New()
+		dep := sdk.NewDependencyWithID("lodash@4.17.21", sdk.Dependency{
+			Coordinates: sdk.Coordinates{Name: "lodash", Version: "4.17.21"},
+			Locations:   []sdk.PackageLocation{{RealPath: "package-lock.json", Position: &sdk.SourcePosition{File: "package-lock.json", Line: 8}}},
+		})
+		if err := g.AddNode(dep); err != nil {
+			t.Fatalf("AddNode: %v", err)
+		}
+
+		rebaseGraphLocations(g, rel)
+
+		node, _ := g.Node("lodash@4.17.21")
+		if node.Locations[0].RealPath != "package-lock.json" || node.Locations[0].Position.File != "package-lock.json" {
+			t.Fatalf("RelativePath %q must be a no-op, got %#v", rel, node.Locations[0])
+		}
+	}
+}
+
+func TestRebaseGraphLocations_SkipsAbsoluteAndAlreadyPrefixed(t *testing.T) {
+	g := sdk.New()
+	dep := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{Name: "pkg", Version: "1.0.0"},
+		Locations: []sdk.PackageLocation{
+			{RealPath: "/abs/pom.xml", Position: &sdk.SourcePosition{File: "/abs/pom.xml", Line: 1}},
+			{RealPath: "apps/web/already.json", Position: &sdk.SourcePosition{File: "apps/web/already.json", Line: 2}},
+		},
+	})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("AddNode: %v", err)
+	}
+
+	rebaseGraphLocations(g, "apps/web")
+
+	node, _ := g.Node("pkg@1.0.0")
+	if got := node.Locations[0].RealPath; got != "/abs/pom.xml" {
+		t.Fatalf("absolute path = %q, want untouched", got)
+	}
+	if got := node.Locations[1].RealPath; got != "apps/web/already.json" {
+		t.Fatalf("already-prefixed path = %q, want untouched (no double prefix)", got)
+	}
+}
+
+// TestConsolidateGraphs_RebasesCoreDetectorLocations proves the core-gated
+// rebasing fires through the real consolidation entry point.
+func TestConsolidateGraphs_RebasesCoreDetectorLocations(t *testing.T) {
+	g := sdk.New()
+	dep := sdk.NewDependency(sdk.Dependency{
+		Coordinates: sdk.Coordinates{Ecosystem: "npm", Name: "lodash", Version: "4.17.21"},
+		Locations:   []sdk.PackageLocation{{RealPath: "package-lock.json", Position: &sdk.SourcePosition{File: "package-lock.json", Line: 8}}},
+	})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("AddNode: %v", err)
+	}
+
+	consolidated, err := ConsolidateGraphs([]sdk.DetectionResult{{
+		SubprojectInfo: sdk.Subproject{
+			ExecutionTarget:         sdk.ExecutionTarget{Kind: sdk.ExecutionTargetWorkingDirectory, Location: "/repo"},
+			RelativePath:            "apps/web",
+			PrimaryDetector:         "npm-detector",
+			DetectedPackageManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+			Ecosystem:               sdk.EcosystemNPM,
+		},
+		DetectorName: "npm-detector",
+		Origin:       sdk.CoreOrigin,
+		Technique:    sdk.BuildToolTechnique,
+		Graphs:       sdk.SingleGraphContainer(g, sdk.ManifestMetadata{Path: "apps/web/package-lock.json", Kind: "package-lock.json"}),
+	}})
+	if err != nil {
+		t.Fatalf("ConsolidateGraphs() error = %v", err)
+	}
+
+	graph, err := consolidated.Graphs.ConsolidatedGraph()
+	if err != nil {
+		t.Fatalf("ConsolidatedGraph() error = %v", err)
+	}
+	var node *sdk.Dependency
+	for _, n := range graph.Nodes() {
+		if n != nil && n.Name == "lodash" {
+			node = n
+			break
+		}
+	}
+	if node == nil {
+		t.Fatalf("expected lodash node, got %v", graph.Nodes())
+	}
+	if len(node.Locations) == 0 || node.Locations[0].Position == nil || node.Locations[0].Position.File != "apps/web/package-lock.json" {
+		t.Fatalf("consolidated location = %#v, want apps/web/package-lock.json", node.Locations)
+	}
+}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,31 @@
+package git
+
+import "testing"
+
+func TestParseChangedLineRanges(t *testing.T) {
+	diff := `diff --git a/package-lock.json b/package-lock.json
+index 1111111..2222222 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -8 +8 @@
+-      "version": "4.17.20"
++      "version": "4.17.21"
+diff --git a/README.md b/README.md
+index 3333333..4444444 100644
+--- a/README.md
++++ b/README.md
+@@ -0,0 +1,2 @@
++hello
++world
+@@ -5,2 +6,0 @@
+-old
+-lines
+`
+	got := parseChangedLineRanges(diff)
+	if len(got["package-lock.json"]) != 1 || got["package-lock.json"][0] != (LineRange{Start: 8, End: 8}) {
+		t.Fatalf("package-lock ranges = %#v, want line 8", got["package-lock.json"])
+	}
+	if len(got["README.md"]) != 1 || got["README.md"][0] != (LineRange{Start: 1, End: 2}) {
+		t.Fatalf("README ranges = %#v, want lines 1-2", got["README.md"])
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,11 +5,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/bomly-dev/bomly-cli/internal/system"
 	"go.uber.org/zap"
 )
+
+// LineRange is an inclusive 1-based line range in a repository file.
+type LineRange struct {
+	Start int
+	End   int
+}
+
+var diffHunkHeader = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 
 // CloneTemp clones repoURL into a temporary directory and optionally checks out ref.
 // The caller owns cleanup of the returned directory.
@@ -57,6 +67,20 @@ func VerifyRef(repoPath, ref string) error {
 		return fmt.Errorf("verify git ref %q: %w", ref, err)
 	}
 	return nil
+}
+
+// ChangedLineRanges returns added/changed head-side line ranges from a git
+// diff. Deleted-only hunks are omitted because there is no head line for SARIF
+// to annotate.
+func ChangedLineRanges(repoPath, baseRef, headRef string) (map[string][]LineRange, error) {
+	if err := ensureGitAvailable(); err != nil {
+		return nil, err
+	}
+	out, err := runGit(repoPath, "diff", "--unified=0", "--no-ext-diff", "--no-color", baseRef, headRef)
+	if err != nil {
+		return nil, fmt.Errorf("git diff %q..%q: %w", baseRef, headRef, err)
+	}
+	return parseChangedLineRanges(out), nil
 }
 
 // CheckoutRef checks out ref in repoPath.
@@ -179,4 +203,48 @@ func runGit(workingDir string, args ...string) (string, error) {
 		return "", fmt.Errorf("%w: %s", err, message)
 	}
 	return stdout.String(), nil
+}
+
+func parseChangedLineRanges(diff string) map[string][]LineRange {
+	ranges := make(map[string][]LineRange)
+	currentFile := ""
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ "):
+			path := strings.TrimSpace(strings.TrimPrefix(line, "+++ "))
+			currentFile = normalizeDiffPath(path)
+		case strings.HasPrefix(line, "@@ "):
+			if currentFile == "" || currentFile == "/dev/null" {
+				continue
+			}
+			matches := diffHunkHeader.FindStringSubmatch(line)
+			if matches == nil {
+				continue
+			}
+			start, err := strconv.Atoi(matches[1])
+			if err != nil {
+				continue
+			}
+			count := 1
+			if matches[2] != "" {
+				parsed, err := strconv.Atoi(matches[2])
+				if err != nil {
+					continue
+				}
+				count = parsed
+			}
+			if count <= 0 {
+				continue
+			}
+			ranges[currentFile] = append(ranges[currentFile], LineRange{Start: start, End: start + count - 1})
+		}
+	}
+	return ranges
+}
+
+func normalizeDiffPath(path string) string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "a/")
+	path = strings.TrimPrefix(path, "b/")
+	return filepath.ToSlash(path)
 }

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -159,6 +159,14 @@ type SARIFOptions struct {
 	IncludeReachability bool
 	LocationGraphs      []*sdk.Graph
 	BaselineState       string
+	ChangedLines        map[string][]SARIFLineRange
+}
+
+// SARIFLineRange is an inclusive 1-based line range used to prefer
+// dependency locations that intersect a source diff.
+type SARIFLineRange struct {
+	Start int
+	End   int
 }
 
 // WriteSARIF writes findings as a SARIF 2.1.0 document to w.
@@ -379,9 +387,15 @@ func sarifFrameDescription(frame sdk.CallFrame) string {
 // and no region. This is honest: we know which file the dep lives
 // in but not exactly where.
 func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options []SARIFOptions) ([]sarifLocation, []string) {
-	locations := make([]sarifLocation, 0)
+	type candidate struct {
+		location sarifLocation
+		uri      string
+		score    int
+	}
+	candidates := make([]candidate, 0)
 	originalURIs := make([]string, 0)
 	seen := make(map[string]struct{})
+	changedLines := sarifChangedLines(options)
 
 	for _, dep := range dependenciesForFinding(f, options) {
 		for _, loc := range dep.Locations {
@@ -397,16 +411,36 @@ func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options [
 				continue
 			}
 			seen[key] = struct{}{}
-			locations = append(locations, sarifLocation{
+			location := sarifLocation{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: safeURI},
 					Region:           region,
 				},
+			}
+			candidates = append(candidates, candidate{
+				location: location,
+				uri:      safeURI,
+				score:    sarifLocationDiffScore(safeURI, region, changedLines),
 			})
 		}
 	}
 
-	if len(locations) > 0 {
+	if len(candidates) > 0 {
+		bestScore := 2
+		if len(changedLines) > 0 {
+			for _, candidate := range candidates {
+				if candidate.score < bestScore {
+					bestScore = candidate.score
+				}
+			}
+		}
+		locations := make([]sarifLocation, 0, len(candidates))
+		for _, candidate := range candidates {
+			if len(changedLines) > 0 && candidate.score != bestScore {
+				continue
+			}
+			locations = append(locations, candidate.location)
+		}
 		return locations, originalURIs
 	}
 
@@ -424,6 +458,40 @@ func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options [
 			},
 		},
 	}, originalURIs
+}
+
+func sarifChangedLines(options []SARIFOptions) map[string][]SARIFLineRange {
+	if len(options) == 0 || len(options[0].ChangedLines) == 0 {
+		return nil
+	}
+	return options[0].ChangedLines
+}
+
+func sarifLocationDiffScore(uri string, region *sarifRegion, changedLines map[string][]SARIFLineRange) int {
+	if len(changedLines) == 0 {
+		return 2
+	}
+	uri = filepath.ToSlash(strings.TrimSpace(uri))
+	ranges := changedLines[uri]
+	if len(ranges) == 0 {
+		return 2
+	}
+	if region == nil || region.StartLine == 0 {
+		return 1
+	}
+	end := region.EndLine
+	if end == 0 {
+		end = region.StartLine
+	}
+	for _, r := range ranges {
+		if r.Start <= 0 || r.End <= 0 {
+			continue
+		}
+		if region.StartLine <= r.End && end >= r.Start {
+			return 0
+		}
+	}
+	return 1
 }
 
 func dependenciesForFinding(f sdk.Finding, options []SARIFOptions) []*sdk.Dependency {

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -387,17 +387,13 @@ func sarifFrameDescription(frame sdk.CallFrame) string {
 // and no region. This is honest: we know which file the dep lives
 // in but not exactly where.
 func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options []SARIFOptions) ([]sarifLocation, []string) {
-	type candidate struct {
-		location sarifLocation
-		uri      string
-		score    int
-	}
-	candidates := make([]candidate, 0)
+	locations := make([]sarifLocation, 0)
 	originalURIs := make([]string, 0)
 	seen := make(map[string]struct{})
 	changedLines := sarifChangedLines(options)
 
 	for _, dep := range dependenciesForFinding(f, options) {
+		candidates := make([]sarifLocationCandidate, 0, len(dep.Locations))
 		for _, loc := range dep.Locations {
 			uri, region := sarifLocationURIAndRegion(loc)
 			uri = strings.TrimSpace(uri)
@@ -417,30 +413,15 @@ func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options [
 					Region:           region,
 				},
 			}
-			candidates = append(candidates, candidate{
+			candidates = append(candidates, sarifLocationCandidate{
 				location: location,
-				uri:      safeURI,
 				score:    sarifLocationDiffScore(safeURI, region, changedLines),
 			})
 		}
+		locations = append(locations, selectSARIFLocationCandidates(candidates, changedLines)...)
 	}
 
-	if len(candidates) > 0 {
-		bestScore := 2
-		if len(changedLines) > 0 {
-			for _, candidate := range candidates {
-				if candidate.score < bestScore {
-					bestScore = candidate.score
-				}
-			}
-		}
-		locations := make([]sarifLocation, 0, len(candidates))
-		for _, candidate := range candidates {
-			if len(changedLines) > 0 && candidate.score != bestScore {
-				continue
-			}
-			locations = append(locations, candidate.location)
-		}
+	if len(locations) > 0 {
 		return locations, originalURIs
 	}
 
@@ -458,6 +439,33 @@ func sarifLocationsForFinding(f sdk.Finding, includeReachability bool, options [
 			},
 		},
 	}, originalURIs
+}
+
+type sarifLocationCandidate struct {
+	location sarifLocation
+	score    int
+}
+
+func selectSARIFLocationCandidates(candidates []sarifLocationCandidate, changedLines map[string][]SARIFLineRange) []sarifLocation {
+	if len(candidates) == 0 {
+		return nil
+	}
+	bestScore := 2
+	if len(changedLines) > 0 {
+		for _, candidate := range candidates {
+			if candidate.score < bestScore {
+				bestScore = candidate.score
+			}
+		}
+	}
+	locations := make([]sarifLocation, 0, len(candidates))
+	for _, candidate := range candidates {
+		if len(changedLines) > 0 && candidate.score != bestScore {
+			continue
+		}
+		locations = append(locations, candidate.location)
+	}
+	return locations
 }
 
 func sarifChangedLines(options []SARIFOptions) map[string][]SARIFLineRange {

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -364,6 +364,78 @@ func TestWriteSARIF_UsesDependencyLocationsFromGraph(t *testing.T) {
 	}
 }
 
+func TestWriteSARIF_PrefersLocationIntersectingChangedLines(t *testing.T) {
+	graph := sdk.New()
+	dep := sdk.NewDependencyWithID("actions:checkout@v5", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "actions/checkout"}, PackageRef: "actions:checkout@v5",
+		Locations: []sdk.PackageLocation{
+			{RealPath: ".github/workflows/old.yml", Position: &sdk.SourcePosition{File: ".github/workflows/old.yml", Line: 4}},
+			{RealPath: ".github/workflows/guard.yml", Position: &sdk.SourcePosition{File: ".github/workflows/guard.yml", Line: 12}},
+		},
+	})
+	if err := graph.AddNode(dep); err != nil {
+		t.Fatalf("AddNode: %v", err)
+	}
+	finding := sdk.Finding{ID: "policy:actions", PackageRef: dep.PackageRef, DependencyRefs: []string{dep.ID}, Title: "Denied action"}
+
+	var buf bytes.Buffer
+	err := WriteSARIF(&buf, []sdk.Finding{finding}, nil, "bomly", "0.1.0", SARIFOptions{
+		LocationGraphs: []*sdk.Graph{graph},
+		ChangedLines: map[string][]SARIFLineRange{
+			".github/workflows/guard.yml": {{Start: 12, End: 12}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("decode SARIF: %v\n%s", err, buf.String())
+	}
+	locations := doc.Runs[0].Results[0].Locations
+	if len(locations) != 1 {
+		t.Fatalf("locations = %d, want only changed-line location", len(locations))
+	}
+	if got := locations[0].PhysicalLocation.ArtifactLocation.URI; got != ".github/workflows/guard.yml" {
+		t.Fatalf("location uri = %q, want changed workflow", got)
+	}
+}
+
+func TestWriteSARIF_PrefersChangedFileWhenLineDoesNotIntersect(t *testing.T) {
+	graph := sdk.New()
+	dep := sdk.NewDependencyWithID("lodash@4.17.21", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash"}, PackageRef: sarifTestPURL,
+		Locations: []sdk.PackageLocation{
+			{RealPath: "package-lock.json", Position: &sdk.SourcePosition{File: "package-lock.json", Line: 8}},
+			{RealPath: "package.json", Position: &sdk.SourcePosition{File: "package.json", Line: 22}},
+		},
+	})
+	if err := graph.AddNode(dep); err != nil {
+		t.Fatalf("AddNode: %v", err)
+	}
+	finding := sdk.Finding{ID: "CVE-2021-23337", PackageRef: dep.PackageRef, DependencyRefs: []string{dep.ID}, Title: "Vuln"}
+
+	var buf bytes.Buffer
+	err := WriteSARIF(&buf, []sdk.Finding{finding}, nil, "bomly", "0.1.0", SARIFOptions{
+		LocationGraphs: []*sdk.Graph{graph},
+		ChangedLines: map[string][]SARIFLineRange{
+			"package.json": {{Start: 30, End: 30}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("decode SARIF: %v\n%s", err, buf.String())
+	}
+	locations := doc.Runs[0].Results[0].Locations
+	if len(locations) != 1 {
+		t.Fatalf("locations = %d, want only changed-file location", len(locations))
+	}
+	if got := locations[0].PhysicalLocation.ArtifactLocation.URI; got != "package.json" {
+		t.Fatalf("location uri = %q, want changed file", got)
+	}
+}
+
 func TestWriteSARIF_RewritesNonFileLocationSchemes(t *testing.T) {
 	graph := sdk.New()
 	dep := sdk.NewDependencyWithID("actions:checkout@v5", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "actions/checkout"}, PackageRef: "actions:checkout@v5",

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -436,6 +436,65 @@ func TestWriteSARIF_PrefersChangedFileWhenLineDoesNotIntersect(t *testing.T) {
 	}
 }
 
+func TestWriteSARIF_SelectsChangedLocationsPerDependency(t *testing.T) {
+	graph := sdk.New()
+	touched := sdk.NewDependencyWithID("lodash@4.17.21", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "lodash"}, PackageRef: "pkg:npm/lodash@4.17.21",
+		Locations: []sdk.PackageLocation{
+			{RealPath: "package-lock.json", Position: &sdk.SourcePosition{File: "package-lock.json", Line: 9}},
+			{RealPath: "package.json", Position: &sdk.SourcePosition{File: "package.json", Line: 22}},
+		},
+	})
+	unchanged := sdk.NewDependencyWithID("minimist@1.2.8", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "minimist"}, PackageRef: "pkg:npm/minimist@1.2.8",
+		Locations: []sdk.PackageLocation{
+			{RealPath: "yarn.lock", Position: &sdk.SourcePosition{File: "yarn.lock", Line: 33}},
+		},
+	})
+	if err := graph.AddNode(touched); err != nil {
+		t.Fatalf("AddNode touched: %v", err)
+	}
+	if err := graph.AddNode(unchanged); err != nil {
+		t.Fatalf("AddNode unchanged: %v", err)
+	}
+	finding := sdk.Finding{
+		ID:             "policy:multi",
+		PackageRef:     touched.PackageRef,
+		DependencyRefs: []string{touched.ID, unchanged.ID},
+		Title:          "Denied package set",
+	}
+
+	var buf bytes.Buffer
+	err := WriteSARIF(&buf, []sdk.Finding{finding}, nil, "bomly", "0.1.0", SARIFOptions{
+		LocationGraphs: []*sdk.Graph{graph},
+		ChangedLines: map[string][]SARIFLineRange{
+			"package.json": {{Start: 22, End: 22}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("decode SARIF: %v\n%s", err, buf.String())
+	}
+	locations := doc.Runs[0].Results[0].Locations
+	if len(locations) != 2 {
+		t.Fatalf("locations = %d, want changed touched dep plus unchanged dep", len(locations))
+	}
+	got := map[string]int{}
+	for _, loc := range locations {
+		got[loc.PhysicalLocation.ArtifactLocation.URI] = loc.PhysicalLocation.Region.StartLine
+	}
+	if got["package.json"] != 22 {
+		t.Fatalf("locations = %#v, want package.json line 22", got)
+	}
+	if got["yarn.lock"] != 33 {
+		t.Fatalf("locations = %#v, want yarn.lock line 33", got)
+	}
+	if _, hasOld := got["package-lock.json"]; hasOld {
+		t.Fatalf("locations = %#v, did not expect non-changed candidate for touched dep", got)
+	}
+}
+
 func TestWriteSARIF_RewritesNonFileLocationSchemes(t *testing.T) {
 	graph := sdk.New()
 	dep := sdk.NewDependencyWithID("actions:checkout@v5", sdk.Dependency{Coordinates: sdk.Coordinates{Name: "actions/checkout"}, PackageRef: "actions:checkout@v5",


### PR DESCRIPTION
## Summary
- Pass changed git line ranges through diff resolution into SARIF output
- Attach multiple declaration-site positions for detectors so package locations stay accurate across manifests and versions
- Expand detector tests to cover version-aware and duplicate-location cases

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SARIF results now prioritize findings that overlap changed lines, making diffs more relevant.
  * Dependency locations are now captured more precisely across several ecosystems, including multiple matching source locations when needed.

* **Bug Fixes**
  * Improved line-number accuracy for Python, Maven, npm, pnpm, NuGet, Conan, SwiftPM, Pub, GitHub Actions, and Git diffs.
  * Lockfile-based scans now include the same location details as other resolution paths.

* **Tests**
  * Added coverage for changed-line SARIF behavior and updated detector position expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->