### PR TITLE
test(interfaces): strengthen compact and plugin contracts

### DIFF
--- a/internal/mcp/compact_limits_test.go
+++ b/internal/mcp/compact_limits_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/output"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestCompactScanInventoryCapIsDeterministicAndCounted(t *testing.T) {
+	dependencies := make([]output.ScanDependency, 0, maxInventoryEntries+17)
+	for i := maxInventoryEntries + 16; i >= 0; i-- {
+		dependencies = append(dependencies, output.ScanDependency{
+			ID:      fmt.Sprintf("dep-%03d", i),
+			Name:    fmt.Sprintf("package-%03d", i),
+			Version: "1.0.0",
+		})
+	}
+	run := ScanRunResult{Response: output.ScanResponse{
+		Manifests: []output.ScanManifest{{Path: "package.json", Dependencies: dependencies}},
+	}}
+	first := BuildCompactScan(run)
+	second := BuildCompactScan(run)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("compact inventory changed for identical input")
+	}
+	if len(first.Packages) != maxInventoryEntries {
+		t.Fatalf("inventory length = %d, want %d", len(first.Packages), maxInventoryEntries)
+	}
+	if first.Truncation == nil || !first.Truncation.Truncated || first.Truncation.OmittedPackages != 17 {
+		t.Fatalf("inventory truncation = %#v", first.Truncation)
+	}
+	if first.Packages[0] != "package-000@1.0.0" ||
+		first.Packages[len(first.Packages)-1] != "package-199@1.0.0" {
+		t.Fatalf("inventory is not sorted before truncation: first=%q last=%q", first.Packages[0], first.Packages[len(first.Packages)-1])
+	}
+}
+
+func TestCompactScanCapsDiagnosticsWithVisibleMarker(t *testing.T) {
+	diagnostics := make([]Diagnostic, maxDiagnosticsReported+9)
+	for i := range diagnostics {
+		diagnostics[i] = Diagnostic{Stage: "detect", Source: fmt.Sprintf("source-%02d", i), Message: "degraded"}
+	}
+	response := BuildCompactScan(ScanRunResult{Diagnostics: diagnostics})
+	if len(response.Diagnostics) != maxDiagnosticsReported+1 {
+		t.Fatalf("diagnostics length = %d, want %d", len(response.Diagnostics), maxDiagnosticsReported+1)
+	}
+	last := response.Diagnostics[len(response.Diagnostics)-1]
+	if last.Stage != "meta" || last.Message == "" {
+		t.Fatalf("missing visible diagnostic truncation marker: %#v", last)
+	}
+}
+
+func TestCompactRemediationCapsAliasesAndFindingsWithCounters(t *testing.T) {
+	in := remediationFixture(t)
+	pkg, ok := in.Registry.Get("pkg:npm/lib-a@1.0.0")
+	if !ok {
+		t.Fatal("fixture package missing")
+	}
+	pkg.Vulnerabilities[0].Aliases = []string{"CVE-1", "CVE-2", "CVE-3", "CVE-4", "CVE-5"}
+	for i := 0; i < maxFindingsPerGroup+6; i++ {
+		id := fmt.Sprintf("GHSA-extra-%02d", i)
+		pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
+			ID:             id,
+			Aliases:        []string{"A-1", "A-2", "A-3", "A-4"},
+			ParsedSeverity: sdk.SeverityLow,
+			FixState:       sdk.FixStateFixed,
+			FixedIn:        "1.2.0",
+		})
+		in.Findings = append(in.Findings, sdk.Finding{
+			ID:              id,
+			VulnerabilityID: id,
+			Kind:            sdk.FindingKindVulnerability,
+			Severity:        sdk.SeverityLow,
+			PackageRef:      pkg.PURL,
+			DependencyRefs:  append([]string(nil), in.Findings[0].DependencyRefs...),
+		})
+	}
+	result := buildRemediations(in)
+	direct := groupByAction(t, result.Remediations, ActionDirectBump)
+	if len(direct.Fixes) != maxFindingsPerGroup {
+		t.Fatalf("fix count = %d, want %d", len(direct.Fixes), maxFindingsPerGroup)
+	}
+	if result.Truncation == nil || result.Truncation.OmittedFindings != 7 {
+		t.Fatalf("finding truncation = %#v", result.Truncation)
+	}
+	for _, finding := range direct.Fixes {
+		if len(finding.Aliases) > maxAliases {
+			t.Fatalf("aliases exceeded cap: %#v", finding.Aliases)
+		}
+	}
+}

