### PR TITLE
Document Bomly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ To gate pull requests, use the [Bomly Guard action](https://github.com/bomly-dev
 
 ## Use Bomly With AI Agents
 
-Bomly can run as an MCP server so AI agents can call the same `scan`, `explain`, and `diff` capabilities you use on the command line:
+Bomly can run as a local MCP server so AI agents can call the same dependency graph tools you use on the command line:
 
 ```bash
 bomly mcp serve
 ```
 
-Add Bomly to an MCP-aware agent such as Claude Code, Cursor, VS Code, or a custom tool, and the agent receives structured JSON it can summarize or reason over. See [Getting Started](docs/GETTING_STARTED.md) for setup recipes.
+Add Bomly to an MCP-aware agent such as Claude Code, Cursor, VS Code, or a custom tool, and the agent receives structured JSON it can summarize or reason over. See [MCP Server](docs/MCP.md) for setup recipes and the tool reference.
 
 ## Configure and Extend
 
@@ -201,6 +201,7 @@ See [Plugins](docs/PLUGINS.md) for install, trust, and authoring guidance.
 - [SBOM Formats](docs/SBOM.md) - SPDX 2.3 and CycloneDX 1.6, ingest, and conversion recipes
 - [CI Integration](docs/CI_INTEGRATION.md) - GitHub Actions, GitLab, Jenkins, Azure, CircleCI
 - [Bomly Guard](docs/BOMLY_GUARD.md) - turnkey GitHub Action for PR dependency review
+- [MCP Server](docs/MCP.md) - connect Bomly to Claude Code, Cursor, VS Code, or another MCP client
 - [Reachability](docs/REACHABILITY.md) - experimental reachable-vulnerability triage
 - [Plugins](docs/PLUGINS.md) - managed external detectors, matchers, and auditors
 - [All Documentation](docs/README.md) - full docs index

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -128,6 +128,16 @@ bomly diff --sbom --base ./old.spdx.json --head ./new.spdx.json --json
 
 Add `--audit --fail-on high` to fail PRs that introduce new high-severity findings without complaining about pre-existing ones.
 
+## Use Bomly with an AI agent
+
+Bomly can run as a local MCP server so an agent can call `scan`, `explain`, `diff`, vulnerability fix context, and plugin-list tools directly:
+
+```bash
+bomly mcp serve
+```
+
+See [MCP Server](MCP.md) for Claude Code, Cursor, VS Code, and tool-reference details.
+
 ## Inspect the interactive view
 
 ```bash
@@ -140,5 +150,6 @@ Opens a terminal UI with tabs for packages, vulnerabilities, licenses, findings,
 
 - [Output formats](OUTPUT_FORMATS.md) — text, JSON, SARIF, SBOM
 - [Configuration](CONFIG_REFERENCE.md) — every config key, env var, and flag
+- [MCP server](MCP.md) — connect Bomly to AI agents
 - [Troubleshooting](TROUBLESHOOTING.md) — common errors and fixes
 - [CI integration](CI_INTEGRATION.md) — GitHub Actions, GitLab, Jenkins recipes

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -95,11 +95,13 @@ Bomly registers five MCP tools.
 
 | Tool | Use it for | Required arguments | Optional arguments | Enrichment behavior |
 | --- | --- | --- | --- | --- |
-| `bomly_scan` | Scan a path, Git URL, container image, or SBOM and return packages, manifests, and optional findings. | None | `path`, `image`, `container` (deprecated alias), `url`, `ref`, `enrich`, `audit`, `analyze`, `fail_on`, `ecosystems`, `scope` | Calls external matchers only when `enrich` is true. `audit` evaluates data already present on packages and usually pairs with `enrich`. |
+| `bomly_scan` | Scan a path, Git URL, container image, or SBOM and return packages, manifests, and optional findings. | None | `path`, `image`, `url`, `ref`, `enrich`, `audit`, `analyze`, `fail_on`, `ecosystems`, `scope` | Calls external matchers only when `enrich` is true. `audit` evaluates data already present on packages and usually pairs with `enrich`. |
 | `bomly_explain` | Explain why a package is present by returning dependency paths to it. | `package` | `path`, `enrich`, `audit`, `analyze` | Calls external matchers only when `enrich` is true. |
-| `bomly_diff` | Compare dependency state across two Git refs or container tags/digests. | `base`, `head` | `path`, `image`, `container` (deprecated alias), `enrich`, `audit`, `analyze`, `fail_on`, `allow_vulnerability_ids`, `allow_licenses`, `deny_licenses`, `license_exempt_packages`, `deny_packages`, `deny_groups`, `protected_packages`, `typosquat_threshold`, `typosquat_mode`, `warn_only` | Calls external matchers only when `enrich` is true. |
+| `bomly_diff` | Compare dependency state across two Git refs or container tags/digests. | `base`, `head` | `path`, `image`, `enrich`, `audit`, `analyze`, `fail_on`, `allow_vulnerability_ids`, `allow_licenses`, `deny_licenses`, `license_exempt_packages`, `deny_packages`, `deny_groups`, `protected_packages`, `typosquat_threshold`, `typosquat_mode`, `warn_only` | Calls external matchers only when `enrich` is true. |
 | `bomly_vuln_fix_context` | Return fix context for vulnerabilities on one package, including affected manifests and dependency paths. | `package` | `vuln_id`, `path` | Always enriches, because vulnerability data is required to compute fix context. |
 | `bomly_plugins` | List built-in and installed external plugins with their enabled state. | None | None | Does not enrich package data. |
+
+MCP coverage matches Bomly CLI coverage: `bomly_scan`, `bomly_explain`, and `bomly_diff` use the same detector, matcher, auditor, and analyzer registry as the CLI. See [Support Matrix](SUPPORT_MATRIX.md) for the current ecosystem and package-manager list.
 
 Tool responses are JSON text results. `bomly_scan`, `bomly_explain`, and `bomly_diff` use the same response shapes documented in [JSON Schemas](SCHEMAS.md). `bomly_vuln_fix_context` returns a smaller remediation-focused payload with the package, matched vulnerabilities, dependency paths, affected manifests, and recommendation text.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,193 @@
+# MCP Server
+
+Bomly can run as a local Model Context Protocol (MCP) server. This lets an MCP-aware agent call Bomly's dependency graph tools directly instead of asking you to paste scan output into chat.
+
+The server is local and stdio-based:
+
+- the MCP client starts `bomly mcp serve` as a child process
+- Bomly reads the same project files the CLI can read
+- tool results are returned as structured JSON
+- Bomly does not host a remote MCP endpoint
+
+## Prerequisites
+
+Install Bomly first and make sure the `bomly` executable is on `PATH`:
+
+```bash
+bomly version
+```
+
+If that command fails, install Bomly from [Installation](INSTALLATION.md) or use the absolute path to the binary in your MCP client config.
+
+Start the server by hand when you want to check that the command works:
+
+```bash
+bomly mcp serve
+```
+
+The command writes its startup banner to stderr and then waits for an MCP client on stdio. It is not meant to be used as an interactive shell command after startup.
+
+## Claude Code
+
+Add Bomly as a local stdio server:
+
+```bash
+claude mcp add --transport stdio bomly -- bomly mcp serve
+```
+
+For a project-scoped config you can also commit a `.mcp.json` file:
+
+```json
+{
+  "mcpServers": {
+    "bomly": {
+      "type": "stdio",
+      "command": "bomly",
+      "args": ["mcp", "serve"],
+      "env": {}
+    }
+  }
+}
+```
+
+Claude Code prompts before using project-scoped servers from `.mcp.json`. Use `/mcp` inside Claude Code to inspect the connection and available tools.
+
+## Cursor
+
+Create or update `.cursor/mcp.json` in a project, or `~/.cursor/mcp.json` for your user:
+
+```json
+{
+  "mcpServers": {
+    "bomly": {
+      "type": "stdio",
+      "command": "bomly",
+      "args": ["mcp", "serve"],
+      "env": {}
+    }
+  }
+}
+```
+
+Then open Cursor's MCP settings and confirm that the Bomly server is enabled. If Cursor cannot start the server, run `bomly mcp serve` in a terminal from the same environment Cursor uses.
+
+## VS Code
+
+Create or update `.vscode/mcp.json` in a workspace, or your user MCP config:
+
+```json
+{
+  "servers": {
+    "bomly": {
+      "type": "stdio",
+      "command": "bomly",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Use the command palette action `MCP: List Servers` or `MCP: Open Workspace Folder MCP Configuration` to inspect the server. VS Code also supports sandbox settings for local stdio servers if you want to restrict filesystem or network access.
+
+## Tools
+
+Bomly registers five MCP tools.
+
+| Tool | Use it for | Required arguments | Optional arguments | Enrichment behavior |
+| --- | --- | --- | --- | --- |
+| `bomly_scan` | Scan a path, Git URL, container image, or SBOM and return packages, manifests, and optional findings. | None | `path`, `image`, `container` (deprecated alias), `url`, `ref`, `enrich`, `audit`, `analyze`, `fail_on`, `ecosystems`, `scope` | Calls external matchers only when `enrich` is true. `audit` evaluates data already present on packages and usually pairs with `enrich`. |
+| `bomly_explain` | Explain why a package is present by returning dependency paths to it. | `package` | `path`, `enrich`, `audit`, `analyze` | Calls external matchers only when `enrich` is true. |
+| `bomly_diff` | Compare dependency state across two Git refs or container tags/digests. | `base`, `head` | `path`, `image`, `container` (deprecated alias), `enrich`, `audit`, `analyze`, `fail_on`, `allow_vulnerability_ids`, `allow_licenses`, `deny_licenses`, `license_exempt_packages`, `deny_packages`, `deny_groups`, `protected_packages`, `typosquat_threshold`, `typosquat_mode`, `warn_only` | Calls external matchers only when `enrich` is true. |
+| `bomly_vuln_fix_context` | Return fix context for vulnerabilities on one package, including affected manifests and dependency paths. | `package` | `vuln_id`, `path` | Always enriches, because vulnerability data is required to compute fix context. |
+| `bomly_plugins` | List built-in and installed external plugins with their enabled state. | None | None | Does not enrich package data. |
+
+Tool responses are JSON text results. `bomly_scan`, `bomly_explain`, and `bomly_diff` use the same response shapes documented in [JSON Schemas](SCHEMAS.md). `bomly_vuln_fix_context` returns a smaller remediation-focused payload with the package, matched vulnerabilities, dependency paths, affected manifests, and recommendation text.
+
+## Example Prompts
+
+After the server is connected, ask your agent for focused dependency tasks:
+
+```text
+Use Bomly to scan this project and summarize high-severity findings.
+```
+
+```text
+Use Bomly to explain why lodash is present before changing package.json.
+```
+
+```text
+Use Bomly to diff this branch against main and tell me whether the PR introduces new vulnerable dependencies.
+```
+
+For repeatable team behavior, put a short instruction in your repository's agent guidance:
+
+```text
+Before committing dependency or lockfile changes, use Bomly's MCP tools to run a dependency diff against the base branch and explain any new vulnerable package.
+```
+
+This is a workflow hint, not a security guarantee. Review the tool output and the proposed code changes.
+
+## Security And Network Behavior
+
+Bomly's MCP server runs as your user on your machine. Treat it like running the Bomly CLI from the same repository:
+
+- it can read project files that the Bomly process can access
+- it can invoke package-manager tools used by detectors if those tools are on `PATH`
+- it inherits the environment passed by your MCP client
+- it does not need a Bomly account, API key, or token
+
+Network enrichment is opt-in via `enrich` for `bomly_scan`, `bomly_explain`, and `bomly_diff`. Without enrichment, matchers do not call vulnerability, license, lifecycle, or scorecard services. Some detectors may still invoke package-manager commands, and those tools can contact package registries as part of normal dependency resolution. See [Detectors](DETECTORS.md#network-behavior) for the detector-level breakdown.
+
+`bomly_vuln_fix_context` always enables enrichment because it needs vulnerability records and fixed-version data. Use it only when you want that network-backed fix context.
+
+## Troubleshooting
+
+### `spawn bomly ENOENT`
+
+Your MCP client cannot find `bomly` on `PATH`. Run:
+
+```bash
+which bomly
+```
+
+Then either fix the client environment or use the absolute path:
+
+```json
+{
+  "command": "/usr/local/bin/bomly",
+  "args": ["mcp", "serve"]
+}
+```
+
+### The Server Starts But No Tools Appear
+
+Check the MCP client's server status panel first. Then run:
+
+```bash
+bomly mcp serve
+```
+
+If the command exits immediately, fix the printed error. If you recently changed the config, restart the MCP server or reset the client's cached tool list.
+
+### A Scan Takes A Long Time
+
+The MCP tools run the real Bomly pipeline. Large repositories, container images, Git clones, enrichment, and build-tool-backed detectors can take longer than small lockfile-only scans.
+
+Use narrower arguments when possible:
+
+```json
+{
+  "path": "./services/api",
+  "scope": "runtime"
+}
+```
+
+For clients with per-tool timeouts, increase the timeout for the Bomly server rather than retrying the same scan in a loop.
+
+### A Detector Says A Package Manager Is Missing
+
+Bomly does not install package managers for you. Install the package manager the project uses, or scan from an environment where that tool is already available. Lockfile-parser detectors and SBOM ingest do not need package-manager binaries.
+
+### The JSON Output Is Large
+
+Dependency graphs can be large. Ask the agent to summarize specific fields, use `bomly_explain` for one package, or use `bomly_diff` to compare two refs instead of scanning the whole graph when your question is about a change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Task-oriented walkthroughs.
 - [SBOM Formats](SBOM.md) — SPDX vs. CycloneDX, write and ingest
 - [CI Integration](CI_INTEGRATION.md) — GitHub Actions, GitLab, Jenkins, Azure, CircleCI
 - [Bomly Guard](BOMLY_GUARD.md) — the turnkey GitHub Action for PR dependency review
+- [MCP Server](MCP.md) — connect Bomly to Claude Code, Cursor, VS Code, or another MCP client
 - [Interactive TUI](TUI.md) — keybindings and tabs for `--interactive`
 - [Troubleshooting](TROUBLESHOOTING.md) — common errors and fixes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,8 +26,8 @@ How Bomly thinks about your project.
 - [Matchers](MATCHERS.md) — enriching the graph with vulnerability, license, lifecycle data
 - [Auditors](AUDITORS.md) — evaluating the graph against policy
 - [Reachability](REACHABILITY.md) — narrowing findings to code your app actually calls
-- [Plugins](PLUGINS.md) — install, trust, configure, and package external plugins
 - [MCP Server](MCP.md) — connect Bomly to Claude Code, Cursor, VS Code, or another MCP client
+- [Plugins](PLUGINS.md) — install, trust, configure, and package external plugins
 - Plugin implementation guides: [detector](plugins/how-to-implement-detector.md), [matcher](plugins/how-to-implement-matcher.md), [auditor](plugins/how-to-implement-auditor.md)
 - Example plugin repos: [Bun detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector), [ClearlyDefined matcher](https://github.com/bomly-dev/bomly-plugin-clearlydefined-matcher), [EOL lifecycle matcher](https://github.com/bomly-dev/bomly-plugin-eol-matcher), [Meme auditor](https://github.com/bomly-dev/bomly-plugin-meme-auditor)
 - [Glossary](GLOSSARY.md) — every term, one sentence each

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,6 @@ Task-oriented walkthroughs.
 - [SBOM Formats](SBOM.md) — SPDX vs. CycloneDX, write and ingest
 - [CI Integration](CI_INTEGRATION.md) — GitHub Actions, GitLab, Jenkins, Azure, CircleCI
 - [Bomly Guard](BOMLY_GUARD.md) — the turnkey GitHub Action for PR dependency review
-- [MCP Server](MCP.md) — connect Bomly to Claude Code, Cursor, VS Code, or another MCP client
 - [Interactive TUI](TUI.md) — keybindings and tabs for `--interactive`
 - [Troubleshooting](TROUBLESHOOTING.md) — common errors and fixes
 
@@ -28,6 +27,7 @@ How Bomly thinks about your project.
 - [Auditors](AUDITORS.md) — evaluating the graph against policy
 - [Reachability](REACHABILITY.md) — narrowing findings to code your app actually calls
 - [Plugins](PLUGINS.md) — install, trust, configure, and package external plugins
+- [MCP Server](MCP.md) — connect Bomly to Claude Code, Cursor, VS Code, or another MCP client
 - Plugin implementation guides: [detector](plugins/how-to-implement-detector.md), [matcher](plugins/how-to-implement-matcher.md), [auditor](plugins/how-to-implement-auditor.md)
 - Example plugin repos: [Bun detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector), [ClearlyDefined matcher](https://github.com/bomly-dev/bomly-plugin-clearlydefined-matcher), [EOL lifecycle matcher](https://github.com/bomly-dev/bomly-plugin-eol-matcher), [Meme auditor](https://github.com/bomly-dev/bomly-plugin-meme-auditor)
 - [Glossary](GLOSSARY.md) — every term, one sentence each

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -150,7 +150,7 @@
       "slug": "mcp",
       "title": "MCP server",
       "description": "Connect Bomly's dependency graph tools to Claude Code, Cursor, VS Code, or another MCP client.",
-      "group": "operations"
+      "group": "concepts"
     },
     {
       "slug": "troubleshooting",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -147,6 +147,12 @@
       "group": "operations"
     },
     {
+      "slug": "mcp",
+      "title": "MCP server",
+      "description": "Connect Bomly's dependency graph tools to Claude Code, Cursor, VS Code, or another MCP client.",
+      "group": "operations"
+    },
+    {
       "slug": "troubleshooting",
       "title": "Troubleshooting",
       "description": "Common errors and how to fix them, organized by exit code and symptom.",


### PR DESCRIPTION
## Summary

Adds a dedicated public MCP server guide for Bomly CLI and wires it into the existing docs navigation.

## Changes

- Add `docs/MCP.md` with setup snippets for Claude Code, Cursor, and VS Code.
- Document the five exposed MCP tools, their arguments, and enrichment behavior.
- Clarify local stdio server behavior, security/network expectations, and common troubleshooting paths.
- Link the guide from the README, Getting Started, docs index, and docs manifest.

## Validation

- `go run ./cmd/bomly mcp serve --help`
- `go test ./internal/mcp ./internal/cli -run 'Mcp|MCP'`
- `git diff --check`
- `make test`

Note: the first `make test` run hit transient Java readiness timeouts in Gradle/Maven/sbt detector tests. The affected packages passed when rerun directly, and the full `make test` rerun passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for using Bomly as a local MCP server with AI agents.
  * Expanded setup instructions with example commands and guidance for common MCP clients.
  * Updated the getting-started and docs index pages to link to the new MCP server documentation.
  * Refined AI-agent guidance to better reflect available local capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->