### PR TITLE
Contain automatic baseline discovery

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -220,13 +220,17 @@ projects. Discovery happens during normal target preparation: scan and explain
 read the materialized project tree, including repositories cloned through
 `--url`, while Git diff independently reads the base and head trees. A detected
 baseline is logged with its path, entry count, selection mode, and target kind;
-each evaluation logs findings evaluated and accepted. Output receives ordinary
-findings whose policy status may be `suppressed` through
-`Finding.PolicyStatus` / `policy_status`, and no baseline-specific output model
-or pipeline stage exists. Renaming the earlier finding field is an intentional
-breaking output-contract change while the CLI output schema identifier remains
-`1.0` and the compact MCP schema remains `mcp/1`. Protocol-v1 decoding still
-accepts the earlier wire field from existing external auditor plugins.
+automatic discovery rejects a symbolic-link `.bomly` directory or baseline
+file so repository content cannot redirect the read outside the materialized
+target. Explicit baseline paths remain trusted user-selected inputs and may
+refer outside the project or through a symbolic link. Each evaluation logs
+findings evaluated and accepted. Output receives ordinary findings whose policy
+status may be `suppressed` through `Finding.PolicyStatus` / `policy_status`, and
+no baseline-specific output model or pipeline stage exists. Renaming the
+earlier finding field is an intentional breaking output-contract change while
+the CLI output schema identifier remains `1.0` and the compact MCP schema
+remains `mcp/1`. Protocol-v1 decoding still accepts the earlier wire field from
+existing external auditor plugins.
 
 ### Decision: registry matching eligibility is an occurrence-level engine boundary
 

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -220,10 +220,12 @@ projects. Discovery happens during normal target preparation: scan and explain
 read the materialized project tree, including repositories cloned through
 `--url`, while Git diff independently reads the base and head trees. A detected
 baseline is logged with its path, entry count, selection mode, and target kind;
-automatic discovery rejects a symbolic-link `.bomly` directory or baseline
-file so repository content cannot redirect the read outside the materialized
-target. Explicit baseline paths remain trusted user-selected inputs and may
-refer outside the project or through a symbolic link. Each evaluation logs
+automatic discovery warns and behaves as though no baseline exists when path
+inspection finds a symbolic-link `.bomly` directory or baseline file. This
+rejects discovered links but cannot prevent another process from replacing a
+path between inspection and reading. Explicit baseline paths remain trusted
+user-selected inputs and may refer outside the project or through a symbolic
+link. Each evaluation logs
 findings evaluated and accepted. Output receives ordinary findings whose policy
 status may be `suppressed` through `Finding.PolicyStatus` / `policy_status`, and
 no baseline-specific output model or pipeline stage exists. Renaming the

--- a/docs/AUDITORS.md
+++ b/docs/AUDITORS.md
@@ -163,7 +163,9 @@ A project may commit `.bomly/baseline.json` to suppress accepted package
 findings without removing them from reports. Policy-status resolution is part of
 auditing: auditors first emit ordinary findings, then the audit stage marks
 compatible entries `suppressed`. It never removes a finding or suppresses
-pipeline diagnostics. See [Finding Baselines](BASELINES.md).
+pipeline diagnostics. Automatic discovery rejects symbolic links at the
+conventional baseline path; an explicit `--baseline <path>` remains a
+trusted user-selected path. See [Finding Baselines](BASELINES.md).
 
 ## See also
 

--- a/docs/AUDITORS.md
+++ b/docs/AUDITORS.md
@@ -163,9 +163,10 @@ A project may commit `.bomly/baseline.json` to suppress accepted package
 findings without removing them from reports. Policy-status resolution is part of
 auditing: auditors first emit ordinary findings, then the audit stage marks
 compatible entries `suppressed`. It never removes a finding or suppresses
-pipeline diagnostics. Automatic discovery rejects symbolic links at the
-conventional baseline path; an explicit `--baseline <path>` remains a
-trusted user-selected path. See [Finding Baselines](BASELINES.md).
+pipeline diagnostics. If automatic discovery finds a symbolic link at the
+conventional baseline path, Bomly warns and behaves as though no baseline
+exists. An explicit `--baseline <path>` remains a trusted user-selected
+path. See [Finding Baselines](BASELINES.md).
 
 ## See also
 

