### PR TITLE
Verify HTTP trust boundaries

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -443,6 +443,22 @@ Permitted enrichment-time services:
 
 Installed external matcher plugins may use their own documented services.
 
+**Custom network settings are trusted authority.** The OSV and Scorecard base
+URLs may point to public, private, loopback, or plain HTTP services. Proxy
+destinations and additional CA files have the same reach. Bomly supports these
+choices for self-hosted services and enterprise networks; it does not apply a
+private-network block. Only the user config is loaded automatically. A
+repository config must be selected with `--config` or `BOMLY_CONFIG`, and
+network-specific environment variables are also explicit inputs.
+
+The shared SDK HTTP client follows Go's normal redirect rules. Redirects are
+allowed because custom services commonly use them, but sensitive headers are
+not forwarded to a different hostname. Proxy and endpoint passwords must not
+appear in errors or logs. Configured PEM certificates extend the system trust
+roots for the current process rather than replacing them. The executable
+assurance matrix is recorded in
+[`test/assurance/NETWORK_BOUNDARIES.md`](../test/assurance/NETWORK_BOUNDARIES.md).
+
 **Native plugins are trusted processes, not sandboxes.** Installation verifies
 the managed artifact and records it disabled by default. Enabling a plugin
 authorizes a native process with the same user-level filesystem, network,

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -453,10 +453,12 @@ network-specific environment variables are also explicit inputs.
 
 The shared SDK HTTP client follows Go's normal redirect rules. Redirects are
 allowed because custom services commonly use them, but sensitive headers are
-not forwarded to a different hostname. Proxy and endpoint passwords must not
-appear in errors or logs. Configured PEM certificates extend the system trust
-roots for the current process rather than replacing them. The executable
-assurance matrix is recorded in
+not forwarded to a different hostname. The standard client also permits an
+HTTPS endpoint to redirect to HTTP. This is intentional trusted-endpoint
+behavior for self-hosted services; Bomly does not add a downgrade block. Proxy
+and endpoint passwords must not appear in errors or logs. Configured PEM
+certificates extend the system trust roots for the current process rather than
+replacing them. The executable assurance matrix is recorded in
 [`test/assurance/NETWORK_BOUNDARIES.md`](../test/assurance/NETWORK_BOUNDARIES.md).
 
 **Native plugins are trusted processes, not sandboxes.** Installation verifies

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,9 @@ supported, including private-network destinations. These are trusted settings:
 use the user config, a file selected with `--config` or `BOMLY_CONFIG`, or the
 documented environment variables. Repository config is not loaded
 automatically. Bomly follows normal redirects and does not block private
-addresses so self-hosted services and enterprise proxies can work.
+addresses so self-hosted services and enterprise proxies can work. This also
+means a trusted HTTPS endpoint may redirect to HTTP; Bomly does not add a
+downgrade block.
 
 ## Build variants
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,13 @@ install and enable them. See
 [Detectors → Network behavior](DETECTORS.md#network-behavior) and
 [Matchers](MATCHERS.md).
 
+Custom OSV and Scorecard endpoints, proxies, and additional CA files are
+supported, including private-network destinations. These are trusted settings:
+use the user config, a file selected with `--config` or `BOMLY_CONFIG`, or the
+documented environment variables. Repository config is not loaded
+automatically. Bomly follows normal redirects and does not block private
+addresses so self-hosted services and enterprise proxies can work.
+
 ## Build variants
 
 Bomly ships in two variants. The full binary (`bomly`) links the Syft and Grype libraries directly and needs no external tools. The lite binary (`bomly-lite`) shells out to `syft` and `grype` on your `PATH` for a smaller download. Both behave the same from the command line. See [Installation](INSTALLATION.md) for which to pick.

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -762,6 +762,72 @@ func TestCommandContextInitialize_RepositoryConfigCannotGrantAuthorityImplicitly
 	}
 }
 
