### PR TITLE
Redact credentials from endpoint logs

### DIFF
--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -389,10 +390,19 @@ func (r *Registry) registerScorecardMatcher() {
 		r.RegisterMatcherWithOptions(matcher, ComponentOptions{DefaultEnabled: false})
 	}
 	r.logger.Debug("scorecard matcher configured",
-		zap.String("api_base", scoreCfg.APIBase),
+		zap.String("api_base", endpointForLog(scoreCfg.APIBase)),
 		zap.String("cache_dir", scoreCfg.CacheDir),
 		zap.Duration("cache_ttl", scoreCfg.CacheTTL),
 	)
+}
+
+func endpointForLog(value string) string {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "[invalid URL]"
+	}
+	parsed.User = nil
+	return parsed.String()
 }
 
 func (r *Registry) httpClientProvider() *sdk.HTTPClientProvider {

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -2,11 +2,14 @@ package registry
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestBuildScanRegistryRegistersDetectorForEveryPackageManager(t *testing.T) {
@@ -153,5 +156,29 @@ func TestRegistryHTTPClientProviderReusesTransport(t *testing.T) {
 	}
 	if first.Timeout != 15*time.Second || second.Timeout != 30*time.Second {
 		t.Fatalf("timeouts = %v/%v, want 15s/30s", first.Timeout, second.Timeout)
+	}
+}
+
+func TestRegisterScorecardMatcherDoesNotLogEndpointCredentials(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	builtins := NewRegistry(Configs{
+		ScorecardAPIBase: "https://agent:super-secret@scorecard.example/api",
+	}, *zap.New(core))
+
+	builtins.registerScorecardMatcher()
+
+	entries := logs.FilterMessage("scorecard matcher configured").All()
+	if len(entries) != 1 {
+		t.Fatalf("scorecard configuration logs = %d, want 1", len(entries))
+	}
+	apiBase, ok := entries[0].ContextMap()["api_base"].(string)
+	if !ok {
+		t.Fatalf("api_base log field = %#v, want string", entries[0].ContextMap()["api_base"])
+	}
+	if apiBase != "https://scorecard.example/api" {
+		t.Fatalf("api_base log field = %q, want URL without credentials", apiBase)
+	}
+	if strings.Contains(apiBase, "agent") || strings.Contains(apiBase, "super-secret") {
+		t.Fatalf("api_base log field leaked credentials: %q", apiBase)
 	}
 }


### PR DESCRIPTION
## What changed

- Remove URL user information before writing the configured Scorecard API endpoint to debug logs.
- Replace malformed endpoint text with a fixed marker rather than logging the original value.
- Add a registry-level regression test that captures the debug event and proves credentials are absent.

## Root cause

The Scorecard matcher registration logged the configured API base verbatim. An explicitly trusted endpoint containing URL credentials therefore exposed its username and password at `-vv`.

## User impact

Debug logs retain the endpoint scheme, host, path, cache directory, and cache lifetime needed for troubleshooting without exposing URL credentials.

## Validation

- `go test ./internal/registry`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- `git diff --check`