### PR TITLE
Prefer Maven property version locations

### DIFF
--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -16,10 +16,19 @@ import (
 var (
 	pomDependencyOpen  = regexp.MustCompile(`<dependency>`)
 	pomDependencyClose = regexp.MustCompile(`</dependency>`)
+	pomPropertiesOpen  = regexp.MustCompile(`<properties>`)
+	pomPropertiesClose = regexp.MustCompile(`</properties>`)
 	pomGroupID         = regexp.MustCompile(`<groupId>([^<]+)</groupId>`)
 	pomArtifactID      = regexp.MustCompile(`<artifactId>([^<]+)</artifactId>`)
 	pomVersion         = regexp.MustCompile(`<version>([^<]+)</version>`)
+	pomProperty        = regexp.MustCompile(`^\s*<([A-Za-z0-9_.-]+)>\s*([^<]+)\s*</[A-Za-z0-9_.-]+>\s*$`)
+	pomPropertyRef     = regexp.MustCompile(`^\$\{([A-Za-z0-9_.-]+)\}$`)
 )
+
+type pomPropertyPosition struct {
+	value string
+	line  int
+}
 
 // pomPositions returns name -> position by scanning every
 // `<dependency>` block in pom.xml. The key is the bare artifactId
@@ -28,6 +37,8 @@ var (
 // best-effort attribution to the parent pom.
 func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 	out := make(map[string][]*sdk.SourcePosition)
+	properties := make(map[string]pomPropertyPosition)
+	insideProperties := false
 	insideDep := false
 	pendingGroup := ""
 	pendingArtifactLine := 0
@@ -35,6 +46,22 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 	pendingVersion := ""
 	pendingVersionLine := 0
 	_ = detectors.ScanLines(path, func(line int, text string) {
+		if !insideDep {
+			if pomPropertiesOpen.MatchString(text) {
+				insideProperties = true
+				return
+			}
+			if pomPropertiesClose.MatchString(text) {
+				insideProperties = false
+				return
+			}
+			if insideProperties {
+				if m := pomProperty.FindStringSubmatch(text); m != nil {
+					properties[strings.TrimSpace(m[1])] = pomPropertyPosition{value: strings.TrimSpace(m[2]), line: line}
+				}
+				return
+			}
+		}
 		if pomDependencyOpen.MatchString(text) {
 			insideDep = true
 			pendingGroup = ""
@@ -47,18 +74,23 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 		if pomDependencyClose.MatchString(text) {
 			if pendingArtifactName != "" && pendingArtifactLine > 0 {
 				positionLine := pendingArtifactLine
+				version := pendingVersion
 				if pendingVersionLine > 0 {
 					positionLine = pendingVersionLine
 				}
+				if propertyVersion, propertyLine, ok := pomResolvedPropertyVersion(pendingVersion, properties); ok {
+					version = propertyVersion
+					positionLine = propertyLine
+				}
 				pos := &sdk.SourcePosition{File: relPath, Line: positionLine}
 				detectors.AppendPosition(out, pendingArtifactName, pos)
-				if pendingVersion != "" {
-					detectors.AppendPosition(out, pendingArtifactName+"@"+pendingVersion, pos)
+				if version != "" {
+					detectors.AppendPosition(out, pendingArtifactName+"@"+version, pos)
 				}
 				if pendingGroup != "" {
 					detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName, pos)
-					if pendingVersion != "" {
-						detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+pendingVersion, pos)
+					if version != "" {
+						detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+version, pos)
 					}
 				}
 			}
@@ -88,6 +120,18 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 		}
 	})
 	return out
+}
+
+func pomResolvedPropertyVersion(version string, properties map[string]pomPropertyPosition) (string, int, bool) {
+	matches := pomPropertyRef.FindStringSubmatch(strings.TrimSpace(version))
+	if matches == nil {
+		return "", 0, false
+	}
+	prop, ok := properties[matches[1]]
+	if !ok || prop.value == "" || prop.line == 0 {
+		return "", 0, false
+	}
+	return prop.value, prop.line, true
 }
 
 // AttachPomPositions wires pom.xml line numbers into a maven graph.

--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -37,8 +37,7 @@ type pomPropertyPosition struct {
 // best-effort attribution to the parent pom.
 func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 	out := make(map[string][]*sdk.SourcePosition)
-	properties := make(map[string]pomPropertyPosition)
-	insideProperties := false
+	properties := pomProperties(path)
 	insideDep := false
 	pendingGroup := ""
 	pendingArtifactLine := 0
@@ -46,22 +45,6 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 	pendingVersion := ""
 	pendingVersionLine := 0
 	_ = detectors.ScanLines(path, func(line int, text string) {
-		if !insideDep {
-			if pomPropertiesOpen.MatchString(text) {
-				insideProperties = true
-				return
-			}
-			if pomPropertiesClose.MatchString(text) {
-				insideProperties = false
-				return
-			}
-			if insideProperties {
-				if m := pomProperty.FindStringSubmatch(text); m != nil {
-					properties[strings.TrimSpace(m[1])] = pomPropertyPosition{value: strings.TrimSpace(m[2]), line: line}
-				}
-				return
-			}
-		}
 		if pomDependencyOpen.MatchString(text) {
 			insideDep = true
 			pendingGroup = ""
@@ -117,6 +100,28 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 		if m := pomVersion.FindStringSubmatch(text); m != nil {
 			pendingVersion = strings.TrimSpace(m[1])
 			pendingVersionLine = line
+		}
+	})
+	return out
+}
+
+func pomProperties(path string) map[string]pomPropertyPosition {
+	out := make(map[string]pomPropertyPosition)
+	insideProperties := false
+	_ = detectors.ScanLines(path, func(line int, text string) {
+		if pomPropertiesOpen.MatchString(text) {
+			insideProperties = true
+			return
+		}
+		if pomPropertiesClose.MatchString(text) {
+			insideProperties = false
+			return
+		}
+		if !insideProperties {
+			return
+		}
+		if m := pomProperty.FindStringSubmatch(text); m != nil {
+			out[strings.TrimSpace(m[1])] = pomPropertyPosition{value: strings.TrimSpace(m[2]), line: line}
 		}
 	})
 	return out

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -304,6 +304,31 @@ func TestMavenPomPositions(t *testing.T) {
 	}
 }
 
+func TestMavenPomPositionsResolvePropertiesAfterDependencies(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pom.xml", `<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+  </dependencies>
+  <properties>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+  </properties>
+</project>
+`)
+	g := sdk.New()
+	mustPkg(t, g, "commons-lang3", "3.17.0", func(p *sdk.Dependency) { p.Org = "org.apache.commons" })
+	maven.AttachPomPositions(g, dir)
+
+	lang3, _ := g.Node("org.apache.commons:commons-lang3@3.17.0")
+	if lang3 == nil || len(lang3.Locations) == 0 || lang3.Locations[0].Position.Line != 10 {
+		t.Fatalf("commons-lang3 location = %+v, want late property line 10", lang3)
+	}
+}
+
 func TestGradlePositions(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "build.gradle", `dependencies {

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -263,6 +263,9 @@ lodash@^4.0.0, lodash@^4.17.0:
 func TestMavenPomPositions(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "pom.xml", `<project>
+  <properties>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -274,20 +277,30 @@ func TestMavenPomPositions(t *testing.T) {
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
   </dependencies>
 </project>
 `)
 	g := sdk.New()
 	mustPkg(t, g, "jackson-databind", "2.17.0", func(p *sdk.Dependency) { p.Org = "com.fasterxml.jackson.core" })
 	mustPkg(t, g, "junit", "4.13.2", func(p *sdk.Dependency) { p.Org = "junit" })
+	mustPkg(t, g, "commons-lang3", "3.17.0", func(p *sdk.Dependency) { p.Org = "org.apache.commons" })
 	maven.AttachPomPositions(g, dir)
 	jd, _ := g.Node("com.fasterxml.jackson.core:jackson-databind@2.17.0")
-	if jd == nil || len(jd.Locations) == 0 || jd.Locations[0].Position.Line != 6 {
+	if jd == nil || len(jd.Locations) == 0 || jd.Locations[0].Position.Line != 9 {
 		t.Errorf("jackson-databind location wrong: %+v", jd)
 	}
 	ju, _ := g.Node("junit:junit@4.13.2")
-	if ju == nil || len(ju.Locations) == 0 || ju.Locations[0].Position.Line != 11 {
+	if ju == nil || len(ju.Locations) == 0 || ju.Locations[0].Position.Line != 14 {
 		t.Errorf("junit location wrong: %+v", ju)
+	}
+	lang3, _ := g.Node("org.apache.commons:commons-lang3@3.17.0")
+	if lang3 == nil || len(lang3.Locations) == 0 || lang3.Locations[0].Position.Line != 3 {
+		t.Errorf("commons-lang3 location wrong: %+v", lang3)
 	}
 }
 


### PR DESCRIPTION
## Summary
- collect simple Maven property definitions from `<properties>` blocks while extracting package locations
- attach property-backed dependency versions to the property line when the graph has the resolved concrete version
- keep existing inline `<version>` dependency location behavior unchanged

## Test Plan
- `go test ./internal/detectors ./internal/detectors/maven`
- `make test`
- `git diff --check`

## Context
Follow-up to the PackageLocation improvements: WebGoat updates `commons-lang3.version` in `<properties>`, so the changed line is the property definition rather than the dependency block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven dependency location detection when versions are defined through properties in `pom.xml`.
  * Dependency line references now more accurately point to the property value line when a version is resolved from a placeholder.
  * Existing dependency positions continue to be reported, with updated line handling for version-related entries.

* **Tests**
  * Expanded Maven position coverage to include a property-based dependency version and verified its reported line number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->