+func TestCommandContextInitialize_ExplicitConfigCanSelectPrivateNetworkSettings(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "trusted.yaml")
+	writeConfigFile(t, configPath, map[string]any{
+		"network": map[string]any{
+			"proxy": map[string]any{
+				"url":      "http://proxy.internal.test:8080",
+				"no_proxy": "advisories.internal.test,127.0.0.0/8",
+			},
+			"ca_cert_file": "private-ca.pem",
+		},
+		"matchers": map[string]any{
+			"osv": map[string]any{
+				"api_base": "http://127.0.0.1:8081",
+			},
+			"scorecard": map[string]any{
+				"api_base": "https://scorecard.internal.test",
+			},
+		},
+		"plugins": map[string]any{
+			"private.matcher": map[string]any{
+				"endpoint": "https://advisories.internal.test",
+			},
+		},
+	})
+
+	options := &Options{}
+	root := newTestRootCommand(t)
+	if err := options.Bind(root); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := root.ParseFlags([]string{"--config", configPath}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	if err := options.ResolveConfig(root); err != nil {
+		t.Fatalf("ResolveConfig() error = %v", err)
+	}
+
+	got := options.GetConfig()
+	if got.HTTPProxy != "http://proxy.internal.test:8080" {
+		t.Fatalf("HTTP proxy = %q", got.HTTPProxy)
+	}
+	if got.HTTPNoProxy != "advisories.internal.test,127.0.0.0/8" {
+		t.Fatalf("HTTP no-proxy = %q", got.HTTPNoProxy)
+	}
+	if got.HTTPCACertFile != filepath.Join(configDir, "private-ca.pem") {
+		t.Fatalf("HTTP CA certificate = %q", got.HTTPCACertFile)
+	}
+	if got.OsvAPIBase != "http://127.0.0.1:8081" {
+		t.Fatalf("OSV API base = %q", got.OsvAPIBase)
+	}
+	if got.ScorecardAPIBase != "https://scorecard.internal.test" {
+		t.Fatalf("Scorecard API base = %q", got.ScorecardAPIBase)
+	}
+	if got.Plugins["private.matcher"]["endpoint"] != "https://advisories.internal.test" {
+		t.Fatalf("plugin config = %#v", got.Plugins)
+	}
+	if len(got.LoadedFiles) != 1 || got.LoadedFiles[0] != configPath {
+		t.Fatalf("loaded files = %#v, want explicit config", got.LoadedFiles)
+	}
+}
+
 func TestCommandContextInitialize_ConfigSelection(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -762,7 +762,7 @@ func TestCommandContextInitialize_RepositoryConfigCannotGrantAuthorityImplicitly
 	}
 }
 
