### PR TITLE
Fix Maven ANSI TGF parsing

### DIFF
--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -155,7 +155,7 @@ func (d Detector) resolveGraph(ctx context.Context, stderr io.Writer, projectPat
 }
 
 func mavenDependencyTreeArgs(prefixArgs []string, scopeFilter sdk.Scope) []string {
-	args := append(append([]string(nil), prefixArgs...), "dependency:tree", "-DoutputType=tgf")
+	args := append(append([]string(nil), prefixArgs...), "-B", "dependency:tree", "-DoutputType=tgf")
 	switch scopeFilter {
 	case sdk.ScopeRuntime:
 		args = append(args, "-Dscope=runtime")
@@ -311,7 +311,7 @@ func depGraphFromMavenTGF(raw []byte) (*sdk.Graph, error) {
 }
 
 func normalizeMavenTGFLine(line string) (string, bool) {
-	trimmed := strings.TrimSpace(line)
+	trimmed := strings.TrimSpace(stripMavenANSI(line))
 	if trimmed == "" {
 		return "", false
 	}
@@ -324,6 +324,27 @@ func normalizeMavenTGFLine(line string) (string, bool) {
 	}
 
 	return trimmed, true
+}
+
+func stripMavenANSI(value string) string {
+	var out strings.Builder
+	inEscape := false
+	for idx := 0; idx < len(value); idx++ {
+		ch := value[idx]
+		if inEscape {
+			if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
+				inEscape = false
+			}
+			continue
+		}
+		if ch == 0x1b && idx+1 < len(value) && value[idx+1] == '[' {
+			inEscape = true
+			idx++
+			continue
+		}
+		out.WriteByte(ch)
+	}
+	return out.String()
 }
 
 func looksLikeTGFNodeLine(line string) bool {

--- a/internal/detectors/maven/detector_test.go
+++ b/internal/detectors/maven/detector_test.go
@@ -130,6 +130,29 @@ func TestDepGraphFromMavenTGF_WithMavenLogPrefixes(t *testing.T) {
 	}
 }
 
+func TestDepGraphFromMavenTGF_WithColoredMavenLogPrefixes(t *testing.T) {
+	raw := []byte("[\x1b[1;34mINFO\x1b[m] Scanning for projects...\n" +
+		"[\x1b[1;34mINFO\x1b[m] 1 com.example:demo-app:jar:1.0.0\n" +
+		"[\x1b[1;34mINFO\x1b[m] 2 org.apache.commons:commons-configuration2:jar:2.7:compile\n" +
+		"[\x1b[1;34mINFO\x1b[m] 3 org.apache.commons:commons-text:jar:1.8:compile\n" +
+		"[\x1b[1;34mINFO\x1b[m] #\n" +
+		"[\x1b[1;34mINFO\x1b[m] 1 2 compile\n" +
+		"[\x1b[1;34mINFO\x1b[m] 2 3 compile\n" +
+		"[\x1b[1;34mINFO\x1b[m] BUILD SUCCESS\n")
+
+	g, err := depGraphFromMavenTGF(raw)
+	if err != nil {
+		t.Fatalf("depGraphFromMavenTGF() error = %v", err)
+	}
+
+	if g.Size() != 3 {
+		t.Fatalf("expected 3 packages, got %d", g.Size())
+	}
+
+	requireMavenEdge(t, g, "com.example:demo-app@1.0.0", "org.apache.commons:commons-configuration2@2.7")
+	requireMavenEdge(t, g, "org.apache.commons:commons-configuration2@2.7", "org.apache.commons:commons-text@1.8")
+}
+
 func TestNodeFromMavenCoords_WithClassifier(t *testing.T) {
 	node, err := nodeFromMavenCoords("com.example:demo-artifact:jar:sources:1.0.0:test")
 	if err != nil {
@@ -223,19 +246,19 @@ func TestMavenDependencyTreeArgsScopeFilter(t *testing.T) {
 		{
 			name:  "unknown resolves full tree",
 			scope: sdk.ScopeUnknown,
-			want:  []string{"dependency:tree", "-DoutputType=tgf"},
+			want:  []string{"-B", "dependency:tree", "-DoutputType=tgf"},
 		},
 		{
 			name:   "runtime selects runtime scope",
 			prefix: []string{"./mvnw"},
 			scope:  sdk.ScopeRuntime,
-			want:   []string{"./mvnw", "dependency:tree", "-DoutputType=tgf", "-Dscope=runtime"},
+			want:   []string{"./mvnw", "-B", "dependency:tree", "-DoutputType=tgf", "-Dscope=runtime"},
 		},
 		{
 			name:      "development selects test scope",
 			prefix:    []string{"-f", "demo/pom.xml"},
 			scope:     sdk.ScopeDevelopment,
-			want:      []string{"-f", "demo/pom.xml", "dependency:tree", "-DoutputType=tgf", "-Dscope=test"},
+			want:      []string{"-f", "demo/pom.xml", "-B", "dependency:tree", "-DoutputType=tgf", "-Dscope=test"},
 			unchanged: []string{"-f", "demo/pom.xml"},
 		},
 	}


### PR DESCRIPTION
## Summary

- run Maven dependency tree in batch mode so captured TGF output avoids colored log prefixes and progress output
- strip ANSI CSI sequences before normalizing Maven `[INFO]` prefixes as a defensive parser fallback
- add regression coverage for colored Maven output preserving a transitive dependency edge

## Root cause

Maven can emit ANSI-colored `[INFO]` prefixes even when Bomly captures stdout through a pipe. The Maven TGF normalizer only recognized literal `[INFO]`, so colored output caused every node and edge line to be skipped. That made the Maven detector fall back to manifest-only resolution and could hide transitive dependencies.

Closes #243.

## Validation

- `go test ./internal/detectors/maven`
- `git diff --check`
- `go test ./internal/detectors/gradle ./internal/detectors/sbt`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven dependency parsing so colored terminal output is handled correctly.
  * Reduced parsing issues caused by formatted log lines and extra terminal escape characters.
  * Maven dependency collection now runs in a more stable non-interactive mode for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->