### PR TITLE
test(performance): record reproducible run evidence

### DIFF
--- a/.github/workflows/portable-assurance.yml
+++ b/.github/workflows/portable-assurance.yml
@@ -1,0 +1,96 @@
+name: Portable stability assurance
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  portable:
+    name: Portable suite (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Repeat portable suite twice
+        shell: bash
+        run: |
+          set -euo pipefail
+          for iteration in 1 2; do
+            echo "portable suite iteration ${iteration}"
+            go test ./... -count=1
+          done
+
+  linux-stability:
+    name: Linux repeated stability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Repeat Java suites ten times
+        run: |
+          set -euo pipefail
+          for iteration in $(seq 1 10); do
+            echo "Java suite iteration ${iteration}"
+            go test ./internal/detectors/gradle ./internal/detectors/maven ./internal/detectors/sbt ./internal/analyzers/jvmreach -count=1
+          done
+
+      - name: Repeat complete suite five times
+        run: |
+          set -euo pipefail
+          for iteration in $(seq 1 5); do
+            echo "complete suite iteration ${iteration}"
+            go test ./... -count=1
+          done
+
+      - name: Cross-build release targets
+        run: |
+          set -euo pipefail
+          targets=(
+            "linux amd64"
+            "linux arm64"
+            "darwin amd64"
+            "darwin arm64"
+            "windows amd64"
+            "windows arm64"
+          )
+          for target in "${targets[@]}"; do
+            read -r target_os target_arch <<<"${target}"
+            suffix=""
+            if [[ "${target_os}" == "windows" ]]; then
+              suffix=".exe"
+            fi
+            echo "cross-build ${target_os}/${target_arch}"
+            GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
+              go build -o "bin/bomly-${target_os}-${target_arch}${suffix}" ./cmd/bomly
+            GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
+              go build -tags "bomly_external_syft,bomly_external_grype" \
+              -o "bin/bomly-lite-${target_os}-${target_arch}${suffix}" ./cmd/bomly
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Core passes these env vars. Plugin discovery: `~/.bomly/plugins/bomly-*` overrid
 - Generated docs are part of the contract: update `docs/CONFIG_REFERENCE.md`, `docs/schemas/*`, and `docs/SUPPORT_MATRIX.md` via `make generate` when their source packages change.
 - Fake binaries (npm, go, Gradle, plugin) are built in `TestMain` — see `internal/cli/root_test_main_test.go`.
 - No test conditionally skipped without a recorded reason.
+- Use plain language in documentation and user-facing text. Prefer short, direct sentences; explain necessary technical terms when they first appear.
 
 ## Feature Checklist
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ EXE_SUFFIX=$(if $(filter Windows_NT,$(OS)),.exe,)
 GOLANGCI_LINT=$(GOPATH_BIN)/golangci-lint$(EXE_SUFFIX)
 FUZZTIME?=60s
 
-.PHONY: build build-full build-lite fmt fmt-check lint install-hooks test fuzz run generate docs-config docs-schema docs-schema-md docs-support-matrix docs-components smoke benchmark benchmark-report licenses
+.PHONY: build build-full build-lite fmt fmt-check lint install-hooks test fuzz run generate docs-config docs-schema docs-schema-md docs-support-matrix docs-components smoke benchmark benchmark-samples benchmark-report licenses
 
 build: build-full build-lite
 
@@ -43,6 +43,10 @@ smoke:
 
 benchmark: build-full
 	bin/$(BINARY_NAME)$(EXE_SUFFIX) benchmark $(if $(ARGS),$(ARGS),)
+
+benchmark-samples: build-lite
+	go run ./internal/tools/benchmarkrun -output .benchmark-runs/performance -case canonical-sbom-scan -samples 5 -network-state offline -- \
+		./bin/$(BINARY_NAME)-lite$(EXE_SUFFIX) scan --sbom --path test/smoke/testdata/sboms/go.spdx.json --detectors sbom --format json
 
 benchmark-report:
 	go run ./internal/tools/benchmarkreport

--- a/internal/tools/benchmarkrun/main.go
+++ b/internal/tools/benchmarkrun/main.go
@@ -1,0 +1,462 @@
+// Command benchmarkrun repeatedly executes one deterministic assurance case
+// and records cold/warm samples in a versioned machine-readable manifest.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	runSchemaVersion   = "bomly.benchmark-run/v1"
+	normalizationV1    = "bomly.benchmark-normalization/v1"
+	defaultSamples     = 5
+	defaultOutput      = ".benchmark-runs/performance"
+	defaultNetworkMode = "unknown"
+)
+
+type runManifest struct {
+	SchemaVersion        string        `json:"schema_version"`
+	NormalizationVersion string        `json:"normalization_version"`
+	GeneratedAt          string        `json:"generated_at"`
+	Source               sourceInfo    `json:"source"`
+	Tool                 toolInfo      `json:"tool"`
+	Host                 hostInfo      `json:"host"`
+	Case                 caseInfo      `json:"case"`
+	Samples              []sample      `json:"samples"`
+	Summaries            []modeSummary `json:"summaries"`
+	Gates                gateSummary   `json:"gates"`
+}
+
+type sourceInfo struct {
+	Revision string `json:"revision"`
+	Dirty    bool   `json:"dirty"`
+}
+
+type toolInfo struct {
+	Path    string `json:"path"`
+	Version string `json:"version,omitempty"`
+	SHA256  string `json:"sha256"`
+}
+
+type hostInfo struct {
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	Go       string `json:"go_version"`
+	CPUs     int    `json:"cpus"`
+	Hostname string `json:"hostname,omitempty"`
+}
+
+type caseInfo struct {
+	Name           string   `json:"name"`
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	WorkingDir     string   `json:"working_directory"`
+	SamplesPerMode int      `json:"samples_per_mode"`
+	NetworkState   string   `json:"network_state"`
+	CacheModes     []string `json:"cache_modes"`
+}
+
+type sample struct {
+	Mode             string             `json:"mode"`
+	Index            int                `json:"index"`
+	StartedAt        string             `json:"started_at"`
+	FinishedAt       string             `json:"finished_at"`
+	ExitCode         int                `json:"exit_code"`
+	StageTimingsMS   map[string]float64 `json:"stage_timings_ms"`
+	PeakMemoryBytes  uint64             `json:"peak_memory_bytes,omitempty"`
+	StdoutBytes      int                `json:"stdout_bytes"`
+	StderrBytes      int                `json:"stderr_bytes"`
+	StdoutSHA256     string             `json:"stdout_sha256"`
+	NormalizedSHA256 string             `json:"normalized_stdout_sha256"`
+	StderrSHA256     string             `json:"stderr_sha256"`
+	CacheDirectory   string             `json:"cache_directory"`
+	StdoutPath       string             `json:"stdout_path"`
+	StderrPath       string             `json:"stderr_path"`
+}
+
+type modeSummary struct {
+	Mode                 string     `json:"mode"`
+	Samples              int        `json:"samples"`
+	MedianMS             float64    `json:"median_ms"`
+	MeanMS               float64    `json:"mean_ms"`
+	StandardDeviationMS  float64    `json:"standard_deviation_ms"`
+	MedianAbsoluteDevMS  float64    `json:"median_absolute_deviation_ms"`
+	ConfidenceInterval95 [2]float64 `json:"confidence_interval_95_ms"`
+	PeakMemoryBytes      uint64     `json:"peak_memory_bytes"`
+	MedianOutputBytes    float64    `json:"median_output_bytes"`
+}
+
+type gateSummary struct {
+	Passed                 bool   `json:"passed"`
+	AllExitCodesZero       bool   `json:"all_exit_codes_zero"`
+	NormalizedOutputStable bool   `json:"normalized_output_stable"`
+	OutputCapBytes         int    `json:"output_cap_bytes,omitempty"`
+	OutputCapPassed        bool   `json:"output_cap_passed"`
+	FailureReason          string `json:"failure_reason,omitempty"`
+}
+
+func main() {
+	var outputDir string
+	var caseName string
+	var samples int
+	var networkState string
+	var outputCap int
+	flag.StringVar(&outputDir, "output", defaultOutput, "directory for raw samples and run-manifest.json")
+	flag.StringVar(&caseName, "case", "benchmark-case", "stable case name")
+	flag.IntVar(&samples, "samples", defaultSamples, "cold and warm sample count")
+	flag.StringVar(&networkState, "network-state", defaultNetworkMode, "online, offline, or unknown")
+	flag.IntVar(&outputCap, "max-output-bytes", 0, "optional stable stdout byte cap")
+	flag.Parse()
+	command := flag.Args()
+	if len(command) == 0 {
+		fmt.Fprintln(os.Stderr, "benchmarkrun requires a command after --")
+		os.Exit(2)
+	}
+	if samples < 1 {
+		fmt.Fprintln(os.Stderr, "samples must be positive")
+		os.Exit(2)
+	}
+	switch networkState {
+	case "online", "offline", "unknown":
+	default:
+		fmt.Fprintln(os.Stderr, "network-state must be online, offline, or unknown")
+		os.Exit(2)
+	}
+	if err := run(outputDir, caseName, samples, networkState, outputCap, command[0], command[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(outputDir, caseName string, sampleCount int, networkState string, outputCap int, executable string, args []string) error {
+	absoluteOutput, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("resolve output directory: %w", err)
+	}
+	if err := os.MkdirAll(absoluteOutput, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	tool, err := inspectTool(executable)
+	if err != nil {
+		return err
+	}
+	revision, dirty := gitState()
+	hostname, _ := os.Hostname()
+	manifest := runManifest{
+		SchemaVersion:        runSchemaVersion,
+		NormalizationVersion: normalizationV1,
+		GeneratedAt:          time.Now().UTC().Format(time.RFC3339Nano),
+		Source:               sourceInfo{Revision: revision, Dirty: dirty},
+		Tool:                 tool,
+		Host:                 hostInfo{OS: runtime.GOOS, Arch: runtime.GOARCH, Go: runtime.Version(), CPUs: runtime.NumCPU(), Hostname: hostname},
+		Case: caseInfo{
+			Name: caseName, Command: executable, Args: append([]string(nil), args...),
+			WorkingDir: workingDir, SamplesPerMode: sampleCount, NetworkState: networkState,
+			CacheModes: []string{"cold", "warm"},
+		},
+	}
+
+	for _, mode := range []string{"cold", "warm"} {
+		for index := 1; index <= sampleCount; index++ {
+			cacheDir := filepath.Join(absoluteOutput, "cache", mode)
+			if mode == "cold" {
+				cacheDir = filepath.Join(absoluteOutput, "cache", fmt.Sprintf("cold-%02d", index))
+			}
+			if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+				return fmt.Errorf("create %s cache: %w", mode, err)
+			}
+			current, err := executeSample(absoluteOutput, mode, index, cacheDir, executable, args)
+			if err != nil {
+				manifest.Samples = append(manifest.Samples, current)
+				manifest.Summaries = summarizeModes(manifest.Samples)
+				manifest.Gates = evaluateGates(manifest.Samples, outputCap)
+				_ = writeManifest(absoluteOutput, manifest)
+				return err
+			}
+			manifest.Samples = append(manifest.Samples, current)
+		}
+	}
+	manifest.Summaries = summarizeModes(manifest.Samples)
+	manifest.Gates = evaluateGates(manifest.Samples, outputCap)
+	if err := writeManifest(absoluteOutput, manifest); err != nil {
+		return err
+	}
+	if !manifest.Gates.Passed {
+		return fmt.Errorf("benchmark invariant gate failed: %s", manifest.Gates.FailureReason)
+	}
+	return nil
+}
+
+func executeSample(outputDir, mode string, index int, cacheDir, executable string, args []string) (sample, error) {
+	started := time.Now().UTC()
+	command := exec.Command(executable, args...)
+	command.Env = append(os.Environ(),
+		"CI=1",
+		"NO_COLOR=1",
+		"BOMLY_NO_ANIMATION=1",
+		"XDG_CACHE_HOME="+cacheDir,
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	finished := time.Now().UTC()
+	exitCode := 0
+	if err != nil {
+		exitCode = -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+
+	sampleDir := filepath.Join(outputDir, "samples")
+	if mkdirErr := os.MkdirAll(sampleDir, 0o755); mkdirErr != nil {
+		return sample{}, fmt.Errorf("create sample directory: %w", mkdirErr)
+	}
+	prefix := fmt.Sprintf("%s-%02d", mode, index)
+	stdoutPath := filepath.Join(sampleDir, prefix+".stdout")
+	stderrPath := filepath.Join(sampleDir, prefix+".stderr")
+	if writeErr := os.WriteFile(stdoutPath, stdout.Bytes(), 0o600); writeErr != nil {
+		return sample{}, fmt.Errorf("write sample stdout: %w", writeErr)
+	}
+	if writeErr := os.WriteFile(stderrPath, stderr.Bytes(), 0o600); writeErr != nil {
+		return sample{}, fmt.Errorf("write sample stderr: %w", writeErr)
+	}
+	elapsedMS := float64(finished.Sub(started).Microseconds()) / 1000
+	current := sample{
+		Mode: mode, Index: index,
+		StartedAt: started.Format(time.RFC3339Nano), FinishedAt: finished.Format(time.RFC3339Nano),
+		ExitCode: exitCode, StageTimingsMS: map[string]float64{"command": elapsedMS},
+		PeakMemoryBytes: peakMemoryBytes(command.ProcessState),
+		StdoutBytes:     len(stdout.Bytes()), StderrBytes: len(stderr.Bytes()),
+		StdoutSHA256: hashBytes(stdout.Bytes()), NormalizedSHA256: hashBytes(normalizeOutput(stdout.Bytes())),
+		StderrSHA256:   hashBytes(stderr.Bytes()),
+		CacheDirectory: cacheDir,
+		StdoutPath:     filepath.ToSlash(stdoutPath), StderrPath: filepath.ToSlash(stderrPath),
+	}
+	if err != nil {
+		return current, fmt.Errorf("%s sample %d exited %d: %w", mode, index, exitCode, err)
+	}
+	return current, nil
+}
+
+func normalizeOutput(data []byte) []byte {
+	var value any
+	if json.Unmarshal(data, &value) != nil {
+		return data
+	}
+	removeVolatile(value)
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		return data
+	}
+	return normalized
+}
+
+func removeVolatile(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, key := range []string{"generated_at", "timestamp", "started_at", "finished_at", "duration_ms"} {
+			delete(typed, key)
+		}
+		for _, child := range typed {
+			removeVolatile(child)
+		}
+	case []any:
+		for _, child := range typed {
+			removeVolatile(child)
+		}
+	}
+}
+
+func summarizeModes(samples []sample) []modeSummary {
+	var summaries []modeSummary
+	for _, mode := range []string{"cold", "warm"} {
+		var durations []float64
+		var outputSizes []float64
+		var peak uint64
+		for _, current := range samples {
+			if current.Mode != mode {
+				continue
+			}
+			durations = append(durations, current.StageTimingsMS["command"])
+			outputSizes = append(outputSizes, float64(current.StdoutBytes))
+			if current.PeakMemoryBytes > peak {
+				peak = current.PeakMemoryBytes
+			}
+		}
+		if len(durations) == 0 {
+			continue
+		}
+		mean, deviation := meanAndDeviation(durations)
+		margin := 1.96 * deviation / math.Sqrt(float64(len(durations)))
+		summaries = append(summaries, modeSummary{
+			Mode: mode, Samples: len(durations),
+			MedianMS: median(durations), MeanMS: mean, StandardDeviationMS: deviation,
+			MedianAbsoluteDevMS:  medianAbsoluteDeviation(durations),
+			ConfidenceInterval95: [2]float64{math.Max(0, mean-margin), mean + margin},
+			PeakMemoryBytes:      peak, MedianOutputBytes: median(outputSizes),
+		})
+	}
+	return summaries
+}
+
+func evaluateGates(samples []sample, outputCap int) gateSummary {
+	gate := gateSummary{Passed: true, AllExitCodesZero: true, NormalizedOutputStable: true, OutputCapBytes: outputCap, OutputCapPassed: true}
+	hashes := map[string]map[string]struct{}{"cold": {}, "warm": {}}
+	for _, current := range samples {
+		if current.ExitCode != 0 {
+			gate.AllExitCodesZero = false
+		}
+		hashes[current.Mode][current.NormalizedSHA256] = struct{}{}
+		if outputCap > 0 && current.StdoutBytes > outputCap {
+			gate.OutputCapPassed = false
+		}
+	}
+	for _, values := range hashes {
+		if len(values) > 1 {
+			gate.NormalizedOutputStable = false
+		}
+	}
+	var failures []string
+	if !gate.AllExitCodesZero {
+		failures = append(failures, "non-zero exit code")
+	}
+	if !gate.NormalizedOutputStable {
+		failures = append(failures, "normalized output changed within a cache mode")
+	}
+	if !gate.OutputCapPassed {
+		failures = append(failures, "stdout exceeded configured cap")
+	}
+	gate.Passed = len(failures) == 0
+	gate.FailureReason = strings.Join(failures, "; ")
+	return gate
+}
+
+func inspectTool(path string) (toolInfo, error) {
+	resolved, err := exec.LookPath(path)
+	if err != nil {
+		return toolInfo{}, fmt.Errorf("resolve benchmark command: %w", err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return toolInfo{}, fmt.Errorf("read benchmark command: %w", err)
+	}
+	versionCommand := exec.Command(resolved, "version")
+	versionCommand.Env = append(os.Environ(), "CI=1", "NO_COLOR=1", "BOMLY_NO_ANIMATION=1")
+	versionOutput, _ := versionCommand.CombinedOutput()
+	return toolInfo{Path: resolved, Version: strings.TrimSpace(string(versionOutput)), SHA256: hashBytes(data)}, nil
+}
+
+func gitState() (string, bool) {
+	revisionBytes, revisionErr := exec.Command("git", "rev-parse", "HEAD").Output()
+	statusBytes, statusErr := exec.Command("git", "status", "--porcelain").Output()
+	if revisionErr != nil || statusErr != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(revisionBytes)), len(bytes.TrimSpace(statusBytes)) > 0
+}
+
+func peakMemoryBytes(state *os.ProcessState) uint64 {
+	if state == nil {
+		return 0
+	}
+	value := reflect.ValueOf(state.SysUsage())
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	field := value.FieldByName("Maxrss")
+	if !field.IsValid() {
+		return 0
+	}
+	var rss uint64
+	switch field.Kind() {
+	case reflect.Int, reflect.Int32, reflect.Int64:
+		if field.Int() > 0 {
+			rss = uint64(field.Int())
+		}
+	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+		rss = field.Uint()
+	}
+	if runtime.GOOS != "darwin" {
+		rss *= 1024
+	}
+	return rss
+}
+
+func meanAndDeviation(values []float64) (float64, float64) {
+	var total float64
+	for _, value := range values {
+		total += value
+	}
+	mean := total / float64(len(values))
+	if len(values) < 2 {
+		return mean, 0
+	}
+	var squared float64
+	for _, value := range values {
+		delta := value - mean
+		squared += delta * delta
+	}
+	return mean, math.Sqrt(squared / float64(len(values)-1))
+}
+
+func median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	middle := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[middle]
+	}
+	return (sorted[middle-1] + sorted[middle]) / 2
+}
+
+func medianAbsoluteDeviation(values []float64) float64 {
+	center := median(values)
+	deviations := make([]float64, len(values))
+	for index, value := range values {
+		deviations[index] = math.Abs(value - center)
+	}
+	return median(deviations)
+}
+
+func hashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeManifest(outputDir string, manifest runManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode benchmark run manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(outputDir, "run-manifest.json"), data, 0o600); err != nil {
+		return fmt.Errorf("write benchmark run manifest: %w", err)
+	}
+	return nil
+}