--- a/internal/output/cross_surface_contract_test.go
+++ b/internal/output/cross_surface_contract_test.go
@@ -1,0 +1,88 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestStructuredAndSARIFFindingContractsAgree(t *testing.T) {
+	const purl = "pkg:npm/@scope/library@1.0.0"
+	registry := sdk.NewPackageRegistry()
+	registry.Add(&sdk.Package{
+		Coordinates: sdk.Coordinates{
+			PURL: purl, Ecosystem: sdk.EcosystemNPM, Org: "scope", Name: "library", Version: "1.0.0",
+		},
+		Vulnerabilities: []sdk.Vulnerability{{
+			ID:             "GHSA-contract",
+			Aliases:        []string{"CVE-2026-4242"},
+			ParsedSeverity: sdk.SeverityHigh,
+			FixedIn:        "1.1.0",
+			Reachability: &sdk.Reachability{
+				Status: sdk.ReachabilityReachable,
+				Tier:   sdk.TierPackage,
+				Reason: "imported package",
+			},
+		}},
+	})
+	findings := []sdk.Finding{{
+		ID:              "GHSA-contract",
+		Kind:            sdk.FindingKindVulnerability,
+		Title:           "Contract fixture",
+		Severity:        sdk.SeverityHigh,
+		PolicyStatus:    sdk.FindingPolicyStatusSuppressed,
+		RuleID:          "advisory",
+		PackageRef:      purl,
+		DependencyRefs:  []string{"dep-contract"},
+		VulnerabilityID: "GHSA-contract",
+	}}
+
+	structured := FindingsFromScan(findings, registry)
+	if len(structured) != 1 {
+		t.Fatalf("structured finding count = %d", len(structured))
+	}
+	if structured[0].ID != findings[0].ID ||
+		structured[0].PolicyStatus != findings[0].PolicyStatus ||
+		structured[0].RuleID != findings[0].RuleID ||
+		structured[0].Package.Purl != purl {
+		t.Fatalf("structured finding lost canonical fields: %#v", structured[0])
+	}
+
+	var encoded bytes.Buffer
+	if err := WriteSARIF(&encoded, findings, registry, "bomly", "test", SARIFOptions{IncludeReachability: true}); err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Runs []struct {
+			Results []struct {
+				RuleID       string `json:"ruleId"`
+				Level        string `json:"level"`
+				Suppressions []struct {
+					Kind string `json:"kind"`
+				} `json:"suppressions"`
+				Properties struct {
+					RuleID       string   `json:"rule_id"`
+					PackageRef   string   `json:"package_ref"`
+					Dependencies []string `json:"dependency_refs"`
+					Reachability string   `json:"reachability"`
+				} `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(encoded.Bytes(), &document); err != nil {
+		t.Fatalf("decode SARIF: %v", err)
+	}
+	result := document.Runs[0].Results[0]
+	if result.RuleID != findings[0].ID ||
+		result.Level != "note" ||
+		len(result.Suppressions) != 1 ||
+		result.Suppressions[0].Kind != "external" ||
+		result.Properties.RuleID != findings[0].RuleID ||
+		result.Properties.PackageRef != purl ||
+		len(result.Properties.Dependencies) != 1 ||
+		result.Properties.Reachability != string(sdk.ReachabilityReachable) {
+		t.Fatalf("SARIF finding disagrees with structured contract: %#v", result)
+	}
+}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -859,6 +859,7 @@ func cloneDetectorDescriptor(descriptor *plugschema.DetectorDescriptor) *plugsch
 	copyValue.SupportedEcosystems = append([]plugschema.Ecosystem(nil), descriptor.SupportedEcosystems...)
 	copyValue.SupportedManagers = append([]plugschema.PackageManager(nil), descriptor.SupportedManagers...)
 	copyValue.PackageManagerSupport = clonePackageManagerSupport(descriptor.PackageManagerSupport)
+	copyValue.Aliases = append([]string(nil), descriptor.Aliases...)
 	copyValue.Tags = append([]string(nil), descriptor.Tags...)
 	copyValue.FallbackDetectors = append([]string(nil), descriptor.FallbackDetectors...)
 	copyValue.IgnoredDirectories = append([]string(nil), descriptor.IgnoredDirectories...)
@@ -952,5 +953,7 @@ func cloneAuditorDescriptor(descriptor *plugschema.AuditorDescriptor) *plugschem
 	copyValue := *descriptor
 	copyValue.SupportedEcosystems = append([]plugschema.Ecosystem(nil), descriptor.SupportedEcosystems...)
 	copyValue.SupportedManagers = append([]plugschema.PackageManager(nil), descriptor.SupportedManagers...)
+	copyValue.Aliases = append([]string(nil), descriptor.Aliases...)
+	copyValue.Tags = append([]string(nil), descriptor.Tags...)
 	return &copyValue
 }

--- a/internal/plugin/types_clone_test.go
+++ b/internal/plugin/types_clone_test.go
@@ -9,6 +9,8 @@ import (
 func TestCloneDetectorDescriptorDeepCopiesDiscoveryFields(t *testing.T) {
 	original := &plugschema.DetectorDescriptor{
 		Name:                    "example",
+		Aliases:                 []string{"example-alias"},
+		Tags:                    []string{"dependency-detection"},
 		IgnoredDirectories:      []string{"node_modules"},
 		IgnoredDirectoryMarkers: []string{"pyvenv.cfg"},
 		PackageManagerSupport: []plugschema.PackageManagerSupport{
@@ -30,7 +32,56 @@ func TestCloneDetectorDescriptorDeepCopiesDiscoveryFields(t *testing.T) {
 	// Mutating the clone's slices must not touch the original.
 	clone.IgnoredDirectories[0] = "mutated"
 	clone.IgnoredDirectoryMarkers[0] = "mutated"
-	if original.IgnoredDirectories[0] != "node_modules" || original.IgnoredDirectoryMarkers[0] != "pyvenv.cfg" {
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.PackageManagerSupport[0].EvidencePatterns[0] = "mutated"
+	if original.IgnoredDirectories[0] != "node_modules" ||
+		original.IgnoredDirectoryMarkers[0] != "pyvenv.cfg" ||
+		original.Aliases[0] != "example-alias" ||
+		original.Tags[0] != "dependency-detection" ||
+		original.PackageManagerSupport[0].EvidencePatterns[0] != "package.json" {
 		t.Fatal("clone shares backing arrays with the original descriptor")
+	}
+}
+
+func TestCloneMatcherDescriptorDeepCopiesSlices(t *testing.T) {
+	original := &plugschema.MatcherDescriptor{
+		Name:                "matcher",
+		Aliases:             []string{"matcher-alias"},
+		Tags:                []string{"vulnerability"},
+		SupportedEcosystems: []plugschema.Ecosystem{plugschema.EcosystemNPM},
+		SupportedManagers:   []plugschema.PackageManager{plugschema.PackageManagerNPM},
+	}
+	clone := cloneMatcherDescriptor(original)
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.SupportedEcosystems[0] = plugschema.EcosystemGo
+	clone.SupportedManagers[0] = plugschema.PackageManagerGoMod
+	if original.Aliases[0] != "matcher-alias" ||
+		original.Tags[0] != "vulnerability" ||
+		original.SupportedEcosystems[0] != plugschema.EcosystemNPM ||
+		original.SupportedManagers[0] != plugschema.PackageManagerNPM {
+		t.Fatal("matcher clone shares backing arrays with the original descriptor")
+	}
+}
+
+func TestCloneAuditorDescriptorDeepCopiesSlices(t *testing.T) {
+	original := &plugschema.AuditorDescriptor{
+		Name:                "auditor",
+		Aliases:             []string{"auditor-alias"},
+		Tags:                []string{"policy"},
+		SupportedEcosystems: []plugschema.Ecosystem{plugschema.EcosystemNPM},
+		SupportedManagers:   []plugschema.PackageManager{plugschema.PackageManagerNPM},
+	}
+	clone := cloneAuditorDescriptor(original)
+	clone.Aliases[0] = "mutated"
+	clone.Tags[0] = "mutated"
+	clone.SupportedEcosystems[0] = plugschema.EcosystemGo
+	clone.SupportedManagers[0] = plugschema.PackageManagerGoMod
+	if original.Aliases[0] != "auditor-alias" ||
+		original.Tags[0] != "policy" ||
+		original.SupportedEcosystems[0] != plugschema.EcosystemNPM ||
+		original.SupportedManagers[0] != plugschema.PackageManagerNPM {
+		t.Fatal("auditor clone shares backing arrays with the original descriptor")
 	}
 }

--- a/internal/plugin/types_clone_test.go
+++ b/internal/plugin/types_clone_test.go
@@ -85,3 +85,66 @@ func TestCloneAuditorDescriptorDeepCopiesSlices(t *testing.T) {
 		t.Fatal("auditor clone shares backing arrays with the original descriptor")
 	}
 }
+
+func TestProtocolV1DetectorSnapshotDefaultsAbsentOptionalCapabilities(t *testing.T) {
+	snapshot := RuntimeDescriptorSnapshot{
+		ID:               "legacy-detector",
+		Kind:             plugschema.PluginKindDetector,
+		PluginAPIVersion: plugschema.PluginAPIVersion,
+		DetectorDescriptor: &plugschema.DetectorDescriptor{
+			Name: "legacy-detector",
+			PackageManagerSupport: []plugschema.PackageManagerSupport{
+				plugschema.Support(plugschema.PackageManagerNPM, "package.json"),
+			},
+		},
+	}
+	normalized := normalizeRuntimeSnapshot(snapshot)
+	if err := validateRuntimeSnapshot(normalized); err != nil {
+		t.Fatalf("legacy protocol-v1 snapshot rejected: %v", err)
+	}
+	descriptor := normalized.DetectorDescriptor
+	if descriptor.SupportsInstallFirst ||
+		len(descriptor.IgnoredDirectories) != 0 ||
+		len(descriptor.IgnoredDirectoryMarkers) != 0 {
+		t.Fatalf("absent optional capabilities did not retain safe defaults: %#v", descriptor)
+	}
+}
+
+func TestRuntimeSnapshotRejectsUnadvertisedOrMalformedRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot RuntimeDescriptorSnapshot
+	}{
+		{
+			name: "detector kind without detector descriptor",
+			snapshot: RuntimeDescriptorSnapshot{
+				ID: "broken", Kind: plugschema.PluginKindDetector,
+				PluginAPIVersion:  plugschema.PluginAPIVersion,
+				MatcherDescriptor: &plugschema.MatcherDescriptor{Name: "broken"},
+			},
+		},
+		{
+			name: "matcher kind with malformed descriptor",
+			snapshot: RuntimeDescriptorSnapshot{
+				ID: "broken", Kind: plugschema.PluginKindMatcher,
+				PluginAPIVersion:  plugschema.PluginAPIVersion,
+				MatcherDescriptor: &plugschema.MatcherDescriptor{},
+			},
+		},
+		{
+			name: "unknown API version",
+			snapshot: RuntimeDescriptorSnapshot{
+				ID: "broken", Kind: plugschema.PluginKindMatcher,
+				PluginAPIVersion:  "bomly.plugin.v999",
+				MatcherDescriptor: &plugschema.MatcherDescriptor{Name: "broken"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateRuntimeSnapshot(normalizeRuntimeSnapshot(test.snapshot)); err == nil {
+				t.Fatalf("validateRuntimeSnapshot accepted %#v", test.snapshot)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- prove deterministic compact MCP inventory, diagnostic, alias, and finding caps with visible omission evidence
- cross-check canonical finding identity, policy state, dependency references, and reachability between structured output and SARIF
- verify protocol-v1 plugins retain safe defaults when optional capabilities are absent and malformed role snapshots are rejected

This assurance PR is stacked on #306, which fixes descriptor snapshot ownership.

## Validation

- `go test ./internal/mcp ./internal/output ./internal/plugin -run "Compact|Contract|ProtocolV1|RuntimeSnapshot|Clone.*Descriptor" -count=1`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`