### PR TITLE
fix(matchers): pass distro and upstreams to Grype for OS packages

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -257,6 +257,27 @@ Subproject discovery inspects only the execution-target root unless `--recursive
 
 Tier-3 source analyzers discover local workspace and module hierarchies from declarative project files while the consolidated detector graph remains the source of truth for external package edges. `jsreach` follows package-name imports across npm, Yarn, and pnpm workspace members. `jvmreach` follows source namespace imports across Maven `<modules>` and standard Gradle `include` declarations. This keeps hierarchy traversal automatic, avoids package-manager installation or network activity during reachability analysis, and prevents unused sibling projects from widening the reachable set.
 
+### Decision: Grype OS-package distro comes from the PURL, not pipeline plumbing
+
+Grype's OS matchers (apk, dpkg, rpm, portage, pacman) are distro-namespace
+driven: a package that reaches them without a distro matches nothing, and
+because Bomly passes no CPEs and leaves `UseCPEs` false the stock matcher does
+not pick up the slack — container OS packages came back clean rather than
+unchecked (issue #316). The builtin matcher
+(`internal/matchers/grype/purl_builtin.go`) derives the distro, and the upstream
+source package, from the `distro=` and `upstream=` PURL qualifiers Syft records,
+mirroring Grype's own PURL provider.
+
+The alternative was carrying the detected `linux.Release` from the Syft detector
+through the graph container, consolidation, and the match stage into
+`grypepkg.Context`. The PURL is the better carrier: it is already the registry
+key so nothing new has to be threaded through four stages, it survives SBOM
+input where no live distro detection is possible, and it keeps a per-package
+distro (correct for a graph consolidated from more than one image) instead of a
+single scan-wide one. The cost is that OS matching depends on the qualifier
+being present — true for image scans and for SBOMs produced from them, false
+for hand-written PURLs, which is documented in `docs/matchers/grype.md`.
+
 ### Decision: Scorecard matcher reads precomputed runs, not the library
 
 The OpenSSF Scorecard matcher (`internal/matchers/scorecard`) fetches precomputed per-repo scores from `api.scorecard.dev` instead of importing `github.com/ossf/scorecard/v5` and running checks in-process. Three reasons:

--- a/docs/matchers/grype.md
+++ b/docs/matchers/grype.md
@@ -46,6 +46,16 @@ Grype reads from a local vulnerability database that it syncs on first use and r
 
 The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls -- Grype manages its own cache.
 
+## OS packages (apk / dpkg / rpm)
+
+Grype matches OS packages through per-distro advisory namespaces, so a package only matches when Bomly can tell Grype which distro it came from. Bomly reads that from the `distro=` PURL qualifier Syft records while cataloguing the image (plus the `upstream=` qualifier, so advisories filed against a source package -- an Alpine origin package, a Debian source package, a source RPM -- match the binary packages built from it).
+
+```bash
+bomly scan --image alpine:3.20 --enrich --matchers grype
+```
+
+That qualifier is present for container-image scans and for SBOMs generated from an image. A hand-written PURL without it (`pkg:apk/openssl@3.0.8-r0`) has no distro to match against and reports nothing -- there is no distro-independent advisory feed for OS packages to fall back on.
+
 ## Output fields
 
 Each `vulnerabilities[]` entry on a package carries:
@@ -80,6 +90,6 @@ GRYPE_DB_AUTO_UPDATE=false bomly-lite scan --enrich
 ## Limitations
 
 - **Grype's container-image strength does not transfer to source scans.** Grype was designed to scan container images; on source trees, OSV-class matching is usually equal or better.
-- **Linux distro matching** (Alpine apk, Debian dpkg, RHEL rpm) is Grype's strongest suit and a primary reason to keep it in the default matcher set for container scans.
+- **Linux distro matching** (Alpine apk, Debian dpkg, RHEL rpm) is Grype's strongest suit and a primary reason to keep it in the default matcher set for container scans. It needs the distro the package came from; see [OS packages](#os-packages-apk--dpkg--rpm) for when that is available.
 - **`bomly-lite` requires the right `grype` version on `PATH`.** The full `bomly` binary pins a known-compatible version; the lite binary uses whatever is installed and may exhibit different behavior.
 - **DB freshness is your responsibility in offline environments.** A multi-day-old DB will miss new advisories.

--- a/internal/matchers/grype/builtin.go
+++ b/internal/matchers/grype/builtin.go
@@ -104,14 +104,21 @@ func (a Matcher) Match(_ context.Context, req sdk.MatchRequest) (sdk.MatchResult
 // graphPkgToGrypePkg builds a Grype package from a registry package, using the
 // canonical PURL as the correlation ID so matches can be mapped back to the
 // registry.
+//
+// Distro and upstream (origin) packages are derived from the PURL qualifiers
+// Syft records for OS packages — Grype's OS matchers are distro-namespace
+// driven and match nothing without them. See purl_builtin.go.
 func graphPkgToGrypePkg(p *sdk.Package) grypepkg.Package {
+	syftType := ecosystemToSyftType(string(p.Ecosystem))
 	return grypepkg.Package{
-		ID:       grypepkg.ID(p.PURL),
-		Name:     p.Name,
-		Version:  p.Version,
-		PURL:     p.PURL,
-		Type:     ecosystemToSyftType(string(p.Ecosystem)),
-		Language: ecosystemToSyftLanguage(string(p.Ecosystem)),
+		ID:        grypepkg.ID(p.PURL),
+		Name:      p.Name,
+		Version:   p.Version,
+		PURL:      p.PURL,
+		Type:      syftType,
+		Language:  ecosystemToSyftLanguage(string(p.Ecosystem)),
+		Distro:    distroFromPURL(p.PURL),
+		Upstreams: upstreamsFromPURL(p.PURL, p.Name, syftType),
 	}
 }
 
@@ -123,12 +130,12 @@ func graphPkgToGrypePkg(p *sdk.Package) grypepkg.Package {
 // This is every Bomly ecosystem Syft has a package type for. Only sbom (not a
 // package ecosystem) and snap (no Syft type) are absent.
 //
-// The OS-level entries — alpm, apk, dpkg, rpm, portage, homebrew — are typed
-// correctly but currently reach Grype without a distro (graphPkgToGrypePkg
-// sets no Distro, and FindMatches gets an empty package Context), and Grype's
-// OS matchers are distro-namespace driven, so they match nothing today. See
-// issue #316; the declaration becomes fully accurate once the distro is
-// plumbed through.
+// The OS-level entries — alpm, apk, dpkg, rpm, portage, homebrew — are matched
+// through Grype's distro-namespace matchers, which need the distro the package
+// came from. graphPkgToGrypePkg derives it (plus the upstream source package)
+// from the PURL qualifiers Syft records, so those ecosystems only match when
+// the PURL carries a `distro=` qualifier — true for image scans and for SBOMs
+// produced from one, not for a bare `pkg:apk/openssl@3.0.8-r0`.
 var supportedEcosystems = []sdk.Ecosystem{
 	sdk.EcosystemNPM,
 	sdk.EcosystemMaven,

--- a/internal/matchers/grype/purl_builtin.go
+++ b/internal/matchers/grype/purl_builtin.go
@@ -1,0 +1,106 @@
+//go:build !bomly_external_grype
+
+package grype
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	grypedistro "github.com/anchore/grype/grype/distro"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+// sourceRPMPattern extracts the name, version, release, and arch from a source
+// RPM file name (e.g. "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm"). It mirrors
+// the pattern Grype uses for the same purpose so upstream matching behaves the
+// same whether Grype reads the package or Bomly hands it over.
+var sourceRPMPattern = regexp.MustCompile(`^(?P<name>.*)-(?P<version>.*)-(?P<release>.*)\.(?P<arch>[a-zA-Z][^.]+)(\.rpm)$`)
+
+// distroFromPURL derives the Grype distro from the `distro` PURL qualifier.
+//
+// Grype's OS matchers (apk, dpkg, rpm, portage, pacman) are distro-namespace
+// driven: a package without a distro matches nothing at all. Syft records the
+// distro it detected while cataloguing an image as a PURL qualifier, so the
+// qualifier is the one carrier that survives both live image scans and SBOM
+// input. This mirrors Grype's own PURL provider.
+func distroFromPURL(purl string) *grypedistro.Distro {
+	parsed := sdk.ParsePackageURL(purl)
+	if parsed == nil {
+		return nil
+	}
+	for _, qualifier := range parsed.Qualifiers {
+		if qualifier.Key != syftPkg.PURLQualifierDistro {
+			continue
+		}
+		name, version := grypedistro.ParseDistroString(qualifier.Value)
+		if name == "" {
+			continue
+		}
+		if distro := grypedistro.NewFromNameVersion(name, version); distro != nil {
+			return distro
+		}
+	}
+	return nil
+}
+
+// upstreamsFromPURL derives the origin (source) packages from the `upstream`
+// PURL qualifier. Distro advisories are frequently recorded against the source
+// package rather than the binary package built from it (an Alpine origin
+// package, a Debian source package, a source RPM), so without upstreams the OS
+// matchers still under-report. This mirrors Grype's own PURL provider.
+func upstreamsFromPURL(purl, name string, syftType syftPkg.Type) []grypepkg.UpstreamPackage {
+	parsed := sdk.ParsePackageURL(purl)
+	if parsed == nil {
+		return nil
+	}
+	var upstreams []grypepkg.UpstreamPackage
+	for _, qualifier := range parsed.Qualifiers {
+		if qualifier.Key != syftPkg.PURLQualifierUpstream {
+			continue
+		}
+		for _, upstream := range parseUpstream(name, qualifier.Value, syftType) {
+			if slices.Contains(upstreams, upstream) {
+				continue
+			}
+			upstreams = append(upstreams, upstream)
+		}
+	}
+	return upstreams
+}
+
+func parseUpstream(name, value string, syftType syftPkg.Type) []grypepkg.UpstreamPackage {
+	if syftType == syftPkg.RpmPkg {
+		return upstreamsFromSourceRPM(name, value)
+	}
+	fields := strings.Split(value, "@")
+	switch len(fields) {
+	case 1:
+		if fields[0] == name || fields[0] == "" {
+			return nil
+		}
+		return []grypepkg.UpstreamPackage{{Name: fields[0]}}
+	case 2:
+		if fields[0] == name || fields[0] == "" {
+			return nil
+		}
+		return []grypepkg.UpstreamPackage{{Name: fields[0], Version: fields[1]}}
+	}
+	return nil
+}
+
+func upstreamsFromSourceRPM(name, sourceRPM string) []grypepkg.UpstreamPackage {
+	groups := sourceRPMPattern.FindStringSubmatch(sourceRPM)
+	if groups == nil {
+		return nil
+	}
+	upstreamName := groups[sourceRPMPattern.SubexpIndex("name")]
+	version := groups[sourceRPMPattern.SubexpIndex("version")]
+	release := groups[sourceRPMPattern.SubexpIndex("release")]
+	if upstreamName == "" || upstreamName == name || version == "" || release == "" {
+		return nil
+	}
+	return []grypepkg.UpstreamPackage{{Name: upstreamName, Version: version + "-" + release}}
+}

--- a/internal/matchers/grype/purl_builtin_test.go
+++ b/internal/matchers/grype/purl_builtin_test.go
@@ -1,0 +1,205 @@
+//go:build !bomly_external_grype
+
+package grype
+
+import (
+	"testing"
+
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/bomly-dev/bomly-cli/sdk"
+)
+
+func TestDistroFromPURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		purl        string
+		wantDistro  string
+		wantVersion string
+	}{
+		{
+			name:        "alpine apk",
+			purl:        "pkg:apk/alpine/openssl@3.0.8-r0?arch=x86_64&distro=alpine-3.17.2&upstream=openssl",
+			wantDistro:  "alpine",
+			wantVersion: "3.17.2",
+		},
+		{
+			name:        "debian deb",
+			purl:        "pkg:deb/debian/libc6@2.31-13?arch=amd64&distro=debian-11",
+			wantDistro:  "debian",
+			wantVersion: "11",
+		},
+		{
+			name:        "rhel rpm",
+			purl:        "pkg:rpm/rhel/openssl@1:1.1.1k-9.el8?arch=x86_64&distro=rhel-8.6",
+			wantDistro:  "redhat",
+			wantVersion: "8.6",
+		},
+		{
+			name:       "distro without version",
+			purl:       "pkg:apk/wolfi/openssl@3.0.8-r0?distro=wolfi",
+			wantDistro: "wolfi",
+		},
+		{
+			name: "no distro qualifier",
+			purl: "pkg:apk/openssl@3.0.8-r0",
+		},
+		{
+			name: "language package",
+			purl: "pkg:npm/lodash@4.17.20",
+		},
+		{
+			name: "unparseable purl",
+			purl: "not-a-purl",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			distro := distroFromPURL(tc.purl)
+			if tc.wantDistro == "" {
+				if distro != nil {
+					t.Fatalf("distroFromPURL(%q) = %v, want nil", tc.purl, distro)
+				}
+				return
+			}
+			if distro == nil {
+				t.Fatalf("distroFromPURL(%q) = nil, want %q", tc.purl, tc.wantDistro)
+			}
+			if got := distro.Name(); got != tc.wantDistro {
+				t.Errorf("distro name = %q, want %q", got, tc.wantDistro)
+			}
+			if got := distro.Version; got != tc.wantVersion {
+				t.Errorf("distro version = %q, want %q", got, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestUpstreamsFromPURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		purl     string
+		pkgName  string
+		syftType syftPkg.Type
+		want     []grypepkg.UpstreamPackage
+	}{
+		{
+			name:     "apk origin package",
+			purl:     "pkg:apk/alpine/libcrypto3@3.0.8-r0?arch=x86_64&distro=alpine-3.17.2&upstream=openssl",
+			pkgName:  "libcrypto3",
+			syftType: syftPkg.ApkPkg,
+			want:     []grypepkg.UpstreamPackage{{Name: "openssl"}},
+		},
+		{
+			name:     "deb source package with version",
+			purl:     "pkg:deb/debian/libssl1.1@1.1.1n-0%2Bdeb11u4?arch=amd64&distro=debian-11&upstream=openssl%401.1.1n-0%2Bdeb11u4",
+			pkgName:  "libssl1.1",
+			syftType: syftPkg.DebPkg,
+			want:     []grypepkg.UpstreamPackage{{Name: "openssl", Version: "1.1.1n-0+deb11u4"}},
+		},
+		{
+			name:     "source rpm",
+			purl:     "pkg:rpm/rhel/openssl-libs@1:1.1.1k-9.el8?arch=x86_64&distro=rhel-8.6&upstream=openssl-1.1.1k-9.el8.src.rpm",
+			pkgName:  "openssl-libs",
+			syftType: syftPkg.RpmPkg,
+			want:     []grypepkg.UpstreamPackage{{Name: "openssl", Version: "1.1.1k-9.el8"}},
+		},
+		{
+			name:     "source rpm matching package name is dropped",
+			purl:     "pkg:rpm/rhel/openssl@1:1.1.1k-9.el8?arch=x86_64&distro=rhel-8.6&upstream=openssl-1.1.1k-9.el8.src.rpm",
+			pkgName:  "openssl",
+			syftType: syftPkg.RpmPkg,
+		},
+		{
+			name:     "malformed source rpm",
+			purl:     "pkg:rpm/rhel/openssl-libs@1:1.1.1k-9.el8?distro=rhel-8.6&upstream=openssl",
+			pkgName:  "openssl-libs",
+			syftType: syftPkg.RpmPkg,
+		},
+		{
+			name:     "upstream matching package name is dropped",
+			purl:     "pkg:apk/alpine/openssl@3.0.8-r0?distro=alpine-3.17.2&upstream=openssl",
+			pkgName:  "openssl",
+			syftType: syftPkg.ApkPkg,
+		},
+		{
+			name:     "no upstream qualifier",
+			purl:     "pkg:apk/alpine/openssl@3.0.8-r0?distro=alpine-3.17.2",
+			pkgName:  "openssl",
+			syftType: syftPkg.ApkPkg,
+		},
+		{
+			name:     "language package",
+			purl:     "pkg:npm/lodash@4.17.20",
+			pkgName:  "lodash",
+			syftType: syftPkg.NpmPkg,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := upstreamsFromPURL(tc.purl, tc.pkgName, tc.syftType)
+			if len(got) != len(tc.want) {
+				t.Fatalf("upstreamsFromPURL(%q) = %+v, want %+v", tc.purl, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("upstream[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// An OS package has to reach Grype with a distro attached: every OS matcher
+// bails out without one, which is why container OS packages used to come back
+// clean instead of vulnerable (issue #316).
+func TestGraphPkgToGrypePkgCarriesDistroAndUpstreams(t *testing.T) {
+	pkg := graphPkgToGrypePkg(&sdk.Package{
+		Coordinates: sdk.Coordinates{
+			PURL:      "pkg:apk/alpine/libcrypto3@3.0.8-r0?arch=x86_64&distro=alpine-3.17.2&upstream=openssl",
+			Ecosystem: sdk.EcosystemAPK,
+			Name:      "libcrypto3",
+			Version:   "3.0.8-r0",
+		},
+	})
+
+	if pkg.Type != syftPkg.ApkPkg {
+		t.Errorf("type = %q, want %q", pkg.Type, syftPkg.ApkPkg)
+	}
+	if pkg.Distro == nil {
+		t.Fatal("distro = nil, want alpine 3.17.2")
+	}
+	if got, want := pkg.Distro.Name(), "alpine"; got != want {
+		t.Errorf("distro name = %q, want %q", got, want)
+	}
+	if got, want := pkg.Distro.Version, "3.17.2"; got != want {
+		t.Errorf("distro version = %q, want %q", got, want)
+	}
+	if len(pkg.Upstreams) != 1 || pkg.Upstreams[0].Name != "openssl" {
+		t.Errorf("upstreams = %+v, want [{openssl }]", pkg.Upstreams)
+	}
+}
+
+// Language packages must be unaffected: no distro, no upstreams.
+func TestGraphPkgToGrypePkgLanguagePackageUnchanged(t *testing.T) {
+	pkg := graphPkgToGrypePkg(&sdk.Package{
+		Coordinates: sdk.Coordinates{
+			PURL:      "pkg:npm/lodash@4.17.20",
+			Ecosystem: sdk.EcosystemNPM,
+			Name:      "lodash",
+			Version:   "4.17.20",
+		},
+	})
+
+	if pkg.Distro != nil {
+		t.Errorf("distro = %v, want nil", pkg.Distro)
+	}
+	if len(pkg.Upstreams) != 0 {
+		t.Errorf("upstreams = %+v, want none", pkg.Upstreams)
+	}
+	if pkg.Language != syftPkg.JavaScript {
+		t.Errorf("language = %q, want %q", pkg.Language, syftPkg.JavaScript)
+	}
+}

--- a/internal/support/prose/matchers/grype.md
+++ b/internal/support/prose/matchers/grype.md
@@ -26,6 +26,16 @@ Grype reads from a local vulnerability database that it syncs on first use and r
 
 The DB sync is the only network call Grype makes. Once synced, matching is local. Bomly's enrichment cache does not wrap Grype calls -- Grype manages its own cache.
 
+## OS packages (apk / dpkg / rpm)
+
+Grype matches OS packages through per-distro advisory namespaces, so a package only matches when Bomly can tell Grype which distro it came from. Bomly reads that from the `distro=` PURL qualifier Syft records while cataloguing the image (plus the `upstream=` qualifier, so advisories filed against a source package -- an Alpine origin package, a Debian source package, a source RPM -- match the binary packages built from it).
+
+```bash
+bomly scan --image alpine:3.20 --enrich --matchers grype
+```
+
+That qualifier is present for container-image scans and for SBOMs generated from an image. A hand-written PURL without it (`pkg:apk/openssl@3.0.8-r0`) has no distro to match against and reports nothing -- there is no distro-independent advisory feed for OS packages to fall back on.
+
 ## Output fields
 
 Each `vulnerabilities[]` entry on a package carries:
@@ -60,6 +70,6 @@ GRYPE_DB_AUTO_UPDATE=false bomly-lite scan --enrich
 ## Limitations
 
 - **Grype's container-image strength does not transfer to source scans.** Grype was designed to scan container images; on source trees, OSV-class matching is usually equal or better.
-- **Linux distro matching** (Alpine apk, Debian dpkg, RHEL rpm) is Grype's strongest suit and a primary reason to keep it in the default matcher set for container scans.
+- **Linux distro matching** (Alpine apk, Debian dpkg, RHEL rpm) is Grype's strongest suit and a primary reason to keep it in the default matcher set for container scans. It needs the distro the package came from; see [OS packages](#os-packages-apk--dpkg--rpm) for when that is available.
 - **`bomly-lite` requires the right `grype` version on `PATH`.** The full `bomly` binary pins a known-compatible version; the lite binary uses whatever is installed and may exhibit different behavior.
 - **DB freshness is your responsibility in offline environments.** A multi-day-old DB will miss new advisories.


### PR DESCRIPTION
Fixes #316.

## Problem

Grype's OS matchers (apk, dpkg, rpm, portage, pacman) are distro-namespace driven and bail out when the package has no distro. `graphPkgToGrypePkg` typed container OS packages correctly but built `grypepkg.Package` without a `Distro`, so they fell through to the stock matcher — which needs a language namespace or CPEs. Bomly passes neither (`UseCPEs` false, no CPEs set), so the result was **zero matches rather than an error**: `bomly scan --image ... --enrich --matchers grype` reported container OS packages as clean rather than as unchecked. The issue's read of the code was correct.

## Fix

Derive the distro from the `distro=` PURL qualifier Syft records while cataloguing an image, and the upstream source package from `upstream=` — mirroring Grype's own PURL provider (`grype/pkg/purl_provider.go`). New file `internal/matchers/grype/purl_builtin.go`; `graphPkgToGrypePkg` now sets `Distro` and `Upstreams`.

Upstreams matter as much as the distro here: distro advisories are frequently filed against the source package (an Alpine origin package, a Debian source package, a source RPM), so distro alone still under-reports — `libcrypto3` / `libssl3` only match through origin `openssl`.

### Why the PURL rather than plumbing the distro through the pipeline

The alternative was carrying Syft's detected `linux.Release` through the graph container, consolidation, and the match stage into `grypepkg.Context`. The PURL is the better carrier: it is already the registry key (nothing new to thread through four stages), it survives SBOM input where live distro detection is impossible, and it keeps the distro per-package — correct for a graph consolidated from more than one image — instead of one scan-wide value. `grypepkg.Context.Distro` turns out to feed only VEX processing and alerting, not matching, so it is not the lever anyway.

The tradeoff: OS matching depends on the qualifier being present. True for image scans and SBOMs produced from them; false for a hand-written `pkg:apk/openssl@3.0.8-r0`, which has no distro to match against and no distro-independent OS feed to fall back on. Documented in `docs/matchers/grype.md`.

## Verification

Local images (arm64, Grype DB of 2026-07-23), same binary before and after the change:

| Image | Vulnerable packages before | After | Advisories after |
| --- | --- | --- | --- |
| `alpine:3.17.2` | 0 | 7 | 78 |
| `debian:11.6-slim` | 0 | 54 | 305 |
| `rockylinux:8.7` | 1 (a pypi package) | 71 | 727 |

Language ecosystems are unchanged — they carry no distro qualifier and reach Grype exactly as before; a unit test pins that.

`make test`, `make lint` clean; lite build (`bomly_external_syft,bomly_external_grype`) compiles and vets.

## No smoke test

Deliberate: no smoke case runs the Grype matcher today, because it needs a ~1.7 GB vulnerability DB in CI, and a golden pinned to a live Grype DB would churn every time new CVEs land against a pinned base image (the existing enrich smoke tests use a **mock** OSV server for exactly this reason). Coverage is unit-level over the PURL→distro/upstream mapping plus the three-distro manual verification above. Happy to add a smoke slice if you'd rather pay the DB cost.

## Notes

- `docs/matchers/grype.md` regenerated via `make generate` from `internal/support/prose/matchers/grype.md`.
- Decision-log entry added to `dev-docs/ARCHITECTURE.md`.
- The `supportedEcosystems` comment from #315 that pointed at this gap is now accurate.
- External (`bomly-lite`) mode is untouched: it hands an SPDX document to the `grype` CLI, which does its own PURL enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)