### PR TITLE
docs: add GitHub release downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/bomly-dev/bomly-cli/actions/workflows/ci.yml"><img src="https://github.com/bomly-dev/bomly-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/bomly-dev/bomly-cli"><img src="https://api.scorecard.dev/projects/github.com/bomly-dev/bomly-cli/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://github.com/bomly-dev/bomly-cli/releases/latest"><img src="https://img.shields.io/github/v/release/bomly-dev/bomly-cli?sort=semver" alt="Latest release"></a>
+  <a href="https://github.com/bomly-dev/bomly-cli/releases"><img src="https://img.shields.io/github/downloads/bomly-dev/bomly-cli/total" alt="GitHub release downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/bomly-dev/bomly-cli" alt="License: Apache-2.0"></a>
   <a href="https://pkg.go.dev/github.com/bomly-dev/bomly-cli"><img src="https://pkg.go.dev/badge/github.com/bomly-dev/bomly-cli.svg" alt="Go Reference"></a>
   <a href="https://goreportcard.com/report/github.com/bomly-dev/bomly-cli"><img src="https://goreportcard.com/badge/github.com/bomly-dev/bomly-cli" alt="Go Report Card"></a>


### PR DESCRIPTION
## What changed

Adds a GitHub release downloads badge to the README badge row, between the latest-release and license badges. It uses shields.io's `github/downloads/<owner>/<repo>/total` endpoint, which sums release-asset download counts across all releases.

## Why

Surfaces adoption/usage signal directly in the README, requested as a way to show how many times the GitHub release binaries have been downloaded.

## Reviewer notes

- The badge counts only assets fetched from **GitHub Releases**. Homebrew tap, `install.sh`, and winget installs that pull GitHub assets count; mirror/CDN-cached downloads do not.
- `/total` is all-releases. Swap to `.../latest/total` if you'd prefer latest-release-only.
- Verified live: badge currently renders `downloads: 131`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release downloads badge to the top of the README, linking directly to the project’s releases page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->