### PR TITLE
Show persisted findings in diff text output

### DIFF
--- a/internal/cli/diff_cmd_test.go
+++ b/internal/cli/diff_cmd_test.go
@@ -33,7 +33,7 @@ func TestRenderDiffTextShowsFindingsSummaryLine(t *testing.T) {
 	}
 
 	report := render.StripANSI(out.String())
-	if !strings.Contains(report, "No new findings introduced.") {
+	if !strings.Contains(report, "No findings introduced or persisted.") {
 		t.Fatalf("expected findings summary line, got:\n%s", report)
 	}
 	// Removed sections should not appear
@@ -121,6 +121,61 @@ func TestRenderDiffTextShowsHighFindingsWhenIntroduced(t *testing.T) {
 	report := render.StripANSI(out.String())
 	if !strings.Contains(report, "2 new finding(s) introduced.") {
 		t.Fatalf("expected high-severity count line, got:\n%s", report)
+	}
+}
+
+func TestRenderDiffTextShowsPersistedFindings(t *testing.T) {
+	payload := output.DiffResponse{
+		Audit: &output.DiffAudit{
+			Persisted: []output.AuditFinding{
+				{ID: "CVE-2024-1234", Severity: "high", Package: output.PackageRef{Name: "minimist", Version: "0.0.10"}},
+				{ID: "CVE-2024-5678", Severity: "medium", Package: output.PackageRef{Name: "minimist", Version: "1.2.8"}},
+			},
+		},
+	}
+	var out bytes.Buffer
+	if err := render.Diff(&out, payload); err != nil {
+		t.Fatalf("render.Diff() error = %v", err)
+	}
+	report := render.StripANSI(out.String())
+	for _, want := range []string{
+		"2 finding(s) persisted.",
+		"persisted  [HIGH]      CVE-2024-1234  minimist@0.0.10",
+		"persisted  [MEDIUM]    CVE-2024-5678  minimist@1.2.8",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("expected text report to contain %q, got:\n%s", want, report)
+		}
+	}
+	if strings.Contains(report, "No new findings introduced.") {
+		t.Fatalf("did not expect stale no-new-findings message, got:\n%s", report)
+	}
+}
+
+func TestRenderDiffTextShowsIntroducedAndPersistedFindings(t *testing.T) {
+	payload := output.DiffResponse{
+		Audit: &output.DiffAudit{
+			Introduced: []output.AuditFinding{
+				{ID: "CVE-NEW", Severity: "critical", Package: output.PackageRef{Name: "react", Version: "19.0.0"}},
+			},
+			Persisted: []output.AuditFinding{
+				{ID: "CVE-KEPT", Severity: "high", Package: output.PackageRef{Name: "minimist", Version: "1.2.8"}},
+			},
+		},
+	}
+	var out bytes.Buffer
+	if err := render.Diff(&out, payload); err != nil {
+		t.Fatalf("render.Diff() error = %v", err)
+	}
+	report := render.StripANSI(out.String())
+	for _, want := range []string{
+		"1 new finding(s) introduced; 1 finding(s) persisted.",
+		"introduced  [CRITICAL]  CVE-NEW",
+		"persisted   [HIGH]      CVE-KEPT",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("expected text report to contain %q, got:\n%s", want, report)
+		}
 	}
 }
 

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -71,51 +71,97 @@ func dependencyTextSections(results output.DiffDependencyResults) []string {
 	return lines
 }
 
-// findingsSummaryLine produces a summary line plus a list of each introduced
-// finding when audit data is present. N/A-severity findings (e.g. unknown
+// findingsSummaryLine produces a summary line plus a list of each introduced or
+// persisted finding when audit data is present. N/A-severity findings (e.g. unknown
 // license) are omitted — they belong in the policy section, not the compact
 // summary. The summary intentionally omits a severity qualifier so it stays