--- a/internal/tools/benchmarkrun/main_test.go
+++ b/internal/tools/benchmarkrun/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func TestNormalizeOutputRemovesOnlyVolatileJSONFields(t *testing.T) {
+	first := normalizeOutput([]byte(`{"generated_at":"one","project":{"name":"demo"},"items":[{"timestamp":"one","id":"a"}]}`))
+	second := normalizeOutput([]byte(`{"generated_at":"two","project":{"name":"demo"},"items":[{"timestamp":"two","id":"a"}]}`))
+	if string(first) != string(second) {
+		t.Fatalf("normalized outputs differ:\n%s\n%s", first, second)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(first, &value); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := value["generated_at"]; exists {
+		t.Fatal("generated_at survived normalization")
+	}
+}
+
+func TestSummarizeModesReportsMedianDispersionAndConfidenceInterval(t *testing.T) {
+	samples := []sample{
+		{Mode: "cold", StageTimingsMS: map[string]float64{"command": 10}, StdoutBytes: 100, PeakMemoryBytes: 1000},
+		{Mode: "cold", StageTimingsMS: map[string]float64{"command": 20}, StdoutBytes: 200, PeakMemoryBytes: 3000},
+		{Mode: "cold", StageTimingsMS: map[string]float64{"command": 30}, StdoutBytes: 300, PeakMemoryBytes: 2000},
+	}
+	summary := summarizeModes(samples)
+	if len(summary) != 1 {
+		t.Fatalf("summary count = %d", len(summary))
+	}
+	got := summary[0]
+	if got.MedianMS != 20 || got.MeanMS != 20 || got.MedianAbsoluteDevMS != 10 ||
+		got.PeakMemoryBytes != 3000 || got.MedianOutputBytes != 200 {
+		t.Fatalf("unexpected summary: %#v", got)
+	}
+	if got.StandardDeviationMS != 10 {
+		t.Fatalf("standard deviation = %f", got.StandardDeviationMS)
+	}
+	if got.ConfidenceInterval95[0] >= got.MeanMS || got.ConfidenceInterval95[1] <= got.MeanMS {
+		t.Fatalf("confidence interval does not contain mean: %#v", got.ConfidenceInterval95)
+	}
+}
+
+func TestEvaluateGatesUsesNormalizedHashesAndStableCaps(t *testing.T) {
+	samples := []sample{
+		{Mode: "cold", ExitCode: 0, NormalizedSHA256: "same", StdoutBytes: 90},
+		{Mode: "cold", ExitCode: 0, NormalizedSHA256: "same", StdoutBytes: 100},
+		{Mode: "warm", ExitCode: 0, NormalizedSHA256: "warm", StdoutBytes: 95},
+	}
+	if gate := evaluateGates(samples, 100); !gate.Passed {
+		t.Fatalf("stable samples failed: %#v", gate)
+	}
+	samples[1].NormalizedSHA256 = "changed"
+	if gate := evaluateGates(samples, 100); gate.Passed || gate.NormalizedOutputStable {
+		t.Fatalf("unstable output passed: %#v", gate)
+	}
+	samples[1].NormalizedSHA256 = "same"
+	samples[1].StdoutBytes = 101
+	if gate := evaluateGates(samples, 100); gate.Passed || gate.OutputCapPassed {
+		t.Fatalf("oversized output passed: %#v", gate)
+	}
+}
+
+func TestMedianHandlesEvenAndEmptyInputs(t *testing.T) {
+	if median(nil) != 0 || median([]float64{4, 2}) != 3 {
+		t.Fatal("median boundary behavior changed")
+	}
+	if mean, deviation := meanAndDeviation([]float64{7}); mean != 7 || math.Abs(deviation) > 0 {
+		t.Fatalf("single sample statistics = %f, %f", mean, deviation)
+	}
+}

--- a/test/assurance/BENCHMARK_RUNS.md
+++ b/test/assurance/BENCHMARK_RUNS.md
@@ -1,0 +1,29 @@
+# Benchmark run evidence
+
+`make benchmark-samples` records a deterministic, offline canonical scan as
+five isolated cold samples and five shared-cache warm samples. Raw stdout,
+stderr, caches, and the machine-readable run manifest are written beneath the
+ignored `.benchmark-runs` directory.
+
+The `bomly.benchmark-run/v1` manifest records:
+
+- repository revision and dirty state;
+- executable path, version output, and SHA-256;
+- UTC timestamps, runtime, operating system, architecture, CPU count, and
+  hostname;
+- cache and network state, command, arguments, and working directory;
+- exit status, command-stage duration, peak resident memory, output byte
+  counts, raw hashes, normalized hashes, and raw artifact paths per sample;
+- cold and warm medians, means, standard deviations, median absolute
+  deviations, approximate 95% confidence intervals, peak memory, and median
+  output bytes.
+
+Only stable invariants gate the runner: successful exit status, identical
+normalized output within each cache mode, and an optional explicit output-size
+cap. Wall-clock time, memory, and confidence intervals are evidence rather than
+merge thresholds.
+
+Normalization is separately versioned as
+`bomly.benchmark-normalization/v1`. It removes only documented volatile JSON
+timestamp and duration fields before hashing and never changes the retained
+raw samples.

--- a/test/assurance/BENCHMARK_RUNS.md
+++ b/test/assurance/BENCHMARK_RUNS.md
@@ -1,29 +1,52 @@
-# Benchmark run evidence
+# Measuring speed and stability
 
-`make benchmark-samples` records a deterministic, offline canonical scan as
-five isolated cold samples and five shared-cache warm samples. Raw stdout,
-stderr, caches, and the machine-readable run manifest are written beneath the
-ignored `.benchmark-runs` directory.
+`make benchmark-samples` measures the same offline Bomly scan ten times:
 
-The `bomly.benchmark-run/v1` manifest records:
+- five runs start with an empty cache;
+- five runs share a cache, like repeated scans normally do.
 
-- repository revision and dirty state;
-- executable path, version output, and SHA-256;
-- UTC timestamps, runtime, operating system, architecture, CPU count, and
-  hostname;
-- cache and network state, command, arguments, and working directory;
-- exit status, command-stage duration, peak resident memory, output byte
-  counts, raw hashes, normalized hashes, and raw artifact paths per sample;
-- cold and warm medians, means, standard deviations, median absolute
-  deviations, approximate 95% confidence intervals, peak memory, and median
-  output bytes.
+Running the same scan several times gives a more useful result than timing it
+once. It also shows whether Bomly returns the same result every time.
 
-Only stable invariants gate the runner: successful exit status, identical
-normalized output within each cache mode, and an optional explicit output-size
-cap. Wall-clock time, memory, and confidence intervals are evidence rather than
-merge thresholds.
+The command saves its files under `.benchmark-runs`, which Git ignores. These
+files include the raw command output, errors, caches, and a report named
+`bomly.benchmark-run/v1`.
 
-Normalization is separately versioned as
-`bomly.benchmark-normalization/v1`. It removes only documented volatile JSON
-timestamp and duration fields before hashing and never changes the retained
-raw samples.
+## What the report contains
+
+The report includes:
+
+- the repository revision and whether local files had changed;
+- the Bomly executable's path, version, and SHA-256 checksum;
+- the operating system, processor architecture, CPU count, and hostname;
+- the exact command, working directory, cache setting, and network setting;
+- whether each run succeeded;
+- the time, peak memory, and output size for each run;
+- checksums used to compare the raw and normalized output;
+- summary numbers showing the typical result and how much the samples varied.
+
+The command fails when Bomly exits with an error, when repeated runs produce
+different normalized output, or when an optional output-size limit is
+exceeded. It does not fail simply because one machine ran more slowly or used
+more memory. Timing and memory measurements are evidence for people to review,
+not fixed pass-or-fail limits.
+
+Some JSON fields, such as timestamps and durations, naturally change on every
+run. The comparison removes only those documented fields before calculating a
+checksum. This comparison format is named
+`bomly.benchmark-normalization/v1`. The saved raw output is never changed.
+
+## Checking supported systems
+
+The `Portable stability assurance` workflow runs only when someone starts it
+from GitHub Actions. It:
+
+- runs the complete test suite twice on Linux, macOS, and Windows;
+- runs the Java-related tests ten times to catch intermittent failures;
+- runs the complete Linux test suite five more times;
+- builds both Bomly binaries for every supported Linux, macOS, and Windows
+  processor target.
+
+This workflow is separate from normal pull request checks because it performs
+many repeated test runs. Use it before closing a broad assurance effort or
+when investigating platform-specific or intermittent failures.


### PR DESCRIPTION
## What this checks

This change makes Bomly performance and stability checks repeatable and easier to review.

`make benchmark-samples` runs the same offline scan five times with an empty cache and five times with a shared cache. It records timing, memory, output size, checksums, and enough system information to understand where each result came from. Raw files stay in the ignored `.benchmark-runs` directory.

A separate workflow:

- runs the full test suite twice on Linux, macOS, and Windows;
- repeats Java-related tests ten times;
- repeats the full Linux suite five times;
- builds both Bomly binaries for every supported Linux, macOS, and Windows target.

The checks fail for command errors, inconsistent normalized output, or an optional output-size limit. They do not fail only because one machine was slower than another.

## Validation

- `go test ./internal/tools/benchmarkrun -count=1`
- `make benchmark-samples` with five cold and five warm samples
- `make fmt-check`
- `make lint`
- `make test`
- `make build`

Cross-platform and repeated workflow results will be recorded after the workflow is available on the default branch.