### PR TITLE
docs: README audit (R3) — no-login framing + inline Action snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Bomly is a free, open-source CLI for dependency intelligence. It scans source trees, SBOMs, Git refs, and container images; explains why dependencies are present; enriches packages with vulnerability and license data when you ask for it; evaluates policy; and writes automation-friendly output for CI.
 
-One binary. No service to host. No telemetry. No outbound matcher calls unless you opt in with `--enrich`.
+Free and open source, no account, no login. One binary. No service to host. No telemetry. No outbound matcher calls unless you opt in with `--enrich`.
 
 ## Install Bomly
 
@@ -154,7 +154,19 @@ bomly scan --format cyclonedx
 
 Exit codes are stable for scripts: `0` for clean results, `2` for policy violations, and separate values for usage, runtime, and no-supported-project failures. See [Output Formats](docs/OUTPUT_FORMATS.md), [SBOM Formats](docs/SBOM.md), and [Exit Codes](docs/EXIT_CODES.md).
 
-To gate pull requests, use the [Bomly Guard action](https://github.com/bomly-dev/bomly-guard) or call the CLI directly from your workflow. See [Bomly Guard](docs/BOMLY_GUARD.md) and [CI Integration](docs/CI_INTEGRATION.md).
+To gate pull requests, use the [Bomly Guard action](https://github.com/bomly-dev/bomly-guard) or call the CLI directly from your workflow:
+
+```yaml
+# .github/workflows/bomly.yml
+- uses: actions/checkout@v5
+  with:
+    fetch-depth: 0
+- uses: bomly-dev/bomly-guard@v1
+  with:
+    fail-on: high
+```
+
+See [Bomly Guard](docs/BOMLY_GUARD.md) and [CI Integration](docs/CI_INTEGRATION.md).
 
 <p align="center">
   <img src="assets/readme/guard-check.png" alt="GitHub pull request checks showing Bomly Guard failing a required dependency check" width="900">


### PR DESCRIPTION
Repo-hygiene task **R3** (campaign-plan §8: README audit against the standard flow).

The README already covers the full flow (one-liner → quickstart → screenshots → what it helps with → CLI usage → outputs → ecosystems → privacy note → docs → contributing). This is a light, targeted pass, not a rewrite:

- **No-login framing.** Lead the intro with "Free and open source, no account, no login" per the campaign style guide (plan §8/§9 — this audience reads friction as a funnel). Accurate: it's a local binary.
- **Inline Action usage.** Added a minimal copy-paste Bomly Guard workflow snippet next to the existing links, so "Action usage" is visible without leaving the README.

No claims added; `--enrich` framing untouched and still accurate.

Draft — for Ahmed to review/merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the project’s introduction to state it is free and open source.
  * Added clearer guidance on when outbound matcher calls occur, including the opt-in `--enrich` behavior.
  * Expanded the pull-request gating section with a concrete GitHub Actions workflow example.
  * Added a follow-up reference to additional CI integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->