### PR TITLE
Document command and SDK package surfaces

### DIFF
--- a/cmd/bomly/doc.go
+++ b/cmd/bomly/doc.go
@@ -1,0 +1,18 @@
+// Command bomly scans source trees, SBOMs, Git refs, and container images for
+// dependency intelligence.
+//
+// Bomly can generate and ingest SBOMs, explain why packages are present,
+// compare dependency graphs, enrich packages with vulnerability and license
+// data, evaluate policy, and run as an MCP server:
+//
+//	bomly scan
+//	bomly scan --enrich --audit --fail-on high
+//	bomly diff --base main --head HEAD
+//	bomly explain pkg:npm/react
+//	bomly mcp serve
+//
+// Scans run locally and do not make outbound matcher calls unless enrichment is
+// requested with flags such as --enrich. See the repository README and docs for
+// installation, configuration, output formats, CI integration, and plugin
+// authoring guides.
+package main

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -18,6 +18,8 @@ Use the implementation guides when you are writing one:
 - [How To Implement A Matcher Plugin](plugins/how-to-implement-matcher.md)
 - [How To Implement An Auditor Plugin](plugins/how-to-implement-auditor.md)
 
+Use the [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-cli/sdk) for the Go types, runtime entrypoints, request/response payloads, graph model, package registry, and finding contract those guides use.
+
 Example plugin repositories live outside this repo so each plugin type can show a realistic package, release, and README:
 
 - [Bun Lock Detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector) — detector example using `PackageManagerOther`

--- a/docs/plugins/how-to-implement-auditor.md
+++ b/docs/plugins/how-to-implement-auditor.md
@@ -4,6 +4,8 @@ An auditor plugin evaluates the dependency graph and package registry after dete
 
 External auditor plugins are served with `sdk.ServeAuditor`.
 
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-cli/sdk) documents the `sdk.ServeAuditor` entrypoint, `sdk.ServedAuditor` interface, `sdk.AuditRequest`, `sdk.AuditResult`, reference-style findings, and risk-score types used below.
+
 ## Minimum Shape
 
 Create a Go `main` package that imports the Bomly SDK:

--- a/docs/plugins/how-to-implement-detector.md
+++ b/docs/plugins/how-to-implement-detector.md
@@ -4,6 +4,8 @@ A detector plugin turns project evidence into a Bomly dependency graph. Use a de
 
 External detector plugins are served with `sdk.ServeDetector`.
 
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-cli/sdk) documents the `sdk.ServeDetector` entrypoint, `sdk.ServedDetector` interface, `sdk.DetectionRequest`, `sdk.DetectionResult`, graph helpers, coordinates, and package-manager support types used below.
+
 ## Minimum Shape
 
 Create a Go `main` package that imports the Bomly SDK:

--- a/docs/plugins/how-to-implement-matcher.md
+++ b/docs/plugins/how-to-implement-matcher.md
@@ -4,6 +4,8 @@ A matcher plugin enriches packages after detection. Use a matcher when you want 
 
 External matcher plugins are served with `sdk.ServeMatcher`.
 
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-cli/sdk) documents the `sdk.ServeMatcher` entrypoint, `sdk.ServedMatcher` interface, `sdk.MatchRequest`, `sdk.MatchResult`, PURL-keyed package registry, and enrichment types used below.
+
 ## Minimum Shape
 
 Create a Go `main` package that imports the Bomly SDK:

--- a/sdk/auditor.go
+++ b/sdk/auditor.go
@@ -65,4 +65,7 @@ type Auditor interface {
 }
 
 // AuditResponse is the auditor response payload exposed to plugins.
+//
+// It aliases AuditResult so plugin code can name payload types by role while
+// sharing the same transport shape Bomly core uses internally.
 type AuditResponse = AuditResult

--- a/sdk/coordinates.go
+++ b/sdk/coordinates.go
@@ -2,10 +2,10 @@ package sdk
 
 import "strings"
 
