### PR TITLE
Improve Java readiness checks for JVM scans

### DIFF
--- a/internal/analyzers/govulncheck/analyzer.go
+++ b/internal/analyzers/govulncheck/analyzer.go
@@ -49,7 +49,7 @@ func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
 // Ready reports whether the analyzer is callable. Always true; the runner
 // surfaces missing-toolchain errors at Run time as Status=Unknown rather
 // than blocking applicability.
-func (a Analyzer) Ready() bool { return true }
+func (a Analyzer) Ready(context.Context, model.AnalyzeRequest) error { return nil }
 
 // Applicable reports whether the request graph contains at least one Go
 // package with attached vulnerabilities. Without vulnerabilities to

--- a/internal/analyzers/govulncheck/testdata_test.go
+++ b/internal/analyzers/govulncheck/testdata_test.go
@@ -70,8 +70,8 @@ func TestParseGovulncheckJSONFromTestdataRecoversAfterMalformedRecord(t *testing
 
 func TestGovulncheckDescriptorAndRunnerHelpers(t *testing.T) {
 	a := Analyzer{}
-	if !a.Ready() || a.Descriptor().Name != Name {
-		t.Fatalf("descriptor = %+v ready=%v", a.Descriptor(), a.Ready())
+	if err := a.Ready(context.Background(), model.AnalyzeRequest{}); err != nil || a.Descriptor().Name != Name {
+		t.Fatalf("descriptor = %+v ready_err=%v", a.Descriptor(), a.Ready(context.Background(), model.AnalyzeRequest{}))
 	}
 	if !(Finding{OSV: "GO-1", ImportedBy: true}).hasResult() {
 		t.Fatal("imported finding should be actionable")

--- a/internal/analyzers/jsreach/analyzer.go
+++ b/internal/analyzers/jsreach/analyzer.go
@@ -55,7 +55,7 @@ func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
 // Ready reports whether the analyzer is callable. Always true; the
 // runner surfaces missing-toolchain or parser errors at Run time as
 // Status=Unknown rather than blocking applicability.
-func (a Analyzer) Ready() bool { return true }
+func (a Analyzer) Ready(context.Context, model.AnalyzeRequest) error { return nil }
 
 // Applicable reports whether the request graph contains at least one
 // npm package with attached vulnerabilities. Without vulnerabilities

--- a/internal/analyzers/jsreach/runner_testdata_test.go
+++ b/internal/analyzers/jsreach/runner_testdata_test.go
@@ -64,8 +64,8 @@ func TestJSDynamicImportDetectionFromTestdata(t *testing.T) {
 
 func TestJSDescriptorAndRunnerResult(t *testing.T) {
 	a := Analyzer{}
-	if !a.Ready() || a.Descriptor().Name != Name {
-		t.Fatalf("descriptor = %+v ready=%v", a.Descriptor(), a.Ready())
+	if err := a.Ready(context.Background(), model.AnalyzeRequest{}); err != nil || a.Descriptor().Name != Name {
+		t.Fatalf("descriptor = %+v ready_err=%v", a.Descriptor(), a.Ready(context.Background(), model.AnalyzeRequest{}))
 	}
 	if !(RunnerResult{EntryPoints: []string{"index.js"}}).hasResult() || (RunnerResult{}).hasResult() {
 		t.Fatal("runner result actionability mismatch")

--- a/internal/analyzers/jvmreach/analyzer.go
+++ b/internal/analyzers/jvmreach/analyzer.go
@@ -55,7 +55,7 @@ func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
 	}
 }
 
-func (a Analyzer) Ready() bool { return true }
+func (a Analyzer) Ready(context.Context, model.AnalyzeRequest) error { return nil }
 
 func (a Analyzer) Applicable(_ context.Context, req model.AnalyzeRequest) (bool, error) {
 	if req.Graph == nil || req.Registry == nil {

--- a/internal/analyzers/jvmreach/runner_testdata_test.go
+++ b/internal/analyzers/jvmreach/runner_testdata_test.go
@@ -54,8 +54,8 @@ func TestJVMDynamicImportDetectionFromTestdata(t *testing.T) {
 
 func TestJVMDescriptorAndRunnerResult(t *testing.T) {
 	a := Analyzer{}
-	if !a.Ready() || a.Descriptor().Name != Name {
-		t.Fatalf("descriptor = %+v ready=%v", a.Descriptor(), a.Ready())
+	if err := a.Ready(context.Background(), model.AnalyzeRequest{}); err != nil || a.Descriptor().Name != Name {
+		t.Fatalf("descriptor = %+v ready_err=%v", a.Descriptor(), a.Ready(context.Background(), model.AnalyzeRequest{}))
 	}
 	if !(RunnerResult{SourceFiles: 1}).hasResult() || (RunnerResult{}).hasResult() {
 		t.Fatal("runner result actionability mismatch")

--- a/internal/analyzers/pyreach/analyzer.go
+++ b/internal/analyzers/pyreach/analyzer.go
@@ -65,7 +65,7 @@ func (a Analyzer) Descriptor() model.AnalyzerDescriptor {
 // Ready reports whether the analyzer is callable. Always true; the
 // runner surfaces missing-source / parse errors at Run time as
 // Status=Unknown rather than blocking applicability.
-func (a Analyzer) Ready() bool { return true }
+func (a Analyzer) Ready(context.Context, model.AnalyzeRequest) error { return nil }
 
 // Applicable reports whether the request graph contains at least one
 // Python package with attached vulnerabilities.

--- a/internal/analyzers/pyreach/testdata_test.go
+++ b/internal/analyzers/pyreach/testdata_test.go
@@ -80,8 +80,8 @@ func TestPythonDynamicImportDetectionFromTestdata(t *testing.T) {
 
 func TestPythonDescriptorAndFailureReasons(t *testing.T) {
 	a := Analyzer{}
-	if !a.Ready() || a.Descriptor().Name != Name {
-		t.Fatalf("descriptor = %+v ready=%v", a.Descriptor(), a.Ready())
+	if err := a.Ready(context.Background(), model.AnalyzeRequest{}); err != nil || a.Descriptor().Name != Name {
+		t.Fatalf("descriptor = %+v ready_err=%v", a.Descriptor(), a.Ready(context.Background(), model.AnalyzeRequest{}))
 	}
 	if !(RunnerResult{SourceFiles: 1}).hasResult() || (RunnerResult{}).hasResult() {
 		t.Fatal("runner result actionability mismatch")

--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -34,8 +34,8 @@ func (a Auditor) Descriptor() sdk.AuditorDescriptor {
 	}
 }
 
-func (a Auditor) Ready() bool {
-	return true
+func (a Auditor) Ready(context.Context, sdk.AuditRequest) error {
+	return nil
 }
 
 func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -26,8 +26,8 @@ func (a Auditor) Descriptor() sdk.AuditorDescriptor {
 	}
 }
 
-func (a Auditor) Ready() bool {
-	return true
+func (a Auditor) Ready(context.Context, sdk.AuditRequest) error {
+	return nil
 }
 
 func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {

--- a/internal/auditors/vulnerability/auditor.go
+++ b/internal/auditors/vulnerability/auditor.go
@@ -21,8 +21,8 @@ func (a Auditor) Descriptor() sdk.AuditorDescriptor {
 	}
 }
 
-func (a Auditor) Ready() bool {
-	return true
+func (a Auditor) Ready(context.Context, sdk.AuditRequest) error {
+	return nil
 }
 
 func (a Auditor) Applicable(_ context.Context, req sdk.AuditRequest) (bool, error) {

--- a/internal/cli/opts/filters_test.go
+++ b/internal/cli/opts/filters_test.go
@@ -211,8 +211,8 @@ func (f fakeMatcher) Descriptor() sdk.MatcherDescriptor {
 	return f.descriptor
 }
 
-func (f fakeMatcher) Ready() bool {
-	return true
+func (f fakeMatcher) Ready(context.Context, sdk.MatchRequest) error {
+	return nil
 }
 
 func (f fakeMatcher) Applicable(context.Context, sdk.MatchRequest) (bool, error) {
@@ -235,8 +235,8 @@ func (f fakeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return nil
 }
 
-func (f fakeDetector) Ready() bool {
-	return true
+func (f fakeDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 func (f fakeDetector) Applicable(context.Context, sdk.DetectionRequest) (bool, error) {
@@ -255,8 +255,8 @@ func (f fakeAuditor) Descriptor() sdk.AuditorDescriptor {
 	return f.descriptor
 }
 
-func (f fakeAuditor) Ready() bool {
-	return true
+func (f fakeAuditor) Ready(context.Context, sdk.AuditRequest) error {
+	return nil
 }
 
 func (f fakeAuditor) Applicable(context.Context, sdk.AuditRequest) (bool, error) {
@@ -275,8 +275,8 @@ func (f fakeAnalyzer) Descriptor() sdk.AnalyzerDescriptor {
 	return f.descriptor
 }
 
-func (f fakeAnalyzer) Ready() bool {
-	return true
+func (f fakeAnalyzer) Ready(context.Context, sdk.AnalyzeRequest) error {
+	return nil
 }
 
 func (f fakeAnalyzer) Applicable(context.Context, sdk.AnalyzeRequest) (bool, error) {

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -519,8 +519,8 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		info := detectorPluginInfo(&d, coreVersion, reg.DefaultEnabledDetectorNames(), string(reg.DetectorOrigin(d.Name)))
 		if det, ok := detectorInstances[d.Name]; ok {
 			det := det
-			info.ReadyFn = func(_ context.Context) (bool, string, error) {
-				return det.Ready(), "detector-ready", nil
+			info.ReadyFn = func(ctx context.Context) (bool, string, error) {
+				return det.Ready(ctx, plugschema.DetectionRequest{}) == nil, "detector-ready", nil
 			}
 		}
 		infos = append(infos, info)
@@ -544,8 +544,8 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		info := detectorPluginInfo(&d, coreVersion, reg.DefaultEnabledDetectorNames(), string(reg.DetectorOrigin(d.Name)))
 		if det, ok := detectorInstances[d.Name]; ok {
 			det := det
-			info.ReadyFn = func(_ context.Context) (bool, string, error) {
-				return det.Ready(), "detector-ready", nil
+			info.ReadyFn = func(ctx context.Context) (bool, string, error) {
+				return det.Ready(ctx, plugschema.DetectionRequest{}) == nil, "detector-ready", nil
 			}
 		}
 		infos = append(infos, info)
@@ -556,8 +556,8 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		info := matcherPluginInfo(&d, coreVersion, reg.DefaultEnabledMatcherNames())
 		if m, ok := matcherInstances[d.Name]; ok {
 			m := m
-			info.ReadyFn = func(_ context.Context) (bool, string, error) {
-				return m.Ready(), "matcher-ready", nil
+			info.ReadyFn = func(ctx context.Context) (bool, string, error) {
+				return m.Ready(ctx, plugschema.MatchRequest{}) == nil, "matcher-ready", nil
 			}
 		}
 		infos = append(infos, info)
@@ -567,8 +567,8 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		info := auditorPluginInfo(&d, coreVersion, reg.DefaultEnabledAuditorNames())
 		if a, ok := auditorInstances[d.Name]; ok {
 			a := a
-			info.ReadyFn = func(_ context.Context) (bool, string, error) {
-				return a.Ready(), "auditor-ready", nil
+			info.ReadyFn = func(ctx context.Context) (bool, string, error) {
+				return a.Ready(ctx, plugschema.AuditRequest{}) == nil, "auditor-ready", nil
 			}
 		}
 		infos = append(infos, info)
@@ -578,8 +578,8 @@ func builtInPluginInfos(current config.Resolved, coreVersion string) []managedpl
 		info := analyzerPluginInfo(&d, coreVersion, reg.DefaultEnabledAnalyzerNames())
 		if a, ok := analyzerInstances[d.Name]; ok {
 			a := a
-			info.ReadyFn = func(_ context.Context) (bool, string, error) {
-				return a.Ready(), "analyzer-ready", nil
+			info.ReadyFn = func(ctx context.Context) (bool, string, error) {
+				return a.Ready(ctx, plugschema.AnalyzeRequest{}) == nil, "analyzer-ready", nil
 			}
 		}
 		infos = append(infos, info)

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -56,12 +56,35 @@ func buildSharedTestHelpers(dir string) error {
 	}
 	fakeGradleBinPath = gradlePath
 
+	javaPath := filepath.Join(dir, executableName("java"))
+	if err := buildHelperBinary(dir, javaPath, fakeJavaSource()); err != nil {
+		return err
+	}
+
 	goPath := filepath.Join(dir, executableName("go"))
 	if err := buildHelperBinary(dir, goPath, fakeGoSource()); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func fakeJavaSource() string {
+	return `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if os.Getenv("BOMLY_FAKE_JAVA_FAIL") == "1" {
+		fmt.Fprintln(os.Stderr, "The operation couldn't be completed. Unable to locate a Java Runtime.")
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stderr, "openjdk version \"21-test\"")
+}
+`
 }
 
 func executableName(base string) string {
@@ -2589,6 +2612,48 @@ func TestRoot_ScanCommand_MavenSBOMJSONOutput(t *testing.T) {
 	}
 }
 
+func TestRoot_ScanCommand_MavenMissingJavaReturnsResolutionFailure(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tempHome)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "pom.xml"), []byte("<project/>\n"), 0o644); err != nil {
+		t.Fatalf("write pom.xml: %v", err)
+	}
+	binDir := t.TempDir()
+	writeFakeMavenScript(t, binDir, "mvn", "")
+	writeFakeJavaScript(t, binDir, true)
+	t.Setenv("PATH", binDir)
+
+	root, err := newRootCmd("0.9.0-test")
+	if err != nil {
+		t.Fatalf("newRootCmd() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"scan", "--path", projectDir, "--ecosystems", "maven", "--detectors", "maven-detector", "--format", "json"})
+
+	err = root.Execute()
+	if err == nil {
+		t.Fatal("expected scan to fail when Java is unavailable")
+	}
+	if got := exit.Code(err); got != 3 {
+		t.Fatalf("expected resolution failure exit code 3, got %d (err=%v)", got, err)
+	}
+	if !strings.Contains(err.Error(), "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime message in error, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on resolution failure, got %q", stdout.String())
+	}
+}
+
 func TestRoot_WhyCommand_GoModules_JSONOutput(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
@@ -2722,6 +2787,7 @@ func setFakeMavenOnPath(t *testing.T, mavenTGF string) {
 	t.Helper()
 	binDir := t.TempDir()
 	writeFakeMavenScript(t, binDir, "mvn", mavenTGF)
+	writeFakeJavaScript(t, binDir, false)
 	separator := string(os.PathListSeparator)
 	pathEnv := binDir
 	if existing := os.Getenv("PATH"); existing != "" {
@@ -2733,10 +2799,13 @@ func setFakeMavenOnPath(t *testing.T, mavenTGF string) {
 func writeFakeMavenWrapper(t *testing.T, projectDir, mavenTGF string) {
 	t.Helper()
 	writeFakeMavenScript(t, projectDir, "mvnw", mavenTGF)
+	writeFakeJavaScript(t, projectDir, false)
+	prependPath(t, projectDir)
 }
 
 func setFakeGradleOnPath(t *testing.T, gradleOutput string) {
 	t.Helper()
+	t.Setenv("BOMLY_FAKE_JAVA_FAIL", "")
 	t.Setenv("BOMLY_FAKE_GRADLE_FAIL", "")
 	t.Setenv("BOMLY_FAKE_GRADLE_OUTPUT", gradleOutput)
 	t.Setenv("BOMLY_FAKE_GRADLE_OUTPUT_FILE", "")
@@ -2745,6 +2814,7 @@ func setFakeGradleOnPath(t *testing.T, gradleOutput string) {
 
 func setFailingFakeGradleOnPath(t *testing.T) {
 	t.Helper()
+	t.Setenv("BOMLY_FAKE_JAVA_FAIL", "")
 	t.Setenv("BOMLY_FAKE_GRADLE_FAIL", "1")
 	t.Setenv("BOMLY_FAKE_GRADLE_OUTPUT", "")
 	t.Setenv("BOMLY_FAKE_GRADLE_OUTPUT_FILE", "")
@@ -2753,6 +2823,9 @@ func setFailingFakeGradleOnPath(t *testing.T) {
 
 func writeFakeGradleWrapper(t *testing.T, projectDir, gradleOutput string) {
 	t.Helper()
+	writeFakeJavaScript(t, projectDir, false)
+	prependPath(t, projectDir)
+
 	outputFile := filepath.Join(projectDir, "gradle-dependencies.txt")
 	if err := os.WriteFile(outputFile, []byte(gradleOutput), 0o644); err != nil {
 		t.Fatalf("write fake gradle output: %v", err)
@@ -2801,6 +2874,34 @@ func writeFakeMavenScript(t *testing.T, dir, baseName, mavenTGF string) {
 	if runtime.GOOS != "windows" {
 		if err := os.Chmod(scriptPath, 0o755); err != nil {
 			t.Fatalf("chmod fake maven script: %v", err)
+		}
+	}
+}
+
+func writeFakeJavaScript(t *testing.T, dir string, fail bool) {
+	t.Helper()
+	scriptPath := filepath.Join(dir, "java")
+	if runtime.GOOS == "windows" {
+		scriptPath += ".cmd"
+	}
+	var script string
+	if runtime.GOOS == "windows" {
+		if fail {
+			script = "@echo off\r\necho The operation couldn't be completed. Unable to locate a Java Runtime. 1>&2\r\nexit /b 1\r\n"
+		} else {
+			script = "@echo off\r\necho openjdk version \"21-test\" 1>&2\r\n"
+		}
+	} else if fail {
+		script = "#!/bin/sh\necho \"The operation couldn't be completed. Unable to locate a Java Runtime.\" >&2\nexit 1\n"
+	} else {
+		script = "#!/bin/sh\necho 'openjdk version \"21-test\"' >&2\n"
+	}
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake java script: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(scriptPath, 0o755); err != nil {
+			t.Fatalf("chmod fake java script: %v", err)
 		}
 	}
 }

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -77,8 +77,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether Cargo is available.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether Cargo manifests are present.

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -45,8 +45,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed Podfile.lock files can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether Podfile.lock is present.

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -48,8 +48,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector can run in the current environment.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether a Composer lockfile is present.

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -63,8 +63,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed Conan files can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether Conan files are present.

--- a/internal/detectors/githubactions/detector.go
+++ b/internal/detectors/githubactions/detector.go
@@ -48,8 +48,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector can run in the current environment.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether GitHub workflow or local action manifests are present.

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -77,9 +77,9 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the Go CLI is available.
-func (d Detector) Ready() bool {
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := goExecLookPath("go")
-	return err == nil
+	return detectors.CommandNotReadyError("go", err)
 }
 
 // Applicable reports whether the target project contains a go.mod file.

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -35,13 +35,32 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGradle, evidencePatterns...)}
 }
 
+// WithWorkingDir returns a copy of the detector scoped to workingDir.
+func (d Detector) WithWorkingDir(workingDir string) sdk.Detector {
+	d.WorkingDir = workingDir
+	return d
+}
+
 // Ready returns true if a Gradle wrapper is present for the project or gradle is on PATH.
 func (d Detector) Ready() bool {
-	if d.WorkingDir == "" {
-		return true
+	return d.ReadyReason() == ""
+}
+
+// ReadyReason returns the reason the Gradle detector is not ready.
+func (d Detector) ReadyReason() string {
+	workingDir := d.WorkingDir
+	executableName := "gradle"
+	if workingDir == "" {
+		if _, err := system.LookPath(executableName); err != nil {
+			return detectors.CommandReadyReason(executableName, err)
+		}
+	} else if _, _, err := d.commandSpec(workingDir); err != nil {
+		return detectors.CommandReadyReason(executableName, err)
 	}
-	_, _, err := d.commandSpec(d.WorkingDir)
-	return err == nil
+	if ok, reason := detectors.JavaReady(); !ok {
+		return reason
+	}
+	return ""
 }
 
 // Applicable returns true when the project looks like a Gradle build.
@@ -79,8 +98,8 @@ func (d Detector) Descriptor() sdk.DetectorDescriptor {
 }
 
 // ResolveGraph resolves a Gradle dependency graph for the scan engine.
-func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
-	depsGraph, err := d.resolveGraph(req.Stderr, req.ProjectPath, req.Verbose, req.ScopeFilter)
+func (d Detector) ResolveGraph(ctx context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
+	depsGraph, err := d.resolveGraph(ctx, req.Stderr, req.ProjectPath, req.Verbose, req.ScopeFilter)
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
@@ -101,7 +120,7 @@ func (d Detector) FallbackDetector() sdk.Detector {
 	return d.Fallback
 }
 
-func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose bool, scopeFilter sdk.Scope) (*sdk.Graph, error) {
+func (d Detector) resolveGraph(ctx context.Context, stderr io.Writer, projectPath string, verbose bool, scopeFilter sdk.Scope) (*sdk.Graph, error) {
 	logger := d.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -118,7 +137,7 @@ func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose boo
 	}
 
 	if scopedArgs := gradleScopedDependenciesArgs(args, scopeFilter); len(scopedArgs) > 0 {
-		depsGraph, err := d.runDependencies(stderr, workingDir, verbose, executable, scopedArgs)
+		depsGraph, err := d.runDependencies(ctx, stderr, workingDir, verbose, executable, scopedArgs)
 		if err == nil {
 			return depsGraph, nil
 		}
@@ -130,16 +149,16 @@ func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose boo
 		)
 	}
 
-	return d.runDependencies(stderr, workingDir, verbose, executable, args)
+	return d.runDependencies(ctx, stderr, workingDir, verbose, executable, args)
 }
 
-func (d Detector) runDependencies(stderr io.Writer, workingDir string, verbose bool, executable string, args []string) (*sdk.Graph, error) {
+func (d Detector) runDependencies(ctx context.Context, stderr io.Writer, workingDir string, verbose bool, executable string, args []string) (*sdk.Graph, error) {
 	logger := d.Logger
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	cmd := system.Command(executable, args...)
+	cmd := system.CommandContext(ctx, executable, args...)
 	cmd.Dir = workingDir
 	commandStderr := logging.NewCommandStderr(stderr, verbose)
 	cmd.Stderr = commandStderr
@@ -441,7 +460,7 @@ func scopeFromGradleConfiguration(value string) sdk.Scope {
 }
 
 // Install prepares Gradle dependencies before graph resolution.
-func (d Detector) Install(_ context.Context, req sdk.DetectionRequest) error {
+func (d Detector) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	logger := d.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -455,7 +474,7 @@ func (d Detector) Install(_ context.Context, req sdk.DetectionRequest) error {
 		return fmt.Errorf("resolve gradle command: %w", err)
 	}
 	args = append(args, req.InstallArgs...)
-	cmd := system.Command(executable, args...)
+	cmd := system.CommandContext(ctx, executable, args...)
 	cmd.Dir = workingDir
 	commandStderr := logging.NewCommandStderr(req.Stderr, req.Verbose)
 	cmd.Stderr = commandStderr

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -35,32 +35,22 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerGradle, evidencePatterns...)}
 }
 
-// WithWorkingDir returns a copy of the detector scoped to workingDir.
-func (d Detector) WithWorkingDir(workingDir string) sdk.Detector {
-	d.WorkingDir = workingDir
-	return d
-}
-
-// Ready returns true if a Gradle wrapper is present for the project or gradle is on PATH.
-func (d Detector) Ready() bool {
-	return d.ReadyReason() == ""
-}
-
-// ReadyReason returns the reason the Gradle detector is not ready.
-func (d Detector) ReadyReason() string {
+// Ready returns nil when a Gradle wrapper is present for the request's working
+// directory (or gradle is on PATH) and a usable Java runtime is available.
+func (d Detector) Ready(ctx context.Context, req sdk.DetectionRequest) error {
+	const executableName = "gradle"
 	workingDir := d.WorkingDir
-	executableName := "gradle"
+	if workingDir == "" {
+		workingDir = detectors.RequestWorkingDir(req)
+	}
 	if workingDir == "" {
 		if _, err := system.LookPath(executableName); err != nil {
-			return detectors.CommandReadyReason(executableName, err)
+			return detectors.CommandNotReadyError(executableName, err)
 		}
 	} else if _, _, err := d.commandSpec(workingDir); err != nil {
-		return detectors.CommandReadyReason(executableName, err)
+		return detectors.CommandNotReadyError(executableName, err)
 	}
-	if ok, reason := detectors.JavaReady(); !ok {
-		return reason
-	}
-	return ""
+	return detectors.JavaReady(ctx)
 }
 
 // Applicable returns true when the project looks like a Gradle build.

--- a/internal/detectors/gradle/detector_test.go
+++ b/internal/detectors/gradle/detector_test.go
@@ -93,11 +93,12 @@ func TestDetectorReadyRequiresJava(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := Detector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without a usable Java runtime")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
-		t.Fatalf("expected Java runtime reason, got %q", reason)
+	if !strings.Contains(err.Error(), "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", err)
 	}
 }
 
@@ -107,11 +108,12 @@ func TestDetectorReadyRequiresGradleRunner(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := Detector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without gradle")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "gradle executable not found") {
-		t.Fatalf("expected missing gradle reason, got %q", reason)
+	if !strings.Contains(err.Error(), "gradle executable not found") {
+		t.Fatalf("expected missing gradle reason, got %q", err)
 	}
 }
 
@@ -122,9 +124,9 @@ func TestDetectorReadyWithWrapperAndJava(t *testing.T) {
 	writeExecutable(t, binDir, "java", successScript())
 	t.Setenv("PATH", binDir)
 
-	detector := Detector{WorkingDir: projectDir}
-	if !detector.Ready() {
-		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
+	detector := Detector{}
+	if err := detector.Ready(context.Background(), sdk.DetectionRequest{ProjectPath: projectDir}); err != nil {
+		t.Fatalf("expected detector to be ready, got %v", err)
 	}
 }
 

--- a/internal/detectors/gradle/detector_test.go
+++ b/internal/detectors/gradle/detector_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -82,6 +83,48 @@ func TestDetectorCommandSpec_MakesUnixWrapperExecutable(t *testing.T) {
 	}
 	if info.Mode()&0o111 == 0 {
 		t.Fatalf("expected wrapper to be executable, mode=%#o", info.Mode().Perm())
+	}
+}
+
+func TestDetectorReadyRequiresJava(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "gradle", successScript())
+	writeExecutable(t, binDir, "java", failingJavaScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without a usable Java runtime")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", reason)
+	}
+}
+
+func TestDetectorReadyRequiresGradleRunner(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without gradle")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "gradle executable not found") {
+		t.Fatalf("expected missing gradle reason, got %q", reason)
+	}
+}
+
+func TestDetectorReadyWithWrapperAndJava(t *testing.T) {
+	projectDir := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, projectDir, "gradlew", successScript())
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{WorkingDir: projectDir}
+	if !detector.Ready() {
+		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
 	}
 }
 
@@ -236,7 +279,7 @@ func TestRunDependencies_UsesSettingsGradleRootName(t *testing.T) {
 		t.Fatalf("write gradle fixture: %v", err)
 	}
 
-	g, err := (Detector{}).runDependencies(&bytes.Buffer{}, projectDir, false, gradlePath, nil)
+	g, err := (Detector{}).runDependencies(context.Background(), &bytes.Buffer{}, projectDir, false, gradlePath, nil)
 	if err != nil {
 		t.Fatalf("runDependencies() error = %v", err)
 	}
@@ -246,4 +289,35 @@ func TestRunDependencies_UsesSettingsGradleRootName(t *testing.T) {
 	if _, ok := g.Node(filepath.Base(projectDir)); ok {
 		t.Fatalf("did not expect temp directory root node")
 	}
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("chmod executable %s: %v", name, err)
+		}
+	}
+	return path
+}
+
+func successScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho ok 1>&2\r\n"
+	}
+	return "#!/bin/sh\necho ok >&2\n"
+}
+
+func failingJavaScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho The operation couldn't be completed. Unable to locate a Java Runtime. 1>&2\r\nexit /b 1\r\n"
+	}
+	return "#!/bin/sh\necho \"The operation couldn't be completed. Unable to locate a Java Runtime.\" >&2\nexit 1\n"
 }

--- a/internal/detectors/java_ready.go
+++ b/internal/detectors/java_ready.go
@@ -14,39 +14,43 @@ import (
 
 const javaReadyTimeout = 5 * time.Second
 
-// JavaReady verifies that a Java runtime is available for JVM build tools.
-func JavaReady() (bool, string) {
+// JavaReady verifies that a Java runtime is available for JVM build tools. It
+// returns nil when a runtime is usable and a non-nil error describing the
+// reason otherwise. The probe is bound to ctx and additionally guarded by an
+// internal timeout so a hung `java` cannot stall a scan.
+func JavaReady(ctx context.Context) error {
 	if _, err := system.LookPath("java"); err != nil {
-		return false, "java executable not found on PATH"
+		return errors.New("java executable not found on PATH")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), javaReadyTimeout)
+	probeCtx, cancel := context.WithTimeout(ctx, javaReadyTimeout)
 	defer cancel()
 
-	cmd := system.CommandContext(ctx, "java", "-version")
+	cmd := system.CommandContext(probeCtx, "java", "-version")
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Run(); err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return false, fmt.Sprintf("java readiness check timed out after %s", javaReadyTimeout)
+		if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("java readiness check timed out after %s", javaReadyTimeout)
 		}
 		message := strings.TrimSpace(output.String())
 		if message == "" {
 			message = err.Error()
 		}
-		return false, "java runtime is unavailable: " + message
+		return fmt.Errorf("java runtime is unavailable: %s", message)
 	}
-	return true, ""
+	return nil
 }
 
-// CommandReadyReason returns a compact readiness message for missing tools.
-func CommandReadyReason(name string, err error) string {
+// CommandNotReadyError returns a compact readiness error for a missing tool, or
+// nil when err is nil.
+func CommandNotReadyError(name string, err error) error {
 	if err == nil {
-		return ""
+		return nil
 	}
 	if errors.Is(err, exec.ErrNotFound) {
-		return fmt.Sprintf("%s executable not found on PATH", name)
+		return fmt.Errorf("%s executable not found on PATH", name)
 	}
-	return fmt.Sprintf("resolve %s executable: %v", name, err)
+	return fmt.Errorf("resolve %s executable: %w", name, err)
 }

--- a/internal/detectors/java_ready.go
+++ b/internal/detectors/java_ready.go
@@ -1,0 +1,52 @@
+package detectors
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/bomly-dev/bomly-cli/internal/system"
+)
+
+const javaReadyTimeout = 5 * time.Second
+
+// JavaReady verifies that a Java runtime is available for JVM build tools.
+func JavaReady() (bool, string) {
+	if _, err := system.LookPath("java"); err != nil {
+		return false, "java executable not found on PATH"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), javaReadyTimeout)
+	defer cancel()
+
+	cmd := system.CommandContext(ctx, "java", "-version")
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return false, fmt.Sprintf("java readiness check timed out after %s", javaReadyTimeout)
+		}
+		message := strings.TrimSpace(output.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return false, "java runtime is unavailable: " + message
+	}
+	return true, ""
+}
+
+// CommandReadyReason returns a compact readiness message for missing tools.
+func CommandReadyReason(name string, err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return fmt.Sprintf("%s executable not found on PATH", name)
+	}
+	return fmt.Sprintf("resolve %s executable: %v", name, err)
+}

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -50,13 +50,26 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerMaven, evidencePatterns...)}
 }
 
+// WithWorkingDir returns a copy of the detector scoped to workingDir.
+func (d Detector) WithWorkingDir(workingDir string) sdk.Detector {
+	d.WorkingDir = workingDir
+	return d
+}
+
 // Ready reports whether a Maven wrapper is present or Maven is installed.
 func (d Detector) Ready() bool {
-	if d.WorkingDir == "" {
-		return true
+	return d.ReadyReason() == ""
+}
+
+// ReadyReason returns the reason the Maven detector is not ready.
+func (d Detector) ReadyReason() string {
+	if _, _, err := d.resolveRunner(); err != nil {
+		return detectors.CommandReadyReason("mvn", err)
 	}
-	_, _, err := d.resolveRunner()
-	return err == nil
+	if ok, reason := detectors.JavaReady(); !ok {
+		return reason
+	}
+	return ""
 }
 
 // Applicable reports whether the project looks like a Maven project.
@@ -85,8 +98,8 @@ func (d Detector) Descriptor() sdk.DetectorDescriptor {
 }
 
 // ResolveGraph resolves a Maven dependency graph for the scan engine.
-func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
-	depsGraph, err := d.resolveGraph(req.Stderr, req.ProjectPath, req.Verbose, req.ScopeFilter)
+func (d Detector) ResolveGraph(ctx context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
+	depsGraph, err := d.resolveGraph(ctx, req.Stderr, req.ProjectPath, req.Verbose, req.ScopeFilter)
 	if err != nil {
 		return sdk.DetectionResult{}, err
 	}
@@ -107,7 +120,7 @@ func (d Detector) FallbackDetector() sdk.Detector {
 	return d.Fallback
 }
 
-func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose bool, scopeFilter sdk.Scope) (*sdk.Graph, error) {
+func (d Detector) resolveGraph(ctx context.Context, stderr io.Writer, projectPath string, verbose bool, scopeFilter sdk.Scope) (*sdk.Graph, error) {
 	logger := d.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -119,7 +132,7 @@ func (d Detector) resolveGraph(stderr io.Writer, projectPath string, verbose boo
 	}
 
 	args := mavenDependencyTreeArgs(prefixArgs, scopeFilter)
-	cmd := system.Command(executable, args...)
+	cmd := system.CommandContext(ctx, executable, args...)
 	cmd.Dir = projectPath
 	if d.WorkingDir != "" {
 		cmd.Dir = d.WorkingDir
@@ -415,7 +428,7 @@ func scopeFromMavenScope(value string) sdk.Scope {
 }
 
 // Install prepares Maven dependencies before graph resolution.
-func (d Detector) Install(_ context.Context, req sdk.DetectionRequest) error {
+func (d Detector) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	logger := d.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -426,7 +439,7 @@ func (d Detector) Install(_ context.Context, req sdk.DetectionRequest) error {
 	}
 	args := append(prefixArgs, "dependency:resolve")
 	args = append(args, req.InstallArgs...)
-	cmd := system.Command(executable, args...)
+	cmd := system.CommandContext(ctx, executable, args...)
 	cmd.Dir = req.ProjectPath
 	if d.WorkingDir != "" {
 		cmd.Dir = d.WorkingDir

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -50,26 +50,13 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerMaven, evidencePatterns...)}
 }
 
-// WithWorkingDir returns a copy of the detector scoped to workingDir.
-func (d Detector) WithWorkingDir(workingDir string) sdk.Detector {
-	d.WorkingDir = workingDir
-	return d
-}
-
-// Ready reports whether a Maven wrapper is present or Maven is installed.
-func (d Detector) Ready() bool {
-	return d.ReadyReason() == ""
-}
-
-// ReadyReason returns the reason the Maven detector is not ready.
-func (d Detector) ReadyReason() string {
-	if _, _, err := d.resolveRunner(); err != nil {
-		return detectors.CommandReadyReason("mvn", err)
+// Ready reports whether a Maven wrapper is present or Maven is installed and a
+// usable Java runtime is available for the request's working directory.
+func (d Detector) Ready(ctx context.Context, req sdk.DetectionRequest) error {
+	if _, _, err := d.resolveRunner(detectors.RequestWorkingDir(req)); err != nil {
+		return detectors.CommandNotReadyError("mvn", err)
 	}
-	if ok, reason := detectors.JavaReady(); !ok {
-		return reason
-	}
-	return ""
+	return detectors.JavaReady(ctx)
 }
 
 // Applicable reports whether the project looks like a Maven project.

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -168,6 +168,48 @@ func TestMavenDetectorApplicable(t *testing.T) {
 	}
 }
 
+func TestMavenDetectorReadyRequiresJava(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "mvn", successScript())
+	writeExecutable(t, binDir, "java", failingJavaScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without a usable Java runtime")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", reason)
+	}
+}
+
+func TestMavenDetectorReadyRequiresMavenRunner(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without mvn")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "mvn executable not found") {
+		t.Fatalf("expected missing mvn reason, got %q", reason)
+	}
+}
+
+func TestMavenDetectorReadyWithWrapperAndJava(t *testing.T) {
+	projectDir := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, projectDir, "mvnw", successScript())
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := Detector{WorkingDir: projectDir}
+	if !detector.Ready() {
+		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
+	}
+}
+
 func TestMavenDependencyTreeArgsScopeFilter(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -241,6 +283,37 @@ func TestMavenDetectorResolveRunner_PrefersWrapper(t *testing.T) {
 	if len(prefixArgs) != 0 {
 		t.Fatalf("expected no prefix args for unix wrapper, got %#v", prefixArgs)
 	}
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("chmod executable %s: %v", name, err)
+		}
+	}
+	return path
+}
+
+func successScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho ok 1>&2\r\n"
+	}
+	return "#!/bin/sh\necho ok >&2\n"
+}
+
+func failingJavaScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho The operation couldn't be completed. Unable to locate a Java Runtime. 1>&2\r\nexit /b 1\r\n"
+	}
+	return "#!/bin/sh\necho \"The operation couldn't be completed. Unable to locate a Java Runtime.\" >&2\nexit 1\n"
 }
 
 func TestMavenDetectorResolveRunner_MakesUnixWrapperExecutable(t *testing.T) {

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -175,11 +175,12 @@ func TestMavenDetectorReadyRequiresJava(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := Detector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without a usable Java runtime")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
-		t.Fatalf("expected Java runtime reason, got %q", reason)
+	if !strings.Contains(err.Error(), "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", err)
 	}
 }
 
@@ -189,11 +190,12 @@ func TestMavenDetectorReadyRequiresMavenRunner(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := Detector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without mvn")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "mvn executable not found") {
-		t.Fatalf("expected missing mvn reason, got %q", reason)
+	if !strings.Contains(err.Error(), "mvn executable not found") {
+		t.Fatalf("expected missing mvn reason, got %q", err)
 	}
 }
 
@@ -204,9 +206,9 @@ func TestMavenDetectorReadyWithWrapperAndJava(t *testing.T) {
 	writeExecutable(t, binDir, "java", successScript())
 	t.Setenv("PATH", binDir)
 
-	detector := Detector{WorkingDir: projectDir}
-	if !detector.Ready() {
-		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
+	detector := Detector{}
+	if err := detector.Ready(context.Background(), sdk.DetectionRequest{ProjectPath: projectDir}); err != nil {
+		t.Fatalf("expected detector to be ready, got %v", err)
 	}
 }
 

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -48,8 +48,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed Mix files can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether Mix files are present.

--- a/internal/detectors/node/common_test.go
+++ b/internal/detectors/node/common_test.go
@@ -320,8 +320,8 @@ func TestLockfileDetectorsDoNotRequirePackageManagerBinaries(t *testing.T) {
 		"pnpm": pnpm.LockfileDetector{},
 		"yarn": yarn.LockfileDetector{},
 	} {
-		if !detector.Ready() {
-			t.Fatalf("expected %s lockfile detector to be ready without package manager on PATH", name)
+		if err := detector.Ready(context.Background(), sdk.DetectionRequest{}); err != nil {
+			t.Fatalf("expected %s lockfile detector to be ready without package manager on PATH: %v", name, err)
 		}
 	}
 
@@ -395,8 +395,8 @@ func (d *installRecorderDetector) PackageManagerSupport() []sdk.PackageManagerSu
 	return nil
 }
 
-func (d *installRecorderDetector) Ready() bool {
-	return true
+func (d *installRecorderDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 func (d *installRecorderDetector) Applicable(context.Context, sdk.DetectionRequest) (bool, error) {

--- a/internal/detectors/node/npm/npm_lockfile.go
+++ b/internal/detectors/node/npm/npm_lockfile.go
@@ -28,8 +28,8 @@ func (d LockfileDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether npm is available.
-func (d LockfileDetector) Ready() bool {
-	return true
+func (d LockfileDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether an npm lockfile is present.

--- a/internal/detectors/node/npm/npm_native.go
+++ b/internal/detectors/node/npm/npm_native.go
@@ -24,9 +24,9 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether npm is available.
-func (d NativeDetector) Ready() bool {
+func (d NativeDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("npm")
-	return err == nil
+	return detectors.CommandNotReadyError("npm", err)
 }
 
 // Applicable reports whether npm manifests are present.

--- a/internal/detectors/node/pnpm/pnpm_lockfile.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile.go
@@ -28,8 +28,8 @@ func (d LockfileDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether pnpm is available.
-func (d LockfileDetector) Ready() bool {
-	return true
+func (d LockfileDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether a pnpm lockfile is present.

--- a/internal/detectors/node/pnpm/pnpm_native.go
+++ b/internal/detectors/node/pnpm/pnpm_native.go
@@ -24,9 +24,9 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether pnpm is available.
-func (d NativeDetector) Ready() bool {
+func (d NativeDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("pnpm")
-	return err == nil
+	return detectors.CommandNotReadyError("pnpm", err)
 }
 
 // Applicable reports whether pnpm manifests are present.

--- a/internal/detectors/node/yarn/yarn_lockfile.go
+++ b/internal/detectors/node/yarn/yarn_lockfile.go
@@ -28,8 +28,8 @@ func (d LockfileDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether Yarn is available.
-func (d LockfileDetector) Ready() bool {
-	return true
+func (d LockfileDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether a Yarn lockfile is present.

--- a/internal/detectors/node/yarn/yarn_native.go
+++ b/internal/detectors/node/yarn/yarn_native.go
@@ -24,9 +24,9 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether Yarn is available.
-func (d NativeDetector) Ready() bool {
+func (d NativeDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("yarn")
-	return err == nil
+	return detectors.CommandNotReadyError("yarn", err)
 }
 
 // Applicable reports whether Yarn manifests are present.

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -82,8 +82,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector can parse committed NuGet files.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether a NuGet lockfile, legacy packages.config, or project file is present.

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -48,8 +48,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed pub lockfiles can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether pub manifests are present.

--- a/internal/detectors/pub/pub_native.go
+++ b/internal/detectors/pub/pub_native.go
@@ -29,9 +29,9 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the dart binary is available.
-func (d NativeDetector) Ready() bool {
+func (d NativeDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("dart")
-	return err == nil
+	return detectors.CommandNotReadyError("dart", err)
 }
 
 // Applicable reports whether pub manifests are present.

--- a/internal/detectors/python/pip.go
+++ b/internal/detectors/python/pip.go
@@ -25,9 +25,9 @@ func (d PipDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether a Python interpreter is available.
-func (d PipDetector) Ready() bool {
+func (d PipDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := pythonCommand()
-	return err == nil
+	return detectors.CommandNotReadyError("python", err)
 }
 
 // Applicable reports whether pip-style manifests are present.

--- a/internal/detectors/python/pipenv.go
+++ b/internal/detectors/python/pipenv.go
@@ -29,9 +29,9 @@ func (d PipenvDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether Pipenv is available.
-func (d PipenvDetector) Ready() bool {
+func (d PipenvDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("pipenv")
-	return err == nil
+	return detectors.CommandNotReadyError("pipenv", err)
 }
 
 // Applicable reports whether Pipenv manifests are present.

--- a/internal/detectors/python/poetry.go
+++ b/internal/detectors/python/poetry.go
@@ -24,9 +24,9 @@ func (d PoetryDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether Poetry is available.
-func (d PoetryDetector) Ready() bool {
+func (d PoetryDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("poetry")
-	return err == nil
+	return detectors.CommandNotReadyError("poetry", err)
 }
 
 // Applicable reports whether Poetry manifests are present.

--- a/internal/detectors/python/uv.go
+++ b/internal/detectors/python/uv.go
@@ -24,9 +24,9 @@ func (d UVDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether uv is available.
-func (d UVDetector) Ready() bool {
+func (d UVDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("uv")
-	return err == nil
+	return detectors.CommandNotReadyError("uv", err)
 }
 
 // Applicable reports whether uv manifests are present.

--- a/internal/detectors/ruby/detector.go
+++ b/internal/detectors/ruby/detector.go
@@ -42,8 +42,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector can run in the current environment.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether a Bundler lockfile is present.

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -26,8 +26,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector can run in the current environment.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether the request targets an explicit SBOM file.

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -39,8 +39,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed sbt files can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether sbt build files are present.

--- a/internal/detectors/sbt/detector_test.go
+++ b/internal/detectors/sbt/detector_test.go
@@ -96,11 +96,12 @@ func TestNativeDetectorReadyRequiresJava(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := NativeDetector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without a usable Java runtime")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
-		t.Fatalf("expected Java runtime reason, got %q", reason)
+	if !strings.Contains(err.Error(), "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", err)
 	}
 }
 
@@ -110,11 +111,12 @@ func TestNativeDetectorReadyRequiresSBT(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := NativeDetector{}
-	if detector.Ready() {
+	err := detector.Ready(context.Background(), sdk.DetectionRequest{})
+	if err == nil {
 		t.Fatal("expected detector to be not ready without sbt")
 	}
-	if reason := detector.ReadyReason(); !strings.Contains(reason, "sbt executable not found") {
-		t.Fatalf("expected missing sbt reason, got %q", reason)
+	if !strings.Contains(err.Error(), "sbt executable not found") {
+		t.Fatalf("expected missing sbt reason, got %q", err)
 	}
 }
 
@@ -125,8 +127,8 @@ func TestNativeDetectorReadyWithSBTAndJava(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	detector := NativeDetector{}
-	if !detector.Ready() {
-		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
+	if err := detector.Ready(context.Background(), sdk.DetectionRequest{}); err != nil {
+		t.Fatalf("expected detector to be ready, got %v", err)
 	}
 }
 

--- a/internal/detectors/sbt/detector_test.go
+++ b/internal/detectors/sbt/detector_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -85,6 +87,78 @@ func TestNativeDetectorApplicable_SkipsOldSBTWithoutDependencyGraphPlugin(t *tes
 	if applicable {
 		t.Fatalf("expected old sbt project without dependency graph plugin to skip native detector")
 	}
+}
+
+func TestNativeDetectorReadyRequiresJava(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "sbt", successScript())
+	writeExecutable(t, binDir, "java", failingJavaScript())
+	t.Setenv("PATH", binDir)
+
+	detector := NativeDetector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without a usable Java runtime")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "Unable to locate a Java Runtime") {
+		t.Fatalf("expected Java runtime reason, got %q", reason)
+	}
+}
+
+func TestNativeDetectorReadyRequiresSBT(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := NativeDetector{}
+	if detector.Ready() {
+		t.Fatal("expected detector to be not ready without sbt")
+	}
+	if reason := detector.ReadyReason(); !strings.Contains(reason, "sbt executable not found") {
+		t.Fatalf("expected missing sbt reason, got %q", reason)
+	}
+}
+
+func TestNativeDetectorReadyWithSBTAndJava(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "sbt", successScript())
+	writeExecutable(t, binDir, "java", successScript())
+	t.Setenv("PATH", binDir)
+
+	detector := NativeDetector{}
+	if !detector.Ready() {
+		t.Fatalf("expected detector to be ready, reason=%q", detector.ReadyReason())
+	}
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("chmod executable %s: %v", name, err)
+		}
+	}
+	return path
+}
+
+func successScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho ok 1>&2\r\n"
+	}
+	return "#!/bin/sh\necho ok >&2\n"
+}
+
+func failingJavaScript() string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\necho The operation couldn't be completed. Unable to locate a Java Runtime. 1>&2\r\nexit /b 1\r\n"
+	}
+	return "#!/bin/sh\necho \"The operation couldn't be completed. Unable to locate a Java Runtime.\" >&2\nexit 1\n"
 }
 
 func TestNativeDetectorApplicable_AllowsOldSBTWithDependencyGraphPlugin(t *testing.T) {

--- a/internal/detectors/sbt/sbt_native.go
+++ b/internal/detectors/sbt/sbt_native.go
@@ -32,10 +32,26 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerSBT, evidencePatterns...)}
 }
 
+// WithWorkingDir returns a copy of the detector scoped to workingDir.
+func (d NativeDetector) WithWorkingDir(workingDir string) sdk.Detector {
+	d.WorkingDir = workingDir
+	return d
+}
+
 // Ready reports whether the sbt binary is available.
 func (d NativeDetector) Ready() bool {
-	_, err := system.LookPath("sbt")
-	return err == nil
+	return d.ReadyReason() == ""
+}
+
+// ReadyReason returns the reason the sbt native detector is not ready.
+func (d NativeDetector) ReadyReason() string {
+	if _, err := system.LookPath("sbt"); err != nil {
+		return detectors.CommandReadyReason("sbt", err)
+	}
+	if ok, reason := detectors.JavaReady(); !ok {
+		return reason
+	}
+	return ""
 }
 
 // Applicable reports whether sbt build files are present.
@@ -67,11 +83,11 @@ func (d NativeDetector) Descriptor() sdk.DetectorDescriptor {
 }
 
 // ResolveGraph resolves an sbt dependency graph via sbt dependencyTree.
-func (d NativeDetector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
+func (d NativeDetector) ResolveGraph(ctx context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
 	logger := d.logger()
 	workingDir := d.workingDir(req.ProjectPath)
 
-	cmd := system.Command("sbt", "--no-colors", "--batch", "dependencyTree")
+	cmd := system.CommandContext(ctx, "sbt", "--no-colors", "--batch", "dependencyTree")
 	cmd.Dir = workingDir
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/internal/detectors/sbt/sbt_native.go
+++ b/internal/detectors/sbt/sbt_native.go
@@ -32,26 +32,12 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return []sdk.PackageManagerSupport{sdk.Support(sdk.PackageManagerSBT, evidencePatterns...)}
 }
 
-// WithWorkingDir returns a copy of the detector scoped to workingDir.
-func (d NativeDetector) WithWorkingDir(workingDir string) sdk.Detector {
-	d.WorkingDir = workingDir
-	return d
-}
-
-// Ready reports whether the sbt binary is available.
-func (d NativeDetector) Ready() bool {
-	return d.ReadyReason() == ""
-}
-
-// ReadyReason returns the reason the sbt native detector is not ready.
-func (d NativeDetector) ReadyReason() string {
+// Ready reports whether the sbt binary and a usable Java runtime are available.
+func (d NativeDetector) Ready(ctx context.Context, _ sdk.DetectionRequest) error {
 	if _, err := system.LookPath("sbt"); err != nil {
-		return detectors.CommandReadyReason("sbt", err)
+		return detectors.CommandNotReadyError("sbt", err)
 	}
-	if ok, reason := detectors.JavaReady(); !ok {
-		return reason
-	}
-	return ""
+	return detectors.JavaReady(ctx)
 }
 
 // Applicable reports whether sbt build files are present.

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -67,8 +67,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether committed SwiftPM files can be parsed.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether SwiftPM files are present.

--- a/internal/detectors/swiftpm/swiftpm_native.go
+++ b/internal/detectors/swiftpm/swiftpm_native.go
@@ -29,9 +29,9 @@ func (d NativeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the swift binary is available.
-func (d NativeDetector) Ready() bool {
+func (d NativeDetector) Ready(context.Context, sdk.DetectionRequest) error {
 	_, err := system.LookPath("swift")
-	return err == nil
+	return detectors.CommandNotReadyError("swift", err)
 }
 
 // Applicable reports whether SwiftPM files are present.

--- a/internal/detectors/syft/detector.go
+++ b/internal/detectors/syft/detector.go
@@ -78,8 +78,8 @@ func (d Detector) PackageManagerSupport() []sdk.PackageManagerSupport {
 }
 
 // Ready reports whether the detector is ready to run.
-func (d Detector) Ready() bool {
-	return true
+func (d Detector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 // Applicable reports whether Syft should run for the requested project.

--- a/internal/detectors/working_dir.go
+++ b/internal/detectors/working_dir.go
@@ -1,0 +1,17 @@
+package detectors
+
+import (
+	"strings"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// RequestWorkingDir returns the directory a detector should operate in for the
+// given request, preferring the explicit project path and falling back to the
+// subproject execution target location.
+func RequestWorkingDir(req sdk.DetectionRequest) string {
+	if wd := strings.TrimSpace(req.ProjectPath); wd != "" {
+		return wd
+	}
+	return strings.TrimSpace(req.ExecutionTarget.Location)
+}

--- a/internal/engine/analyzer_test.go
+++ b/internal/engine/analyzer_test.go
@@ -20,11 +20,11 @@ type fakeAnalyzer struct {
 
 func (f *fakeAnalyzer) Descriptor() sdk.AnalyzerDescriptor { return f.descriptor }
 
-func (f *fakeAnalyzer) Ready() bool {
-	if f.ready == nil {
-		return true
+func (f *fakeAnalyzer) Ready(context.Context, sdk.AnalyzeRequest) error {
+	if f.ready != nil && !*f.ready {
+		return errors.New("not ready")
 	}
-	return *f.ready
+	return nil
 }
 
 func (f *fakeAnalyzer) Applicable(_ context.Context, _ sdk.AnalyzeRequest) (bool, error) {

--- a/internal/engine/diff/diff_test.go
+++ b/internal/engine/diff/diff_test.go
@@ -274,8 +274,8 @@ func (f fakeDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return nil
 }
 
-func (f fakeDetector) Ready() bool {
-	return true
+func (f fakeDetector) Ready(context.Context, sdk.DetectionRequest) error {
+	return nil
 }
 
 func (f fakeDetector) Applicable(context.Context, sdk.DetectionRequest) (bool, error) {
@@ -295,8 +295,8 @@ func (f fakeAuditor) Descriptor() sdk.AuditorDescriptor {
 	return f.descriptor
 }
 
-func (f fakeAuditor) Ready() bool {
-	return true
+func (f fakeAuditor) Ready(context.Context, sdk.AuditRequest) error {
+	return nil
 }
 
 func (f fakeAuditor) Applicable(context.Context, sdk.AuditRequest) (bool, error) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -51,8 +51,8 @@ func (e *Engine) Audit(ctx context.Context, req sdk.AuditRequest) (sdk.AuditResu
 		descriptor := auditor.Descriptor()
 		name := descriptor.Name
 		label := descriptor.Label()
-		if !auditor.Ready() {
-			errs = append(errs, fmt.Errorf("auditor %s: not ready", name))
+		if err := auditor.Ready(ctx, req); err != nil {
+			errs = append(errs, fmt.Errorf("auditor %s: not ready: %w", name, err))
 			continue
 		}
 		applicable, err := auditor.Applicable(ctx, req)
@@ -100,8 +100,8 @@ func (e *Engine) Analyze(ctx context.Context, req sdk.AnalyzeRequest) (sdk.Analy
 		descriptor := analyzer.Descriptor()
 		name := descriptor.Name
 		label := descriptor.Label()
-		if !analyzer.Ready() {
-			errs = append(errs, fmt.Errorf("analyzer %s: not ready", name))
+		if err := analyzer.Ready(ctx, req); err != nil {
+			errs = append(errs, fmt.Errorf("analyzer %s: not ready: %w", name, err))
 			continue
 		}
 		applicable, err := analyzer.Applicable(ctx, req)
@@ -147,8 +147,8 @@ func (e *Engine) Match(ctx context.Context, req sdk.MatchRequest) (MatchResult, 
 	for _, matcher := range matcherList {
 		descriptor := matcher.Descriptor()
 		name := descriptor.Name
-		if !matcher.Ready() {
-			errs = append(errs, fmt.Errorf("matcher %s: not ready", name))
+		if err := matcher.Ready(ctx, req); err != nil {
+			errs = append(errs, fmt.Errorf("matcher %s: not ready: %w", name, err))
 			continue
 		}
 		applicable, err := matcher.Applicable(ctx, req)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -36,15 +36,14 @@ func (f fakeDetector) ResolveGraph(_ context.Context, req ResolveGraphRequest) (
 	return f.result, f.err
 }
 
-func (f fakeDetector) Ready() bool {
-	if f.ready == nil {
-		return true
+func (f fakeDetector) Ready(context.Context, ResolveGraphRequest) error {
+	if f.ready != nil && !*f.ready {
+		if f.readyReason != "" {
+			return errors.New(f.readyReason)
+		}
+		return errors.New("not ready")
 	}
-	return *f.ready
-}
-
-func (f fakeDetector) ReadyReason() string {
-	return f.readyReason
+	return nil
 }
 
 func (f fakeDetector) Applicable(_ context.Context, _ ResolveGraphRequest) (bool, error) {
@@ -90,11 +89,11 @@ func (f fakeAuditor) Audit(_ context.Context, req AuditRequest) (AuditResult, er
 	return f.result, f.err
 }
 
-func (f fakeAuditor) Ready() bool {
-	if f.ready == nil {
-		return true
+func (f fakeAuditor) Ready(context.Context, AuditRequest) error {
+	if f.ready != nil && !*f.ready {
+		return errors.New("not ready")
 	}
-	return *f.ready
+	return nil
 }
 
 func (f fakeAuditor) Applicable(_ context.Context, _ AuditRequest) (bool, error) {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -9,13 +9,14 @@ import (
 )
 
 type fakeDetector struct {
-	descriptor DetectorDescriptor
-	result     ResolveGraphResult
-	err        error
-	ready      *bool
-	applicable *bool
-	applyErr   error
-	onResolve  func(ResolveGraphRequest)
+	descriptor  DetectorDescriptor
+	result      ResolveGraphResult
+	err         error
+	ready       *bool
+	readyReason string
+	applicable  *bool
+	applyErr    error
+	onResolve   func(ResolveGraphRequest)
 }
 
 func (f fakeDetector) Descriptor() DetectorDescriptor { return f.descriptor }
@@ -40,6 +41,10 @@ func (f fakeDetector) Ready() bool {
 		return true
 	}
 	return *f.ready
+}
+
+func (f fakeDetector) ReadyReason() string {
+	return f.readyReason
 }
 
 func (f fakeDetector) Applicable(_ context.Context, _ ResolveGraphRequest) (bool, error) {

--- a/internal/engine/pipeline_resolve.go
+++ b/internal/engine/pipeline_resolve.go
@@ -179,6 +179,7 @@ func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionReques
 }
 
 func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, progress ProgressReporter) ([]sdk.DetectionResult, error) {
+	detector = detectorForRequest(detector, req)
 	descriptor := detector.Descriptor()
 	support := detector.PackageManagerSupport()
 	reportProgressDetail(progress, "Detecting dependencies", detectorProgressDetail(req.Subproject, descriptor.Label()))
@@ -193,11 +194,13 @@ func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest
 	)
 
 	if !detector.Ready() {
+		notReadyErr := detectorNotReadyError(descriptor.Name, detector)
 		p.Logger.Debug("pipeline: detector not ready",
 			zap.String("detector", descriptor.Name),
 			zap.String("subproject", req.Subproject.RelativePath),
+			zap.Error(notReadyErr),
 		)
-		return p.resolveFallback(ctx, req, detector, fmt.Errorf("detector %s: not ready", descriptor.Name), progress)
+		return p.resolveFallback(ctx, req, detector, notReadyErr, progress)
 	}
 
 	applicable, err := detector.Applicable(ctx, req)
@@ -261,6 +264,32 @@ func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest
 		zap.Int("edges", edges),
 	)
 	return []sdk.DetectionResult{result}, nil
+}
+
+func detectorForRequest(detector sdk.Detector, req sdk.DetectionRequest) sdk.Detector {
+	binder, ok := detector.(interface{ WithWorkingDir(string) sdk.Detector })
+	if !ok {
+		return detector
+	}
+	workingDir := strings.TrimSpace(req.ProjectPath)
+	if workingDir == "" {
+		workingDir = strings.TrimSpace(req.Subproject.ExecutionTarget.Location)
+	}
+	if workingDir == "" {
+		return detector
+	}
+	return binder.WithWorkingDir(workingDir)
+}
+
+func detectorNotReadyError(name string, detector sdk.Detector) error {
+	reason := ""
+	if reasoner, ok := detector.(interface{ ReadyReason() string }); ok {
+		reason = strings.TrimSpace(reasoner.ReadyReason())
+	}
+	if reason == "" {
+		return fmt.Errorf("detector %s: not ready", name)
+	}
+	return fmt.Errorf("detector %s: not ready: %s", name, reason)
 }
 
 func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, primaryErr error, progress ProgressReporter) ([]sdk.DetectionResult, error) {

--- a/internal/engine/pipeline_resolve.go
+++ b/internal/engine/pipeline_resolve.go
@@ -179,7 +179,6 @@ func (p *Pipeline) resolveDetectors(ctx context.Context, req sdk.DetectionReques
 }
 
 func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, progress ProgressReporter) ([]sdk.DetectionResult, error) {
-	detector = detectorForRequest(detector, req)
 	descriptor := detector.Descriptor()
 	support := detector.PackageManagerSupport()
 	reportProgressDetail(progress, "Detecting dependencies", detectorProgressDetail(req.Subproject, descriptor.Label()))
@@ -193,8 +192,8 @@ func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest
 		zap.Bool("install_first_supported", descriptor.SupportsInstallFirst),
 	)
 
-	if !detector.Ready() {
-		notReadyErr := detectorNotReadyError(descriptor.Name, detector)
+	if err := detector.Ready(ctx, req); err != nil {
+		notReadyErr := fmt.Errorf("detector %s: not ready: %w", descriptor.Name, err)
 		p.Logger.Debug("pipeline: detector not ready",
 			zap.String("detector", descriptor.Name),
 			zap.String("subproject", req.Subproject.RelativePath),
@@ -264,32 +263,6 @@ func (p *Pipeline) resolveDetector(ctx context.Context, req sdk.DetectionRequest
 		zap.Int("edges", edges),
 	)
 	return []sdk.DetectionResult{result}, nil
-}
-
-func detectorForRequest(detector sdk.Detector, req sdk.DetectionRequest) sdk.Detector {
-	binder, ok := detector.(interface{ WithWorkingDir(string) sdk.Detector })
-	if !ok {
-		return detector
-	}
-	workingDir := strings.TrimSpace(req.ProjectPath)
-	if workingDir == "" {
-		workingDir = strings.TrimSpace(req.Subproject.ExecutionTarget.Location)
-	}
-	if workingDir == "" {
-		return detector
-	}
-	return binder.WithWorkingDir(workingDir)
-}
-
-func detectorNotReadyError(name string, detector sdk.Detector) error {
-	reason := ""
-	if reasoner, ok := detector.(interface{ ReadyReason() string }); ok {
-		reason = strings.TrimSpace(reasoner.ReadyReason())
-	}
-	if reason == "" {
-		return fmt.Errorf("detector %s: not ready", name)
-	}
-	return fmt.Errorf("detector %s: not ready: %s", name, reason)
 }
 
 func (p *Pipeline) resolveFallback(ctx context.Context, req sdk.DetectionRequest, detector sdk.Detector, primaryErr error, progress ProgressReporter) ([]sdk.DetectionResult, error) {

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
@@ -163,6 +164,29 @@ func TestResolveDetectors_DoesNotRunExcludedFallback(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Fatalf("expected no fallback results, got %#v", results)
+	}
+}
+
+func TestResolveDetectors_IncludesReadyReasonWhenDetectorNotReady(t *testing.T) {
+	registry := newTestRegistry()
+	notReady := false
+	registry.registerDetector(fakeDetector{
+		descriptor:  DetectorDescriptor{Name: "maven-detector", SupportedEcosystems: []Ecosystem{EcosystemMaven}, SupportedManagers: []PackageManager{PackageManagerMaven}},
+		ready:       &notReady,
+		readyReason: "java runtime is unavailable: Unable to locate a Java Runtime",
+	})
+
+	pipeline := NewPipeline(registry, zap.NewNop())
+	req := ResolveGraphRequest{
+		Ecosystem:      EcosystemMaven,
+		PackageManager: PackageManagerMaven,
+	}
+	_, err := pipeline.resolveDetectors(context.Background(), req, registry.Detectors(req), nil)
+	if err == nil {
+		t.Fatal("expected detector readiness error")
+	}
+	if !strings.Contains(err.Error(), "detector maven-detector: not ready: java runtime is unavailable") {
+		t.Fatalf("expected readiness reason in error, got %v", err)
 	}
 }
 

--- a/internal/engine/test_compat_test.go
+++ b/internal/engine/test_compat_test.go
@@ -57,8 +57,8 @@ func newTestRegistry() *Registry {
 	return registry
 }
 
-func (f fakeMatcher) Ready() bool {
-	return true
+func (f fakeMatcher) Ready(context.Context, MatchRequest) error {
+	return nil
 }
 
 func (f fakeMatcher) Applicable(_ context.Context, _ MatchRequest) (bool, error) {

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -142,8 +142,8 @@ func (c *Checker) Descriptor() sdk.MatcherDescriptor {
 }
 
 // Ready reports whether the checker can run.
-func (c *Checker) Ready() bool {
-	return true
+func (c *Checker) Ready(context.Context, sdk.MatchRequest) error {
+	return nil
 }
 
 // Applicable reports whether the checker applies to the request.

--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -30,8 +30,8 @@ var clioID = grypeclio.Identification{Name: "grype"}
 // Ready reports whether the bundled Grype matcher can run. The database may be
 // downloaded during Match on first use, so a missing cache does not make the
 // matcher unavailable.
-func (a Matcher) Ready() bool {
-	return true
+func (a Matcher) Ready(context.Context, sdk.MatchRequest) error {
+	return nil
 }
 
 // Match attaches Grype vulnerability matches to packages in the graph.

--- a/internal/matchers/grype/external.go
+++ b/internal/matchers/grype/external.go
@@ -19,9 +19,11 @@ import (
 )
 
 // Ready reports whether the external grype binary is available.
-func (a Matcher) Ready() bool {
-	_, err := exec.LookPath("grype")
-	return err == nil
+func (a Matcher) Ready(context.Context, sdk.MatchRequest) error {
+	if _, err := exec.LookPath("grype"); err != nil {
+		return fmt.Errorf("grype executable not found on PATH: %w", err)
+	}
+	return nil
 }
 
 // Match attaches Grype vulnerability matches by shelling out to the grype CLI binary.

--- a/internal/matchers/grype/matcher_test.go
+++ b/internal/matchers/grype/matcher_test.go
@@ -41,8 +41,8 @@ func TestMatch_NilGraph_ReturnsEmpty(t *testing.T) {
 
 func TestReady_TrueWhenDBDirAbsent(t *testing.T) {
 	a := Matcher{DBDir: filepath.Join(t.TempDir(), "nonexistent-db")}
-	if !a.Ready() {
-		t.Error("Ready() = false, want true because the bundled matcher can download the DB")
+	if err := a.Ready(context.Background(), sdk.MatchRequest{}); err != nil {
+		t.Errorf("Ready() = %v, want nil because the bundled matcher can download the DB", err)
 	}
 }
 

--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -193,8 +193,8 @@ func (a *Matcher) Descriptor() sdk.MatcherDescriptor {
 }
 
 // Ready reports whether this matcher can run. OSV requires no local binary.
-func (a *Matcher) Ready() bool {
-	return true
+func (a *Matcher) Ready(context.Context, sdk.MatchRequest) error {
+	return nil
 }
 
 // Applicable reports whether this matcher applies to the given request.

--- a/internal/matchers/scorecard/matcher.go
+++ b/internal/matchers/scorecard/matcher.go
@@ -134,8 +134,8 @@ func (m *Matcher) Descriptor() sdk.MatcherDescriptor {
 
 // Ready reports whether this matcher can run. The Scorecard matcher only
 // needs HTTP egress; no local binary or auth is required.
-func (m *Matcher) Ready() bool {
-	return true
+func (m *Matcher) Ready(context.Context, sdk.MatchRequest) error {
+	return nil
 }
 
 // Applicable reports whether this matcher applies to the given request.

--- a/internal/matchers/scorecard/matcher_test.go
+++ b/internal/matchers/scorecard/matcher_test.go
@@ -243,7 +243,7 @@ func TestDescriptor_OptIn(t *testing.T) {
 	if d.Name != "scorecard" {
 		t.Errorf("Name = %q", d.Name)
 	}
-	if !matcher.Ready() {
-		t.Error("Ready should be true; no runtime dependency")
+	if err := matcher.Ready(context.Background(), sdk.MatchRequest{}); err != nil {
+		t.Errorf("Ready should succeed; no runtime dependency: %v", err)
 	}
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -9,6 +10,24 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/registry"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
+
+// readyResponseError translates a plugin readiness response into the in-process
+// readiness contract: nil means ready, a non-nil error carries the reason.
+func readyResponseError(resp *sdk.ReadyResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return errors.New("plugin returned no readiness response")
+	}
+	if resp.Ready {
+		return nil
+	}
+	if reason := strings.TrimSpace(resp.Reason); reason != "" {
+		return errors.New(reason)
+	}
+	return errors.New("plugin reported not ready")
+}
 
 type registryWriter interface {
 	RegisterDetector(sdk.Detector)
@@ -66,18 +85,15 @@ func (d externalDetector) PackageManagerSupport() []sdk.PackageManagerSupport {
 	return clonePackageManagerSupport(d.info.DetectorDescriptor.PackageManagerSupport)
 }
 
-func (d externalDetector) Ready() bool {
-	ctx := launchContext(context.Background(), d.launchCtx)
+func (d externalDetector) Ready(ctx context.Context, req sdk.DetectionRequest) error {
+	ctx = launchContext(ctx, d.launchCtx)
 	client, err := startPlugin(ctx, d.info.Entrypoint, d.info.ID)
 	if err != nil {
-		return false
+		return err
 	}
 	defer client.Close()
-	resp, err := client.Raw().DetectorReady(ctx, &sdk.DetectRequest{})
-	if err != nil {
-		return false
-	}
-	return resp != nil && resp.Ready
+	resp, err := client.Raw().DetectorReady(ctx, &req)
+	return readyResponseError(resp, err)
 }
 
 func (d externalDetector) Applicable(ctx context.Context, req sdk.DetectionRequest) (bool, error) {
@@ -141,15 +157,15 @@ func (m externalMatcher) Descriptor() sdk.MatcherDescriptor {
 	return *cloneMatcherDescriptor(m.info.MatcherDescriptor)
 }
 
-func (m externalMatcher) Ready() bool {
-	ctx := launchContext(context.Background(), m.launchCtx)
+func (m externalMatcher) Ready(ctx context.Context, req sdk.MatchRequest) error {
+	ctx = launchContext(ctx, m.launchCtx)
 	client, err := startPlugin(ctx, m.info.Entrypoint, m.info.ID)
 	if err != nil {
-		return false
+		return err
 	}
 	defer client.Close()
-	resp, err := client.Raw().MatcherReady(ctx, &sdk.MatchRequest{})
-	return err == nil && resp != nil && resp.Ready
+	resp, err := client.Raw().MatcherReady(ctx, &req)
+	return readyResponseError(resp, err)
 }
 
 func (m externalMatcher) Applicable(ctx context.Context, req sdk.MatchRequest) (bool, error) {
@@ -200,15 +216,15 @@ func (a externalAuditor) Descriptor() sdk.AuditorDescriptor {
 	return *cloneAuditorDescriptor(a.info.AuditorDescriptor)
 }
 
-func (a externalAuditor) Ready() bool {
-	ctx := launchContext(context.Background(), a.launchCtx)
+func (a externalAuditor) Ready(ctx context.Context, req sdk.AuditRequest) error {
+	ctx = launchContext(ctx, a.launchCtx)
 	client, err := startPlugin(ctx, a.info.Entrypoint, a.info.ID)
 	if err != nil {
-		return false
+		return err
 	}
 	defer client.Close()
-	resp, err := client.Raw().AuditorReady(ctx, &sdk.AuditRequest{})
-	return err == nil && resp != nil && resp.Ready
+	resp, err := client.Raw().AuditorReady(ctx, &req)
+	return readyResponseError(resp, err)
 }
 
 func (a externalAuditor) Applicable(ctx context.Context, req sdk.AuditRequest) (bool, error) {

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -130,6 +130,14 @@ func (d detectorWithDescriptor) Descriptor() sdk.DetectorDescriptor {
 	return d.descriptor
 }
 
+func (d detectorWithDescriptor) ReadyReason() string {
+	reasoner, ok := d.Detector.(interface{ ReadyReason() string })
+	if !ok {
+		return ""
+	}
+	return reasoner.ReadyReason()
+}
+
 type fallbackDetectorWithDescriptor struct {
 	detectorWithDescriptor
 }
@@ -142,12 +150,28 @@ func (d fallbackDetectorWithDescriptor) FallbackDetector() sdk.Detector {
 	return detectorWithDecoratedDescriptor(fallback, decorateDetectorDescriptor(fallback.Descriptor()))
 }
 
+func (d fallbackDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
+	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
+	if !ok {
+		return d
+	}
+	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
+}
+
 type installFirstDetectorWithDescriptor struct {
 	detectorWithDescriptor
 }
 
 func (d installFirstDetectorWithDescriptor) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	return d.Detector.(sdk.InstallFirstDetector).Install(ctx, req)
+}
+
+func (d installFirstDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
+	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
+	if !ok {
+		return d
+	}
+	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
 }
 
 type fallbackInstallFirstDetectorWithDescriptor struct {
@@ -164,6 +188,14 @@ func (d fallbackInstallFirstDetectorWithDescriptor) FallbackDetector() sdk.Detec
 
 func (d fallbackInstallFirstDetectorWithDescriptor) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	return d.Detector.(sdk.InstallFirstDetector).Install(ctx, req)
+}
+
+func (d fallbackInstallFirstDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
+	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
+	if !ok {
+		return d
+	}
+	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
 }
 
 type auditorWithDescriptor struct {

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -130,14 +130,6 @@ func (d detectorWithDescriptor) Descriptor() sdk.DetectorDescriptor {
 	return d.descriptor
 }
 
-func (d detectorWithDescriptor) ReadyReason() string {
-	reasoner, ok := d.Detector.(interface{ ReadyReason() string })
-	if !ok {
-		return ""
-	}
-	return reasoner.ReadyReason()
-}
-
 type fallbackDetectorWithDescriptor struct {
 	detectorWithDescriptor
 }
@@ -150,28 +142,12 @@ func (d fallbackDetectorWithDescriptor) FallbackDetector() sdk.Detector {
 	return detectorWithDecoratedDescriptor(fallback, decorateDetectorDescriptor(fallback.Descriptor()))
 }
 
-func (d fallbackDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
-	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
-	if !ok {
-		return d
-	}
-	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
-}
-
 type installFirstDetectorWithDescriptor struct {
 	detectorWithDescriptor
 }
 
 func (d installFirstDetectorWithDescriptor) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	return d.Detector.(sdk.InstallFirstDetector).Install(ctx, req)
-}
-
-func (d installFirstDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
-	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
-	if !ok {
-		return d
-	}
-	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
 }
 
 type fallbackInstallFirstDetectorWithDescriptor struct {
@@ -188,14 +164,6 @@ func (d fallbackInstallFirstDetectorWithDescriptor) FallbackDetector() sdk.Detec
 
 func (d fallbackInstallFirstDetectorWithDescriptor) Install(ctx context.Context, req sdk.DetectionRequest) error {
 	return d.Detector.(sdk.InstallFirstDetector).Install(ctx, req)
-}
-
-func (d fallbackInstallFirstDetectorWithDescriptor) WithWorkingDir(workingDir string) sdk.Detector {
-	binder, ok := d.Detector.(interface{ WithWorkingDir(string) sdk.Detector })
-	if !ok {
-		return d
-	}
-	return detectorWithDecoratedDescriptor(binder.WithWorkingDir(workingDir), d.descriptor)
 }
 
 type auditorWithDescriptor struct {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -17,6 +18,11 @@ func Abs(path string) (string, error) {
 // Command constructs an external process command.
 func Command(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
+}
+
+// CommandContext constructs an external process command bound to ctx.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
 }
 
 // FileExists reports whether path exists and is a file.

--- a/sdk/analyzer.go
+++ b/sdk/analyzer.go
@@ -72,7 +72,11 @@ type AnalyzeResult struct {
 // abort the pipeline on failure.
 type Analyzer interface {
 	Descriptor() AnalyzerDescriptor
-	Ready() bool
+	// Ready reports whether the analyzer can run for the given request. It
+	// returns nil when ready and a non-nil error describing the reason
+	// otherwise. Implementations may perform lightweight, cancellable I/O and
+	// should honor ctx.
+	Ready(context.Context, AnalyzeRequest) error
 	Applicable(context.Context, AnalyzeRequest) (bool, error)
 	Analyze(context.Context, AnalyzeRequest) (AnalyzeResult, error)
 }

--- a/sdk/auditor.go
+++ b/sdk/auditor.go
@@ -59,7 +59,11 @@ type AuditorDescriptor struct {
 // Auditor analyzes graphs or components and returns findings.
 type Auditor interface {
 	Descriptor() AuditorDescriptor
-	Ready() bool
+	// Ready reports whether the auditor can run for the given request. It
+	// returns nil when ready and a non-nil error describing the reason
+	// otherwise. Implementations may perform lightweight, cancellable I/O and
+	// should honor ctx.
+	Ready(context.Context, AuditRequest) error
 	Applicable(context.Context, AuditRequest) (bool, error)
 	Audit(context.Context, AuditRequest) (AuditResult, error)
 }

--- a/sdk/detector.go
+++ b/sdk/detector.go
@@ -96,7 +96,12 @@ func Support(manager PackageManager, evidencePatterns ...string) PackageManagerS
 type Detector interface {
 	Descriptor() DetectorDescriptor
 	PackageManagerSupport() []PackageManagerSupport
-	Ready() bool
+	// Ready reports whether the detector can run for the given request. It
+	// returns nil when ready and a non-nil error describing the reason
+	// (e.g. a missing toolchain) otherwise. Implementations may perform
+	// lightweight, cancellable I/O (such as probing for a runtime) and should
+	// honor ctx.
+	Ready(context.Context, DetectionRequest) error
 	Applicable(context.Context, DetectionRequest) (bool, error)
 	ResolveGraph(context.Context, DetectionRequest) (DetectionResult, error)
 }

--- a/sdk/matcher.go
+++ b/sdk/matcher.go
@@ -66,7 +66,11 @@ type MatcherStats struct {
 // Matcher enriches registry packages with license and vulnerability data.
 type Matcher interface {
 	Descriptor() MatcherDescriptor
-	Ready() bool
+	// Ready reports whether the matcher can run for the given request. It
+	// returns nil when ready and a non-nil error describing the reason
+	// otherwise. Implementations may perform lightweight, cancellable I/O and
+	// should honor ctx.
+	Ready(context.Context, MatchRequest) error
 	Applicable(context.Context, MatchRequest) (bool, error)
 	Match(context.Context, MatchRequest) (MatchResult, error)
 }

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -36,6 +36,9 @@ type PluginTargetType string
 // ReadyResponse reports whether a plugin is ready to run.
 type ReadyResponse struct {
 	Ready bool `json:"ready"`
+	// Reason explains why the plugin is not ready. It is ignored when Ready is
+	// true and surfaced to users (and resolution errors) when Ready is false.
+	Reason string `json:"reason,omitempty"`
 }
 
 // ApplicableResponse reports whether a plugin should run for the given request.


### PR DESCRIPTION
## Summary
- Move Maven, Gradle, and SBT native Java/toolchain checks into detector readiness.
- Surface readiness reasons, including missing Java runtime messages, through resolution failures.
- Bind detectors to subproject working directories before readiness checks so wrappers like `./mvnw` and `./gradlew` are honored.
- Use context-aware subprocess execution for JVM build-tool commands.

## Why
Scanning JVM projects could appear to hang when the underlying build tool emitted a Java runtime failure. The detector readiness gate now catches missing Java/toolchain state before resolution work begins, while preserving fallback behavior.

## Validation
- `go test ./internal/detectors/maven ./internal/detectors/gradle ./internal/detectors/sbt`
- `go test ./internal/engine`
- targeted CLI regression tests for Maven/Gradle wrapper and missing-Java behavior
- `git diff --check`
- `make test`