-func TestCommandContextInitialize_ExplicitConfigCanSelectPrivateNetworkSettings(t *testing.T) {
+func TestCommandContextInitialize_ExplicitConfigResolvesRelativeCAPathAndPrivateNetworkSettings(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 	t.Setenv("USERPROFILE", tempHome)
@@ -811,6 +811,7 @@ func TestCommandContextInitialize_ExplicitConfigCanSelectPrivateNetworkSettings(
 	if got.HTTPNoProxy != "advisories.internal.test,127.0.0.0/8" {
 		t.Fatalf("HTTP no-proxy = %q", got.HTTPNoProxy)
 	}
+	// CA paths are resolved from the selected config file, not the process CWD.
 	if got.HTTPCACertFile != filepath.Join(configDir, "private-ca.pem") {
 		t.Fatalf("HTTP CA certificate = %q", got.HTTPCACertFile)
 	}

--- a/sdk/http_assurance_test.go
+++ b/sdk/http_assurance_test.go
@@ -182,6 +182,45 @@ func TestHTTPClientFollowsRedirectToPrivateDestinationWithoutForwardingCredentia
 	}
 }
 
+func TestHTTPClientPreservesCredentialsOnSameHostRedirect(t *testing.T) {
+	var redirectedAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			username, password, ok := r.BasicAuth()
+			if !ok || username != "agent" || password != "redirect-secret" {
+				t.Errorf("origin credentials = %q/%q/%t", username, password, ok)
+			}
+			http.Redirect(w, r, "/advisories", http.StatusFound)
+		case "/advisories":
+			redirectedAuthorization = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://unused-proxy.invalid",
+		NoProxy:  "*",
+		Timeout:  5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	endpoint := strings.Replace(server.URL, "http://", "http://agent:redirect-secret@", 1) + "/start"
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		t.Fatalf("GET redirected endpoint: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if redirectedAuthorization == "" {
+		t.Fatal("redirected Authorization header is empty, want same-host credentials")
+	}
+}
+
 func TestHTTPClientTransportErrorDoesNotExposeEndpointPassword(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/sdk/http_assurance_test.go
+++ b/sdk/http_assurance_test.go
@@ -1,0 +1,210 @@
+package sdk
+
+import (
+	"context"
+	"encoding/pem"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientRoutesRequestsThroughExplicitProxy(t *testing.T) {
+	var proxyRequests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyRequests.Add(1)
+		if r.URL.Host != "packages.example.test" {
+			t.Errorf("proxy request host = %q, want packages.example.test", r.URL.Host)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxy.Close()
+
+	client, err := NewHTTPClient(HTTPClientConfig{ProxyURL: proxy.URL})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	resp, err := client.Get("http://packages.example.test/advisories")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	_ = resp.Body.Close()
+	if proxyRequests.Load() != 1 {
+		t.Fatalf("proxy requests = %d, want 1", proxyRequests.Load())
+	}
+}
+
+func TestHTTPClientBypassesExplicitProxyForNoProxyDestination(t *testing.T) {
+	var proxyRequests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyRequests.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	var destinationRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		destinationRequests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer destination.Close()
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: proxy.URL,
+		NoProxy:  ".internal.test",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	destinationAddress := strings.TrimPrefix(destination.URL, "http://")
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, destinationAddress)
+	}
+
+	resp, err := client.Get("http://advisories.internal.test/v1/query")
+	if err != nil {
+		t.Fatalf("GET with proxy bypass: %v", err)
+	}
+	_ = resp.Body.Close()
+	if proxyRequests.Load() != 0 {
+		t.Fatalf("proxy requests = %d, want 0", proxyRequests.Load())
+	}
+	if destinationRequests.Load() != 1 {
+		t.Fatalf("destination requests = %d, want 1", destinationRequests.Load())
+	}
+}
+
+func TestHTTPClientNoProxyMatchesHostsAndNetworks(t *testing.T) {
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://proxy.example.test:8080",
+		NoProxy:  "api.internal.test,.corp.test,10.0.0.0/8,192.0.2.10",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		requestURL string
+		wantProxy  bool
+	}{
+		{name: "exact host", requestURL: "https://api.internal.test/v1", wantProxy: false},
+		{name: "domain suffix", requestURL: "https://packages.corp.test/v1", wantProxy: false},
+		{name: "CIDR", requestURL: "https://10.20.30.40/v1", wantProxy: false},
+		{name: "IP address", requestURL: "https://192.0.2.10/v1", wantProxy: false},
+		{name: "other host", requestURL: "https://public.example.test/v1", wantProxy: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyURL := proxyForRequest(t, client, tt.requestURL)
+			if tt.wantProxy && proxyURL == nil {
+				t.Fatal("proxy = nil, want configured proxy")
+			}
+			if !tt.wantProxy && proxyURL != nil {
+				t.Fatalf("proxy = %v, want direct connection", proxyURL)
+			}
+		})
+	}
+}
+
+func TestHTTPClientTrustsConfiguredAdditionalCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	certificate := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+	certificatePath := filepath.Join(t.TempDir(), "private-ca.pem")
+	if err := os.WriteFile(certificatePath, certificate, 0o600); err != nil {
+		t.Fatalf("write CA certificate: %v", err)
+	}
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL:   "http://unused-proxy.invalid",
+		NoProxy:    "*",
+		CACertFile: certificatePath,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET with additional CA: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestHTTPClientFollowsRedirectToPrivateDestinationWithoutForwardingCredentials(t *testing.T) {
+	var redirectedAuthorization string
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer destination.Close()
+	privateDestination := strings.Replace(destination.URL, "127.0.0.1", "localhost", 1)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "agent" || password != "redirect-secret" {
+			t.Errorf("origin credentials = %q/%q/%t", username, password, ok)
+		}
+		http.Redirect(w, r, privateDestination+"/advisories", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://unused-proxy.invalid",
+		NoProxy:  "*",
+		Timeout:  5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	endpoint := strings.Replace(origin.URL, "http://", "http://agent:redirect-secret@", 1)
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		t.Fatalf("GET redirected endpoint: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if redirectedAuthorization != "" {
+		t.Fatalf("redirected Authorization header = %q, want empty", redirectedAuthorization)
+	}
+}
+
+func TestHTTPClientTransportErrorDoesNotExposeEndpointPassword(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		ProxyURL: "http://unused-proxy.invalid",
+		NoProxy:  "*",
+		Timeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error = %v", err)
+	}
+	_, err = client.Get("http://agent:endpoint-secret@" + address)
+	if err == nil {
+		t.Fatal("GET error = nil, want connection error")
+	}
+	if strings.Contains(err.Error(), "endpoint-secret") {
+		t.Fatalf("transport error exposed endpoint password: %q", err)
+	}
+}

