### PR TITLE
ci(smoke): resilient goldens pipeline — per-invocation timeout + parallel per-ecosystem regeneration

### DIFF
--- a/test/smoke/helpers_test.go
+++ b/test/smoke/helpers_test.go
@@ -4,7 +4,9 @@ package smoke
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -16,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -49,10 +52,26 @@ func runBomlyWithEnv(t *testing.T, env []string, args ...string) (stdout, stderr
 	return runBomlyBinaryWithEnv(t, bomlyBin, env, args...)
 }
 
+// bomlyInvocationTimeout bounds a single CLI invocation. Smoke scans hit
+// live networks (git clones, Maven Central, enrichment APIs), and a stalled
+// remote with no per-call deadline would otherwise run until go test's
+// global -timeout kills the whole binary — failing every case in the run
+// (and, in -update mode, aborting the goldens refresh) instead of just the
+// stalled one. The slowest healthy case on CI runs in under 2 minutes, so
+// 5 minutes is stall detection, not a tight budget.
+const bomlyInvocationTimeout = 5 * time.Minute
+
 func runBomlyBinaryWithEnv(t *testing.T, bin string, env []string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
 
-	cmd := exec.Command(bin, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), bomlyInvocationTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	// Descendants (mvn, gradle daemons) can inherit the stdout/stderr pipes
+	// and keep them open after the CLI is killed; WaitDelay stops Wait from
+	// blocking on those readers forever.
+	cmd.WaitDelay = 10 * time.Second
 	cmd.Env = append(os.Environ(), env...)
 
 	// Isolate plugin/config discovery to a throwaway home directory so the
@@ -77,6 +96,10 @@ func runBomlyBinaryWithEnv(t *testing.T, bin string, env []string, args ...strin
 	cmd.Stderr = &errBuf
 
 	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("bomly %s did not finish within %s (stalled network call?)\nstderr:\n%s",
+			strings.Join(args, " "), bomlyInvocationTimeout, errBuf.String())
+	}
 	exitCode = 0
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
## Why

[Update Smoke Goldens run 29571173463](https://github.com/bomly-dev/bomly-cli/actions/runs/29571173463) and [re-run 29573048390](https://github.com/bomly-dev/bomly-cli/actions/runs/29573048390) both died with `go test`'s global 15m timeout because a single `bomly` scan stalled on the network — `scan-java-maven-reachability` in the first run, plain `scan-maven` in the second. Both stalls sat inside `mvn dependency:tree` against a cold `~/.m2`, so Maven Central flakiness takes down the entire all-or-nothing job and no goldens PR gets opened, even though ~50 goldens had already regenerated. Meanwhile the nightly Smoke workflow has been red since July 14 on golden drift from the recent graph-shape PRs (#270/#271/#275/#282).

## What

**Commit 1 — per-invocation timeout (`test/smoke/helpers_test.go`)**
- Every smoke CLI invocation now runs under `exec.CommandContext` with a 5-minute deadline (slowest healthy case is <2m) plus `WaitDelay` so pipes inherited by mvn/Gradle daemons can't block `Wait` after the kill. A stall fails one case with the command line and stderr instead of nuking the run.

**Commit 2 — parallel goldens workflow (`.github/workflows/update-smoke-goldens.yml`)**
- Regeneration is split into 21 matrix slices (one per ecosystem; the slow, network-heavy reachability cases isolated into their own slices). Actions minutes are no longer a concern with the repo public.
- Each slice uploads its changed goldens as an artifact; a final `open-pr` job (`if: always()`) merges all artifacts and opens the goldens PR even when some slices failed, listing failed slices in a warning in the PR body — partial progress instead of all-or-nothing, and failed slices can be re-run individually.
- Slice patterns were verified against a stub test tree mirroring all smoke test names: every golden file is produced by exactly one slice (no gaps, no overlaps).
- Both workflows invoke `go test` directly instead of `make smoke ARGS=...` because slice patterns use `$` anchors that make would expand (`$|` → empty).

**Nightly Smoke coverage fixes (`.github/workflows/smoke.yml`)**
- `scan-bun`, `scan-recursive-monorepo`, `scan-java-maven-reachability`, `TestPluginWorkflows`, and `TestLiteVersion` were not matched by any slice and silently never ran; they are now covered (new `plugin` slice, extended `java`/`node` slices).

## Verification

- `actionlint` clean on both workflows.
- `go vet -tags smoke` clean; live smoke case passes through the new helper path; `make test` passes (known local sbt java-ready parallel flake excepted, passes in isolation).
- Slice coverage proven by simulation against a stub package using go's real `-run` matcher.
- Test dispatch of the parallel workflow from this branch: see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)