### PR TITLE
ci(assurance): explain workflow results

### DIFF
--- a/.github/workflows/portable-assurance.yml
+++ b/.github/workflows/portable-assurance.yml
@@ -26,13 +26,67 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Repeat portable suite twice
+        id: portable-tests
         shell: bash
         run: |
           set -euo pipefail
+          completed=0
+          failed=0
           for iteration in 1 2; do
             echo "portable suite iteration ${iteration}"
-            go test ./... -count=1
+            if go test ./... -count=1; then
+              completed="${iteration}"
+            else
+              failed="${iteration}"
+              break
+            fi
           done
+          echo "completed=${completed}" >> "${GITHUB_OUTPUT}"
+          echo "failed=${failed}" >> "${GITHUB_OUTPUT}"
+          if [[ "${failed}" != "0" ]]; then
+            exit 1
+          fi
+
+      - name: Explain this platform result
+        if: always()
+        shell: bash
+        env:
+          TEST_RESULT: ${{ steps.portable-tests.outcome }}
+          COMPLETED: ${{ steps.portable-tests.outputs.completed }}
+          FAILED: ${{ steps.portable-tests.outputs.failed }}
+        run: |
+          set -euo pipefail
+          completed="${COMPLETED:-0}"
+          failed="${FAILED:-0}"
+          if [[ "${TEST_RESULT}" == "success" ]]; then
+            result="Passed"
+            icon="✅"
+          else
+            result="Failed"
+            icon="❌"
+          fi
+          if [[ "${failed}" == "0" ]]; then
+            failed_display="—"
+          else
+            failed_display="${failed}"
+          fi
+          {
+            echo "## ${icon} ${RUNNER_OS}/${RUNNER_ARCH}: ${result}"
+            echo
+            echo "The complete Go test suite was scheduled twice on this platform. Each run used \`-count=1\` so Go did not reuse test results."
+            echo
+            echo "| Planned runs | Completed runs | Failed run |"
+            echo "|---:|---:|---:|"
+            echo "| 2 | ${completed} | ${failed_display} |"
+            echo
+            echo "### Need more detail?"
+            echo
+            echo "Open the **Repeat portable suite twice** step to find the failing package and test. To reproduce the same check locally:"
+            echo
+            echo '```sh'
+            echo "go test ./... -count=1"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   linux-stability:
     name: Linux repeated stability
@@ -55,24 +109,53 @@ jobs:
           java-version: "21"
 
       - name: Repeat Java suites ten times
+        id: java-tests
         run: |
           set -euo pipefail
+          completed=0
+          failed=0
           for iteration in $(seq 1 10); do
             echo "Java suite iteration ${iteration}"
-            go test ./internal/detectors/gradle ./internal/detectors/maven ./internal/detectors/sbt ./internal/analyzers/jvmreach -count=1
+            if go test ./internal/detectors/gradle ./internal/detectors/maven ./internal/detectors/sbt ./internal/analyzers/jvmreach -count=1; then
+              completed="${iteration}"
+            else
+              failed="${iteration}"
+              break
+            fi
           done
+          echo "completed=${completed}" >> "${GITHUB_OUTPUT}"
+          echo "failed=${failed}" >> "${GITHUB_OUTPUT}"
+          if [[ "${failed}" != "0" ]]; then
+            exit 1
+          fi
 
       - name: Repeat complete suite five times
+        id: complete-tests
         run: |
           set -euo pipefail
+          completed=0
+          failed=0
           for iteration in $(seq 1 5); do
             echo "complete suite iteration ${iteration}"
-            go test ./... -count=1
+            if go test ./... -count=1; then
+              completed="${iteration}"
+            else
+              failed="${iteration}"
+              break
+            fi
           done
+          echo "completed=${completed}" >> "${GITHUB_OUTPUT}"
+          echo "failed=${failed}" >> "${GITHUB_OUTPUT}"
+          if [[ "${failed}" != "0" ]]; then
+            exit 1
+          fi
 
       - name: Cross-build release targets
+        id: release-builds
         run: |
           set -euo pipefail
+          completed=0
+          failed=""
           targets=(
             "linux amd64"
             "linux arm64"
@@ -88,9 +171,135 @@ jobs:
               suffix=".exe"
             fi
             echo "cross-build ${target_os}/${target_arch}"
-            GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
-              go build -o "bin/bomly-${target_os}-${target_arch}${suffix}" ./cmd/bomly
-            GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
+            if GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
+              go build -o "bin/bomly-${target_os}-${target_arch}${suffix}" ./cmd/bomly; then
+              completed=$((completed + 1))
+            else
+              failed="${target_os}/${target_arch} full"
+              break
+            fi
+            if GOOS="${target_os}" GOARCH="${target_arch}" CGO_ENABLED=0 \
               go build -tags "bomly_external_syft,bomly_external_grype" \
-              -o "bin/bomly-lite-${target_os}-${target_arch}${suffix}" ./cmd/bomly
+              -o "bin/bomly-lite-${target_os}-${target_arch}${suffix}" ./cmd/bomly; then
+              completed=$((completed + 1))
+            else
+              failed="${target_os}/${target_arch} lite"
+              break
+            fi
           done
+          echo "completed=${completed}" >> "${GITHUB_OUTPUT}"
+          echo "failed=${failed}" >> "${GITHUB_OUTPUT}"
+          if [[ -n "${failed}" ]]; then
+            exit 1
+          fi
+
+      - name: Explain Linux stability result
+        if: always()
+        env:
+          JAVA_RESULT: ${{ steps.java-tests.outcome }}
+          JAVA_COMPLETED: ${{ steps.java-tests.outputs.completed }}
+          JAVA_FAILED: ${{ steps.java-tests.outputs.failed }}
+          COMPLETE_RESULT: ${{ steps.complete-tests.outcome }}
+          COMPLETE_COMPLETED: ${{ steps.complete-tests.outputs.completed }}
+          COMPLETE_FAILED: ${{ steps.complete-tests.outputs.failed }}
+          BUILD_RESULT: ${{ steps.release-builds.outcome }}
+          BUILD_COMPLETED: ${{ steps.release-builds.outputs.completed }}
+          BUILD_FAILED: ${{ steps.release-builds.outputs.failed }}
+        run: |
+          set -euo pipefail
+          if [[ "${JAVA_RESULT}" == "success" && "${COMPLETE_RESULT}" == "success" && "${BUILD_RESULT}" == "success" ]]; then
+            result="Passed"
+            icon="✅"
+          else
+            result="Failed"
+            icon="❌"
+          fi
+          show_failure() {
+            if [[ -z "${1:-}" || "${1}" == "0" ]]; then
+              printf "—"
+            else
+              printf "%s" "${1}"
+            fi
+          }
+          {
+            echo "## ${icon} Linux stability and release builds: ${result}"
+            echo
+            echo "This job repeats the areas most likely to reveal intermittent failures, then checks that every release binary can be built."
+            echo
+            echo "| Check | Planned | Completed | Failed at |"
+            echo "|---|---:|---:|---|"
+            echo "| Java detector tests | 10 runs | ${JAVA_COMPLETED:-0} | $(show_failure "${JAVA_FAILED:-0}") |"
+            echo "| Complete test suite | 5 runs | ${COMPLETE_COMPLETED:-0} | $(show_failure "${COMPLETE_FAILED:-0}") |"
+            echo "| Release binaries | 12 builds | ${BUILD_COMPLETED:-0} | $(show_failure "${BUILD_FAILED:-}") |"
+            echo
+            echo "The release check builds full and lite binaries for Linux, macOS, and Windows on amd64 and arm64."
+            echo
+            echo "### Need more detail?"
+            echo
+            echo "Open the failed step for the test name or release target. Reproduce the test checks with:"
+            echo
+            echo '```sh'
+            echo "go test ./internal/detectors/gradle ./internal/detectors/maven ./internal/detectors/sbt ./internal/analyzers/jvmreach -count=1"
+            echo "go test ./... -count=1"
+            echo '```'
+            echo
+            echo "For a failed release build, use the operating system, architecture, and variant shown in the table with the build command from **Cross-build release targets**."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  summary:
+    name: Explain overall result
+    if: always()
+    needs:
+      - portable
+      - linux-stability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize workflow
+        env:
+          PORTABLE_RESULT: ${{ needs.portable.result }}
+          STABILITY_RESULT: ${{ needs.linux-stability.result }}
+        run: |
+          set -euo pipefail
+          if [[ "${PORTABLE_RESULT}" == "success" && "${STABILITY_RESULT}" == "success" ]]; then
+            result="Passed"
+            icon="✅"
+          else
+            result="Failed"
+            icon="❌"
+          fi
+          if [[ "${PORTABLE_RESULT}" == "success" ]]; then
+            portable_label="Passed"
+          else
+            portable_label="Failed"
+          fi
+          if [[ "${STABILITY_RESULT}" == "success" ]]; then
+            stability_label="Passed"
+          else
+            stability_label="Failed"
+          fi
+          {
+            echo "# ${icon} Portable stability assurance: ${result}"
+            echo
+            echo "This workflow checked that the test suite is repeatable across supported development platforms and that release binaries build for every target."
+            echo
+            echo "| Area | Result | What ran |"
+            echo "|---|---|---|"
+            echo "| Linux, macOS, and Windows | ${portable_label} | Complete suite twice on each platform |"
+            echo "| Linux stability and release builds | ${stability_label} | Java tests 10 times, complete suite 5 times, and 12 release builds |"
+            echo
+            echo "Each job has its own summary with completed counts and the exact point of failure."
+            echo
+            echo "## Need more detail?"
+            echo
+            echo "Show only failed logs:"
+            echo
+            echo '```sh'
+            echo "gh run view ${GITHUB_RUN_ID} --log-failed"
+            echo '```'
+            echo
+            echo "After fixing a problem, rerun only the failed jobs:"
+            echo
+            echo '```sh'
+            echo "gh run rerun ${GITHUB_RUN_ID} --failed"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/portable-assurance.yml
+++ b/.github/workflows/portable-assurance.yml
@@ -214,23 +214,46 @@ jobs:
             result="Failed"
             icon="❌"
           fi
+          show_result() {
+            case "${1}" in
+              success) printf "Passed" ;;
+              failure) printf "Failed" ;;
+              cancelled) printf "Cancelled" ;;
+              skipped) printf "Skipped" ;;
+              *) printf "Not run" ;;
+            esac
+          }
+          show_completed() {
+            case "${1}" in
+              success|failure) printf "%s" "${2:-0}" ;;
+              *) printf "—" ;;
+            esac
+          }
           show_failure() {
-            if [[ -z "${1:-}" || "${1}" == "0" ]]; then
-              printf "—"
-            else
-              printf "%s" "${1}"
-            fi
+            case "${1}" in
+              success) printf "—" ;;
+              failure)
+                if [[ -z "${2:-}" || "${2}" == "0" ]]; then
+                  printf "See step log"
+                else
+                  printf "%s" "${2}"
+                fi
+                ;;
+              cancelled) printf "Cancelled" ;;
+              skipped) printf "Skipped" ;;
+              *) printf "Not run" ;;
+            esac
           }
           {
             echo "## ${icon} Linux stability and release builds: ${result}"
             echo
             echo "This job repeats the areas most likely to reveal intermittent failures, then checks that every release binary can be built."
             echo
-            echo "| Check | Planned | Completed | Failed at |"
-            echo "|---|---:|---:|---|"
-            echo "| Java detector tests | 10 runs | ${JAVA_COMPLETED:-0} | $(show_failure "${JAVA_FAILED:-0}") |"
-            echo "| Complete test suite | 5 runs | ${COMPLETE_COMPLETED:-0} | $(show_failure "${COMPLETE_FAILED:-0}") |"
-            echo "| Release binaries | 12 builds | ${BUILD_COMPLETED:-0} | $(show_failure "${BUILD_FAILED:-}") |"
+            echo "| Check | Result | Planned | Completed | Failed at |"
+            echo "|---|---|---:|---:|---|"
+            echo "| Java detector tests | $(show_result "${JAVA_RESULT}") | 10 runs | $(show_completed "${JAVA_RESULT}" "${JAVA_COMPLETED:-}") | $(show_failure "${JAVA_RESULT}" "${JAVA_FAILED:-}") |"
+            echo "| Complete test suite | $(show_result "${COMPLETE_RESULT}") | 5 runs | $(show_completed "${COMPLETE_RESULT}" "${COMPLETE_COMPLETED:-}") | $(show_failure "${COMPLETE_RESULT}" "${COMPLETE_FAILED:-}") |"
+            echo "| Release binaries | $(show_result "${BUILD_RESULT}") | 12 builds | $(show_completed "${BUILD_RESULT}" "${BUILD_COMPLETED:-}") | $(show_failure "${BUILD_RESULT}" "${BUILD_FAILED:-}") |"
             echo
             echo "The release check builds full and lite binaries for Linux, macOS, and Windows on amd64 and arm64."
             echo

--- a/.github/workflows/sbom-interoperability.yml
+++ b/.github/workflows/sbom-interoperability.yml
@@ -48,7 +48,7 @@ jobs:
         if: always()
         env:
           VALIDATION_RESULT: ${{ steps.validate.outcome }}
-          EVIDENCE_RESULT: ${{ steps.evidence.outcome }}
+          EVIDENCE_ARTIFACT_ID: ${{ steps.evidence.outputs.artifact-id }}
         run: |
           set -euo pipefail
           if [[ "${VALIDATION_RESULT}" == "success" ]]; then
@@ -58,12 +58,17 @@ jobs:
             result="Failed"
             icon="❌"
           fi
+          if [[ -n "${EVIDENCE_ARTIFACT_ID}" ]]; then
+            evidence="Uploaded (artifact ID \`${EVIDENCE_ARTIFACT_ID}\`)"
+          else
+            evidence="Not produced"
+          fi
           {
             printf '# SBOM compatibility check: %s %s\n\n' "${icon}" "${result}"
             printf 'Bomly generated SPDX 2.3 and CycloneDX 1.6 files, then asked the official validators to check them.\n\n'
             printf -- '- **Revision:** `%s`\n' "${GITHUB_SHA}"
             printf -- '- **Validation:** `%s`\n' "${VALIDATION_RESULT}"
-            printf -- '- **Evidence upload:** `%s`\n\n' "${EVIDENCE_RESULT}"
+            printf -- '- **Evidence:** %s\n\n' "${evidence}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
           manifest="sbom-assurance-artifacts/run-manifest.json"

--- a/.github/workflows/sbom-interoperability.yml
+++ b/.github/workflows/sbom-interoperability.yml
@@ -31,13 +31,90 @@ jobs:
         run: make build-lite
 
       - name: Generate and validate canonical SBOMs
+        id: validate
         run: go run ./internal/tools/sbomassurance -bomly ./bin/bomly-lite -output sbom-assurance-artifacts
 
       - name: Upload assurance evidence
+        id: evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-interoperability-${{ github.run_id }}
           path: sbom-assurance-artifacts/
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14
+
+      - name: Explain the result
+        if: always()
+        env:
+          VALIDATION_RESULT: ${{ steps.validate.outcome }}
+          EVIDENCE_RESULT: ${{ steps.evidence.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "${VALIDATION_RESULT}" == "success" ]]; then
+            result="Passed"
+            icon="✅"
+          else
+            result="Failed"
+            icon="❌"
+          fi
+          {
+            printf '# SBOM compatibility check: %s %s\n\n' "${icon}" "${result}"
+            printf 'Bomly generated SPDX 2.3 and CycloneDX 1.6 files, then asked the official validators to check them.\n\n'
+            printf -- '- **Revision:** `%s`\n' "${GITHUB_SHA}"
+            printf -- '- **Validation:** `%s`\n' "${VALIDATION_RESULT}"
+            printf -- '- **Evidence upload:** `%s`\n\n' "${EVIDENCE_RESULT}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          manifest="sbom-assurance-artifacts/run-manifest.json"
+          if [[ -f "${manifest}" ]]; then
+            {
+              printf '## Validators\n\n'
+              printf '| Validator | Version | Result | Time |\n'
+              printf '|---|---:|---|---:|\n'
+              jq -r '
+                . as $run
+                | .validators[]
+                | . as $validator
+                | ($run.commands[]
+                    | select(
+                        (.executable == "java" and $validator.name == "spdx-tools-java")
+                        or
+                        (.executable | endswith("cyclonedx-cli") and $validator.name == "cyclonedx-cli")
+                      )
+                  ) as $command
+                | "| \($validator.name) | \($validator.version) | "
+                  + (if $command.exit_code == 0 then "Passed" else "Failed (exit \($command.exit_code))" end)
+                  + " | \($command.duration_ms) ms |"
+              ' "${manifest}"
+              printf '\n## Generated files\n\n'
+              printf '| Format | Size | SHA-256 |\n'
+              printf '|---|---:|---|\n'
+              jq -r '.artifacts[] | "| \(.format) | \(.bytes) bytes | `\(.sha256)` |"' "${manifest}"
+              printf '\n## Validator messages\n\n'
+              jq -r '
+                .commands[]
+                | select(.executable == "java" or (.executable | endswith("cyclonedx-cli")))
+                | (if .executable == "java" then "SPDX" else "CycloneDX" end) as $name
+                | [(.stdout // ""), (.stderr // "")]
+                | map(select(length > 0))
+                | join("\n")
+                | gsub("\r"; "")
+                | gsub("\n+$"; "")
+                | (if length == 0 then "No messages" else gsub("\n"; "<br>") end) as $message
+                | "- **\($name):** \($message)"
+              ' "${manifest}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          else
+            printf '\nNo run report was created. Open the failed build or validation step first.\n' >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          {
+            printf '\n## Need more detail?\n\n'
+            printf 'Download the saved files with:\n\n'
+            printf '```bash\n'
+            printf 'gh run download %s -n sbom-interoperability-%s -D sbom-assurance-artifacts\n' "${GITHUB_RUN_ID}" "${GITHUB_RUN_ID}"
+            printf 'jq . sbom-assurance-artifacts/run-manifest.json\n'
+            printf '```\n\n'
+            printf 'The report contains every command, exit code, duration, validator message, version, and checksum. The full command output is also available in the **Generate and validate canonical SBOMs** step log.\n'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/test/assurance/BENCHMARK_RUNS.md
+++ b/test/assurance/BENCHMARK_RUNS.md
@@ -41,11 +41,15 @@ checksum. This comparison format is named
 The `Portable stability assurance` workflow runs only when someone starts it
 from GitHub Actions. It:
 
-- runs the complete test suite twice on Linux, macOS, and Windows;
-- runs the Java-related tests ten times to catch intermittent failures;
-- runs the complete Linux test suite five more times;
+- runs the Go unit tests twice on Linux, macOS, and Windows;
+- runs the Java-related unit tests ten times to catch intermittent failures;
+- runs all Go unit tests on Linux five more times;
 - builds both Bomly binaries for every supported Linux, macOS, and Windows
   processor target.
+
+The test steps use `go test`; they do not run the smoke tests against real
+repositories or services. Apart from the repeated unit tests, the only other
+check is whether all release binaries can be built.
 
 This workflow is separate from normal pull request checks because it performs
 many repeated test runs. Use it before closing a broad assurance effort or

--- a/test/assurance/BENCHMARK_RUNS.md
+++ b/test/assurance/BENCHMARK_RUNS.md
@@ -50,3 +50,23 @@ from GitHub Actions. It:
 This workflow is separate from normal pull request checks because it performs
 many repeated test runs. Use it before closing a broad assurance effort or
 when investigating platform-specific or intermittent failures.
+
+## Reading a portable run
+
+Open the workflow run's **Summary** page first. The overall section explains
+what ran and whether each area passed. Each platform also has a short section
+showing how many test runs completed and which run failed, if any. The Linux
+section does the same for repeated tests and release builds.
+
+If something fails, open the named job and failed step for the test or build
+output. To show only failed logs with the GitHub CLI, run:
+
+```sh
+gh run view RUN_ID --log-failed
+```
+
+After fixing the problem, rerun only the failed jobs:
+
+```sh
+gh run rerun RUN_ID --failed
+```

--- a/test/assurance/SBOM_INTEROPERABILITY.md
+++ b/test/assurance/SBOM_INTEROPERABILITY.md
@@ -13,6 +13,20 @@ separate from normal tests because it downloads the validators and takes
 longer to run. Bomly never downloads or installs these tools during normal CLI
 use.
 
+## Reading the result
+
+Open the workflow run's **Summary** page first. It shows:
+
+- whether validation passed;
+- the version and result of each validator;
+- the size and checksum of each generated file;
+- any messages returned by the validators.
+
+If validation fails, open the **Generate and validate canonical SBOMs** step
+to see its full output. The summary also provides a command that downloads the
+saved evidence. The downloaded `run-manifest.json` records every command, exit
+code, duration, validator message, version, and checksum.
+
 ## What the workflow saves
 
 The workflow uploads the generated SBOM files and a report named


### PR DESCRIPTION
## What changed

- Add an always-on summary to the SBOM compatibility workflow.
- Show validator versions and results, generated file sizes and checksums, validator messages, and the evidence upload result.
- Add per-platform and overall summaries to the portable stability workflow.
- Show planned and completed repetitions, the failed repetition or release target, and clear follow-up commands.
- Explain how to read both workflow results in the assurance guides.

## Why

A successful manual run previously showed only that its jobs passed. Understanding what was checked required reading the raw logs. These summaries put the useful result on the Actions Summary page while preserving logs and artifacts for deeper investigation.

The summary steps use `always()` so they still explain partial progress and point to the right log when an earlier step fails.

## Validation

- Workflow YAML syntax check
- Workflow shell syntax check
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- `git diff --check`

`make generate` was not needed because no generated contract source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clearer pass/fail summaries for portability, stability, cross-platform builds, and SBOM validation checks.
  * Reports now identify completed runs, failed stages, build variants, validator results, artifact details, and troubleshooting guidance.
  * Missing SBOM evidence is reported as a warning with instructions for reviewing available results.

* **Documentation**
  * Expanded guidance for interpreting assurance results, locating failures, rerunning failed checks, and inspecting generated SBOM evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->