-// Coordinates is the shared coordinates view for manifest dependencies and
-// matched registry packages. It intentionally excludes graph-only fields
-// (scopes, locations, package refs) and enrichment-only fields (licenses,
-// vulnerabilities, scorecard) so Dependency and Package remain distinct
+// Coordinates is the shared identity view embedded by Dependency and Package.
+// It intentionally excludes graph-only fields (scopes, locations, package refs)
+// and enrichment-only fields (licenses, vulnerabilities, scorecard) so
+// detection-time graph nodes and matching-stage package records remain distinct
 // domain models.
 type Coordinates struct {
 	PURL           string         `json:"purl,omitempty"`

--- a/sdk/detector.go
+++ b/sdk/detector.go
@@ -71,7 +71,9 @@ type DetectorDescriptor struct {
 	SupportsInstallFirst  bool                    `json:"supportsInstallFirst,omitempty"`
 }
 
-// PackageManagerSupport records package-manager discovery metadata for a detector.
+// PackageManagerSupport records package-manager discovery metadata for a
+// detector. External detector plugins return this so Bomly can include them in
+// subproject discovery and scan planning before the detector runs.
 type PackageManagerSupport struct {
 	PackageManager   PackageManager `json:"packageManager"`
 	EvidencePatterns []string       `json:"evidencePatterns,omitempty"`
@@ -111,7 +113,13 @@ type InstallFirstDetector interface {
 }
 
 // DetectRequest is the detector request payload exposed to plugins.
+//
+// It aliases DetectionRequest so plugin code can name payload types by role
+// while sharing the same transport shape Bomly core uses internally.
 type DetectRequest = DetectionRequest
 
 // DetectResponse is the detector response payload exposed to plugins.
+//
+// It aliases DetectionResult so plugin code can name payload types by role
+// while sharing the same transport shape Bomly core uses internally.
 type DetectResponse = DetectionResult

--- a/sdk/doc.go
+++ b/sdk/doc.go
@@ -1,0 +1,66 @@
+// Package sdk is Bomly's public Go contract for dependency graphs, package
+// enrichment, policy findings, and managed external plugins.
+//
+// Most external developers use this package to build a managed plugin. Managed
+// plugins are native Go binaries that Bomly launches as separate subprocesses
+// over the HashiCorp go-plugin gRPC transport. A plugin implements exactly one
+// externally supported role:
+//
+//   - detector: reads project evidence and returns dependency graphs
+//   - matcher: enriches PURL-keyed package records with vulnerability, license,
+//     lifecycle, or other package metadata
+//   - auditor: evaluates graph and registry data and emits findings or risk
+//     scores
+//
+// Reachability analyzers are represented in the SDK for Bomly core and built-in
+// analyzers, but external analyzer plugins are not currently supported by the
+// managed plugin runtime.
+//
+// A plugin binary serves its role from main by calling one of the runtime
+// entrypoints:
+//
+//	func main() {
+//		sdk.ServeDetector(&detector{})
+//	}
+//
+// The corresponding plugin-facing interfaces are ServedDetector, ServedMatcher,
+// and ServedAuditor. They use the same request and response types as Bomly core:
+// DetectionRequest and DetectionResult for detectors, MatchRequest and
+// MatchResult for matchers, and AuditRequest and AuditResult for auditors.
+//
+// The central data model deliberately separates pipeline stages. Dependency is
+// a detection-time graph node with identity, locations, scopes, and edges.
+// PackageRegistry is a PURL-keyed set of deduplicated Package records that
+// matchers enrich once per package version. Vulnerability records are
+// OSV-aligned package enrichment data, including Bomly fields such as CVSS,
+// EPSS, KEV, fixed versions, affected symbols, and reachability. Finding is a
+// reference-style audit result: it points back to packages by PURL and, for
+// vulnerability findings, to Vulnerability.ID rather than copying the whole
+// package or advisory payload.
+//
+// Coordinates is the shared embedded identity shape used by Dependency and
+// Package. Plugin authors should prefer canonical PURLs, fill Coordinates where
+// possible, and use typed values such as Ecosystem, PackageManager,
+// PackageType, Scope, and SeverityLevel instead of raw strings. PackageManager
+// is string-backed for compatibility; use PackageManagerOther or a custom
+// PackageManager value when Bomly does not yet have a first-class constant for
+// a package manager.
+//
+// Plugin identity is split across package metadata and runtime metadata. The
+// bomly-plugin.json manifest describes packaging and install fields such as ID,
+// version, kind, runtime, plugin API version, entrypoint, homepage, and license.
+// The runtime descriptor returned by Descriptor describes the served component:
+// name, display name, aliases, tags, supported ecosystems, supported package
+// managers, and role-specific behavior. Bomly verifies that manifest identity
+// and runtime descriptor identity match when a packaged plugin is installed, and
+// records installed trust state separately.
+//
+// Plugins that need configuration should read only their per-plugin config with
+// DecodePluginConfigFromEnv. Plugins that make HTTP calls should create a
+// process-local provider with NewHTTPClientProviderFromEnv so Bomly's proxy,
+// no-proxy, and CA certificate settings are honored consistently.
+//
+// The repository documentation contains the workflow-oriented guides for
+// packaging, installing, testing, and distributing plugins. This package
+// documentation is the API-oriented reference for the types those guides use.
+package sdk

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -40,7 +40,9 @@ const (
 	EnvPluginID = "BOMLY_PLUGIN_ID"
 )
 
-// HTTPClientConfig configures Bomly's shared outbound HTTP client.
+// HTTPClientConfig configures Bomly's shared outbound HTTP client. External
+// plugins normally obtain this from HTTPClientConfigFromEnv instead of building
+// it by hand, so Bomly-managed proxy and CA settings are honored.
 type HTTPClientConfig struct {
 	ProxyURL      string
 	NoProxy       string
@@ -53,7 +55,9 @@ type HTTPClientConfig struct {
 	Timeout       time.Duration
 }
 
-// HTTPClientProvider owns reusable HTTP transport state for one Bomly execution.
+// HTTPClientProvider owns reusable HTTP transport state for one Bomly execution
+// or plugin process. Reuse one provider for repeated outbound calls so
+// connection pools, proxy settings, and TLS configuration stay consistent.
 type HTTPClientProvider struct {
 	transport      *http.Transport
 	defaultTimeout time.Duration
@@ -100,7 +104,8 @@ func NewHTTPClientProvider(config HTTPClientConfig) (*HTTPClientProvider, error)
 }
 
 // NewHTTPClientProviderFromEnv creates a provider from Bomly HTTP environment
-// variables, with standard proxy environment variables honored as fallback.
+// variables, with standard proxy environment variables honored as fallback. Use
+// this in external plugins that make outbound HTTP calls.
 func NewHTTPClientProviderFromEnv() (*HTTPClientProvider, error) {
 	return NewHTTPClientProvider(HTTPClientConfigFromEnv())
 }
@@ -278,7 +283,10 @@ func RawPluginConfigFromEnv() ([]byte, error) {
 	return data, nil
 }
 
-// DecodePluginConfigFromEnv decodes the per-plugin JSON config file into target.
+// DecodePluginConfigFromEnv decodes the current plugin's JSON config file into
+// target. Bomly writes this file from the enabled plugin's own
+// plugins.<plugin-id> config block and exposes its path through the plugin
+// environment.
 func DecodePluginConfigFromEnv(target any) error {
 	data, err := RawPluginConfigFromEnv()
 	if err != nil {

--- a/sdk/matcher.go
+++ b/sdk/matcher.go
@@ -72,4 +72,7 @@ type Matcher interface {
 }
 
 // MatchResponse is the matcher response payload exposed to plugins.
+//
+// It aliases MatchResult so plugin code can name payload types by role while
+// sharing the same transport shape Bomly core uses internally.
 type MatchResponse = MatchResult

--- a/sdk/package_manager.go
+++ b/sdk/package_manager.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-// PackageManager identifies the concrete package manager or manifest family for a target.
+// PackageManager identifies the concrete package manager or manifest family for
+// a target. The type is string-backed so plugins can pass custom values while
+// Bomly grows first-class constants; use PackageManagerOther when no specific
+// manager value is appropriate.
 type PackageManager string
 
 const (

--- a/sdk/serve.go
+++ b/sdk/serve.go
@@ -17,7 +17,10 @@ import (
 
 const pluginName = "bomly"
 
-// ServedDetector is the detector interface exposed to external plugin authors.
+// ServedDetector is the detector interface implemented by external detector
+// plugins. A detector describes its identity and package-manager support,
+// reports readiness/applicability for a planned scan target, and returns one or
+// more manifest-scoped dependency graphs from Detect.
 type ServedDetector interface {
 	Descriptor(context.Context) (*DetectorDescriptor, error)
 	PackageManagerSupport(context.Context) ([]PackageManagerSupport, error)
@@ -26,12 +29,18 @@ type ServedDetector interface {
 	Detect(context.Context, *DetectRequest) (*DetectResponse, error)
 }
 
-// DetectorInstaller optionally performs install-first preparation before detection.
+// DetectorInstaller optionally performs install-first preparation before
+// detection. Implement this only for detectors that need to prepare project
+// dependencies before reading them; Bomly calls it only when install-first
+// execution is requested.
 type DetectorInstaller interface {
 	Install(context.Context, *DetectRequest) (*InstallResponse, error)
 }
 
-// ServedMatcher is the matcher interface exposed to external plugin authors.
+// ServedMatcher is the matcher interface implemented by external matcher
+// plugins. Matchers read the dependency graph and PURL-keyed package registry,
+// then return the registry with package enrichment such as licenses,
+// vulnerabilities, lifecycle data, or other metadata.
 type ServedMatcher interface {
 	Descriptor(context.Context) (*MatcherDescriptor, error)
 	Ready(context.Context, *MatchRequest) (*ReadyResponse, error)
@@ -39,7 +48,9 @@ type ServedMatcher interface {
 	Match(context.Context, *MatchRequest) (*MatchResponse, error)
 }
 
-// ServedAuditor is the auditor interface exposed to external plugin authors.
+// ServedAuditor is the auditor interface implemented by external auditor
+// plugins. Auditors read graph and registry data and return reference-style
+// findings, risk scores, and run metadata.
 type ServedAuditor interface {
 	Descriptor(context.Context) (*AuditorDescriptor, error)
 	Ready(context.Context, *AuditRequest) (*ReadyResponse, error)
@@ -81,17 +92,20 @@ func ClientPluginMap() map[string]hplugin.Plugin {
 	}
 }
 
-// ServeDetector serves a detector plugin over HashiCorp go-plugin gRPC transport.
+// ServeDetector serves one detector plugin over Bomly's managed HashiCorp
+// go-plugin gRPC transport. Call it from the plugin binary's main function.
 func ServeDetector(detector ServedDetector) {
 	serve(detector, nil, nil)
 }
 
-// ServeMatcher serves a matcher plugin over HashiCorp go-plugin gRPC transport.
+// ServeMatcher serves one matcher plugin over Bomly's managed HashiCorp
+// go-plugin gRPC transport. Call it from the plugin binary's main function.
 func ServeMatcher(matcher ServedMatcher) {
 	serve(nil, matcher, nil)
 }
 
-// ServeAuditor serves an auditor plugin over HashiCorp go-plugin gRPC transport.
+// ServeAuditor serves one auditor plugin over Bomly's managed HashiCorp
+// go-plugin gRPC transport. Call it from the plugin binary's main function.
 func ServeAuditor(auditor ServedAuditor) {
 	serve(nil, nil, auditor)
 }


### PR DESCRIPTION
## Summary

- add pkg.go.dev command documentation for `cmd/bomly`
- add a plugin-author-focused package overview for the public `sdk` package
- clarify selected SDK doc comments around plugin runtime interfaces, request/response aliases, package-manager support, HTTP/config helpers, coordinates, and package managers
- cross-link the plugin guides to the pkg.go.dev SDK API reference

## Validation

- `go doc ./cmd/bomly`
- `go doc ./sdk`
- `go test ./cmd/bomly ./sdk`
- `go vet ./sdk`
- `git diff --check`

## Notes

pkg.go.dev renders documentation from indexed module versions. These docs will be available from source immediately after merge, but the public pkg.go.dev page generally updates after a tagged module version containing the change is published or after pkg.go.dev indexes the requested version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running auditor plugins through the SDK.
  * Introduced a response alias for matcher plugins to make plugin payloads easier to use.

* **Documentation**
  * Expanded SDK and command documentation to better explain scanning, enrichment, diffing, and plugin server options.
  * Added clearer guidance and links for implementing detector, matcher, and auditor plugins.
  * Improved reference docs for shared plugin types, HTTP configuration, and package manager values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->