### PR TITLE
Publish Bomly via Homebrew formula instead of cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,19 +135,26 @@ nfpms:
       - src: NOTICE
         dst: /usr/share/doc/bomly/NOTICE
 
-homebrew_casks:
+# Published as a Homebrew formula (not a cask): casks get the
+# com.apple.quarantine attribute, which trips macOS Gatekeeper ("Apple could
+# not verify bomly") for our un-notarized binary. Formula downloads are never
+# quarantined, so the CLI runs without a prompt.
+# NOTE: `brews` is deprecated as of GoReleaser v2.10 but still functional. If it
+# is removed, replace this with a custom step that templates Formula/bomly.rb in
+# the tap from SHA256SUMS (see dev-docs/RELEASE_CHECKLIST.md).
+brews:
   - name: bomly
     ids:
       - bomly
-    binaries:
-      - bomly
     homepage: https://bomly.dev/cli
-    description: Free, open-source CLI for dependency intelligence and SBOM analysis.
+    description: Free, open-source CLI for dependency intelligence and SBOM analysis
     license: Apache-2.0
-    directory: Casks
+    directory: Formula
     commit_msg_template: "Update Bomly CLI to {{ .Tag }}"
-    caveats: |
-      Bomly is installed as the `bomly` command.
+    install: |
+      bin.install "bomly"
+    test: |
+      system "#{bin}/bomly", "version"
     repository:
       owner: bomly-dev
       name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One binary. No service to host. No telemetry. No outbound matcher calls unless y
 
 ```bash
 # macOS / Linuxbrew
-brew install --cask bomly-dev/tap/bomly
+brew install bomly-dev/tap/bomly
 
 # Linux / macOS install script
 curl -fsSL https://bomly.dev/install.sh | sh

--- a/dev-docs/RELEASE_CHECKLIST.md
+++ b/dev-docs/RELEASE_CHECKLIST.md
@@ -35,7 +35,7 @@ tar -xzf bomly_VERSION_linux_amd64.tar.gz bomly
 If practical, verify package-manager installs in clean runners or VMs. The `bomly-dev/tap` Homebrew reference is managed by GoReleaser through `bomly-dev/homebrew-tap`; no manual tap registration is required during release.
 
 ```bash
-brew install --cask bomly-dev/tap/bomly
+brew install bomly-dev/tap/bomly
 dpkg -i bomly_VERSION_linux_amd64.deb
 rpm -i bomly_VERSION_linux_amd64.rpm
 apk add --allow-untrusted bomly_VERSION_linux_amd64.apk

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ Bomly ships as a release binary, package-manager entry, and Linux package. Pick 
 ### macOS / Linuxbrew
 
 ```bash
-brew install --cask bomly-dev/tap/bomly
+brew install bomly-dev/tap/bomly
 bomly version
 ```
 
@@ -34,14 +34,14 @@ If you're ready to scan, jump to [Getting Started](GETTING_STARTED.md).
 Homebrew is the preferred macOS path and also works for Linuxbrew users:
 
 ```bash
-brew install --cask bomly-dev/tap/bomly
+brew install bomly-dev/tap/bomly
 ```
 
 Upgrade and uninstall:
 
 ```bash
-brew upgrade --cask bomly
-brew uninstall --cask bomly
+brew upgrade bomly
+brew uninstall bomly
 ```
 
 ### WinGet
@@ -215,7 +215,7 @@ For pinned CI recipes, see [CI integration](CI_INTEGRATION.md). Prefer a package
 
 Use the package manager that installed Bomly:
 
-- Homebrew: `brew upgrade --cask bomly`
+- Homebrew: `brew upgrade bomly`
 - WinGet: `winget upgrade Bomly.BomlyCLI`
 - Scoop: `scoop update bomly`
 - Linux packages: install the newer package artifact with your system package manager.


### PR DESCRIPTION
## Problem

`brew install --cask bomly-dev/tap/bomly` produces **"'bomly' Not Opened — Apple could not verify…"** on macOS 15 (Sequoia). Homebrew stamps `com.apple.quarantine` on **cask** downloads, and Gatekeeper now hard-blocks our un-notarized binary because of that attribute.

## Fix

Switch the GoReleaser Homebrew integration from `homebrew_casks` to **`brews`** so each release publishes a **formula** (`Formula/bomly.rb`) to `bomly-dev/homebrew-tap`. Formula downloads are never quarantined → the CLI runs with no Gatekeeper prompt, with no Apple Developer account / notarization needed. Formulae are also exempt from Homebrew 5.0's Sept 1 2026 disabling of Gatekeeper-failing casks.

### Changes
- **`.goreleaser.yaml`**: `homebrew_casks` → `brews` (adds `install`/`test` blocks, `directory: Formula`; keeps the same tap repo, PR flow, and `TAP_GITHUB_TOKEN`).
- **Docs** (`README.md`, `docs/INSTALLATION.md`, `dev-docs/RELEASE_CHECKLIST.md`): drop `--cask` from `brew install`/`upgrade`/`uninstall` commands.

### Notes
- `brews` is **deprecated in GoReleaser v2.10** but still functional. `release.yml` uses `goreleaser release --clean`, which runs fine with deprecated properties (warning only) — no `goreleaser check` gate exists. A custom formula-publish fallback (template `Formula/bomly.rb` from `SHA256SUMS`) is documented in the config comment for when `brews` is removed.
- Companion PR in the tap (bomly-dev/homebrew-tap#16) already ships the hand-authored `Formula/bomly.rb` for the current v0.15.0 release so users are unblocked before the next release regenerates it.
- `goreleaser check` passes config validation (only emits the deprecation warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew installation is now available as a standard formula, with updated install, upgrade, and uninstall commands for macOS/Linuxbrew users.
* **Bug Fixes**
  * Replaced the previous cask-based installation flow with the correct formula-based approach.
  * Added clearer install-time checks and metadata for the published package.
* **Documentation**
  * Updated installation and release checklist instructions to match the new Homebrew commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->