### PR TITLE
Remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   <a href="https://github.com/bomly-dev/bomly-cli/releases"><img src="https://img.shields.io/github/downloads/bomly-dev/bomly-cli/total" alt="GitHub release downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/bomly-dev/bomly-cli" alt="License: Apache-2.0"></a>
   <a href="https://pkg.go.dev/github.com/bomly-dev/bomly-cli"><img src="https://pkg.go.dev/badge/github.com/bomly-dev/bomly-cli.svg" alt="Go Reference"></a>
-  <a href="https://goreportcard.com/report/github.com/bomly-dev/bomly-cli"><img src="https://goreportcard.com/badge/github.com/bomly-dev/bomly-cli" alt="Go Report Card"></a>
 </p>
 
 Bomly is a free, open-source CLI for dependency intelligence. It scans source trees, SBOMs, Git refs, and container images; explains why dependencies are present; enriches packages with vulnerability and license data when you ask for it; evaluates policy; and writes automation-friendly output for CI.


### PR DESCRIPTION
## Summary
- remove the retired Go Report Card badge from the README badge cluster

## Why
- Go Report Card has been sunset, so the badge/link no longer provides a reliable project-quality signal
- the README already keeps CI, OpenSSF Scorecard, release, license, and Go Reference badges

## Validation
- `rg -n "Go Report Card|goreportcard|goreportcard.com" README.md` returned no matches
- `make test` was run, but failed in unrelated Java readiness tests for Gradle, Maven, and SBT after the local Java readiness probe timed out after 5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Go Report Card” badge/link from the README header.
  * No other README content or sections were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->