### PR TITLE
Ignore testdata in broad scanner walks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore generated SBOM files
 /sboms
 
+# Ignore committed scanner fixtures during broad repository scans
+**/testdata/**
+
 # Ignore local dependency graph benchmark artifacts
 /.benchmark-runs
 


### PR DESCRIPTION
## Summary
- add a gitignore pattern for committed `testdata` fixture directories so broad repository scanners that honor gitignore skip fixture lockfiles and SBOMs
- keep existing tracked fixtures editable while requiring `git add -f` only for brand-new ignored fixture files

## Why
OpenSSF Scorecard runs its Vulnerabilities check through `osv-scanner` over the repository checkout. The scanner was treating dependency detector fixtures under `testdata` as live project manifests, which produced noisy Code Scanning vulnerability alerts unrelated to the CLI product dependency set.

## Validation
- `git check-ignore --no-index -v internal/detectors/node/testdata/lockfiles/pnpm-v5/pnpm-lock.yaml internal/detectors/ruby/testdata/project/Gemfile.lock test/smoke/testdata/sboms/js.spdx.json`
- temp normal git clone with patched `.gitignore`: `osv-scanner@v1.9.2 scan --skip-git -r` reports `0` non-Go-stdlib vulnerabilities
- `git diff --check`
- `make test`