--- a/test/assurance/NETWORK_BOUNDARIES.md
+++ b/test/assurance/NETWORK_BOUNDARIES.md
@@ -24,14 +24,14 @@ setting takes precedence over the standard variables.
 
 | Boundary | Expected behavior | Main coverage |
 |---|---|---|
-| Explicit proxy | Requests use the selected HTTP, HTTPS, or SOCKS5 proxy | `sdk/http_test.go`, `sdk/http_assurance_test.go` |
-| Proxy bypass | Matching hosts, domains, IP ranges, and CIDRs connect directly | `sdk/http_assurance_test.go` |
-| Additional CA | The configured PEM chain is added to the system trust roots | `sdk/http_assurance_test.go` |
-| Custom endpoint | OSV and Scorecard use the selected base URL | matcher tests under `internal/matchers` |
-| Private destination | Loopback and private destinations are allowed when selected | `sdk/http_assurance_test.go` |
-| Redirect | Normal Go redirect rules apply; credentials are not forwarded to a different hostname | `sdk/http_assurance_test.go` |
-| Error safety | Transport and config errors do not expose endpoint or proxy passwords | `sdk/http_test.go`, `sdk/http_assurance_test.go`, `internal/config/validate_test.go` |
-| Shared transport | Built-in matchers and managed plugin operations reuse the configured proxy and CA behavior | `internal/registry/builder_test.go`, `internal/plugin/http_test.go` |
+| Explicit proxy | Requests use the selected HTTP, HTTPS, or SOCKS5 proxy | `TestHTTPClientRoutesRequestsThroughExplicitProxy`, `TestNewHTTPClientBuildsProxyFromHostPort` |
+| Proxy bypass | Matching hosts, domains, IP ranges, and CIDRs connect directly | `TestHTTPClientBypassesExplicitProxyForNoProxyDestination`, `TestHTTPClientNoProxyMatchesHostsAndNetworks` |
+| Additional CA | The configured PEM chain is added to the system trust roots | `TestHTTPClientTrustsConfiguredAdditionalCA`, `TestCommandContextInitialize_ExplicitConfigResolvesRelativeCAPathAndPrivateNetworkSettings` |
+| Custom endpoint | OSV and Scorecard use the selected base URL | `TestMatcherMatchEnrichesRegistry`, `TestMatch_AttachesScorecardToPackages` |
+| Private destination | Loopback and private destinations are allowed when selected | `TestHTTPClientFollowsRedirectToPrivateDestinationWithoutForwardingCredentials`, `TestCommandContextInitialize_ExplicitConfigResolvesRelativeCAPathAndPrivateNetworkSettings` |
+| Redirect | Same-host credentials are preserved; credentials are removed when the hostname changes | `TestHTTPClientPreservesCredentialsOnSameHostRedirect`, `TestHTTPClientFollowsRedirectToPrivateDestinationWithoutForwardingCredentials` |
+| Error safety | Transport and config errors do not expose endpoint or proxy passwords | `TestHTTPClientTransportErrorDoesNotExposeEndpointPassword`, `TestNewHTTPClientRedactsCredentialsInInvalidProxy`, `TestValidateRedactsCredentialsInInvalidHTTPProxy` |
+| Shared transport | Built-in matchers and managed plugin operations reuse the configured proxy and CA behavior | `TestRegistryHTTPClientProviderReusesTransport`, `TestHTTPClientFromLaunchContextUsesSharedProvider` |
 
 Run the focused suite with:
 
@@ -41,9 +41,11 @@ go test ./sdk ./internal/config ./internal/registry ./internal/plugin ./internal
 
 ## Intentional limits
 
