### PR TITLE
Reject unsupported finding severities in baselines

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -126,7 +126,7 @@ func (d Document) Validate() error {
 		default:
 			return fmt.Errorf("baseline entry %d has unsupported policy_status %q", idx, entry.PolicyStatus)
 		}
-		if entry.Severity != "" && sdk.ParseSeverityLevel(string(entry.Severity)) != entry.Severity {
+		if !validBaselineSeverity(entry.Severity) {
 			return fmt.Errorf("baseline entry %d has unsupported severity %q", idx, entry.Severity)
 		}
 		switch entry.Reachability {
@@ -152,6 +152,24 @@ func (d Document) Validate() error {
 		seen[key] = struct{}{}
 	}
 	return nil
+}
+
+func validBaselineSeverity(severity sdk.SeverityLevel) bool {
+	switch severity {
+	case "",
+		sdk.SeverityUnknown,
+		sdk.SeverityLevel("n/a"),
+		sdk.SeverityLow,
+		sdk.SeverityMedium,
+		sdk.SeverityHigh,
+		sdk.SeverityCritical,
+		sdk.SeverityNote,
+		sdk.SeverityWarning,
+		sdk.SeverityError:
+		return true
+	default:
+		return false
+	}
 }
 
 // Load reads and validates a baseline document.

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -151,6 +151,41 @@ func TestDocumentUsesFriendlyPolicyStatusField(t *testing.T) {
 	}
 }
 
+func TestDocumentRejectsUnsupportedSeverity(t *testing.T) {
+	document := NewDocument([]sdk.Finding{{
+		ID: "rule", Kind: sdk.FindingKindPackage, Auditor: "package",
+		RuleID: "rule", PackageRef: "pkg:npm/example@1.0.0",
+	}}, nil)
+	document.Entries[0].Severity = sdk.SeverityLevel("urgent")
+	if err := document.Validate(); err == nil || !strings.Contains(err.Error(), `unsupported severity "urgent"`) {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestDocumentAcceptsFindingSeverityVocabulary(t *testing.T) {
+	for _, severity := range []sdk.SeverityLevel{
+		"",
+		sdk.SeverityUnknown,
+		sdk.SeverityLevel("n/a"),
+		sdk.SeverityLow,
+		sdk.SeverityMedium,
+		sdk.SeverityHigh,
+		sdk.SeverityCritical,
+		sdk.SeverityNote,
+		sdk.SeverityWarning,
+		sdk.SeverityError,
+	} {
+		document := NewDocument([]sdk.Finding{{
+			ID: "rule", Kind: sdk.FindingKindPackage, Auditor: "package",
+			RuleID: "rule", PackageRef: "pkg:npm/example@1.0.0",
+		}}, nil)
+		document.Entries[0].Severity = severity
+		if err := document.Validate(); err != nil {
+			t.Errorf("severity %q rejected: %v", severity, err)
+		}
+	}
+}
+
 func TestResolvePathSelections(t *testing.T) {
 	root := t.TempDir()
 	sbomPath := filepath.Join(root, "bom.json")


### PR DESCRIPTION
## Summary

- validate baseline severity values against the finding severity vocabulary
- reject arbitrary custom values that previously passed normalization
- preserve the legacy `n/a` spelling and cover every accepted value

## Root cause

Baseline validation compared a parsed severity with the original value. The severity parser intentionally preserves unknown normalized strings, so an arbitrary lowercase value compared equal and was accepted.

## Impact

Malformed baseline files now fail with an actionable unsupported-severity error. No schema version or output contract changes.

## Validation

- `go test ./internal/baseline -count=1`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of finding severity values.
  * Added support for recognized severity options, including unknown and “n/a” values.
  * Invalid severity values now produce a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->