### PR TITLE
fix(plugin): retry GitHub release fetch anonymously on stale token

### DIFF
--- a/internal/plugin/github_release.go
+++ b/internal/plugin/github_release.go
@@ -81,12 +81,11 @@ func resolveGitHubRelease(ctx context.Context, source string) (githubReleaseReso
 		return githubReleaseResolution{}, fmt.Errorf("create GitHub release request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	applyGitHubAuthHeader(req)
 	client, err := githubReleaseHTTPClient(ctx)
 	if err != nil {
 		return githubReleaseResolution{}, err
 	}
-	resp, err := client.Do(req)
+	resp, err := githubDoWithAuthFallback(client, req)
 	if err != nil {
 		return githubReleaseResolution{}, fmt.Errorf("fetch GitHub release metadata: %w", err)
 	}
@@ -193,12 +192,11 @@ func fetchChecksumLine(ctx context.Context, downloadURL, assetName string) (stri
 		return "", err
 	}
 	req.Header.Set("Accept", "application/octet-stream")
-	applyGitHubAuthHeader(req)
 	client, err := githubReleaseHTTPClient(ctx)
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.Do(req)
+	resp, err := githubDoWithAuthFallback(client, req)
 	if err != nil {
 		return "", err
 	}
@@ -230,6 +228,28 @@ func githubReleaseHTTPClient(ctx context.Context) (*http.Client, error) {
 		return pluginHTTPClient, nil
 	}
 	return httpClientFromLaunchContext(ctx, 0)
+}
+
+// githubDoWithAuthFallback issues req against the GitHub API, attaching the
+// configured token when one is present. GitHub rejects an invalid or expired
+// token with 401 ("Bad credentials") even for public resources that need no
+// auth at all, so a stale token in the environment (a common situation with
+// gh, CI helpers, and old dotfiles) would otherwise break installs from public
+// repos. When an authenticated request comes back 401 we retry once
+// anonymously; token auth still works for private and rate-limited repos.
+func githubDoWithAuthFallback(client *http.Client, req *http.Request) (*http.Response, error) {
+	applyGitHubAuthHeader(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized || req.Header.Get("Authorization") == "" {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+	retry := req.Clone(req.Context())
+	retry.Header.Del("Authorization")
+	return client.Do(retry)
 }
 
 func applyGitHubAuthHeader(req *http.Request) {

--- a/internal/plugin/github_release.go
+++ b/internal/plugin/github_release.go
@@ -198,7 +198,7 @@ func fetchChecksumLine(ctx context.Context, downloadURL, assetName string) (stri
 	}
 	resp, err := githubDoWithAuthFallback(client, req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("fetch checksum asset: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -241,7 +241,7 @@ func githubDoWithAuthFallback(client *http.Client, req *http.Request) (*http.Res
 	applyGitHubAuthHeader(req)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("send GitHub request: %w", err)
 	}
 	if resp.StatusCode != http.StatusUnauthorized || req.Header.Get("Authorization") == "" {
 		return resp, nil
@@ -249,7 +249,11 @@ func githubDoWithAuthFallback(client *http.Client, req *http.Request) (*http.Res
 	_ = resp.Body.Close()
 	retry := req.Clone(req.Context())
 	retry.Header.Del("Authorization")
-	return client.Do(retry)
+	retryResp, err := client.Do(retry)
+	if err != nil {
+		return nil, fmt.Errorf("retry GitHub request anonymously: %w", err)
+	}
+	return retryResp, nil
 }
 
 func applyGitHubAuthHeader(req *http.Request) {

--- a/internal/plugin/github_release_test.go
+++ b/internal/plugin/github_release_test.go
@@ -107,6 +107,86 @@ func TestResolveGitHubReleaseAndInstall(t *testing.T) {
 	}
 }
 
+func TestInstallStaleTokenFallbackEndToEnd(t *testing.T) {
+	// Exercises all three githubDoWithAuthFallback call sites (release metadata,
+	// checksum fetch, archive download) in one flow: a stale token is present,
+	// every endpoint rejects authenticated requests with 401, and the install
+	// must still succeed by retrying each request anonymously.
+	t.Setenv("BOMLY_GITHUB_TOKEN", "ghp_stale_and_invalid")
+
+	root := t.TempDir()
+	binaryName := "bomly-plugin-release"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(t.TempDir(), binaryName)
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeDetectorPluginSource("acme.detector.release")); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+
+	manifest := withCanonicalManifestDefaults(Manifest{
+		ID:      "acme.detector.release",
+		Name:    "Acme Release Detector",
+		Version: "1.0.0",
+		Kind:    plugschema.PluginKindDetector,
+		Entrypoint: map[string]string{
+			platformKey(): filepath.ToSlash(filepath.Join("bin", filepath.Base(binaryPath))),
+		},
+	}, "github:acme/release-detector@v1.0.0")
+
+	archiveName := "bomly-plugin-release_" + runtime.GOOS + "_" + runtime.GOARCH + archiveSuffix()
+	archiveBytes := buildPluginArchive(t, manifest, binaryPath)
+	checksum := checksumForBytes(archiveBytes)
+
+	var server *httptest.Server
+	archiveAssetPath := "/repos/acme/release-detector/releases/assets/101"
+	checksumAssetPath := "/repos/acme/release-detector/releases/assets/102"
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject any request that still carries the stale token.
+		if r.Header.Get("Authorization") != "" {
+			http.Error(w, `{"message":"Bad credentials"}`, http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/repos/acme/release-detector/releases/tags/v1.0.0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "v1.0.0",
+				"assets": []map[string]any{
+					{"id": 101, "name": archiveName, "url": server.URL + archiveAssetPath, "browser_download_url": server.URL + "/download/" + archiveName},
+					{"id": 102, "name": "SHA256SUMS", "url": server.URL + checksumAssetPath, "browser_download_url": server.URL + "/download/SHA256SUMS"},
+				},
+			})
+		case archiveAssetPath:
+			_, _ = w.Write(archiveBytes)
+		case checksumAssetPath:
+			_, _ = w.Write([]byte(checksum[len("sha256:"):] + "  dist/" + archiveName + "\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	origBase := githubReleaseAPIBase
+	origClient := pluginHTTPClient
+	githubReleaseAPIBase = server.URL
+	pluginHTTPClient = server.Client()
+	defer func() {
+		githubReleaseAPIBase = origBase
+		pluginHTTPClient = origClient
+	}()
+
+	result, err := Install(context.Background(), root, "github:acme/release-detector@v1.0.0", InstallOptions{})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Manifest.ID != "acme.detector.release" {
+		t.Fatalf("expected release plugin id, got %q", result.Manifest.ID)
+	}
+	if !result.ChecksumVerified {
+		t.Fatalf("expected GitHub release checksum verification to succeed via anonymous retry")
+	}
+}
+
 func TestResolveGitHubReleaseRedactsTokenFromErrors(t *testing.T) {
 	const token = "ghp_secret_error_token"
 	t.Setenv("BOMLY_GITHUB_TOKEN", token)
@@ -182,6 +262,41 @@ func TestResolveGitHubReleaseRetriesAnonymouslyOnStaleToken(t *testing.T) {
 	}
 	if anonAttempts != 1 {
 		t.Fatalf("expected exactly one anonymous retry, got %d", anonAttempts)
+	}
+}
+
+func TestFetchChecksumLineRetriesAnonymouslyOnStaleToken(t *testing.T) {
+	// The checksum fetch path also routes through githubDoWithAuthFallback, so a
+	// stale token must not break checksum verification on a public release.
+	const assetName = "bomly-plugin-demo_linux_amd64.tar.gz"
+	const digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	t.Setenv("BOMLY_GITHUB_TOKEN", "ghp_stale_and_invalid")
+
+	var authedAttempts, anonAttempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			authedAttempts++
+			http.Error(w, `{"message":"Bad credentials"}`, http.StatusUnauthorized)
+			return
+		}
+		anonAttempts++
+		_, _ = w.Write([]byte(digest + "  " + assetName + "\n"))
+	}))
+	defer server.Close()
+
+	origClient := pluginHTTPClient
+	pluginHTTPClient = server.Client()
+	defer func() { pluginHTTPClient = origClient }()
+
+	got, err := fetchChecksumLine(context.Background(), server.URL, assetName)
+	if err != nil {
+		t.Fatalf("fetchChecksumLine() error = %v", err)
+	}
+	if want := "sha256:" + digest; got != want {
+		t.Fatalf("fetchChecksumLine() = %q, want %q", got, want)
+	}
+	if authedAttempts != 1 || anonAttempts != 1 {
+		t.Fatalf("expected one authed + one anonymous attempt, got authed=%d anon=%d", authedAttempts, anonAttempts)
 	}
 }
 

--- a/internal/plugin/github_release_test.go
+++ b/internal/plugin/github_release_test.go
@@ -138,6 +138,53 @@ func TestResolveGitHubReleaseRedactsTokenFromErrors(t *testing.T) {
 	}
 }
 
+func TestResolveGitHubReleaseRetriesAnonymouslyOnStaleToken(t *testing.T) {
+	// A stale/invalid token in the environment must not break installs from a
+	// public repo: GitHub answers an invalid token with 401 even when the
+	// resource needs no auth, so we retry once without the Authorization header.
+	t.Setenv("BOMLY_GITHUB_TOKEN", "ghp_stale_and_invalid")
+
+	var authedAttempts, anonAttempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			authedAttempts++
+			http.Error(w, `{"message":"Bad credentials"}`, http.StatusUnauthorized)
+			return
+		}
+		anonAttempts++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tag_name": "v1.0.0",
+			"assets":   []map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	origBase := githubReleaseAPIBase
+	origClient := pluginHTTPClient
+	githubReleaseAPIBase = server.URL
+	pluginHTTPClient = server.Client()
+	defer func() {
+		githubReleaseAPIBase = origBase
+		pluginHTTPClient = origClient
+	}()
+
+	// No matching asset, so resolution still errors, but it must get past the
+	// 401 to the asset-selection stage rather than failing on credentials.
+	_, err := resolveGitHubRelease(context.Background(), "github:acme/release-detector@v1.0.0")
+	if err == nil {
+		t.Fatal("expected resolveGitHubRelease to fail on missing asset")
+	}
+	if strings.Contains(err.Error(), "Bad credentials") || strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected anonymous retry to bypass the 401, got %v", err)
+	}
+	if authedAttempts != 1 {
+		t.Fatalf("expected exactly one authenticated attempt, got %d", authedAttempts)
+	}
+	if anonAttempts != 1 {
+		t.Fatalf("expected exactly one anonymous retry, got %d", anonAttempts)
+	}
+}
+
 func TestFetchChecksumLineMatchesAssetBasenameVariants(t *testing.T) {
 	const assetName = "bomly-plugin-demo_linux_amd64.tar.gz"
 	const digest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -175,15 +175,17 @@ func installRemoteArchive(ctx context.Context, tempDir, source string, opts Inst
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("create plugin download request: %w", err)
 	}
-	if opts.githubReleaseDownload {
-		req.Header.Set("Accept", "application/octet-stream")
-		applyGitHubAuthHeader(req)
-	}
 	client, err := httpClientFromLaunchContext(ctx, 0)
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	resp, err := client.Do(req)
+	var resp *http.Response
+	if opts.githubReleaseDownload {
+		req.Header.Set("Accept", "application/octet-stream")
+		resp, err = githubDoWithAuthFallback(client, req)
+	} else {
+		resp, err = client.Do(req)
+	}
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("download plugin archive: %w", err)
 	}