-Bomly does not block private-network destinations or cross-host redirects.
-That would prevent self-hosted advisory services and enterprise proxies from
-working. Use only endpoints, proxy servers, and CA files that you trust.
+Bomly does not block private-network destinations, cross-host redirects, or
+redirects from HTTPS to HTTP. These behaviors support self-hosted advisory
+services and enterprise proxies, but an HTTP redirect sends later requests
+without transport encryption. Use only endpoints, proxy servers, and CA files
+that you trust.
 
 An additional CA expands trust for the current Bomly process. It does not
 replace the operating system roots. Redirects use Go's standard limit of ten

--- a/test/assurance/NETWORK_BOUNDARIES.md
+++ b/test/assurance/NETWORK_BOUNDARIES.md
@@ -1,0 +1,52 @@
+# Network boundary assurance
+
+Bomly can connect to public services, private services, and proxies. These
+tests make the trust boundary clear and check that the shared HTTP client
+applies the selected settings consistently.
+
+## What users authorize
+
+`--enrich` allows enabled matchers to make their documented network calls. It
+does not choose a custom destination by itself.
+
+The built-in OSV and Scorecard endpoints can be replaced through the user
+config, a file selected with `--config` or `BOMLY_CONFIG`, or their documented
+environment variables. Repository config files are not loaded automatically.
+Selecting a custom endpoint is an explicit trust decision. Private IP
+addresses, internal hostnames, and plain HTTP endpoints are supported for
+self-hosted services and local testing.
+
+Proxy and CA settings follow the same config rules. Standard `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY` variables remain fallback inputs. A Bomly proxy
+setting takes precedence over the standard variables.
+
+## Behaviors under test
+
+| Boundary | Expected behavior | Main coverage |
+|---|---|---|
+| Explicit proxy | Requests use the selected HTTP, HTTPS, or SOCKS5 proxy | `sdk/http_test.go`, `sdk/http_assurance_test.go` |
+| Proxy bypass | Matching hosts, domains, IP ranges, and CIDRs connect directly | `sdk/http_assurance_test.go` |
+| Additional CA | The configured PEM chain is added to the system trust roots | `sdk/http_assurance_test.go` |
+| Custom endpoint | OSV and Scorecard use the selected base URL | matcher tests under `internal/matchers` |
+| Private destination | Loopback and private destinations are allowed when selected | `sdk/http_assurance_test.go` |
+| Redirect | Normal Go redirect rules apply; credentials are not forwarded to a different hostname | `sdk/http_assurance_test.go` |
+| Error safety | Transport and config errors do not expose endpoint or proxy passwords | `sdk/http_test.go`, `sdk/http_assurance_test.go`, `internal/config/validate_test.go` |
+| Shared transport | Built-in matchers and managed plugin operations reuse the configured proxy and CA behavior | `internal/registry/builder_test.go`, `internal/plugin/http_test.go` |
+
+Run the focused suite with:
+
+```sh
+go test ./sdk ./internal/config ./internal/registry ./internal/plugin ./internal/matchers/...
+```
+
+## Intentional limits
+
+Bomly does not block private-network destinations or cross-host redirects.
+That would prevent self-hosted advisory services and enterprise proxies from
+working. Use only endpoints, proxy servers, and CA files that you trust.
+
+An additional CA expands trust for the current Bomly process. It does not
+replace the operating system roots. Redirects use Go's standard limit of ten
+requests. Native plugins remain trusted processes and can create their own
+network clients; the shared SDK client is a supported convention, not a
+sandbox.


### PR DESCRIPTION
## Summary

- add live assurance tests for explicit proxy routing and no-proxy host, domain, IP, and CIDR matching
- verify additional CA trust, private-network redirects, cross-host credential stripping, and password-safe transport errors
- prove that private endpoints, proxy settings, CA files, and plugin endpoints require a trusted explicitly selected project config
- document the supported custom-endpoint and private-network boundary in plain language

This PR is test and documentation only. Production defects found during the inventory are intentionally being handled in separate focused fixes.

## User impact

The supported behavior is now explicit: users may select self-hosted or private OSV and Scorecard services, enterprise proxies, and additional CAs. Bomly does not block private destinations or normal redirects, so these settings must come from a config source or environment that the user trusts. Repository config remains opt-in.

## Validation

- `make generate`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- focused HTTP, config, registry, plugin, and matcher tests