### PR TITLE
Honor Bomly no-proxy with standard proxy fallback

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -54,8 +54,8 @@ YAML files use the nested keys documented below. Unknown keys and the former fla
 | `pipeline.install_args` | `BOMLY_INSTALL_ARGS` | `[]string` | - | Additional detector-specific install arguments |
 | `logging.quiet` | `BOMLY_QUIET` | `bool` | - | Suppress all non-error output |
 | `logging.verbosity` | `BOMLY_VERBOSE` | `int` | - | Verbosity level (0=normal, 1=verbose, 2+=debug) |
-| `network.proxy.url` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL used by Bomly and managed plugins |
-| `network.proxy.no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy |
+| `network.proxy.url` | `BOMLY_HTTP_PROXY` | `string` | - | Outbound HTTP proxy URL; when set, it replaces standard HTTP_PROXY/HTTPS_PROXY URLs |
+| `network.proxy.no_proxy` | `BOMLY_HTTP_NO_PROXY` | `string` | - | Hosts, domains, or CIDRs added to the standard NO_PROXY/no_proxy bypass list |
 | `network.proxy.type` | `BOMLY_HTTP_PROXY_TYPE` | `string` | http | Outbound proxy type when using host/port proxy settings: http, https, or socks5 |
 | `network.proxy.host` | `BOMLY_HTTP_PROXY_HOST` | `string` | - | Outbound proxy hostname or IP address used when http_proxy is not set |
 | `network.proxy.port` | `BOMLY_HTTP_PROXY_PORT` | `int` | - | Outbound proxy port used with http_proxy_host |
@@ -230,9 +230,9 @@ Flat YAML keys are no longer accepted. Move each existing key to its nested repl
 #   verbosity: 0
 # network:
 #   proxy:
-#     Outbound HTTP proxy URL used by Bomly and managed plugins
+#     Outbound HTTP proxy URL; when set, it replaces standard HTTP_PROXY/HTTPS_PROXY URLs
 #     url: ""
-#     Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy
+#     Hosts, domains, or CIDRs added to the standard NO_PROXY/no_proxy bypass list
 #     no_proxy: ""
 #     Outbound proxy type when using host/port proxy settings: http, https, or socks5
 #     type: http

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,8 +57,8 @@ type Resolved struct {
 	Quiet                 bool     `doc:"Suppress all non-error output" env:"BOMLY_QUIET"`
 	Verbosity             int      `doc:"Verbosity level (0=normal, 1=verbose, 2+=debug)" env:"BOMLY_VERBOSE"`
 	LoadedFiles           []string
-	HTTPProxy             string                    `doc:"Outbound HTTP proxy URL used by Bomly and managed plugins" env:"BOMLY_HTTP_PROXY"`
-	HTTPNoProxy           string                    `doc:"Comma-separated hosts, domains, or CIDRs that should bypass the outbound HTTP proxy" env:"BOMLY_HTTP_NO_PROXY"`
+	HTTPProxy             string                    `doc:"Outbound HTTP proxy URL; when set, it replaces standard HTTP_PROXY/HTTPS_PROXY URLs" env:"BOMLY_HTTP_PROXY"`
+	HTTPNoProxy           string                    `doc:"Hosts, domains, or CIDRs added to the standard NO_PROXY/no_proxy bypass list" env:"BOMLY_HTTP_NO_PROXY"`
 	HTTPProxyType         string                    `doc:"Outbound proxy type when using host/port proxy settings: http, https, or socks5" env:"BOMLY_HTTP_PROXY_TYPE" default:"http"`
 	HTTPProxyHost         string                    `doc:"Outbound proxy hostname or IP address used when http_proxy is not set" env:"BOMLY_HTTP_PROXY_HOST"`
 	HTTPProxyPort         int                       `doc:"Outbound proxy port used with http_proxy_host" env:"BOMLY_HTTP_PROXY_PORT"`

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -151,7 +151,15 @@ func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), 
 	}
 	noProxy := strings.TrimSpace(config.NoProxy)
 	if proxyURL == "" {
-		return http.ProxyFromEnvironment, nil
+		if noProxy == "" {
+			return http.ProxyFromEnvironment, nil
+		}
+		envProxy := httpproxy.FromEnvironment()
+		envProxy.NoProxy = noProxy
+		urlProxy := envProxy.ProxyFunc()
+		return func(req *http.Request) (*url.URL, error) {
+			return urlProxy(req.URL)
+		}, nil
 	}
 	parsed, err := parseProxyURL(proxyURL)
 	if err != nil {

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -149,12 +149,12 @@ func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), 
 	if err != nil {
 		return nil, err
 	}
-	noProxy := strings.TrimSpace(config.NoProxy)
+	envProxy := httpproxy.FromEnvironment()
+	noProxy := mergeNoProxy(envProxy.NoProxy, config.NoProxy)
 	if proxyURL == "" {
-		if noProxy == "" {
+		if strings.TrimSpace(config.NoProxy) == "" {
 			return http.ProxyFromEnvironment, nil
 		}
-		envProxy := httpproxy.FromEnvironment()
 		envProxy.NoProxy = noProxy
 		urlProxy := envProxy.ProxyFunc()
 		return func(req *http.Request) (*url.URL, error) {
@@ -176,6 +176,26 @@ func proxyFunc(config HTTPClientConfig) (func(*http.Request) (*url.URL, error), 
 	return func(req *http.Request) (*url.URL, error) {
 		return urlProxy(req.URL)
 	}, nil
+}
+
+func mergeNoProxy(standard, bomly string) string {
+	entries := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, list := range []string{standard, bomly} {
+		for _, entry := range strings.Split(list, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			key := strings.ToLower(entry)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			entries = append(entries, entry)
+		}
+	}
+	return strings.Join(entries, ",")
 }
 
 // EffectiveProxyURL returns the effective proxy URL after applying Bomly's URL or

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -41,6 +41,25 @@ func TestNewHTTPClientNoProxyBypass(t *testing.T) {
 	}
 }
 
+func TestNewHTTPClientNoProxyAppliesToStandardProxyFallback(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://standard-proxy.example:8080")
+	t.Setenv("HTTPS_PROXY", "http://standard-proxy.example:8080")
+	t.Setenv("ALL_PROXY", "")
+	t.Setenv("NO_PROXY", "")
+
+	client, err := NewHTTPClient(HTTPClientConfig{NoProxy: ".corp.example"})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	if proxyURL := proxyForRequest(t, client, "http://service.corp.example/v1"); proxyURL != nil {
+		t.Fatalf("proxy = %v, want BOMLY_HTTP_NO_PROXY bypass", proxyURL)
+	}
+	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
+	if proxyURL == nil || proxyURL.String() != "http://standard-proxy.example:8080" {
+		t.Fatalf("proxy = %v, want standard environment proxy", proxyURL)
+	}
+}
+
 func TestNewHTTPClientBuildsProxyFromHostPort(t *testing.T) {
 	client, err := NewHTTPClient(HTTPClientConfig{
 		ProxyType:     "socks5",

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -41,22 +41,61 @@ func TestNewHTTPClientNoProxyBypass(t *testing.T) {
 	}
 }
 
-func TestNewHTTPClientNoProxyAppliesToStandardProxyFallback(t *testing.T) {
+func TestNewHTTPClientMergesNoProxyWithStandardProxyFallback(t *testing.T) {
 	t.Setenv("HTTP_PROXY", "http://standard-proxy.example:8080")
 	t.Setenv("HTTPS_PROXY", "http://standard-proxy.example:8080")
 	t.Setenv("ALL_PROXY", "")
-	t.Setenv("NO_PROXY", "")
+	t.Setenv("NO_PROXY", ".standard.example,.shared.example")
+	t.Setenv("no_proxy", "")
 
-	client, err := NewHTTPClient(HTTPClientConfig{NoProxy: ".corp.example"})
+	client, err := NewHTTPClient(HTTPClientConfig{NoProxy: ".bomly.example,.shared.example"})
 	if err != nil {
 		t.Fatalf("NewHTTPClient() error = %v", err)
 	}
-	if proxyURL := proxyForRequest(t, client, "http://service.corp.example/v1"); proxyURL != nil {
-		t.Fatalf("proxy = %v, want BOMLY_HTTP_NO_PROXY bypass", proxyURL)
+	for _, endpoint := range []string{
+		"http://service.standard.example/v1",
+		"http://service.bomly.example/v1",
+		"http://service.shared.example/v1",
+	} {
+		if proxyURL := proxyForRequest(t, client, endpoint); proxyURL != nil {
+			t.Fatalf("proxy for %s = %v, want merged no-proxy bypass", endpoint, proxyURL)
+		}
 	}
 	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
 	if proxyURL == nil || proxyURL.String() != "http://standard-proxy.example:8080" {
 		t.Fatalf("proxy = %v, want standard environment proxy", proxyURL)
+	}
+}
+
+func TestNewHTTPClientMergesNoProxyWithExplicitProxy(t *testing.T) {
+	t.Setenv("NO_PROXY", ".standard.example")
+	t.Setenv("no_proxy", "")
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://bomly-proxy.example:8080",
+		NoProxy:  ".bomly.example",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	for _, endpoint := range []string{
+		"http://service.standard.example/v1",
+		"http://service.bomly.example/v1",
+	} {
+		if proxyURL := proxyForRequest(t, client, endpoint); proxyURL != nil {
+			t.Fatalf("proxy for %s = %v, want merged no-proxy bypass", endpoint, proxyURL)
+		}
+	}
+	proxyURL := proxyForRequest(t, client, "http://service.example/v1")
+	if proxyURL == nil || proxyURL.String() != "http://bomly-proxy.example:8080" {
+		t.Fatalf("proxy = %v, want explicit Bomly proxy", proxyURL)
+	}
+}
+
+func TestMergeNoProxyPreservesOrderAndRemovesDuplicates(t *testing.T) {
+	got := mergeNoProxy(".standard.example, localhost", "LOCALHOST,.bomly.example")
+	if got != ".standard.example,localhost,.bomly.example" {
+		t.Fatalf("mergeNoProxy() = %q", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Apply `BOMLY_HTTP_NO_PROXY` when Bomly uses `HTTP_PROXY` or `HTTPS_PROXY` from the standard environment.
- Preserve standard proxy routing for hosts that do not match the Bomly bypass list.
- Add a regression test covering both bypassed and proxied requests.

## Root cause

When no Bomly-specific proxy URL or host was configured, the shared HTTP client returned Go's environment proxy function immediately. That path honored the standard `NO_PROXY` value but never applied `BOMLY_HTTP_NO_PROXY`.

## User impact

Users can combine a standard environment proxy with Bomly's explicit no-proxy list. Matching internal or on-premises hosts now bypass the proxy as configured.

## Validation

- `go test ./sdk`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound HTTP proxy handling by combining configured bypass hosts with standard environment settings.
  * Ensured configured no-proxy hosts correctly bypass both environment-provided and explicitly configured proxies.
  * Preserved standard proxy behavior when no custom proxy or bypass settings are provided.

* **Documentation**
  * Clarified how configured proxy and no-proxy values interact with standard environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->