-// accurate when only low/medium findings are introduced.
+// accurate when only low/medium findings are introduced or persisted.
 func findingsSummaryLine(audit *output.DiffAudit) []string {
 	if audit == nil {
 		return nil
 	}
-	var introduced []output.AuditFinding
-	for _, f := range audit.Introduced {
-		sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
-		if sev == "n/a" || sev == "" {
-			continue
+	findings := compactAuditFindings(audit)
+	introduced, persisted := auditStatusCounts(findings)
+	if len(findings) == 0 {
+		return []string{"", Style("No findings introduced or persisted.", Gray)}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].status != findings[j].status {
+			return findings[i].status < findings[j].status
 		}
-		introduced = append(introduced, f)
-	}
-	if len(introduced) == 0 {
-		return []string{"", Style("No new findings introduced.", Gray)}
-	}
-	sort.Slice(introduced, func(i, j int) bool {
-		si := severityRankTable(string(introduced[i].Severity))
-		sj := severityRankTable(string(introduced[j].Severity))
+		si := severityRankTable(string(findings[i].finding.Severity))
+		sj := severityRankTable(string(findings[j].finding.Severity))
 		if si != sj {
 			return si < sj
 		}
-		return introduced[i].ID < introduced[j].ID
+		return findings[i].finding.ID < findings[j].finding.ID
 	})
 
 	maxIDWidth := 0
-	for _, f := range introduced {
-		if l := len(f.ID); l > maxIDWidth {
+	maxStatusWidth := 0
+	for _, item := range findings {
+		if l := len(item.finding.ID); l > maxIDWidth {
 			maxIDWidth = l
+		}
+		if l := len(item.status); l > maxStatusWidth {
+			maxStatusWidth = l
 		}
 	}
 
-	lines := []string{"", Style(fmt.Sprintf("%d new finding(s) introduced.", len(introduced)), Red)}
-	for _, f := range introduced {
+	lines := []string{"", Style(compactAuditSummary(introduced, persisted), Red)}
+	for _, item := range findings {
+		f := item.finding
 		pkg := DiffPackageDisplayName(f.Package)
 		if pkg == "" {
 			pkg = "-"
 		}
-		lines = append(lines, fmt.Sprintf("  %s  %-*s  %s", severityLabelFixed(string(f.Severity)), maxIDWidth, f.ID, pkg))
+		lines = append(lines, fmt.Sprintf("  %-*s  %s  %-*s  %s", maxStatusWidth, item.status, severityLabelFixed(string(f.Severity)), maxIDWidth, f.ID, pkg))
 	}
 	return lines
+}
+
+type compactAuditFinding struct {
+	status  string
+	finding output.AuditFinding
+}
+
+func compactAuditFindings(audit *output.DiffAudit) []compactAuditFinding {
+	var findings []compactAuditFinding
+	appendFindings := func(status string, src []output.AuditFinding) {
+		for _, f := range src {
+			sev := strings.ToLower(strings.TrimSpace(string(f.Severity)))
+			if sev == "n/a" || sev == "" {
+				continue
+			}
+			findings = append(findings, compactAuditFinding{status: status, finding: f})
+		}
+	}
+	appendFindings("introduced", audit.Introduced)
+	appendFindings("persisted", audit.Persisted)
+	return findings
+}
+
+func auditStatusCounts(findings []compactAuditFinding) (introduced, persisted int) {
+	for _, item := range findings {
+		switch item.status {
+		case "introduced":
+			introduced++
+		case "persisted":
+			persisted++
+		}
+	}
+	return introduced, persisted
+}
+
+func compactAuditSummary(introduced, persisted int) string {
+	switch {
+	case introduced > 0 && persisted > 0:
+		return fmt.Sprintf("%d new finding(s) introduced; %d finding(s) persisted.", introduced, persisted)
+	case introduced > 0:
+		return fmt.Sprintf("%d new finding(s) introduced.", introduced)
+	default:
+		return fmt.Sprintf("%d finding(s) persisted.", persisted)
+	}
 }
 
 // vulnCountsForPackageRef returns a compact coloured vuln-count string like " 1H 2M"


### PR DESCRIPTION
## Summary

- update compact text diff output to include persisted audit findings alongside introduced findings
- replace the misleading no-new-findings message when persisted findings are present
- add regressions for persisted-only and introduced-plus-persisted text diff summaries

## Root cause

Diff audit findings were split into introduced, resolved, and persisted, but the compact text renderer still only read the introduced bucket. That made persisted findings invisible in text output even though they still gate policy and remain open SARIF alerts.

## Validation

- go test ./internal/cli ./internal/cli/render ./internal/output
- make test
- git diff --check