### PR TITLE
Export-ignore testdata for Scorecard archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/testdata/** export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@
 # Ignore generated SBOM files
 /sboms
 
-# Ignore committed scanner fixtures during broad repository scans
-**/testdata/**
-
 # Ignore local dependency graph benchmark artifacts
 /.benchmark-runs
 


### PR DESCRIPTION
## Summary

- add a `.gitattributes` `export-ignore` rule for `**/testdata/**`
- remove the `.gitignore` testdata workaround so fixture changes can be committed normally

## Why

The previous `.gitignore` change did not clear the OpenSSF Scorecard vulnerability finding because the Scorecard workflow runs the action in GitHub repository/archive mode. In that mode, Scorecard scans the exported archive rather than a normal checkout that honors `.gitignore` during recursive scanner walks.

Git archive generation does honor `.gitattributes` `export-ignore`, so this keeps committed fixture data out of the archive that Scorecard scans while preserving normal developer workflows for adding or editing test fixtures.

## Validation

- `git check-attr export-ignore -- internal/detectors/node/testdata/lockfiles/pnpm-v5/pnpm-lock.yaml internal/detectors/ruby/testdata/project/Gemfile.lock test/smoke/testdata/sboms/js.spdx.json`
- `git archive --worktree-attributes HEAD` extracted to a temp directory and confirmed `0` files under `*/testdata/*`
- `osv-scanner --skip-git -r` over the exported archive reported `0` non-Go-stdlib vulnerabilities after filtering the vulnerabilities Scorecard filters
- `make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated archive/export settings so files under `testdata/` are excluded from release exports.
  * Adjusted ignore rules to stop excluding `testdata/` from local workspace tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->