### PR TITLE
Locate Maven managed dependency properties

### DIFF
--- a/internal/detectors/maven/positions.go
+++ b/internal/detectors/maven/positions.go
@@ -56,24 +56,31 @@ func pomPositions(path, relPath string) map[string][]*sdk.SourcePosition {
 		}
 		if pomDependencyClose.MatchString(text) {
 			if pendingArtifactName != "" && pendingArtifactLine > 0 {
-				positionLine := pendingArtifactLine
+				versionLine := pendingVersionLine
 				version := pendingVersion
-				if pendingVersionLine > 0 {
-					positionLine = pendingVersionLine
-				}
 				if propertyVersion, propertyLine, ok := pomResolvedPropertyVersion(pendingVersion, properties); ok {
 					version = propertyVersion
-					positionLine = propertyLine
+					versionLine = propertyLine
 				}
-				pos := &sdk.SourcePosition{File: relPath, Line: positionLine}
-				detectors.AppendPosition(out, pendingArtifactName, pos)
-				if version != "" {
-					detectors.AppendPosition(out, pendingArtifactName+"@"+version, pos)
+				if version == "" {
+					if propertyVersion, propertyLine, ok := pomArtifactPropertyVersion(pendingArtifactName, properties); ok {
+						version = propertyVersion
+						versionLine = propertyLine
+					}
 				}
+				artifactPos := &sdk.SourcePosition{File: relPath, Line: pendingArtifactLine}
+				detectors.AppendPosition(out, pendingArtifactName, artifactPos)
 				if pendingGroup != "" {
-					detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName, pos)
-					if version != "" {
-						detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+version, pos)
+					detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName, artifactPos)
+				}
+				if version != "" {
+					versionPos := artifactPos
+					if versionLine > 0 {
+						versionPos = &sdk.SourcePosition{File: relPath, Line: versionLine}
+					}
+					detectors.AppendPosition(out, pendingArtifactName+"@"+version, versionPos)
+					if pendingGroup != "" {
+						detectors.AppendPosition(out, pendingGroup+":"+pendingArtifactName+"@"+version, versionPos)
 					}
 				}
 			}
@@ -133,6 +140,18 @@ func pomResolvedPropertyVersion(version string, properties map[string]pomPropert
 		return "", 0, false
 	}
 	prop, ok := properties[matches[1]]
+	if !ok || prop.value == "" || prop.line == 0 {
+		return "", 0, false
+	}
+	return prop.value, prop.line, true
+}
+
+func pomArtifactPropertyVersion(artifact string, properties map[string]pomPropertyPosition) (string, int, bool) {
+	artifact = strings.TrimSpace(artifact)
+	if artifact == "" {
+		return "", 0, false
+	}
+	prop, ok := properties[artifact+".version"]
 	if !ok || prop.value == "" || prop.line == 0 {
 		return "", 0, false
 	}

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -329,6 +329,30 @@ func TestMavenPomPositionsResolvePropertiesAfterDependencies(t *testing.T) {
 	}
 }
 
+func TestMavenPomPositionsUseArtifactPropertyForManagedDependency(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pom.xml", `<project>
+  <properties>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+`)
+	g := sdk.New()
+	mustPkg(t, g, "commons-lang3", "3.17.0", func(p *sdk.Dependency) { p.Org = "org.apache.commons" })
+	maven.AttachPomPositions(g, dir)
+
+	lang3, _ := g.Node("org.apache.commons:commons-lang3@3.17.0")
+	if lang3 == nil || len(lang3.Locations) == 0 || lang3.Locations[0].Position.Line != 3 {
+		t.Fatalf("commons-lang3 location = %+v, want artifact property line 3", lang3)
+	}
+}
+
 func TestGradlePositions(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "build.gradle", `dependencies {

--- a/internal/detectors/positions_extractors_test.go
+++ b/internal/detectors/positions_extractors_test.go
@@ -348,7 +348,7 @@ func TestMavenPomPositionsUseArtifactPropertyForManagedDependency(t *testing.T) 
 	maven.AttachPomPositions(g, dir)
 
 	lang3, _ := g.Node("org.apache.commons:commons-lang3@3.17.0")
-	if lang3 == nil || len(lang3.Locations) == 0 || lang3.Locations[0].Position.Line != 3 {
+	if lang3 == nil || len(lang3.Locations) != 1 || lang3.Locations[0].Position.Line != 3 {
 		t.Fatalf("commons-lang3 location = %+v, want artifact property line 3", lang3)
 	}
 }


### PR DESCRIPTION
## Summary
- use `<artifactId>.version` Maven properties as exact package-version locations when a dependency has no local `<version>` element
- keep bare artifact/group locations on the dependency block so existing fallback behavior stays stable
- add a regression for the WebGoat-style managed dependency case

## Why
WebGoat changes `<commons-lang3.version>` but its `commons-lang3` dependency omits `<version>` and gets the concrete version through dependency management. The previous property-reference support only handled local `<version>${...}</version>` declarations, so SARIF could still prefer the dependency block instead of the changed property line.

## Test Plan
- `go test ./internal/detectors ./internal/detectors/maven`
- `make test`
- `git diff --check`

## Notes
I attempted a full live WebGoat diff/SARIF verification, but the Maven/enrichment run did not complete in a useful interactive window. The new focused regression covers the exact POM shape from WebGoat: property value plus dependency without a local version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how Maven dependency locations are recorded when a version is inherited from project properties.
  * Dependency artifacts now point to the correct source line more reliably, including cases where the version comes from a shared property instead of being written directly on the dependency.
  * This makes dependency navigation and traceability more accurate in Maven projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->