### PR TITLE
Add execution boundary assurance

### DIFF
--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -183,6 +183,63 @@ func TestScanTool_PropagatesScope(t *testing.T) {
 	}
 }
 
+func TestToolsDoNotEnableNetworkOrAnalysisByDefault(t *testing.T) {
+	t.Run("scan", func(t *testing.T) {
+		adapter := &mockAdapter{
+			scanResult: mcp.ScanRunResult{
+				Response: output.ScanResponse{Command: "scan"},
+			},
+		}
+		c := newTestClient(t, adapter)
+		result := callTool(t, c, "bomly_scan", map[string]any{
+			"path": "../../untrusted\npath",
+		})
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %v", result.Content)
+		}
+		if adapter.scanReq.Enrich || adapter.scanReq.Audit || adapter.scanReq.Analyze {
+			t.Fatalf("scan enabled optional work without permission: %#v", adapter.scanReq)
+		}
+	})
+
+	t.Run("explain", func(t *testing.T) {
+		adapter := &mockAdapter{
+			explainResult: mcp.ExplainRunResult{
+				Response: output.ExplainResponse{Command: "explain"},
+			},
+		}
+		c := newTestClient(t, adapter)
+		result := callTool(t, c, "bomly_explain", map[string]any{
+			"package": "pkg:npm/example@1.0.0\nuntrusted",
+		})
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %v", result.Content)
+		}
+		if adapter.explainReq.Enrich || adapter.explainReq.Audit || adapter.explainReq.Analyze {
+			t.Fatalf("explain enabled optional work without permission: %#v", adapter.explainReq)
+		}
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		adapter := &mockAdapter{
+			diffResult: mcp.DiffRunResult{
+				Response: output.DiffResponse{Command: "diff"},
+			},
+		}
+		c := newTestClient(t, adapter)
+		result := callTool(t, c, "bomly_diff", map[string]any{
+			"base": "main\nuntrusted",
+			"head": "HEAD",
+		})
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %v", result.Content)
+		}
+		if adapter.diffReq.Enrich || adapter.diffReq.Audit || adapter.diffReq.Analyze {
+			t.Fatalf("diff enabled optional work without permission: %#v", adapter.diffReq)
+		}
+	})
+}
+
 func TestScanTool_PropagatesPolicyArguments(t *testing.T) {
 	adapter := &mockAdapter{scanResult: mcp.ScanRunResult{Response: output.ScanResponse{Command: "scan"}}}
 	c := newTestClient(t, adapter)

--- a/internal/plugin/env_test.go
+++ b/internal/plugin/env_test.go
@@ -92,6 +92,35 @@ func TestPluginEnvForwardsStandardProxyEnvWhenBomlyProxyUnset(t *testing.T) {
 	}
 }
 