--- a/docs/BASELINES.md
+++ b/docs/BASELINES.md
@@ -49,11 +49,12 @@ with its path, entry count, selection mode, and target kind. Audit completion
 logs include the baseline path, entries, findings evaluated, and findings
 accepted, including when those counts are zero.
 
-For automatic discovery, `.bomly` and `baseline.json` must not be symbolic
-links. Bomly rejects links so repository content cannot redirect the automatic
-read outside the project. An explicit `--baseline <path>` is different: it is a
-trusted path selected by the user and may refer to a symbolic link or a file
-outside the project.
+If automatic discovery sees a symbolic-link `.bomly` directory or
+`baseline.json`, Bomly warns and behaves as though no project baseline exists.
+This rejects links discovered during path inspection; it does not protect
+against another process replacing a path between inspection and reading. An
+explicit `--baseline <path>` is different: it is a trusted path selected by the
+user and may refer to a symbolic link or a file outside the project.
 
 Container targets have no reliable project root, so they require an absolute
 baseline path. For a standalone SBOM file, automatic discovery starts beside

--- a/docs/BASELINES.md
+++ b/docs/BASELINES.md
@@ -49,6 +49,12 @@ with its path, entry count, selection mode, and target kind. Audit completion
 logs include the baseline path, entries, findings evaluated, and findings
 accepted, including when those counts are zero.
 
