### PR TITLE
Harden plugin path handling

### DIFF
--- a/internal/plugin/http_test.go
+++ b/internal/plugin/http_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,6 +57,93 @@ func TestInstallRemoteArchiveUsesConfiguredProxy(t *testing.T) {
 	}
 	if result.Manifest.ID != "acme.detector.proxy" {
 		t.Fatalf("installed id = %q", result.Manifest.ID)
+	}
+}
+
+func TestInstallRemoteArchiveDoesNotUseUnsafeGitHubAssetName(t *testing.T) {
+	root := t.TempDir()
+	tempDir := filepath.Join(root, "install")
+	if err := os.Mkdir(tempDir, 0o755); err != nil {
+		t.Fatalf("create temp install dir: %v", err)
+	}
+
+	binaryName := "bomly-plugin-unsafe-name"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(t.TempDir(), binaryName)
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeDetectorPluginSource("acme.detector.unsafe-name")); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+	manifest := withCanonicalManifestDefaults(Manifest{
+		ID:      "acme.detector.unsafe-name",
+		Name:    "Acme Unsafe Name Detector",
+		Version: "1.0.0",
+		Kind:    plugschema.PluginKindDetector,
+		Entrypoint: map[string]string{
+			platformKey(): filepath.ToSlash(filepath.Join("bin", filepath.Base(binaryPath))),
+		},
+	}, "github:acme/unsafe-name@v1.0.0")
+	archiveBytes := buildPluginArchive(t, manifest, binaryPath)
+
+	escapedName := "bomly-plugin-escape" + archiveSuffix()
+	escapedPath := filepath.Join(filepath.Dir(root), escapedName)
+	_ = os.Remove(escapedPath)
+	defer func() { _ = os.Remove(escapedPath) }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer server.Close()
+
+	result, _, err := installRemoteArchive(context.Background(), tempDir, server.URL+"/asset", InstallOptions{
+		InsecureSkipChecksum:   true,
+		githubReleaseDownload:  true,
+		githubReleaseAssetName: "../" + escapedName,
+	})
+	if err != nil {
+		t.Fatalf("installRemoteArchive() error = %v", err)
+	}
+	if result.ID != "acme.detector.unsafe-name" {
+		t.Fatalf("installed id = %q", result.ID)
+	}
+	if _, err := os.Stat(escapedPath); !os.IsNotExist(err) {
+		t.Fatalf("unsafe asset name created %q", escapedPath)
+	}
+}
+
+func TestInstallArchiveRejectsUnsafeManifestEntrypoint(t *testing.T) {
+	tempDir := filepath.Join(t.TempDir(), "install")
+	if err := os.Mkdir(tempDir, 0o755); err != nil {
+		t.Fatalf("create temp install dir: %v", err)
+	}
+
+	binaryName := "bomly-plugin-unsafe-entrypoint"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(t.TempDir(), binaryName)
+	if err := testutil.BuildGoBinary(t, binaryPath, fakeDetectorPluginSource("acme.detector.unsafe-entrypoint")); err != nil {
+		t.Fatalf("build fake plugin: %v", err)
+	}
+	manifest := withCanonicalManifestDefaults(Manifest{
+		ID:      "acme.detector.unsafe-entrypoint",
+		Name:    "Acme Unsafe Entrypoint Detector",
+		Version: "1.0.0",
+		Kind:    plugschema.PluginKindDetector,
+		Entrypoint: map[string]string{
+			platformKey(): filepath.ToSlash(filepath.Join("..", "bin", filepath.Base(binaryPath))),
+		},
+	}, "file://unsafe-entrypoint")
+	archiveBytes := buildPluginArchive(t, manifest, binaryPath)
+	archivePath := filepath.Join(t.TempDir(), "unsafe-entrypoint"+archiveSuffix())
+	if err := os.WriteFile(archivePath, archiveBytes, 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	_, _, err := installArchiveAtPath(context.Background(), tempDir, archivePath, archivePath, "", true)
+	if err == nil || !strings.Contains(err.Error(), "must stay within the plugin directory") {
+		t.Fatalf("expected unsafe entrypoint error, got %v", err)
 	}
 }
 

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -224,6 +224,7 @@ func installRemoteArchive(ctx context.Context, tempDir, source string, opts Inst
 }
 
 func safeDownloadArchiveName(name string) string {
+	// Remote archive names are only used to preserve a trusted extension for temp-file format detection.
 	name = strings.ReplaceAll(strings.TrimSpace(name), "\\", "/")
 	if name == "" {
 		return ""
@@ -421,6 +422,7 @@ func extractArchiveEntry(name, targetDir string, mode os.FileMode, write func(st
 	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return fmt.Errorf("create plugin archive parent for %q: %w", name, err)
 	}
+	// Symlinks would make the lexical containment checks above vulnerable to writes outside targetDir.
 	if mode&os.ModeSymlink != 0 {
 		return fmt.Errorf("plugin archive entry %q uses unsupported symlink mode", name)
 	}

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -147,7 +147,10 @@ func installDevBinary(ctx context.Context, tempDir, source string) (Manifest, st
 		return Manifest{}, "", err
 	}
 	entry, _ := entrypointForManifest(manifest)
-	targetBinary := filepath.Join(tempDir, entry)
+	targetBinary, err := pathInPluginDir(tempDir, entry)
+	if err != nil {
+		return Manifest{}, "", fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+	}
 	if err := os.MkdirAll(filepath.Dir(targetBinary), 0o755); err != nil {
 		return Manifest{}, "", fmt.Errorf("create plugin binary dir: %w", err)
 	}
@@ -200,14 +203,16 @@ func installRemoteArchive(ctx context.Context, tempDir, source string, opts Inst
 	if downloadName == "" {
 		downloadName = filepath.Base(resp.Request.URL.Path)
 	}
-	if strings.TrimSpace(downloadName) == "" || downloadName == "." || downloadName == "/" {
+	downloadName = safeDownloadArchiveName(downloadName)
+	if downloadName == "" {
 		downloadName = "downloaded-plugin"
 	}
-	archivePath := filepath.Join(filepath.Dir(tempDir), downloadName)
-	file, err := os.Create(archivePath)
+	file, err := os.CreateTemp(filepath.Dir(tempDir), "bomly-plugin-archive-*"+archiveExtension(downloadName))
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("create downloaded plugin archive: %w", err)
 	}
+	archivePath := file.Name()
+	defer func() { _ = os.Remove(archivePath) }()
 	if _, err := io.Copy(file, resp.Body); err != nil {
 		_ = file.Close()
 		return Manifest{}, "", fmt.Errorf("write downloaded plugin archive: %w", err)
@@ -216,6 +221,32 @@ func installRemoteArchive(ctx context.Context, tempDir, source string, opts Inst
 		return Manifest{}, "", fmt.Errorf("close downloaded plugin archive: %w", err)
 	}
 	return installArchiveAtPath(ctx, tempDir, archivePath, source, opts.Checksum, opts.InsecureSkipChecksum)
+}
+
+func safeDownloadArchiveName(name string) string {
+	name = strings.ReplaceAll(strings.TrimSpace(name), "\\", "/")
+	if name == "" {
+		return ""
+	}
+	base := filepath.Base(filepath.FromSlash(name))
+	if base == "." || base == string(os.PathSeparator) || base == ".." || strings.Contains(base, ":") {
+		return ""
+	}
+	return base
+}
+
+func archiveExtension(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".tar.gz"):
+		return ".tar.gz"
+	case strings.HasSuffix(lower, ".tgz"):
+		return ".tgz"
+	case strings.HasSuffix(lower, ".zip"):
+		return ".zip"
+	default:
+		return ""
+	}
 }
 
 func filenameFromContentDisposition(value string) string {
@@ -227,7 +258,7 @@ func filenameFromContentDisposition(value string) string {
 		return ""
 	}
 	if name := strings.TrimSpace(params["filename"]); name != "" {
-		return filepath.Base(name)
+		return safeDownloadArchiveName(name)
 	}
 	return ""
 }
@@ -269,7 +300,10 @@ func installArchiveAtPath(ctx context.Context, tempDir, archivePath, source, exp
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	fullEntrypoint := filepath.Join(tempDir, entry)
+	fullEntrypoint, err := pathInPluginDir(tempDir, entry)
+	if err != nil {
+		return Manifest{}, "", fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+	}
 	if _, err := os.Stat(fullEntrypoint); err != nil {
 		return Manifest{}, "", fmt.Errorf("plugin entrypoint %q is missing: %w", entry, err)
 	}
@@ -330,7 +364,11 @@ func extractZipArchive(archivePath, targetDir string) error {
 }
 
 func extractTarGzArchive(archivePath, targetDir string) error {
-	file, err := os.Open(archivePath)
+	cleanArchivePath, err := filepath.Abs(archivePath)
+	if err != nil {
+		return fmt.Errorf("resolve plugin tar.gz archive: %w", err)
+	}
+	file, err := os.Open(cleanArchivePath)
 	if err != nil {
 		return fmt.Errorf("open plugin tar.gz archive: %w", err)
 	}
@@ -366,19 +404,18 @@ func extractTarGzArchive(archivePath, targetDir string) error {
 }
 
 func extractArchiveEntry(name, targetDir string, mode os.FileMode, write func(string) error) error {
-	cleanName := filepath.Clean(filepath.FromSlash(strings.TrimSpace(name)))
-	if cleanName == "." || cleanName == "" {
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(name) == "." {
 		return nil
 	}
-	if filepath.IsAbs(cleanName) || strings.HasPrefix(cleanName, "..") {
+	destination, err := pathInPluginDir(targetDir, name)
+	if err != nil {
 		return fmt.Errorf("plugin archive entry %q escapes the extraction directory", name)
 	}
-	destination := filepath.Join(targetDir, cleanName)
 	rel, err := filepath.Rel(targetDir, destination)
 	if err != nil {
 		return fmt.Errorf("resolve plugin archive entry %q: %w", name, err)
 	}
-	if strings.HasPrefix(rel, "..") {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("plugin archive entry %q escapes the extraction directory", name)
 	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {

--- a/internal/plugin/test.go
+++ b/internal/plugin/test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	plugschema "github.com/bomly-dev/bomly-cli/sdk"
@@ -62,7 +61,10 @@ func Test(ctx context.Context, root, id string, builtins []Info) (*TestResult, e
 	if err != nil {
 		return nil, err
 	}
-	fullEntrypoint := filepath.Join(record.Path, entry)
+	fullEntrypoint, err := pathInPluginDir(record.Path, entry)
+	if err != nil {
+		return nil, fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+	}
 
 	client, err := startPlugin(launchContext(ctx, nil), fullEntrypoint, manifest.ID)
 	if err != nil {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -236,7 +236,39 @@ func entrypointForManifest(manifest Manifest) (string, error) {
 	if entry == "" {
 		return "", fmt.Errorf("plugin %s@%s does not provide entrypoint for %s", manifest.ID, manifest.Version, platformKey())
 	}
-	return filepath.FromSlash(entry), nil
+	cleanEntry, err := cleanRelativePluginPath(entry)
+	if err != nil {
+		return "", fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+	}
+	return cleanEntry, nil
+}
+
+func cleanRelativePluginPath(value string) (string, error) {
+	slashPath := strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if slashPath == "" || slashPath == "." || strings.Contains(slashPath, ":") {
+		return "", errors.New("invalid relative path")
+	}
+	cleanPath := filepath.Clean(filepath.FromSlash(slashPath))
+	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(os.PathSeparator)) {
+		return "", errors.New("path escapes base directory")
+	}
+	return cleanPath, nil
+}
+
+func pathInPluginDir(root, relativePath string) (string, error) {
+	cleanPath, err := cleanRelativePluginPath(relativePath)
+	if err != nil {
+		return "", err
+	}
+	destination := filepath.Join(root, cleanPath)
+	rel, err := filepath.Rel(root, destination)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", errors.New("path escapes base directory")
+	}
+	return destination, nil
 }
 
 func loadInstalledDB(root string) (InstalledDB, error) {
@@ -421,15 +453,25 @@ func validateManifest(manifest Manifest) error {
 	if err != nil {
 		return err
 	}
-	cleanEntry := filepath.Clean(entry)
-	if filepath.IsAbs(cleanEntry) || strings.HasPrefix(cleanEntry, "..") {
+	if _, err := pathInPluginDir(".", entry); err != nil {
 		return fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
 	}
 	return nil
 }
 
 func checksumFile(path string) (string, error) {
-	file, err := os.Open(path)
+	cleanPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve file for checksum: %w", err)
+	}
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("stat file for checksum: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("checksum path %q is a directory", path)
+	}
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return "", fmt.Errorf("open file for checksum: %w", err)
 	}
@@ -675,6 +717,10 @@ func LoadInstalledPlugins(root string) ([]Info, error) {
 		if err != nil {
 			return nil, err
 		}
+		fullEntrypoint, err := pathInPluginDir(item.Path, entry)
+		if err != nil {
+			return nil, fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+		}
 		snapshot, err := readRuntimeSnapshot(item.Path)
 		if err != nil {
 			return nil, fmt.Errorf("read installed plugin %s: %w", item.ID, err)
@@ -686,7 +732,7 @@ func LoadInstalledPlugins(root string) ([]Info, error) {
 			AuditorDescriptor:  cloneAuditorDescriptor(snapshot.AuditorDescriptor),
 			Installed:          new(item),
 			Enabled:            item.Enabled,
-			Entrypoint:         filepath.Join(item.Path, entry),
+			Entrypoint:         fullEntrypoint,
 			SourceType:         "external",
 		})
 	}
@@ -733,6 +779,10 @@ func LoadRuntimePlugins(root string) ([]Info, error) {
 		if err != nil {
 			return nil, err
 		}
+		fullEntrypoint, err := pathInPluginDir(item.Path, entry)
+		if err != nil {
+			return nil, fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+		}
 		snapshot, err := readRuntimeSnapshot(item.Path)
 		if err != nil {
 			return nil, fmt.Errorf("read installed plugin %s: %w", item.ID, err)
@@ -744,7 +794,7 @@ func LoadRuntimePlugins(root string) ([]Info, error) {
 			AuditorDescriptor:  cloneAuditorDescriptor(snapshot.AuditorDescriptor),
 			Installed:          new(item),
 			Enabled:            item.Enabled,
-			Entrypoint:         filepath.Join(item.Path, entry),
+			Entrypoint:         fullEntrypoint,
 			SourceType:         "external",
 		})
 	}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -460,6 +460,7 @@ func validateManifest(manifest Manifest) error {
 }
 
 func checksumFile(path string) (string, error) {
+	// Callers must constrain path to a trusted location before requesting a checksum.
 	cleanPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("resolve file for checksum: %w", err)

--- a/internal/plugin/verify.go
+++ b/internal/plugin/verify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 // Verify validates one installed managed plugin.
@@ -26,7 +25,10 @@ func Verify(ctx context.Context, root, id string) (*VerifyResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	fullEntrypoint := filepath.Join(record.Path, entry)
+	fullEntrypoint, err := pathInPluginDir(record.Path, entry)
+	if err != nil {
+		return nil, fmt.Errorf("plugin entrypoint %q must stay within the plugin directory", entry)
+	}
 	if _, err := os.Stat(fullEntrypoint); err != nil {
 		return nil, fmt.Errorf("verify plugin entrypoint: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Normalize and validate plugin-relative paths before joining them with install or runtime directories.
- Store downloaded plugin archives in trusted temp files instead of using remote asset names as filesystem paths.
- Add regression coverage for unsafe GitHub release asset names and manifest entrypoints.

## Why

Code scanning reported three uncontrolled path-expression findings in plugin install and checksum handling. The affected paths are derived from plugin manifests, archive metadata, or remote download metadata, so the fix moves containment checks to the trust boundary and reuses them across install, verify, test, and plugin loading paths.

## Validation

- `go test ./internal/plugin`
- `git diff --check`
- `make test`

The first full `make test` run hit transient Java readiness timeouts in Gradle, Maven, and SBT detector tests. Those packages passed on rerun, and the final `make test` passed.