+func TestPluginEnvDoesNotForwardUnrelatedHostEnvironment(t *testing.T) {
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-cloud-secret")
+	t.Setenv("GITHUB_TOKEN", "ambient-github-secret")
+	t.Setenv("DATABASE_URL", "postgres://user:ambient-db-secret@example.com/db")
+	t.Setenv("BOMLY_OSV_API_BASE", "https://unrelated.example.test")
+
+	env, cleanup, err := pluginEnv(LaunchOptions{}, "acme.matcher")
+	if err != nil {
+		t.Fatalf("pluginEnv() error = %v", err)
+	}
+	defer cleanup()
+
+	values := envMap(env)
+	for _, name := range []string{
+		"AWS_SECRET_ACCESS_KEY",
+		"GITHUB_TOKEN",
+		"DATABASE_URL",
+		"BOMLY_OSV_API_BASE",
+	} {
+		if value, ok := values[name]; ok {
+			t.Fatalf("plugin environment forwarded unrelated %s=%q", name, value)
+		}
+	}
+	if values[EnvPluginAPIVersion] != sdk.PluginAPIVersion ||
+		values[sdk.EnvPluginID] != "acme.matcher" {
+		t.Fatalf("plugin environment omitted required protocol values: %#v", values)
+	}
+}
+
 func TestPluginEnvOnlyWritesSelectedPluginConfig(t *testing.T) {
 	env, cleanup, err := pluginEnv(LaunchOptions{
 		PluginConfigs: map[string]map[string]any{

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -34,6 +34,16 @@ func TestInstallDevBinaryVerifyEnableDisableAndUninstall(t *testing.T) {
 	if result.Installed.Enabled {
 		t.Fatalf("expected plugin install to record disabled state by default")
 	}
+	disabledRegistry := engine.NewRegistry(engine.RegistryConfigs{}, *zap.NewNop())
+	disabledRegistry.Build()
+	if err := managedplugin.RegisterRuntimePlugins(context.Background(), disabledRegistry, root); err != nil {
+		t.Fatalf("RegisterRuntimePlugins() with disabled plugin error = %v", err)
+	}
+	for _, detector := range disabledRegistry.AllDetectors() {
+		if detector.Descriptor().Name == "acme.detector.fake" {
+			t.Fatal("disabled external plugin joined the runtime registry")
+		}
+	}
 	manifestBytes, err := os.ReadFile(filepath.Join(result.Installed.Path, "bomly-plugin.json"))
 	if err != nil {
 		t.Fatalf("read installed manifest: %v", err)

--- a/test/assurance/EXECUTION_BOUNDARIES.md
+++ b/test/assurance/EXECUTION_BOUNDARIES.md
@@ -1,51 +1,33 @@
-# Execution boundary assurance
+# Execution Boundary Assurance
 
-These tests check the boundaries where Bomly can run another program or pass
-data to code outside the main process.
+Bomly can start package managers and enabled native plugins. MCP can request
+the same operations as the CLI. These tests separate the controls Bomly
+enforces from authority delegated to a program the user selected.
 
-## Managed plugins
+| Boundary | Regression evidence | What the evidence proves |
+| --- | --- | --- |
+| Managed plugin environment | `TestPluginEnvIncludesProxyAndPluginConfig`, `TestPluginEnvForwardsStandardProxyEnvWhenBomlyProxyUnset`, `TestPluginEnvDoesNotForwardUnrelatedHostEnvironment`, `TestPluginEnvOnlyWritesSelectedPluginConfig` | Managed plugins receive protocol identity, selected plugin config, and configured or standard proxy settings. Unrelated host values such as cloud tokens and database URLs are not copied. |
+| Plugin lifecycle | `TestInstallDevBinaryVerifyEnableDisableAndUninstall`, `TestPrepareLoadsAndRunsExternalDetector`, `TestExternalMatcherReceivesAndReturnsRegistry` | Installation leaves a plugin disabled. Disabled plugins do not join runtime planning; an explicitly enabled plugin can run through its advertised contract. |
+| Protocol and fallback behavior | `TestProtocolV1DetectorSnapshotDefaultsAbsentOptionalCapabilities`, `TestRuntimeSnapshotRejectsUnadvertisedOrMalformedRole`, `TestResolveDetectors_FallbackAnnotatesResult`, `TestPipeline_RunRecordsFallbackWarning` | Older plugins work without optional capabilities. Invalid roles fail, and detector failure uses the normal fallback path. |
+| MCP default authority | `TestToolsDoNotEnableNetworkOrAnalysisByDefault` | Scan, explain, and diff requests do not enable enrichment, audit, or analysis unless their own fields request it. Hostile path, package, and Git text does not panic or silently grant those permissions. |
+| MCP response size | `TestCompactScanInventoryCapIsDeterministicAndCounted`, `TestCompactScanCapsDiagnosticsWithVisibleMarker`, `TestCompactRemediationCapsAliasesAndFindingsWithCounters`, `TestCompactScanSizeStaysUnderBudget` | Compact results stay within configured collection caps and report omitted data. |
+| Central remediation dependencies | `TestRemediationPackageDependencyBoundaries/central_derivation` | `go list -deps -json` checks the complete `internal/remediation` package and its transitive Bomly package graph. It cannot directly import network, OS, process, system, or cache packages, and cannot reach Git, plugins, system execution, or matcher caches transitively. The direct `os` prohibition is deliberately strict: even environment reads are rejected so this policy package cannot quietly gain ambient host authority. |
+| Detector hint dependencies | `TestRemediationPackageDependencyBoundaries/detector_hint_packages` | Each package that owns built-in hints is checked at package granularity. Hint-owning detector packages cannot directly import networking, Git, matcher cache, plugin, or central remediation packages and cannot reach Bomly's Git, cache, plugin, or policy packages transitively. Detector packages legitimately retain `internal/system` and `os/exec` for their separate graph-resolution role. |
+| Remediation data contract | `TestExternalDetectorProvidesAdvertisedRemediationHints`, `TestDerivePackageRemediation`, `TestDerivePackageRemediationsOverwritesAndIsIdempotent`, `TestValidateHintsSanitizesAndBoundsAdvice`, `TestCollectHintsBoundsAndSanitizesDiagnostics`, `TestDeriveRejectsUnadvertisedAndUnknownHints` | Core passes cloned data, validates occurrence references and advertised strategies, bounds provider text, and chooses status, version, and action centrally. Returned hints cannot authorize writes or execution. |
+| Subprocess diagnostics | `TestSanitizeArgsRedactsCredentialValuesAndURLUserinfo`, `TestSanitizeArgsDoesNotTreatOrdinaryAuthoredFlagsAsCredentials`, `TestNewConsoleAndCommandStderr`, `TestCommandStderrNilAndHidden`, `TestInstallLogsReproducibleCommandWithoutCredentials` in PR #334 | Debug logs retain executable, credential-sanitized arguments, and working directory. Arbitrary subprocess stderr is counted but not retained or mirrored. |
 
-Managed plugins are native programs. Enabling one gives it the same user
-permissions as Bomly. Bomly limits what it sends to the plugin process:
+## Residual Authority
 
-- protocol identity and the selected plugin ID;
-- only that plugin's configuration, in a temporary file;
-- configured proxy and CA settings, or the standard proxy variables;
-- no unrelated host variables such as cloud tokens or database credentials.
-
-Tests also confirm that disabled plugins do not join runtime planning, enabled
-plugins can run through the detector and matcher contracts, malformed runtime
-descriptors are rejected, failures use the normal detector fallback path, and
-older protocol-v1 plugins work without optional remediation capabilities.
-
-## MCP tools
-
-MCP scan, explain, and diff calls leave enrichment, auditing, and analysis off
-unless the request enables them. Input containing path traversal text, control
-characters, or unusual package and Git references must not panic or silently
-enable those operations. Compact responses remain bounded by their configured
-caps and report how much data was omitted.
-
-MCP is not a sandbox. A requested local path, Git URL, image, plugin, or
+MCP is not a sandbox. A requested path, Git URL, image, plugin, or
 package-manager operation has the same authority it has in the CLI.
 
-## Remediation guidance
+An enabled external plugin is a native process with the user's privileges. The
+protocol constrains data Bomly accepts from it; it cannot prevent that process
+from reading files, writing files, using the network, or starting another
+program.
 
-Canonical remediation is read-only enrichment. The central derivation code and
-built-in detector hint implementations do not import network, process, cache,
-or filesystem packages and do not call write methods.
-
-Detector hints are untrusted evidence. Core passes cloned graph and registry
-data, validates every occurrence and advertised strategy, bounds provider text,
-and chooses the final status, version, and action itself. An enabled external
-plugin is still native code and can use its process permissions independently;
-the SDK's read-only provider contract is an architectural rule, not an operating
-system sandbox.
-
-## Subprocess logging
-
-Debug logs for package-manager and analysis commands should identify the
-executable, arguments, and working directory so the command can be reproduced.
-Credential-bearing arguments and output must be redacted before logging.
-Assurance for this rule is completed only when every command runner uses the
-shared redaction boundary.
+Detector packages combine read-only hint methods with package-manager graph
+resolution. Their package dependency graphs therefore include process and
+filesystem helpers by design. The SDK provider contract, cloned requests, and
+core validation enforce hint behavior inside Bomly; they are architecture
+controls, not an operating-system sandbox for enabled native plugins.

--- a/test/assurance/EXECUTION_BOUNDARIES.md
+++ b/test/assurance/EXECUTION_BOUNDARIES.md
@@ -1,0 +1,51 @@
+# Execution boundary assurance
+
+These tests check the boundaries where Bomly can run another program or pass
+data to code outside the main process.
+
+## Managed plugins
+
+Managed plugins are native programs. Enabling one gives it the same user
+permissions as Bomly. Bomly limits what it sends to the plugin process:
+
+- protocol identity and the selected plugin ID;
+- only that plugin's configuration, in a temporary file;
+- configured proxy and CA settings, or the standard proxy variables;
+- no unrelated host variables such as cloud tokens or database credentials.
+
+Tests also confirm that disabled plugins do not join runtime planning, enabled
+plugins can run through the detector and matcher contracts, malformed runtime
+descriptors are rejected, failures use the normal detector fallback path, and
+older protocol-v1 plugins work without optional remediation capabilities.
+
+## MCP tools
+
+MCP scan, explain, and diff calls leave enrichment, auditing, and analysis off
+unless the request enables them. Input containing path traversal text, control
+characters, or unusual package and Git references must not panic or silently
+enable those operations. Compact responses remain bounded by their configured
+caps and report how much data was omitted.
+
+MCP is not a sandbox. A requested local path, Git URL, image, plugin, or
+package-manager operation has the same authority it has in the CLI.
+
+## Remediation guidance
+
+Canonical remediation is read-only enrichment. The central derivation code and
+built-in detector hint implementations do not import network, process, cache,
+or filesystem packages and do not call write methods.
+
+Detector hints are untrusted evidence. Core passes cloned graph and registry
+data, validates every occurrence and advertised strategy, bounds provider text,
+and chooses the final status, version, and action itself. An enabled external
+plugin is still native code and can use its process permissions independently;
+the SDK's read-only provider contract is an architectural rule, not an operating
+system sandbox.
+
+## Subprocess logging
+
+Debug logs for package-manager and analysis commands should identify the
+executable, arguments, and working directory so the command can be reproduced.
+Credential-bearing arguments and output must be redacted before logging.
+Assurance for this rule is completed only when every command runner uses the
+shared redaction boundary.

--- a/test/assurance/execution_boundaries_test.go
+++ b/test/assurance/execution_boundaries_test.go
@@ -1,63 +1,135 @@
 package assurance
 
 import (
-	"go/parser"
-	"go/token"
-	"os"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 )
 
-func TestReadOnlyRemediationSourcesDoNotImportExecutionOrIOPackages(t *testing.T) {
-	root := repositoryRoot(t)
-	files := []string{
-		filepath.Join(root, "internal", "remediation", "derive.go"),
-		filepath.Join(root, "internal", "detectors", "remediation.go"),
-	}
-	err := filepath.WalkDir(filepath.Join(root, "internal", "detectors"), func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() || entry.Name() != "remediation.go" {
-			return nil
-		}
-		if path != files[1] {
-			files = append(files, path)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk detector remediation sources: %v", err)
-	}
+type listedPackage struct {
+	ImportPath string
+	Imports    []string
+}
 
-	forbidden := map[string]string{
-		"net":      "network access",
-		"net/http": "network access",
-		"os":       "filesystem or process environment access",
-		"os/exec":  "subprocess execution",
-		"github.com/bomly-dev/bomly-cli/internal/system":         "filesystem or subprocess access",
-		"github.com/bomly-dev/bomly-cli/internal/matchers/cache": "cache filesystem access",
-	}
-	for _, path := range files {
-		path := path
-		t.Run(strings.TrimPrefix(path, root+string(filepath.Separator)), func(t *testing.T) {
-			file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
-			if parseErr != nil {
-				t.Fatalf("parse imports: %v", parseErr)
-			}
-			for _, imported := range file.Imports {
-				name, unquoteErr := strconv.Unquote(imported.Path.Value)
-				if unquoteErr != nil {
-					t.Fatalf("decode import %q: %v", imported.Path.Value, unquoteErr)
-				}
-				if reason, found := forbidden[name]; found {
-					t.Errorf("read-only remediation source imports %q, which permits %s", name, reason)
-				}
-			}
+func TestRemediationPackageDependencyBoundaries(t *testing.T) {
+	root := repositoryRoot(t)
+	const module = "github.com/bomly-dev/bomly-cli/"
+
+	t.Run("central derivation", func(t *testing.T) {
+		packages := goListDependencies(t, root, "./internal/remediation")
+		assertDirectImportsAbsent(t, packages, module+"internal/remediation", map[string]string{
+			"net":                              "network access",
+			"net/http":                         "HTTP access",
+			"os":                               "filesystem or process environment access",
+			"os/exec":                          "subprocess execution",
+			module + "internal/system":         "filesystem or subprocess access",
+			module + "internal/matchers/cache": "cache filesystem access",
 		})
+		assertDependenciesAbsent(t, packages, map[string]string{
+			module + "internal/git":            "Git filesystem or subprocess access",
+			module + "internal/matchers/cache": "cache filesystem access",
+			module + "internal/plugin":         "native plugin execution",
+			module + "internal/system":         "filesystem or subprocess access",
+		})
+	})
+
+	// These packages also own detector resolution, so their complete dependency
+	// graphs legitimately include internal/system and os/exec. At package
+	// granularity, enforce that remediation hints do not acquire network,
+	// cache, plugin, Git, or central-policy dependencies. Request immutability
+	// and read-only provider behavior are covered by the remediation contract
+	// tests named in EXECUTION_BOUNDARIES.md.
+	detectorHintPackages := []struct {
+		name string
+		path string
+	}{
+		{name: "shared", path: "./internal/detectors"},
+		{name: "cargo", path: "./internal/detectors/cargo"},
+		{name: "composer", path: "./internal/detectors/composer"},
+		{name: "gomod", path: "./internal/detectors/gomod"},
+		{name: "gradle", path: "./internal/detectors/gradle"},
+		{name: "maven", path: "./internal/detectors/maven"},
+		{name: "bun", path: "./internal/detectors/node/bun"},
+		{name: "npm", path: "./internal/detectors/node/npm"},
+		{name: "pnpm", path: "./internal/detectors/node/pnpm"},
+		{name: "yarn", path: "./internal/detectors/node/yarn"},
+		{name: "python", path: "./internal/detectors/python"},
+		{name: "ruby", path: "./internal/detectors/ruby"},
+	}
+	t.Run("detector hint packages", func(t *testing.T) {
+		for _, target := range detectorHintPackages {
+			target := target
+			t.Run(target.name, func(t *testing.T) {
+				packages := goListDependencies(t, root, target.path)
+				importPath := module + strings.TrimPrefix(target.path, "./")
+				assertDirectImportsAbsent(t, packages, importPath, map[string]string{
+					"net":                              "network access",
+					"net/http":                         "HTTP access",
+					module + "internal/git":            "Git access",
+					module + "internal/matchers/cache": "cache filesystem access",
+					module + "internal/plugin":         "native plugin execution",
+					module + "internal/remediation":    "central remediation policy",
+				})
+				assertDependenciesAbsent(t, packages, map[string]string{
+					module + "internal/git":            "Git access",
+					module + "internal/matchers/cache": "cache filesystem access",
+					module + "internal/plugin":         "native plugin execution",
+					module + "internal/remediation":    "central remediation policy",
+				})
+			})
+		}
+	})
+}
+
+func goListDependencies(t *testing.T, root, packagePath string) map[string]listedPackage {
+	t.Helper()
+	cmd := exec.Command("go", "list", "-deps", "-json", packagePath)
+	cmd.Dir = root
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list dependencies for %s: %v", packagePath, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	packages := map[string]listedPackage{}
+	for {
+		var listed listedPackage
+		err := decoder.Decode(&listed)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode go list output for %s: %v", packagePath, err)
+		}
+		packages[listed.ImportPath] = listed
+	}
+	return packages
+}
+
+func assertDirectImportsAbsent(t *testing.T, packages map[string]listedPackage, importPath string, forbidden map[string]string) {
+	t.Helper()
+	target, ok := packages[importPath]
+	if !ok {
+		t.Fatalf("go list omitted target package %q", importPath)
+	}
+	for _, imported := range target.Imports {
+		if reason, found := forbidden[imported]; found {
+			t.Errorf("package %q directly imports %q, which permits %s", importPath, imported, reason)
+		}
+	}
+}
+
+func assertDependenciesAbsent(t *testing.T, packages map[string]listedPackage, forbidden map[string]string) {
+	t.Helper()
+	for importPath, reason := range forbidden {
+		if _, found := packages[importPath]; found {
+			t.Errorf("transitive package graph includes %q, which permits %s", importPath, reason)
+		}
 	}
 }
 

--- a/test/assurance/execution_boundaries_test.go
+++ b/test/assurance/execution_boundaries_test.go
@@ -1,0 +1,71 @@
+package assurance
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestReadOnlyRemediationSourcesDoNotImportExecutionOrIOPackages(t *testing.T) {
+	root := repositoryRoot(t)
+	files := []string{
+		filepath.Join(root, "internal", "remediation", "derive.go"),
+		filepath.Join(root, "internal", "detectors", "remediation.go"),
+	}
+	err := filepath.WalkDir(filepath.Join(root, "internal", "detectors"), func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "remediation.go" {
+			return nil
+		}
+		if path != files[1] {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk detector remediation sources: %v", err)
+	}
+
+	forbidden := map[string]string{
+		"net":      "network access",
+		"net/http": "network access",
+		"os":       "filesystem or process environment access",
+		"os/exec":  "subprocess execution",
+		"github.com/bomly-dev/bomly-cli/internal/system":         "filesystem or subprocess access",
+		"github.com/bomly-dev/bomly-cli/internal/matchers/cache": "cache filesystem access",
+	}
+	for _, path := range files {
+		path := path
+		t.Run(strings.TrimPrefix(path, root+string(filepath.Separator)), func(t *testing.T) {
+			file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+			if parseErr != nil {
+				t.Fatalf("parse imports: %v", parseErr)
+			}
+			for _, imported := range file.Imports {
+				name, unquoteErr := strconv.Unquote(imported.Path.Value)
+				if unquoteErr != nil {
+					t.Fatalf("decode import %q: %v", imported.Path.Value, unquoteErr)
+				}
+				if reason, found := forbidden[name]; found {
+					t.Errorf("read-only remediation source imports %q, which permits %s", name, reason)
+				}
+			}
+		})
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, source, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve assurance test source")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(source), "..", ".."))
+}


### PR DESCRIPTION
## What changed

- verify managed plugins receive only selected protocol, plugin, and proxy settings instead of unrelated host secrets
- prove disabled native plugins do not join the runtime registry
- exercise scan, explain, and diff MCP calls with hostile text while enrichment, audit, and analysis remain off by default
- add a static guard that keeps canonical remediation and built-in hint code free of network, process, cache, and filesystem imports
- document the tested execution and trust boundaries in plain language

## Why

Issue 026 needs repeatable evidence for behavior that crosses process and protocol boundaries. These checks make the current plugin, MCP, and read-only remediation guarantees explicit without changing production behavior.

The inventory also found two production concerns that are intentionally excluded from this assurance-only PR: MCP adapter errors are returned verbatim to clients, and subprocess argv logging is not consistently complete or secret-safe. They will be addressed in separate focused fixes before this assurance layer is considered complete.

## Validation

- `go test ./internal/plugin ./internal/mcp ./internal/remediation ./internal/registry ./test/assurance`
- `make generate`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- `git diff --check`