+For automatic discovery, `.bomly` and `baseline.json` must not be symbolic
+links. Bomly rejects links so repository content cannot redirect the automatic
+read outside the project. An explicit `--baseline <path>` is different: it is a
+trusted path selected by the user and may refer to a symbolic link or a file
+outside the project.
+
 Container targets have no reliable project root, so they require an absolute
 baseline path. For a standalone SBOM file, automatic discovery starts beside
 the file; an explicit path is recommended when the baseline lives elsewhere.

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -204,6 +204,11 @@ func ResolversForTarget(selection string, target sdk.ExecutionTarget, logger *za
 	if err != nil || !ok {
 		return LoadResult{}, err
 	}
+	if automatic {
+		if err := validateAutomaticPath(target, path); err != nil {
+			return LoadResult{}, err
+		}
+	}
 	document, err := Load(path)
 	if err != nil {
 		if !required && errors.Is(err, os.ErrNotExist) {
@@ -227,6 +232,48 @@ func ResolversForTarget(selection string, target sdk.ExecutionTarget, logger *za
 		Entries:   len(document.Entries),
 		Automatic: automatic,
 	}, nil
+}
+
+func validateAutomaticPath(target sdk.ExecutionTarget, path string) error {
+	root := baselineRoot(target)
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve automatic baseline root %q: %w", root, err)
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve automatic baseline path %q: %w", path, err)
+	}
+	relative, err := filepath.Rel(absoluteRoot, absolutePath)
+	if err != nil {
+		return fmt.Errorf("check automatic baseline path %q: %w", path, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || filepath.IsAbs(relative) {
+		return fmt.Errorf("automatic baseline path %q escapes the project root", path)
+	}
+
+	current := absoluteRoot
+	for _, component := range strings.Split(relative, string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("inspect automatic baseline path %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf(
+				"automatic baseline path %q uses symbolic link %q; use --baseline none to disable it or --baseline <path> to select a trusted file",
+				path,
+				current,
+			)
+		}
+	}
+	return nil
 }
 
 // Update returns a document that accepts all current entries while retaining
@@ -346,10 +393,7 @@ func ResolvePath(selection string, target sdk.ExecutionTarget) (path string, req
 		if target.Kind != sdk.ExecutionTargetFilesystem && target.Kind != sdk.ExecutionTargetGitRepository {
 			return "", false, false, nil
 		}
-		root := target.Location
-		if info, statErr := os.Stat(root); statErr == nil && !info.IsDir() {
-			root = filepath.Dir(root)
-		}
+		root := baselineRoot(target)
 		return filepath.Join(root, filepath.FromSlash(DefaultRelativePath)), false, true, nil
 	}
 	if strings.EqualFold(selection, "none") {
@@ -358,14 +402,19 @@ func ResolvePath(selection string, target sdk.ExecutionTarget) (path string, req
 	if filepath.IsAbs(selection) {
 		return filepath.Clean(selection), true, true, nil
 	}
-	root := target.Location
-	if info, statErr := os.Stat(root); statErr == nil && !info.IsDir() {
-		root = filepath.Dir(root)
-	}
+	root := baselineRoot(target)
 	if strings.TrimSpace(root) == "" || target.Kind == sdk.ExecutionTargetContainerImage {
 		return "", false, false, fmt.Errorf("relative baseline path requires a filesystem or git project target")
 	}
 	return filepath.Join(root, filepath.Clean(selection)), true, true, nil
+}
+
+func baselineRoot(target sdk.ExecutionTarget) string {
+	root := target.Location
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		return filepath.Dir(root)
+	}
+	return root
 }
 
 // WriteAtomic writes a validated baseline without exposing a partial file.

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -24,6 +24,8 @@ const (
 	DefaultRelativePath = ".bomly/baseline.json"
 )
 
+var errAutomaticBaselineSymlink = errors.New("automatic baseline path uses a symbolic link")
+
 // Document is a portable collection of package-specific finding entries.
 type Document struct {
 	SchemaVersion string  `json:"schema_version"`
@@ -206,6 +208,13 @@ func ResolversForTarget(selection string, target sdk.ExecutionTarget, logger *za
 	}
 	if automatic {
 		if err := validateAutomaticPath(target, path); err != nil {
+			if errors.Is(err, errAutomaticBaselineSymlink) {
+				logger.Warn("baseline: ignored linked project policy",
+					zap.String("path", path),
+					zap.String("target_kind", string(target.Kind)),
+					zap.Error(err))
+				return LoadResult{}, nil
+			}
 			return LoadResult{}, err
 		}
 	}
@@ -248,6 +257,8 @@ func validateAutomaticPath(target sdk.ExecutionTarget, path string) error {
 	if err != nil {
 		return fmt.Errorf("check automatic baseline path %q: %w", path, err)
 	}
+	// ResolvePath currently builds this path from a constant relative name.
+	// Keep the escape check as defense in depth if path construction changes.
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || filepath.IsAbs(relative) {
 		return fmt.Errorf("automatic baseline path %q escapes the project root", path)
 	}
@@ -260,6 +271,8 @@ func validateAutomaticPath(target sdk.ExecutionTarget, path string) error {
 		current = filepath.Join(current, component)
 		info, err := os.Lstat(current)
 		if errors.Is(err, os.ErrNotExist) {
+			// A dangling link is returned by Lstat and handled below. ErrNotExist
+			// therefore means a normal path component is absent.
 			return nil
 		}
 		if err != nil {
@@ -267,7 +280,8 @@ func validateAutomaticPath(target sdk.ExecutionTarget, path string) error {
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf(
-				"automatic baseline path %q uses symbolic link %q; use --baseline none to disable it or --baseline <path> to select a trusted file",
+				"%w: %q resolves through %q",
+				errAutomaticBaselineSymlink,
 				path,
 				current,
 			)

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -269,6 +270,91 @@ func TestResolversForTargetHandlesOptionalRequiredAndURLPolicies(t *testing.T) {
 	}
 	if explicit := logs.All()[1].ContextMap(); explicit["automatic"] != false {
 		t.Fatalf("explicit baseline discovery log fields = %#v", explicit)
+	}
+}
+
+func TestResolversForTargetRejectsSymlinksOnlyForAutomaticSelection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	document := NewDocument([]sdk.Finding{{
+		ID: "rule", Kind: sdk.FindingKindPackage, Auditor: "package",
+		RuleID: "rule", PackageRef: "pkg:npm/example@1.0.0",
+	}}, nil)
+	for _, targetKind := range []sdk.ExecutionTargetKind{
+		sdk.ExecutionTargetFilesystem,
+		sdk.ExecutionTargetGitRepository,
+	} {
+		t.Run(string(targetKind)+"/file symlink", func(t *testing.T) {
+			root := t.TempDir()
+			outside := filepath.Join(t.TempDir(), "baseline.json")
+			if err := WriteAtomic(outside, document, false); err != nil {
+				t.Fatal(err)
+			}
+			baselineDir := filepath.Join(root, ".bomly")
+			if err := os.MkdirAll(baselineDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			link := filepath.Join(baselineDir, "baseline.json")
+			if err := os.Symlink(outside, link); err != nil {
+				t.Fatal(err)
+			}
+			target := sdk.ExecutionTarget{Kind: targetKind, Location: root}
+
+			if _, err := ResolversForTarget("auto", target, nil); err == nil ||
+				!strings.Contains(err.Error(), "uses symbolic link") {
+				t.Fatalf("automatic symlink error = %v", err)
+			}
+			result, err := ResolversForTarget(link, target, nil)
+			if err != nil || len(result.Resolvers) != 1 || result.Automatic {
+				t.Fatalf("explicit trusted symlink = %#v, %v", result, err)
+			}
+		})
+
+		t.Run(string(targetKind)+"/directory symlink", func(t *testing.T) {
+			root := t.TempDir()
+			outsideDir := t.TempDir()
+			if err := WriteAtomic(filepath.Join(outsideDir, "baseline.json"), document, false); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outsideDir, filepath.Join(root, ".bomly")); err != nil {
+				t.Fatal(err)
+			}
+			target := sdk.ExecutionTarget{Kind: targetKind, Location: root}
+
+			if _, err := ResolversForTarget("", target, nil); err == nil ||
+				!strings.Contains(err.Error(), "uses symbolic link") {
+				t.Fatalf("automatic directory symlink error = %v", err)
+			}
+		})
+	}
+}
+
+func TestResolversForTargetAllowsUserSelectedSymlinkAsProjectRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	realRoot := t.TempDir()
+	document := NewDocument([]sdk.Finding{{
+		ID: "rule", Kind: sdk.FindingKindPackage, Auditor: "package",
+		RuleID: "rule", PackageRef: "pkg:npm/example@1.0.0",
+	}}, nil)
+	if err := WriteAtomic(filepath.Join(realRoot, ".bomly", "baseline.json"), document, false); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(t.TempDir(), "project")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ResolversForTarget("auto", sdk.ExecutionTarget{
+		Kind:     sdk.ExecutionTargetFilesystem,
+		Location: linkRoot,
+	}, nil)
+	if err != nil || len(result.Resolvers) != 1 {
+		t.Fatalf("automatic baseline through selected project root = %#v, %v", result, err)
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -273,7 +273,7 @@ func TestResolversForTargetHandlesOptionalRequiredAndURLPolicies(t *testing.T) {
 	}
 }
 
-func TestResolversForTargetRejectsSymlinksOnlyForAutomaticSelection(t *testing.T) {
+func TestResolversForTargetIgnoresAutomaticSymlinksAndAllowsExplicitSelection(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on Windows")
 	}
@@ -302,11 +302,21 @@ func TestResolversForTargetRejectsSymlinksOnlyForAutomaticSelection(t *testing.T
 			}
 			target := sdk.ExecutionTarget{Kind: targetKind, Location: root}
 
-			if _, err := ResolversForTarget("auto", target, nil); err == nil ||
-				!strings.Contains(err.Error(), "uses symbolic link") {
-				t.Fatalf("automatic symlink error = %v", err)
+			core, logs := observer.New(zap.WarnLevel)
+			result, err := ResolversForTarget("auto", target, zap.New(core))
+			if err != nil || len(result.Resolvers) != 0 || result.Path != "" {
+				t.Fatalf("automatic symlink result = %#v, %v", result, err)
 			}
-			result, err := ResolversForTarget(link, target, nil)
+			warnings := logs.FilterMessage("baseline: ignored linked project policy")
+			if warnings.Len() != 1 {
+				t.Fatalf("automatic symlink warnings = %#v", logs.All())
+			}
+			fields := warnings.All()[0].ContextMap()
+			if fields["path"] != link || fields["target_kind"] != string(targetKind) ||
+				!strings.Contains(fmt.Sprint(fields["error"]), "resolves through") {
+				t.Fatalf("automatic symlink warning fields = %#v", fields)
+			}
+			result, err = ResolversForTarget(link, target, nil)
 			if err != nil || len(result.Resolvers) != 1 || result.Automatic {
 				t.Fatalf("explicit trusted symlink = %#v, %v", result, err)
 			}
@@ -323,9 +333,13 @@ func TestResolversForTargetRejectsSymlinksOnlyForAutomaticSelection(t *testing.T
 			}
 			target := sdk.ExecutionTarget{Kind: targetKind, Location: root}
 
-			if _, err := ResolversForTarget("", target, nil); err == nil ||
-				!strings.Contains(err.Error(), "uses symbolic link") {
-				t.Fatalf("automatic directory symlink error = %v", err)
+			core, logs := observer.New(zap.WarnLevel)
+			result, err := ResolversForTarget("", target, zap.New(core))
+			if err != nil || len(result.Resolvers) != 0 || result.Path != "" {
+				t.Fatalf("automatic directory symlink result = %#v, %v", result, err)
+			}
+			if logs.FilterMessage("baseline: ignored linked project policy").Len() != 1 {
+				t.Fatalf("automatic directory symlink warnings = %#v", logs.All())
 			}
 		})
 	}

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -504,7 +504,9 @@ A project may commit `+"`.bomly/baseline.json`"+` to suppress accepted package
 findings without removing them from reports. Policy-status resolution is part of
 auditing: auditors first emit ordinary findings, then the audit stage marks
 compatible entries `+"`suppressed`"+`. It never removes a finding or suppresses
-pipeline diagnostics. See [Finding Baselines](BASELINES.md).
+pipeline diagnostics. Automatic discovery rejects symbolic links at the
+conventional baseline path; an explicit `+"`--baseline <path>`"+` remains a
+trusted user-selected path. See [Finding Baselines](BASELINES.md).
 
 ## See also
 

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -504,9 +504,10 @@ A project may commit `+"`.bomly/baseline.json`"+` to suppress accepted package
 findings without removing them from reports. Policy-status resolution is part of
 auditing: auditors first emit ordinary findings, then the audit stage marks
 compatible entries `+"`suppressed`"+`. It never removes a finding or suppresses
-pipeline diagnostics. Automatic discovery rejects symbolic links at the
-conventional baseline path; an explicit `+"`--baseline <path>`"+` remains a
-trusted user-selected path. See [Finding Baselines](BASELINES.md).
+pipeline diagnostics. If automatic discovery finds a symbolic link at the
+conventional baseline path, Bomly warns and behaves as though no baseline
+exists. An explicit `+"`--baseline <path>`"+` remains a trusted user-selected
+path. See [Finding Baselines](BASELINES.md).
 
 ## See also
 


### PR DESCRIPTION
## What changed

- warn and ignore a symbolic-link `.bomly` directory or `baseline.json` file during automatic baseline discovery
- apply the same behavior to local filesystem and materialized Git targets
- preserve explicitly selected baseline paths as trusted user input, including explicit symlinks and files outside the project
- document that inspection rejects discovered links but cannot prevent concurrent path replacement
- add regression coverage for file links, directory links, user-selected project-root links, warnings, and both target kinds

## Why

A repository-controlled symbolic link can redirect an automatically discovered baseline read outside the scanned project. Bomly therefore warns and behaves as though no automatic baseline exists instead of failing the whole scan. Explicit baseline paths are different because the user deliberately selects and trusts them.

## Validation

- focused baseline, options, and CLI tests
- `make generate`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`
- `git diff --check`