### PR TITLE
ci(release): fail fast when the winget PAT is expired or revoked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    # Fail within seconds if WINGET_GITHUB_TOKEN is expired or revoked,
+    # instead of 14 minutes into GoReleaser — after it has already created
+    # the draft release and opened the Homebrew/Scoop PRs — which strands
+    # the release in a half-published state (see the v0.18.2 run). The
+    # winget publisher is the only one on a long-lived PAT: the release-bot
+    # app token cannot open PRs on microsoft/winget-pkgs, where the app is
+    # not installed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check winget token validity and expiry
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          headers_file="$(mktemp)"
+          status="$(curl -sS -o /dev/null -D "$headers_file" -w '%{http_code}' \
+            -H "Authorization: Bearer ${WINGET_GITHUB_TOKEN}" \
+            https://api.github.com/repos/bomly-dev/winget-pkgs)"
+          if [ "$status" != "200" ]; then
+            echo "::error::WINGET_GITHUB_TOKEN cannot read bomly-dev/winget-pkgs (HTTP ${status}). The PAT has likely expired or been revoked — mint a new one (public_repo scope, it must be able to open PRs on microsoft/winget-pkgs) and update the secret: gh secret set WINGET_GITHUB_TOKEN -R bomly-dev/bomly-cli"
+            exit 1
+          fi
+
+          expiry="$(grep -i '^github-authentication-token-expiration:' "$headers_file" | cut -d' ' -f2- | tr -d '\r' || true)"
+          if [ -n "$expiry" ]; then
+            expiry_epoch="$(date -u -d "$expiry" +%s)"
+            days_left=$(( (expiry_epoch - $(date -u +%s)) / 86400 ))
+            echo "WINGET_GITHUB_TOKEN expires ${expiry} UTC (${days_left} days from now)."
+            if [ "$days_left" -lt 14 ]; then
+              echo "::warning::WINGET_GITHUB_TOKEN expires in ${days_left} days (${expiry} UTC). Rotate it soon: gh secret set WINGET_GITHUB_TOKEN -R bomly-dev/bomly-cli"
+            fi
+          else
+            echo "WINGET_GITHUB_TOKEN has no expiration date."
+          fi
+
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -36,7 +74,7 @@ jobs:
         run: go vet ./...
 
   release:
-    needs: validate
+    needs: [preflight, validate]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
## Why

The [v0.18.2 release run](https://github.com/bomly-dev/bomly-cli/actions/runs/29567349939) failed with `401 Bad Credentials` on the winget publisher — 14 minutes into GoReleaser, **after** the draft release was created and the Homebrew/Scoop PRs were opened, stranding the release half-published (no winget PR, no SLSA provenance).

Root cause: `WINGET_GITHUB_TOKEN` is a 30-day PAT set on 2026-06-17 07:47 UTC. It expired the morning of 2026-07-17 — the v0.18.1 run created its winget PR at 07:46, one minute before expiry; the v0.18.2 run hit the dead token at 09:02. The winget publisher is the only one on a long-lived PAT (the release-bot app token can't open PRs on `microsoft/winget-pkgs`, where the app isn't installed), so it's the only one that can rot.

## What

Adds a `preflight` job (release now `needs: [preflight, validate]`) that:

- validates the token can read `bomly-dev/winget-pkgs`, failing within seconds with an actionable rotation message instead of 14 minutes in;
- parses the `github-authentication-token-expiration` response header and emits a workflow warning when the token is within 14 days of expiry, so the next rotation happens before a release breaks.

`[skip release]` — CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)