### PR TITLE
Fix install script versioned asset names

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,12 +21,14 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
   throw "Could not resolve Bomly version."
 }
 
+$AssetVersion = $Version -replace "^v", ""
+
 $arch = switch ((Get-CimInstance Win32_OperatingSystem).OSArchitecture) {
   { $_ -match "ARM64" } { "arm64"; break }
   default { "amd64" }
 }
 
-$archive = "${Binary}_${Version}_windows_${arch}.zip"
+$archive = "${Binary}_${AssetVersion}_windows_${arch}.zip"
 $baseUrl = "https://github.com/$Repo/releases/download/$Version"
 $tmp = New-Item -ItemType Directory -Path ([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid()))
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,8 @@ if [ -z "$version" ]; then
   exit 1
 fi
 
-archive="${binary}_${version}_${os}_${arch}.tar.gz"
+asset_version="${version#v}"
+archive="${binary}_${asset_version}_${os}_${arch}.tar.gz"
 base_url="https://github.com/${repo}/releases/download/${version}"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT INT TERM


### PR DESCRIPTION
## Summary

- Fix Unix and PowerShell install scripts to keep release tag URLs as `vX.Y.Z` while using non-prefixed `X.Y.Z` in release asset filenames
- Restores `BOMLY_VERSION=v0.16.2` installs for the currently published asset naming scheme

## Validation

- `sh -n scripts/install.sh`
- `BOMLY_VERSION=v0.16.2 BOMLY_INSTALL_DIR=<tmp> sh scripts/install.sh`
- `<tmp>/bomly version`

Note: PowerShell syntax validation was not run locally because `pwsh` is not installed on this machine.