### PR TITLE
fix(jvm): parse Gradle settings on Windows

### DIFF
--- a/internal/analyzers/jvmreach/discover.go
+++ b/internal/analyzers/jvmreach/discover.go
@@ -34,7 +34,7 @@ type mavenProject struct {
 
 var (
 	gradleParenthesizedInclude = regexp.MustCompile(`(?s)\binclude\s*\((.*?)\)`)
-	gradleLineInclude          = regexp.MustCompile(`(?m)^\s*include\s+([^\r\n]+)$`)
+	gradleLineInclude          = regexp.MustCompile(`(?m)^[\t ]*include[\t ]+([^\r\n]+)`)
 	gradleQuotedValue          = regexp.MustCompile(`["']([^"']+)["']`)
 	gradleProjectDir           = regexp.MustCompile(`(?m)project\s*\(\s*["']([^"']+)["']\s*\)\.projectDir\s*=\s*file\s*\(\s*["']([^"']+)["']\s*\)`)
 	gradleGroup                = regexp.MustCompile(`(?m)^\s*group\s*=\s*["']([^"']+)["']`)

--- a/internal/analyzers/jvmreach/modules_testdata_test.go
+++ b/internal/analyzers/jvmreach/modules_testdata_test.go
@@ -111,6 +111,7 @@ func TestGradleIncludedProjectPaths(t *testing.T) {
 		want []string
 	}{
 		{"Groovy line", "include ':app', ':shared'\n", []string{":app", ":shared"}},
+		{"Groovy line with Windows endings", "include ':app', ':shared'\r\n", []string{":app", ":shared"}},
 		{"Kotlin single line", "include(\":app\", \":shared\")\n", []string{":app", ":shared"}},
 		{"Kotlin multiline", "include(\n  \":app\",\n  \":nested:shared\",\n)\n", []string{":app", ":nested:shared"}},
 		{"deduplicated", "include ':app'\ninclude(\":app\")\n", []string{":app"}},


### PR DESCRIPTION
## What changed

Bomly now reads Groovy Gradle `include` lines with either Unix or Windows line endings. A regression test covers the Windows form.

## Why this is needed

The portable assurance run on `main` found that JVM module discovery missed a Gradle settings file on Windows. Bomly then treated a nested module as the project root instead of walking up to the real Gradle root.

The parser expected a newline immediately after the include list. Windows uses a carriage return followed by a newline, so the line did not match.

## Impact

Gradle projects using Groovy settings files now keep the correct module hierarchy when Bomly runs on Windows. Unix behavior is unchanged.

## Validation

- focused JVM hierarchy and Gradle parser tests
- `make fmt-check`
- `make lint`
- `make test`
- `make build`

Found by portable assurance run `30057576000`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gradle project detection for indented `include` statements.
  * Added support for parsing Gradle include statements with Windows-style line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->