### PR DESCRIPTION
## Problem

`bomly plugin install github:<owner>/<repo>@<tag>` against a **public** repo fails with:

```
Error: fetch GitHub release metadata: unexpected status 401 Unauthorized ({
  "message": "Bad credentials", ...
})
```

…whenever the environment contains an invalid or expired GitHub token. A public release lookup needs no auth (`api.github.com/.../releases/tags/<tag>` returns `200` anonymously), but the release-metadata, checksum, and archive-download requests all attached a token **unconditionally** when any of `BOMLY_GITHUB_TOKEN` / `GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_AUTH_TOKEN` was set. GitHub rejects an *invalid* token with `401 Bad credentials` even for resources that require no auth, so a stale token left over from `gh`, CI helpers, or old dotfiles broke installs that should have succeeded anonymously.

This was caught during final pre-announcement checks and would have hit many launch-day users who have a stale GitHub token floating around in their shell.

## Fix

Added `githubDoWithAuthFallback` and routed all three GitHub request sites (release metadata, checksum fetch, archive download) through it. It attaches the token as before — so private and rate-limited repos still authenticate — but if an authenticated request comes back `401`, it retries **once anonymously** without the `Authorization` header.

## Testing

- New regression test `TestResolveGitHubReleaseRetriesAnonymouslyOnStaleToken` asserts exactly one authenticated attempt followed by one anonymous retry, and that the `401` no longer surfaces.
- `go vet ./internal/plugin/` and the full `internal/plugin` test suite pass.

## Reviewer notes

- Workaround for affected users until this ships: `env -u GITHUB_TOKEN -u GH_TOKEN -u GITHUB_AUTH_TOKEN -u BOMLY_GITHUB_TOKEN bomly plugin install github:...`.
- The retry only fires on `401` with an attached token; non-GitHub direct-URL installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release downloads to retry once without authentication if a token is invalid or expired, helping downloads continue instead of failing immediately.
  * Kept checksum and asset selection behavior unchanged while making release retrieval more resilient.
  * Added coverage for the fallback behavior to verify stale-token handling works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->