### PR TITLE
fix(plugin): fully isolate descriptor snapshots

### DIFF
--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -859,6 +859,7 @@ func cloneDetectorDescriptor(descriptor *plugschema.DetectorDescriptor) *plugsch
 	copyValue.SupportedEcosystems = append([]plugschema.Ecosystem(nil), descriptor.SupportedEcosystems...)
 	copyValue.SupportedManagers = append([]plugschema.PackageManager(nil), descriptor.SupportedManagers...)
 	copyValue.PackageManagerSupport = clonePackageManagerSupport(descriptor.PackageManagerSupport)
+	copyValue.Aliases = append([]string(nil), descriptor.Aliases...)
 	copyValue.Tags = append([]string(nil), descriptor.Tags...)
 	copyValue.FallbackDetectors = append([]string(nil), descriptor.FallbackDetectors...)
 	copyValue.IgnoredDirectories = append([]string(nil), descriptor.IgnoredDirectories...)
@@ -952,5 +953,7 @@ func cloneAuditorDescriptor(descriptor *plugschema.AuditorDescriptor) *plugschem
 	copyValue := *descriptor
 	copyValue.SupportedEcosystems = append([]plugschema.Ecosystem(nil), descriptor.SupportedEcosystems...)
 	copyValue.SupportedManagers = append([]plugschema.PackageManager(nil), descriptor.SupportedManagers...)
+	copyValue.Aliases = append([]string(nil), descriptor.Aliases...)
+	copyValue.Tags = append([]string(nil), descriptor.Tags...)
 	return &copyValue
 }

--- a/internal/plugin/types_clone_test.go
+++ b/internal/plugin/types_clone_test.go
@@ -9,6 +9,8 @@ import (
 func TestCloneDetectorDescriptorDeepCopiesDiscoveryFields(t *testing.T) {
 	original := &plugschema.DetectorDescriptor{
 		Name:                    "example",
+		Aliases:                 []string{"example-alias"},
+		Tags:                    []string{"dependency-detection"},
 		IgnoredDirectories:      []string{"node_modules"},
 		IgnoredDirectoryMarkers: []string{"pyvenv.cfg"},
 		PackageManagerSupport: []plugschema.PackageManagerSupport{
@@ -30,7 +32,56 @@ func TestCloneDetectorDescriptorDeepCopiesDiscoveryFields(t *testing.T) {
 	// Mutating the clone's slices must not touch the original.
 	clone.IgnoredDirectories[0] = "mutated"
 	clone.IgnoredDirectoryMarkers[0] = "mutated"
-	if original.IgnoredDirectories[0] != "node_modules" || original.IgnoredDirectoryMarkers[0] != "pyvenv.cfg" {
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.PackageManagerSupport[0].EvidencePatterns[0] = "mutated"
+	if original.IgnoredDirectories[0] != "node_modules" ||
+		original.IgnoredDirectoryMarkers[0] != "pyvenv.cfg" ||
+		original.Aliases[0] != "example-alias" ||
+		original.Tags[0] != "dependency-detection" ||
+		original.PackageManagerSupport[0].EvidencePatterns[0] != "package.json" {
 		t.Fatal("clone shares backing arrays with the original descriptor")
+	}
+}
+
+func TestCloneMatcherDescriptorDeepCopiesSlices(t *testing.T) {
+	original := &plugschema.MatcherDescriptor{
+		Name:                "matcher",
+		Aliases:             []string{"matcher-alias"},
+		Tags:                []string{"vulnerability"},
+		SupportedEcosystems: []plugschema.Ecosystem{plugschema.EcosystemNPM},
+		SupportedManagers:   []plugschema.PackageManager{plugschema.PackageManagerNPM},
+	}
+	clone := cloneMatcherDescriptor(original)
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.SupportedEcosystems[0] = plugschema.EcosystemGo
+	clone.SupportedManagers[0] = plugschema.PackageManagerGoMod
+	if original.Aliases[0] != "matcher-alias" ||
+		original.Tags[0] != "vulnerability" ||
+		original.SupportedEcosystems[0] != plugschema.EcosystemNPM ||
+		original.SupportedManagers[0] != plugschema.PackageManagerNPM {
+		t.Fatal("matcher clone shares backing arrays with the original descriptor")
+	}
+}
+
+func TestCloneAuditorDescriptorDeepCopiesSlices(t *testing.T) {
+	original := &plugschema.AuditorDescriptor{
+		Name:                "auditor",
+		Aliases:             []string{"auditor-alias"},
+		Tags:                []string{"policy"},
+		SupportedEcosystems: []plugschema.Ecosystem{plugschema.EcosystemNPM},
+		SupportedManagers:   []plugschema.PackageManager{plugschema.PackageManagerNPM},
+	}
+	clone := cloneAuditorDescriptor(original)
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.SupportedEcosystems[0] = plugschema.EcosystemGo
+	clone.SupportedManagers[0] = plugschema.PackageManagerGoMod
+	if original.Aliases[0] != "auditor-alias" ||
+		original.Tags[0] != "policy" ||
+		original.SupportedEcosystems[0] != plugschema.EcosystemNPM ||
+		original.SupportedManagers[0] != plugschema.PackageManagerNPM {
+		t.Fatal("auditor clone shares backing arrays with the original descriptor")
 	}
 }


### PR DESCRIPTION
## Summary

- deep-copy detector aliases in runtime descriptor snapshots
- deep-copy auditor aliases and tags alongside ecosystem and package-manager slices
- cover every detector, matcher, and auditor descriptor slice against caller mutation

## Validation

- `go test ./internal/plugin -run "TestClone.*Descriptor" -count=1`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved descriptor cloning to keep copied plugin configuration data independent from the original.
  - Prevented changes to cloned detector, matcher, and auditor settings from unintentionally affecting the source configuration.

- **Tests**
  - Added coverage validating independent copies of aliases, tags, package manager details, ecosystems, and other list-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->