### PR TITLE
fix(osv): surface degraded batch enrichment

### DIFF
--- a/internal/matchers/osv/matcher.go
+++ b/internal/matchers/osv/matcher.go
@@ -288,15 +288,20 @@ func (a *Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResul
 		}
 		results, err := a.client.QueryBatch(queries)
 		if err != nil {
-			// Non-fatal: return what we have with a warning.
+			// Return partial enrichment together with the error. The engine
+			// degrades matcher failures into pipeline warnings while preserving
+			// any cache-backed evidence already collected.
 			a.logger.Warn("osv: batch query failed", zap.Error(err))
 			if a.config.Stderr != nil {
 				if _, werr := fmt.Fprintf(a.config.Stderr, "warn: osv query failed: %v\n", err); werr != nil {
-					return sdk.MatchResult{}, werr
+					return sdk.MatchResult{}, fmt.Errorf("osv write query warning: %w", werr)
 				}
 			}
 			applyPackageVulnerabilityEnrichment(req.Registry, deps, enriched)
-			return sdk.MatchResult{Registry: req.Registry, MatcherStats: osvMatcherStats(enriched, stats.requestedPackages)}, nil
+			return sdk.MatchResult{
+				Registry:     req.Registry,
+				MatcherStats: osvMatcherStats(enriched, stats.requestedPackages),
+			}, fmt.Errorf("osv batch query: %w", err)
 		}
 
 		for i, result := range results {

--- a/internal/matchers/osv/matcher_test.go
+++ b/internal/matchers/osv/matcher_test.go
@@ -267,7 +267,7 @@ func TestAudit_CacheHit_NoHTTPCall(t *testing.T) {
 
 // --- OSV API failure ---
 
-func TestAudit_OSVFailure_NonFatal(t *testing.T) {
+func TestAudit_OSVFailure_ReturnsPartialResultAndWarningError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -288,19 +288,40 @@ func TestAudit_OSVFailure_NonFatal(t *testing.T) {
 		PURL:      "pkg:npm/lodash@4.17.15",
 		Ecosystem: "npm"},
 	})
+	cachedDep := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Name: "cached",
+		Version:   "1.0.0",
+		PURL:      "pkg:npm/cached@1.0.0",
+		Ecosystem: "npm"},
+	})
+	cachedPURL := sdk.CanonicalPackageURLFromDependency(cachedDep)
+	if err := audcache.Set(aud.cache, audcache.NewKey(cachedPURL, "", "", ""), []Vulnerability{{
+		ID:      "OSV-CACHED",
+		Summary: "cached evidence",
+	}}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
 	g := sdk.New()
 	if err := g.AddNode(dep); err != nil {
 		t.Fatalf("AddNode: %v", err)
+	}
+	if err := g.AddNode(cachedDep); err != nil {
+		t.Fatalf("AddNode cached dependency: %v", err)
 	}
 
 	result, err := aud.Match(context.Background(), sdk.MatchRequest{
 		Graph:    g,
 		Registry: sdk.NewPackageRegistry(),
 	})
-	if err != nil {
-		t.Fatalf("Match returned error on API failure (should be non-fatal): %v", err)
+	if err == nil || !strings.Contains(err.Error(), "osv batch query") {
+		t.Fatalf("Match error = %v, want contextual batch-query error", err)
 	}
-	_ = result // partial results are acceptable
+	if result.Registry == nil {
+		t.Fatal("Match discarded the partial registry on API failure")
+	}
+	pkg, ok := result.Registry.Get(cachedPURL)
+	if !ok || len(pkg.Vulnerabilities) != 1 || pkg.Vulnerabilities[0].ID != "OSV-CACHED" {
+		t.Fatalf("cached enrichment was not preserved: %#v, found=%t", pkg, ok)
+	}
 }
 
 // --- KEV enrichment ---


### PR DESCRIPTION
## Summary

- preserve cache-backed vulnerability evidence when an OSV batch request fails
- return a contextual matcher error so the engine records degraded enrichment as a pipeline warning
- keep the failure non-fatal at the pipeline boundary while enabling mutation safety gates

## Validation

- `go test ./internal/matchers/osv -run OSVFailure -count=1`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`