### PR TITLE
Bound untrusted security inputs

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -130,8 +130,11 @@ selection remains visible in logs and run statistics.
 Bomly bounds large documents before decoding them. YAML configuration files are
 limited to 4 MiB. Finding baselines are limited to 16 MiB and 10,000 entries.
 Explicit SBOM inputs are limited to 256 MiB. Successful deps.dev batch responses
-are limited to 16 MiB, and failed responses expose only the HTTP status rather
-than including an upstream response body in errors.
+are limited to 16 MiB. OSV vulnerability and batch responses are limited to
+4 MiB and 64 MiB. CISA KEV responses are limited to 32 MiB, and Scorecard
+project responses are limited to 4 MiB. Failed matcher responses expose only
+the HTTP status rather than including an upstream response body in errors or
+logs.
 
 The shared file reader checks both the size reported when the file is opened and
 the bytes actually read. This keeps the limit in place if a file grows during

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -125,6 +125,27 @@ versioned policy-status contract: they cannot change targets, start network or
 package-manager activity, load plugins, or choose output paths. Their automatic
 selection remains visible in logs and run statistics.
 
+### Decision: untrusted documents have input limits
+
+Bomly bounds large documents before decoding them. YAML configuration files are
+limited to 4 MiB. Finding baselines are limited to 16 MiB and 10,000 entries.
+Explicit SBOM inputs are limited to 256 MiB. Successful deps.dev batch responses
+are limited to 16 MiB, and failed responses expose only the HTTP status rather
+than including an upstream response body in errors.
+
+The shared file reader checks both the size reported when the file is opened and
+the bytes actually read. This keeps the limit in place if a file grows during
+the read. Baseline duplicate checks use an index keyed by package finding
+identity so validation remains linear as the document approaches its entry
+limit.
+
+Two inputs remain intentionally outside these limits. Cache entries are local
+files written by Bomly from already bounded requests and responses, so a
+per-entry read limit is a low-risk follow-up. Git clone size is delegated to Git
+because remote repository scanning is an explicit operation and repositories do
+not have a useful universal size limit. Both are recorded as residual resource
+risks rather than implied to be bounded.
+
 ### Decision: Reachability annotates vulnerabilities, not findings
 
 Reachability data lives on `sdk.Vulnerability.Reachability` rather than on `Finding.Reachability` because `--analyze` must be useful without `--audit`. Matchers populate the OSV-aligned `Vulnerability` record on the PURL-keyed registry package; the analyzer enriches it in place; the output layer resolves the analyzer's annotation by `(Finding.PackageRef, Finding.VulnerabilityID)` when emitting SARIF and the JSON `Finding` projection. This keeps a single source of truth (the registry) and removes the per-manifest sync that the old graph-mutating model required.

--- a/docs/BASELINES.md
+++ b/docs/BASELINES.md
@@ -108,3 +108,5 @@ Baseline failures do not hide pipeline diagnostics. A malformed explicitly
 selected file fails before the audit runs. An automatically discovered baseline
 is loaded only for audited commands, so a malformed file cannot break a plain
 inventory scan; audited commands fail closed rather than silently ignoring it.
+Bomly rejects baseline files larger than 16 MiB and baseline documents with
+more than 10,000 entries.

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -11,6 +11,8 @@ Bomly resolves configuration in the following order, with later sources overridi
 
 Repository config files are never loaded automatically. Select a trusted project file explicitly, for example `--config .bomly/config.yaml` or `BOMLY_CONFIG=.bomly/config.yaml`. When both are set, `--config` wins.
 
+Bomly rejects configuration files larger than 4 MiB before parsing them.
+
 YAML files use the nested keys documented below. Unknown keys and the former flat keys are rejected so configuration mistakes fail fast.
 
 ---

--- a/docs/detectors/ecosystems/sbom/sbom.md
+++ b/docs/detectors/ecosystems/sbom/sbom.md
@@ -26,6 +26,7 @@ Bomly uses this chain when it finds `sbom` evidence.
 | Resolve graph | JSON ingest | None |
 
 Format is auto-detected by content.
+Bomly rejects SBOM input files larger than 256 MiB before decoding them.
 
 ## Network behavior
 

--- a/docs/matchers/depsdev-license-matcher.md
+++ b/docs/matchers/depsdev-license-matcher.md
@@ -43,7 +43,7 @@ Bomly only fills packages that do not already have license data. Detector-resolv
 
 ## Cache and network
 
-The matcher batches version lookups through deps.dev and caches responses for 24 hours under `~/.bomly/cache/licenses/depsdev/`. Cache failures are non-fatal: Bomly logs a warning and still applies the API response.
+The matcher batches version lookups through deps.dev and caches responses for 24 hours under `~/.bomly/cache/licenses/depsdev/`. Each successful batch response is limited to 16 MiB. Cache failures are non-fatal: Bomly logs a warning and still applies the API response. Failed HTTP responses report the status code without including the server's response body in the error.
 
 ## CI recipe
 

--- a/docs/matchers/osv.md
+++ b/docs/matchers/osv.md
@@ -43,6 +43,10 @@ bomly scan --enrich
 Cache directory (Unix/macOS): `~/.bomly/cache/{osv,osv-vulns,kev}/`.
 
 Cache failures are logged at WARN and never abort the scan.
+OSV batch responses are limited to 64 MiB, individual advisory responses to
+4 MiB, and KEV catalog responses to 32 MiB. Larger responses fail with a clear
+size error. Failed HTTP responses report the status without including the
+remote response body in errors or logs.
 
 ## Output fields
 

--- a/docs/matchers/scorecard.md
+++ b/docs/matchers/scorecard.md
@@ -53,6 +53,10 @@ Packages with no resolvable github.com source — and packages whose source is h
 
 Cache directory (Unix/macOS): `~/.bomly/cache/scorecard/`. Cache failures are logged at WARN and never abort the scan. Repositories the OSSF has not scored return HTTP 404; the matcher records a `notScored` sentinel for the TTL so unscored repos are not retried on every run.
 
+Each successful project response is limited to 4 MiB. Larger responses fail
+with a clear size error. Failed HTTP responses report the status without
+including the remote response body in errors or logs.
+
 ## Output fields
 
 When attached, `package.scorecard` holds:

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
 )
@@ -22,6 +23,9 @@ const (
 	SchemaVersion = "bomly.finding-baseline/v1"
 	// DefaultRelativePath is the conventional project baseline location.
 	DefaultRelativePath = ".bomly/baseline.json"
+
+	maxBaselineFileBytes int64 = 16 << 20
+	maxBaselineEntries         = 10_000
 )
 
 // Document is a portable collection of package-specific finding entries.
@@ -116,7 +120,11 @@ func (d Document) Validate() error {
 	if d.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("unsupported baseline schema %q", d.SchemaVersion)
 	}
+	if len(d.Entries) > maxBaselineEntries {
+		return fmt.Errorf("baseline contains %d entries; limit is %d", len(d.Entries), maxBaselineEntries)
+	}
 	seen := map[string]struct{}{}
+	matched := map[entryMatchKey]int{}
 	for idx, entry := range d.Entries {
 		if !strings.HasPrefix(strings.TrimSpace(entry.PackageRef), "pkg:") || entry.Kind == "" || strings.TrimSpace(entry.Auditor) == "" {
 			return fmt.Errorf("baseline entry %d is missing package_ref, kind, or auditor", idx)
@@ -144,14 +152,52 @@ func (d Document) Validate() error {
 		if _, ok := seen[key]; ok {
 			return fmt.Errorf("baseline contains duplicate entry %q", key)
 		}
-		for prior := 0; prior < idx; prior++ {
-			if entriesMatch(d.Entries[prior], entry) {
+		for _, matchKey := range entryMatchKeys(entry) {
+			if prior, ok := matched[matchKey]; ok {
 				return fmt.Errorf("baseline entries %d and %d identify the same package finding", prior, idx)
 			}
 		}
 		seen[key] = struct{}{}
+		for _, matchKey := range entryMatchKeys(entry) {
+			matched[matchKey] = idx
+		}
 	}
 	return nil
+}
+
+type entryMatchKey struct {
+	packageRef string
+	kind       sdk.FindingKind
+	auditor    string
+	identity   string
+}
+
+func entryMatchKeys(entry Entry) []entryMatchKey {
+	base := entryMatchKey{
+		packageRef: entry.PackageRef,
+		kind:       entry.Kind,
+		auditor:    entry.Auditor,
+	}
+	if entry.Kind != sdk.FindingKindVulnerability {
+		base.identity = entry.RuleID
+		return []entryMatchKey{base}
+	}
+	keys := make([]entryMatchKey, 0, len(entry.AdvisoryIDs))
+	seen := make(map[string]struct{}, len(entry.AdvisoryIDs))
+	for _, advisoryID := range entry.AdvisoryIDs {
+		identity := strings.ToLower(advisoryID)
+		if identity == "" {
+			continue
+		}
+		if _, ok := seen[identity]; ok {
+			continue
+		}
+		seen[identity] = struct{}{}
+		key := base
+		key.identity = identity
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func validBaselineSeverity(severity sdk.SeverityLevel) bool {
@@ -174,8 +220,11 @@ func validBaselineSeverity(severity sdk.SeverityLevel) bool {
 
 // Load reads and validates a baseline document.
 func Load(path string) (Document, error) {
-	data, err := os.ReadFile(path)
+	data, err := system.ReadFileLimit(path, maxBaselineFileBytes)
 	if err != nil {
+		if errors.Is(err, system.ErrFileTooLarge) {
+			return Document{}, fmt.Errorf("baseline %q exceeds the 16 MiB limit", path)
+		}
 		return Document{}, fmt.Errorf("read baseline %q: %w", path, err)
 	}
 	var document Document

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -152,13 +152,14 @@ func (d Document) Validate() error {
 		if _, ok := seen[key]; ok {
 			return fmt.Errorf("baseline contains duplicate entry %q", key)
 		}
-		for _, matchKey := range entryMatchKeys(entry) {
+		matchKeys := entryMatchKeys(entry)
+		for _, matchKey := range matchKeys {
 			if prior, ok := matched[matchKey]; ok {
 				return fmt.Errorf("baseline entries %d and %d identify the same package finding", prior, idx)
 			}
 		}
 		seen[key] = struct{}{}
-		for _, matchKey := range entryMatchKeys(entry) {
+		for _, matchKey := range matchKeys {
 			matched[matchKey] = idx
 		}
 	}
@@ -182,13 +183,14 @@ func entryMatchKeys(entry Entry) []entryMatchKey {
 		base.identity = entry.RuleID
 		return []entryMatchKey{base}
 	}
+	// A missing advisory list deliberately produces no keys, matching the old
+	// pairwise loops. Validate rejects that shape before reaching this helper.
 	keys := make([]entryMatchKey, 0, len(entry.AdvisoryIDs))
 	seen := make(map[string]struct{}, len(entry.AdvisoryIDs))
 	for _, advisoryID := range entry.AdvisoryIDs {
-		identity := strings.ToLower(advisoryID)
-		if identity == "" {
-			continue
-		}
+		// Advisory identifiers are ASCII. Folding only A-Z makes that contract
+		// explicit and avoids implying locale-sensitive identifier matching.
+		identity := foldASCII(advisoryID)
 		if _, ok := seen[identity]; ok {
 			continue
 		}
@@ -198,6 +200,16 @@ func entryMatchKeys(entry Entry) []entryMatchKey {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+func foldASCII(value string) string {
+	folded := []byte(value)
+	for idx, char := range folded {
+		if char >= 'A' && char <= 'Z' {
+			folded[idx] = char + ('a' - 'A')
+		}
+	}
+	return string(folded)
 }
 
 func validBaselineSeverity(severity sdk.SeverityLevel) bool {
@@ -222,7 +234,7 @@ func validBaselineSeverity(severity sdk.SeverityLevel) bool {
 func Load(path string) (Document, error) {
 	data, err := system.ReadFileLimit(path, maxBaselineFileBytes)
 	if err != nil {
-		if errors.Is(err, system.ErrFileTooLarge) {
+		if errors.Is(err, system.ErrInputTooLarge) {
 			return Document{}, fmt.Errorf("baseline %q exceeds the 16 MiB limit", path)
 		}
 		return Document{}, fmt.Errorf("read baseline %q: %w", path, err)

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -235,7 +235,7 @@ func Load(path string) (Document, error) {
 	data, err := system.ReadFileLimit(path, maxBaselineFileBytes)
 	if err != nil {
 		if errors.Is(err, system.ErrInputTooLarge) {
-			return Document{}, fmt.Errorf("baseline %q exceeds the 16 MiB limit", path)
+			return Document{}, fmt.Errorf("baseline %q exceeds the 16 MiB limit: %w", path, system.ErrInputTooLarge)
 		}
 		return Document{}, fmt.Errorf("read baseline %q: %w", path, err)
 	}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -314,6 +315,9 @@ func TestLoadRejectsOversizedBaseline(t *testing.T) {
 	_, err := Load(path)
 	if err == nil || !strings.Contains(err.Error(), "exceeds the 16 MiB limit") {
 		t.Fatalf("Load() error = %v", err)
+	}
+	if !errors.Is(err, system.ErrInputTooLarge) {
+		t.Fatalf("Load() error = %v, want wrapped system.ErrInputTooLarge", err)
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -302,6 +302,70 @@ func TestLoadRejectsMalformedAndUnsupportedDocuments(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsOversizedBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(path, maxBaselineFileBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "exceeds the 16 MiB limit") {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
+func TestDocumentEntryLimit(t *testing.T) {
+	t.Run("exact limit", func(t *testing.T) {
+		document := Document{SchemaVersion: SchemaVersion, Entries: make([]Entry, 0, maxBaselineEntries)}
+		for idx := range maxBaselineEntries {
+			document.Entries = append(document.Entries, Entry{
+				PackageRef: fmt.Sprintf("pkg:npm/example-%d@1.0.0", idx),
+				Kind:       sdk.FindingKindPackage,
+				Auditor:    "package",
+				RuleID:     "denied-package",
+			})
+		}
+		if err := document.Validate(); err != nil {
+			t.Fatalf("Validate() at exact entry limit: %v", err)
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		document := Document{SchemaVersion: SchemaVersion, Entries: make([]Entry, maxBaselineEntries+1)}
+		err := document.Validate()
+		if err == nil || !strings.Contains(err.Error(), "limit is 10000") {
+			t.Fatalf("Validate() error = %v", err)
+		}
+	})
+}
+
+func TestDocumentRejectsIndexedAdvisoryOverlap(t *testing.T) {
+	document := Document{
+		SchemaVersion: SchemaVersion,
+		Entries: []Entry{
+			{
+				PackageRef:  "pkg:npm/example@1.0.0",
+				Kind:        sdk.FindingKindVulnerability,
+				Auditor:     "vulnerability",
+				AdvisoryIDs: []string{"CVE-1", "GHSA-shared"},
+			},
+			{
+				PackageRef:  "pkg:npm/example@1.0.0",
+				Kind:        sdk.FindingKindVulnerability,
+				Auditor:     "vulnerability",
+				AdvisoryIDs: []string{"ghsa-SHARED", "OSV-2"},
+			},
+		},
+	}
+	err := document.Validate()
+	if err == nil || !strings.Contains(err.Error(), "entries 0 and 1") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestNewDocumentIsDeterministicAcrossFindingOrder(t *testing.T) {
 	findings := []sdk.Finding{
 		{ID: "b", Kind: sdk.FindingKindPackage, Auditor: "package", RuleID: "b", PackageRef: "pkg:npm/b@1.0.0"},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -45,13 +45,13 @@ func LoadFile(path string) (*File, error) {
 	}
 	data, err := system.ReadFileLimit(path, maxConfigFileBytes)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		if errors.Is(err, system.ErrInputTooLarge) {
-			return nil, fmt.Errorf("config file %q exceeds the 4 MiB limit", path)
+			return nil, fmt.Errorf("config file %q exceeds the 4 MiB limit: %w", path, system.ErrInputTooLarge)
 		}
-		return nil, err
+		return nil, fmt.Errorf("read config file: %w", err)
 	}
 	var cfg File
 	if err := rejectLegacyFlatKeys(data); err != nil {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -14,8 +14,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"gopkg.in/yaml.v3"
 )
+
+const maxConfigFileBytes int64 = 4 << 20
 
 // UserConfigPath returns the path to the user-level config file (~/.bomly/config.yaml).
 // Returns an empty string (no error) when the home directory cannot be determined.
@@ -40,10 +43,13 @@ func LoadFile(path string) (*File, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, nil
 	}
-	data, err := os.ReadFile(path)
+	data, err := system.ReadFileLimit(path, maxConfigFileBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
+		}
+		if errors.Is(err, system.ErrFileTooLarge) {
+			return nil, fmt.Errorf("config file %q exceeds the 4 MiB limit", path)
 		}
 		return nil, err
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -48,7 +48,7 @@ func LoadFile(path string) (*File, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		if errors.Is(err, system.ErrFileTooLarge) {
+		if errors.Is(err, system.ErrInputTooLarge) {
 			return nil, fmt.Errorf("config file %q exceeds the 4 MiB limit", path)
 		}
 		return nil, err

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -299,6 +299,21 @@ func TestLoadFileRejectsLegacyAndUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestLoadFileRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(path, maxConfigFileBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "exceeds the 4 MiB limit") {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+}
+
 func TestApplyFileConfigMergesPluginConfigsByID(t *testing.T) {
 	resolved := Resolved{}
 	ApplyFileConfig(&resolved, File{Plugins: map[string]map[string]any{

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/system"
 )
 
 func TestLoadFileAndEnvProxyPrecedence(t *testing.T) {
@@ -311,6 +314,9 @@ func TestLoadFileRejectsOversizedFile(t *testing.T) {
 	_, err := LoadFile(path)
 	if err == nil || !strings.Contains(err.Error(), "exceeds the 4 MiB limit") {
 		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !errors.Is(err, system.ErrInputTooLarge) {
+		t.Fatalf("LoadFile() error = %v, want wrapped system.ErrInputTooLarge", err)
 	}
 }
 

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/bomly-dev/bomly-cli/internal/detectors"
 	"github.com/bomly-dev/bomly-cli/internal/sbom"
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
 )
+
+const maxSBOMFileBytes int64 = 256 << 20
 
 // Detector resolves graphs from explicit SBOM files using Bomly's first-party decoders.
 type Detector struct {
@@ -70,8 +73,11 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	if sbomPath == "" {
 		sbomPath = req.ProjectPath
 	}
-	data, err := os.ReadFile(sbomPath)
+	data, err := system.ReadFileLimit(sbomPath, maxSBOMFileBytes)
 	if err != nil {
+		if errors.Is(err, system.ErrFileTooLarge) {
+			return sdk.DetectionResult{}, fmt.Errorf("sbom file %q exceeds the 256 MiB limit", sbomPath)
+		}
 		return sdk.DetectionResult{}, fmt.Errorf("read sbom file %q: %w", sbomPath, err)
 	}
 

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -76,7 +76,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	data, err := system.ReadFileLimit(sbomPath, maxSBOMFileBytes)
 	if err != nil {
 		if errors.Is(err, system.ErrInputTooLarge) {
-			return sdk.DetectionResult{}, fmt.Errorf("sbom file %q exceeds the 256 MiB limit", sbomPath)
+			return sdk.DetectionResult{}, fmt.Errorf("sbom file %q exceeds the 256 MiB limit: %w", sbomPath, system.ErrInputTooLarge)
 		}
 		return sdk.DetectionResult{}, fmt.Errorf("read sbom file %q: %w", sbomPath, err)
 	}

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -75,7 +75,7 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	}
 	data, err := system.ReadFileLimit(sbomPath, maxSBOMFileBytes)
 	if err != nil {
-		if errors.Is(err, system.ErrFileTooLarge) {
+		if errors.Is(err, system.ErrInputTooLarge) {
 			return sdk.DetectionResult{}, fmt.Errorf("sbom file %q exceeds the 256 MiB limit", sbomPath)
 		}
 		return sdk.DetectionResult{}, fmt.Errorf("read sbom file %q: %w", sbomPath, err)

--- a/internal/detectors/sbom/detector_test.go
+++ b/internal/detectors/sbom/detector_test.go
@@ -2,6 +2,7 @@ package sbom
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/sbom"
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -146,6 +148,9 @@ func TestDetectorResolveGraph_RejectsOversizedSBOM(t *testing.T) {
 	_, err := (Detector{}).ResolveGraph(context.Background(), requestForSBOMPath(path))
 	if err == nil || !strings.Contains(err.Error(), "exceeds the 256 MiB limit") {
 		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+	if !errors.Is(err, system.ErrInputTooLarge) {
+		t.Fatalf("ResolveGraph() error = %v, want wrapped system.ErrInputTooLarge", err)
 	}
 }
 

--- a/internal/detectors/sbom/detector_test.go
+++ b/internal/detectors/sbom/detector_test.go
@@ -134,6 +134,21 @@ func TestDetectorResolveGraph_RejectsUnsupportedOrMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestDetectorResolveGraph_RejectsOversizedSBOM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input.json")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(path, maxSBOMFileBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (Detector{}).ResolveGraph(context.Background(), requestForSBOMPath(path))
+	if err == nil || !strings.Contains(err.Error(), "exceeds the 256 MiB limit") {
+		t.Fatalf("ResolveGraph() error = %v", err)
+	}
+}
+
 func resolveFixture(t *testing.T, path string) sdk.DetectionResult {
 	t.Helper()
 	detector := Detector{}

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -33,7 +33,8 @@ const (
 
 	// deps.dev versionbatch currently returns at most 100 responses. Keeping
 	// request chunks at that size avoids silently dropping later package lookups.
-	maxBatchRequests = 100
+	maxBatchRequests       = 100
+	maxResponseBytes int64 = 16 << 20
 )
 
 // Config configures the deps.dev license matcher.
@@ -276,11 +277,10 @@ func (c *Checker) fetchBatch(ctx context.Context, items []pending, stats *checkS
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return fmt.Errorf("deps.dev: batch request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+		return fmt.Errorf("deps.dev: batch request failed with status %d", resp.StatusCode)
 	}
 
-	rawBody, err := io.ReadAll(resp.Body)
+	rawBody, err := readResponseLimit(resp.Body, resp.ContentLength, maxResponseBytes)
 	if err != nil {
 		return fmt.Errorf("deps.dev: read batch response: %w", err)
 	}
@@ -321,6 +321,27 @@ func (c *Checker) fetchBatch(ctx context.Context, items []pending, stats *checkS
 		}
 	}
 	return nil
+}
+
+func readResponseLimit(body io.Reader, contentLength, maxBytes int64) ([]byte, error) {
+	if contentLength > maxBytes {
+		return nil, fmt.Errorf("response exceeds the %s limit", byteLimitLabel(maxBytes))
+	}
+	data, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("response exceeds the %s limit", byteLimitLabel(maxBytes))
+	}
+	return data, nil
+}
+
+func byteLimitLabel(size int64) string {
+	if size > 0 && size%(1<<20) == 0 {
+		return fmt.Sprintf("%d MiB", size/(1<<20))
+	}
+	return fmt.Sprintf("%d-byte", size)
 }
 
 func applyLicenses(pkg *sdk.Package, values []string) int {

--- a/internal/matchers/depsdev/matcher.go
+++ b/internal/matchers/depsdev/matcher.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/bomly-dev/bomly-cli/internal/matchers"
 	"github.com/bomly-dev/bomly-cli/internal/matchers/cache"
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 	"go.uber.org/zap"
 )
@@ -280,7 +280,7 @@ func (c *Checker) fetchBatch(ctx context.Context, items []pending, stats *checkS
 		return fmt.Errorf("deps.dev: batch request failed with status %d", resp.StatusCode)
 	}
 
-	rawBody, err := readResponseLimit(resp.Body, resp.ContentLength, maxResponseBytes)
+	rawBody, err := system.ReadLimit(resp.Body, resp.ContentLength, maxResponseBytes)
 	if err != nil {
 		return fmt.Errorf("deps.dev: read batch response: %w", err)
 	}
@@ -321,27 +321,6 @@ func (c *Checker) fetchBatch(ctx context.Context, items []pending, stats *checkS
 		}
 	}
 	return nil
-}
-
-func readResponseLimit(body io.Reader, contentLength, maxBytes int64) ([]byte, error) {
-	if contentLength > maxBytes {
-		return nil, fmt.Errorf("response exceeds the %s limit", byteLimitLabel(maxBytes))
-	}
-	data, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("response exceeds the %s limit", byteLimitLabel(maxBytes))
-	}
-	return data, nil
-}
-
-func byteLimitLabel(size int64) string {
-	if size > 0 && size%(1<<20) == 0 {
-		return fmt.Sprintf("%d MiB", size/(1<<20))
-	}
-	return fmt.Sprintf("%d-byte", size)
 }
 
 func applyLicenses(pkg *sdk.Package, values []string) int {

--- a/internal/matchers/depsdev/matcher_test.go
+++ b/internal/matchers/depsdev/matcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bomly-dev/bomly-cli/internal/logging"
 	"github.com/bomly-dev/bomly-cli/internal/matchers/cache"
 	"github.com/bomly-dev/bomly-cli/sdk"
+	"go.uber.org/zap"
 )
 
 func TestVersionRequestFromPackage(t *testing.T) {
@@ -386,5 +387,63 @@ func TestDescriptorEcosystemsMatchSupportedSystems(t *testing.T) {
 		if !supported && declared[eco] {
 			t.Errorf("descriptor declares %q but depsDevSystem rejects it", eco)
 		}
+	}
+}
+
+func TestReadResponseLimit(t *testing.T) {
+	data, err := readResponseLimit(strings.NewReader("1234"), -1, 4)
+	if err != nil || string(data) != "1234" {
+		t.Fatalf("exact-limit response = %q, %v", data, err)
+	}
+	if _, err := readResponseLimit(strings.NewReader("12345"), -1, 4); err == nil || !strings.Contains(err.Error(), "4-byte limit") {
+		t.Fatalf("streaming over-limit error = %v", err)
+	}
+	if _, err := readResponseLimit(strings.NewReader(""), 5, 4); err == nil || !strings.Contains(err.Error(), "4-byte limit") {
+		t.Fatalf("declared over-limit error = %v", err)
+	}
+}
+
+func TestFetchBatchRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(maxResponseBytes+1, 10))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := &Checker{
+		client: server.Client(),
+		config: Config{APIBase: server.URL},
+		logger: zap.NewNop(),
+	}
+	err := checker.fetchBatch(context.Background(), []pending{{
+		pkg: &sdk.Package{},
+		req: versionRequest{VersionKey: versionKey{System: "NPM", Name: "example", Version: "1.0.0"}},
+	}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "16 MiB limit") {
+		t.Fatalf("fetchBatch() error = %v", err)
+	}
+}
+
+func TestFetchBatchDoesNotExposeErrorResponseBody(t *testing.T) {
+	const privateDetail = "private upstream diagnostic"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, privateDetail, http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	checker := &Checker{
+		client: server.Client(),
+		config: Config{APIBase: server.URL},
+		logger: zap.NewNop(),
+	}
+	err := checker.fetchBatch(context.Background(), []pending{{
+		pkg: &sdk.Package{},
+		req: versionRequest{VersionKey: versionKey{System: "NPM", Name: "example", Version: "1.0.0"}},
+	}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("fetchBatch() error = %v", err)
+	}
+	if strings.Contains(err.Error(), privateDetail) {
+		t.Fatalf("fetchBatch() exposed response body: %v", err)
 	}
 }

--- a/internal/matchers/depsdev/matcher_test.go
+++ b/internal/matchers/depsdev/matcher_test.go
@@ -390,19 +390,6 @@ func TestDescriptorEcosystemsMatchSupportedSystems(t *testing.T) {
 	}
 }
 
-func TestReadResponseLimit(t *testing.T) {
-	data, err := readResponseLimit(strings.NewReader("1234"), -1, 4)
-	if err != nil || string(data) != "1234" {
-		t.Fatalf("exact-limit response = %q, %v", data, err)
-	}
-	if _, err := readResponseLimit(strings.NewReader("12345"), -1, 4); err == nil || !strings.Contains(err.Error(), "4-byte limit") {
-		t.Fatalf("streaming over-limit error = %v", err)
-	}
-	if _, err := readResponseLimit(strings.NewReader(""), 5, 4); err == nil || !strings.Contains(err.Error(), "4-byte limit") {
-		t.Fatalf("declared over-limit error = %v", err)
-	}
-}
-
 func TestFetchBatchRejectsOversizedResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Length", strconv.FormatInt(maxResponseBytes+1, 10))

--- a/internal/matchers/osv/client.go
+++ b/internal/matchers/osv/client.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -17,6 +17,9 @@ const (
 	defaultTimeout   = 30 * time.Second
 	defaultBatchSize = 1000
 	maxRetries       = 3
+
+	maxVulnerabilityResponseBytes int64 = 4 << 20
+	maxBatchResponseBytes         int64 = 64 << 20
 )
 
 // ClientConfig configures the OSV HTTP client.
@@ -89,7 +92,7 @@ func (c *Client) GetVuln(id string) (*Vulnerability, error) {
 		return nil, fmt.Errorf("osv get vuln %s: status %d", id, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20)) // 4 MB per vuln
+	data, err := system.ReadLimit(resp.Body, resp.ContentLength, maxVulnerabilityResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("osv read vuln %s: %w", id, err)
 	}
@@ -160,7 +163,7 @@ func (c *Client) queryChunkAttempt(endpoint string, body []byte, attempt int) (r
 		return nil, fmt.Errorf("osv api returned status %d", resp.StatusCode), nil
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20)) // 64 MB limit
+	data, err := system.ReadLimit(resp.Body, resp.ContentLength, maxBatchResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("osv read response: %w", err), nil
 	}

--- a/internal/matchers/osv/client_limit_test.go
+++ b/internal/matchers/osv/client_limit_test.go
@@ -1,0 +1,90 @@
+package osv
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func oversizedClientResponse(status int, size int64, body string) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    status,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: size,
+			Header:        make(http.Header),
+		}, nil
+	})}
+}
+
+func TestClientRejectsOversizedVulnerabilityResponse(t *testing.T) {
+	client := NewClient(ClientConfig{
+		APIBase:    "https://osv.example.test",
+		HTTPClient: oversizedClientResponse(http.StatusOK, maxVulnerabilityResponseBytes+1, ""),
+	})
+	_, err := client.GetVuln("OSV-1")
+	if err == nil || !strings.Contains(err.Error(), "4 MiB limit exceeded") {
+		t.Fatalf("GetVuln() error = %v", err)
+	}
+}
+
+func TestClientRejectsOversizedBatchResponse(t *testing.T) {
+	client := NewClient(ClientConfig{
+		APIBase:    "https://osv.example.test",
+		HTTPClient: oversizedClientResponse(http.StatusOK, maxBatchResponseBytes+1, ""),
+	})
+	_, err := client.QueryBatch([]BatchQuery{{}})
+	if err == nil || !strings.Contains(err.Error(), "64 MiB limit exceeded") {
+		t.Fatalf("QueryBatch() error = %v", err)
+	}
+}
+
+func TestFetchKEVCatalogRejectsOversizedResponse(t *testing.T) {
+	client := oversizedClientResponse(http.StatusOK, maxKEVResponseBytes+1, "")
+	_, err := FetchKEVCatalog(nil, client)
+	if err == nil || !strings.Contains(err.Error(), "32 MiB limit exceeded") {
+		t.Fatalf("FetchKEVCatalog() error = %v", err)
+	}
+}
+
+func TestOSVAndKEVErrorsDoNotExposeResponseBodies(t *testing.T) {
+	const privateDetail = "private upstream diagnostic"
+	t.Run("vulnerability", func(t *testing.T) {
+		client := NewClient(ClientConfig{
+			APIBase:    "https://osv.example.test",
+			HTTPClient: oversizedClientResponse(http.StatusBadGateway, int64(len(privateDetail)), privateDetail),
+		})
+		_, err := client.GetVuln("OSV-1")
+		requireStatusWithoutBody(t, err, "status 502", privateDetail)
+	})
+	t.Run("batch", func(t *testing.T) {
+		client := NewClient(ClientConfig{
+			APIBase:    "https://osv.example.test",
+			HTTPClient: oversizedClientResponse(http.StatusBadGateway, int64(len(privateDetail)), privateDetail),
+		})
+		_, err := client.QueryBatch([]BatchQuery{{}})
+		requireStatusWithoutBody(t, err, "status 502", privateDetail)
+	})
+	t.Run("kev", func(t *testing.T) {
+		client := oversizedClientResponse(http.StatusBadGateway, int64(len(privateDetail)), privateDetail)
+		_, err := FetchKEVCatalog(nil, client)
+		requireStatusWithoutBody(t, err, "status 502", privateDetail)
+	})
+}
+
+func requireStatusWithoutBody(t *testing.T, err error, status, body string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), status) {
+		t.Fatalf("error = %v, want %q", err, status)
+	}
+	if strings.Contains(err.Error(), body) {
+		t.Fatalf("error exposed response body: %v", err)
+	}
+}

--- a/internal/matchers/osv/kev.go
+++ b/internal/matchers/osv/kev.go
@@ -3,11 +3,11 @@ package osv
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
 	audcache "github.com/bomly-dev/bomly-cli/internal/matchers/cache"
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
@@ -17,7 +17,8 @@ const (
 	kevCacheKey     = "kev-catalog"
 	// by defaultKEVCacheTTL it is intentionally longer than the OSV TTL; the KEV catalog
 	// is updated less frequently than individual vulnerability queries.
-	defaultKEVCacheTTL = 6 * time.Hour
+	defaultKEVCacheTTL        = 6 * time.Hour
+	maxKEVResponseBytes int64 = 32 << 20
 )
 
 // KEVCatalog is the in-memory representation of the CISA KEV catalog.
@@ -66,7 +67,7 @@ func FetchKEVCatalog(cache *audcache.FileCache, clients ...*http.Client) (*KEVCa
 		return nil, fmt.Errorf("kev catalog returned status %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20)) // 32 MB limit
+	data, err := system.ReadLimit(resp.Body, resp.ContentLength, maxKEVResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("read kev catalog: %w", err)
 	}

--- a/internal/matchers/scorecard/client.go
+++ b/internal/matchers/scorecard/client.go
@@ -5,17 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/bomly-dev/bomly-cli/internal/system"
 	"github.com/bomly-dev/bomly-cli/sdk"
 )
 
 const (
-	defaultAPIBase = "https://api.scorecard.dev"
-	defaultTimeout = 15 * time.Second
+	defaultAPIBase         = "https://api.scorecard.dev"
+	defaultTimeout         = 15 * time.Second
+	maxResponseBytes int64 = 4 << 20
 )
 
 // ErrProjectNotScored is returned by FetchProject when api.scorecard.dev has
@@ -100,7 +101,7 @@ func (c *Client) FetchProject(ctx context.Context, repo string) (*Project, error
 		return nil, fmt.Errorf("scorecard: fetch %s: status %d", repo, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20)) // 4 MB cap per project
+	data, err := system.ReadLimit(resp.Body, resp.ContentLength, maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("scorecard: read response for %s: %w", repo, err)
 	}

--- a/internal/matchers/scorecard/client_limit_test.go
+++ b/internal/matchers/scorecard/client_limit_test.go
@@ -1,0 +1,52 @@
+package scorecard
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type responseRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn responseRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func scorecardResponseClient(status int, size int64, body string) *http.Client {
+	return &http.Client{Transport: responseRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    status,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: size,
+			Header:        make(http.Header),
+		}, nil
+	})}
+}
+
+func TestClientRejectsOversizedResponse(t *testing.T) {
+	client := NewClient(ClientConfig{
+		APIBase:    "https://scorecard.example.test",
+		HTTPClient: scorecardResponseClient(http.StatusOK, maxResponseBytes+1, ""),
+	})
+	_, err := client.FetchProject(context.Background(), "github.com/acme/example")
+	if err == nil || !strings.Contains(err.Error(), "4 MiB limit exceeded") {
+		t.Fatalf("FetchProject() error = %v", err)
+	}
+}
+
+func TestClientErrorDoesNotExposeResponseBody(t *testing.T) {
+	const privateDetail = "private upstream diagnostic"
+	client := NewClient(ClientConfig{
+		APIBase:    "https://scorecard.example.test",
+		HTTPClient: scorecardResponseClient(http.StatusBadGateway, int64(len(privateDetail)), privateDetail),
+	})
+	_, err := client.FetchProject(context.Background(), "github.com/acme/example")
+	if err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("FetchProject() error = %v", err)
+	}
+	if strings.Contains(err.Error(), privateDetail) {
+		t.Fatalf("FetchProject() exposed response body: %v", err)
+	}
+}

--- a/internal/support/config_reference.go
+++ b/internal/support/config_reference.go
@@ -138,6 +138,7 @@ func renderConfigMarkdown(fields []configField) string {
 	builder.WriteString("3. `BOMLY_*` environment variables\n")
 	builder.WriteString("4. CLI flags\n\n")
 	builder.WriteString("Repository config files are never loaded automatically. Select a trusted project file explicitly, for example `--config .bomly/config.yaml` or `BOMLY_CONFIG=.bomly/config.yaml`. When both are set, `--config` wins.\n\n")
+	builder.WriteString("Bomly rejects configuration files larger than 4 MiB before parsing them.\n\n")
 	builder.WriteString("YAML files use the nested keys documented below. Unknown keys and the former flat keys are rejected so configuration mistakes fail fast.\n\n")
 	builder.WriteString("---\n\n")
 

--- a/internal/support/prose/detectors/sbom.md
+++ b/internal/support/prose/detectors/sbom.md
@@ -7,6 +7,7 @@
 | Resolve graph | JSON ingest | None |
 
 Format is auto-detected by content.
+Bomly rejects SBOM input files larger than 256 MiB before decoding them.
 
 ## Network behavior
 

--- a/internal/support/prose/matchers/depsdev-license-matcher.md
+++ b/internal/support/prose/matchers/depsdev-license-matcher.md
@@ -22,7 +22,7 @@ Bomly only fills packages that do not already have license data. Detector-resolv
 
 ## Cache and network
 
-The matcher batches version lookups through deps.dev and caches responses for 24 hours under `~/.bomly/cache/licenses/depsdev/`. Cache failures are non-fatal: Bomly logs a warning and still applies the API response.
+The matcher batches version lookups through deps.dev and caches responses for 24 hours under `~/.bomly/cache/licenses/depsdev/`. Each successful batch response is limited to 16 MiB. Cache failures are non-fatal: Bomly logs a warning and still applies the API response. Failed HTTP responses report the status code without including the server's response body in the error.
 
 ## CI recipe
 

--- a/internal/support/prose/matchers/osv.md
+++ b/internal/support/prose/matchers/osv.md
@@ -23,6 +23,10 @@ bomly scan --enrich
 Cache directory (Unix/macOS): `~/.bomly/cache/{osv,osv-vulns,kev}/`.
 
 Cache failures are logged at WARN and never abort the scan.
+OSV batch responses are limited to 64 MiB, individual advisory responses to
+4 MiB, and KEV catalog responses to 32 MiB. Larger responses fail with a clear
+size error. Failed HTTP responses report the status without including the
+remote response body in errors or logs.
 
 ## Output fields
 

--- a/internal/support/prose/matchers/scorecard.md
+++ b/internal/support/prose/matchers/scorecard.md
@@ -33,6 +33,10 @@ Packages with no resolvable github.com source — and packages whose source is h
 
 Cache directory (Unix/macOS): `~/.bomly/cache/scorecard/`. Cache failures are logged at WARN and never abort the scan. Repositories the OSSF has not scored return HTTP 404; the matcher records a `notScored` sentinel for the TTL so unscored repos are not retried on every run.
 
+Each successful project response is limited to 4 MiB. Larger responses fail
+with a clear size error. Failed HTTP responses report the status without
+including the remote response body in errors or logs.
+
 ## Output fields
 
 When attached, `package.scorecard` holds:

--- a/internal/system/read.go
+++ b/internal/system/read.go
@@ -32,7 +32,7 @@ func ReadLimit(input io.Reader, declaredSize, maxBytes int64) ([]byte, error) {
 	}
 	data, err := io.ReadAll(io.LimitReader(input, maxBytes+1))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read input: %w", err)
 	}
 	if int64(len(data)) > maxBytes {
 		return nil, inputTooLargeError(maxBytes)
@@ -47,6 +47,9 @@ func ReadLimit(input io.Reader, declaredSize, maxBytes int64) ([]byte, error) {
 func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
+		// The *os.PathError already carries the "open <path>" operation
+		// context; wrapping again would duplicate it. Callers may keep using
+		// errors.Is(err, os.ErrNotExist) on this path.
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
@@ -55,7 +58,11 @@ func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
 	if info, statErr := file.Stat(); statErr == nil {
 		declaredSize = info.Size()
 	}
-	return ReadLimit(file, declaredSize, maxBytes)
+	data, err := ReadLimit(file, declaredSize, maxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", path, err)
+	}
+	return data, nil
 }
 
 func inputTooLargeError(maxBytes int64) error {

--- a/internal/system/read.go
+++ b/internal/system/read.go
@@ -7,8 +7,38 @@ import (
 	"os"
 )
 
-// ErrFileTooLarge reports that a file exceeds a caller-provided size limit.
-var ErrFileTooLarge = errors.New("file exceeds size limit")
+// ErrInputTooLarge reports that input exceeds a caller-provided size limit.
+var ErrInputTooLarge = errors.New("input too large")
+
+// ByteLimitLabel formats a byte limit for user-facing messages.
+func ByteLimitLabel(size int64) string {
+	if size > 0 && size%(1<<30) == 0 {
+		return fmt.Sprintf("%d GiB", size/(1<<30))
+	}
+	if size > 0 && size%(1<<20) == 0 {
+		return fmt.Sprintf("%d MiB", size/(1<<20))
+	}
+	if size > 0 && size%(1<<10) == 0 {
+		return fmt.Sprintf("%d KiB", size/(1<<10))
+	}
+	return fmt.Sprintf("%d bytes", size)
+}
+
+// ReadLimit reads input while enforcing maxBytes. A negative declaredSize
+// means the size is not known before reading.
+func ReadLimit(input io.Reader, declaredSize, maxBytes int64) ([]byte, error) {
+	if declaredSize > maxBytes {
+		return nil, inputTooLargeError(maxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(input, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, inputTooLargeError(maxBytes)
+	}
+	return data, nil
+}
 
 // ReadFileLimit reads at most maxBytes from path.
 //
@@ -21,15 +51,13 @@ func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
 	}
 	defer func() { _ = file.Close() }()
 
-	if info, statErr := file.Stat(); statErr == nil && info.Size() > maxBytes {
-		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrFileTooLarge, maxBytes)
+	declaredSize := int64(-1)
+	if info, statErr := file.Stat(); statErr == nil {
+		declaredSize = info.Size()
 	}
-	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrFileTooLarge, maxBytes)
-	}
-	return data, nil
+	return ReadLimit(file, declaredSize, maxBytes)
+}
+
+func inputTooLargeError(maxBytes int64) error {
+	return fmt.Errorf("%w: %s limit exceeded", ErrInputTooLarge, ByteLimitLabel(maxBytes))
 }

--- a/internal/system/read.go
+++ b/internal/system/read.go
@@ -1,0 +1,35 @@
+package system
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ErrFileTooLarge reports that a file exceeds a caller-provided size limit.
+var ErrFileTooLarge = errors.New("file exceeds size limit")
+
+// ReadFileLimit reads at most maxBytes from path.
+//
+// The size is checked before reading when it is available and again while
+// reading, so the limit also holds if the file grows after it is opened.
+func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	if info, statErr := file.Stat(); statErr == nil && info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrFileTooLarge, maxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrFileTooLarge, maxBytes)
+	}
+	return data, nil
+}

--- a/internal/system/read_test.go
+++ b/internal/system/read_test.go
@@ -1,0 +1,23 @@
+package system
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFileLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input")
+	if err := os.WriteFile(path, []byte("1234"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ReadFileLimit(path, 4)
+	if err != nil || string(data) != "1234" {
+		t.Fatalf("exact-limit read = %q, %v", data, err)
+	}
+	if _, err := ReadFileLimit(path, 3); !errors.Is(err, ErrFileTooLarge) {
+		t.Fatalf("over-limit error = %v, want ErrFileTooLarge", err)
+	}
+}

--- a/internal/system/read_test.go
+++ b/internal/system/read_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,7 +18,33 @@ func TestReadFileLimit(t *testing.T) {
 	if err != nil || string(data) != "1234" {
 		t.Fatalf("exact-limit read = %q, %v", data, err)
 	}
-	if _, err := ReadFileLimit(path, 3); !errors.Is(err, ErrFileTooLarge) {
-		t.Fatalf("over-limit error = %v, want ErrFileTooLarge", err)
+	if _, err := ReadFileLimit(path, 3); !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("over-limit error = %v, want ErrInputTooLarge", err)
+	}
+}
+
+func TestReadLimitAcceptsExactLimitAndRejectsDeclaredOrStreamedExcess(t *testing.T) {
+	data, err := ReadLimit(bytes.NewBufferString("1234"), -1, 4)
+	if err != nil || string(data) != "1234" {
+		t.Fatalf("exact-limit read = %q, %v", data, err)
+	}
+	if _, err := ReadLimit(bytes.NewBufferString("12345"), -1, 4); !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("streamed over-limit error = %v, want ErrInputTooLarge", err)
+	}
+	if _, err := ReadLimit(bytes.NewBufferString(""), 5, 4); !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("declared over-limit error = %v, want ErrInputTooLarge", err)
+	}
+}
+
+func TestByteLimitLabel(t *testing.T) {
+	for size, want := range map[int64]string{
+		4:       "4 bytes",
+		4 << 10: "4 KiB",
+		4 << 20: "4 MiB",
+		4 << 30: "4 GiB",
+	} {
+		if got := ByteLimitLabel(size); got != want {
+			t.Fatalf("ByteLimitLabel(%d) = %q, want %q", size, got, want)
+		}
 	}
 }

--- a/internal/system/read_test.go
+++ b/internal/system/read_test.go
@@ -21,6 +21,9 @@ func TestReadFileLimit(t *testing.T) {
 	if _, err := ReadFileLimit(path, 3); !errors.Is(err, ErrInputTooLarge) {
 		t.Fatalf("over-limit error = %v, want ErrInputTooLarge", err)
 	}
+	if _, err := ReadFileLimit(filepath.Join(t.TempDir(), "absent"), 4); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing-file error = %v, want os.ErrNotExist", err)
+	}
 }
 
 func TestReadLimitAcceptsExactLimitAndRejectsDeclaredOrStreamedExcess(t *testing.T) {

--- a/test/assurance/UNTRUSTED_INPUT_LIMITS.md
+++ b/test/assurance/UNTRUSTED_INPUT_LIMITS.md
@@ -1,0 +1,27 @@
+# Untrusted input limits
+
+Bomly reads files and network responses that may come from an untrusted project
+or service. These limits stop one input from consuming memory without a bound.
+
+| Input | Limit | Check |
+| --- | ---: | --- |
+| YAML configuration | 4 MiB | Before YAML decoding |
+| Finding baseline | 16 MiB and 10,000 entries | Before JSON decoding and validation |
+| Explicit SBOM | 256 MiB | Before format detection and JSON decoding |
+| Successful deps.dev batch response | 16 MiB | Before JSON decoding |
+
+Tests cover an input at the limit and an input over it. File-backed readers
+check the size when the file is opened and also stop after reading one byte past
+the limit. The second check matters when a file grows while Bomly reads it.
+Failed deps.dev responses report the HTTP status but do not include the response
+body in the returned error.
+
+## Known residual limits
+
+- Matcher cache entries do not have a separate read limit. They are local files
+  written by Bomly from bounded requests and responses. This is a lower-risk
+  local resource concern and remains follow-up work.
+- A remote Git scan does not cap the cloned repository size. The user must
+  explicitly select a URL target, and Git owns the transfer. A fixed limit would
+  reject valid large repositories, so this remains an explicit-operation
+  resource risk.

--- a/test/assurance/UNTRUSTED_INPUT_LIMITS.md
+++ b/test/assurance/UNTRUSTED_INPUT_LIMITS.md
@@ -8,13 +8,17 @@ or service. These limits stop one input from consuming memory without a bound.
 | YAML configuration | 4 MiB | Before YAML decoding |
 | Finding baseline | 16 MiB and 10,000 entries | Before JSON decoding and validation |
 | Explicit SBOM | 256 MiB | Before format detection and JSON decoding |
+| Successful OSV vulnerability response | 4 MiB | Before JSON decoding |
+| Successful OSV batch response | 64 MiB | Before JSON decoding |
+| Successful CISA KEV response | 32 MiB | Before JSON decoding |
+| Successful Scorecard project response | 4 MiB | Before JSON decoding |
 | Successful deps.dev batch response | 16 MiB | Before JSON decoding |
 
 Tests cover an input at the limit and an input over it. File-backed readers
 check the size when the file is opened and also stop after reading one byte past
 the limit. The second check matters when a file grows while Bomly reads it.
-Failed deps.dev responses report the HTTP status but do not include the response
-body in the returned error.
+Failed matcher responses report the HTTP status but do not include the response
+body in returned errors or logs.
 
 ## Known residual limits
 


### PR DESCRIPTION
## Summary

- limit configuration files, finding baselines, explicit SBOMs, and deps.dev responses before decoding
- cap baselines at 10,000 entries and validate duplicate identities with an index instead of a nested scan
- keep deps.dev error response bodies out of returned errors
- document the limits and the remaining cache-entry and explicit Git-clone resource risks

## Limits

| Input | Limit |
| --- | ---: |
| YAML configuration | 4 MiB |
| Finding baseline | 16 MiB and 10,000 entries |
| Explicit SBOM | 256 MiB |
| Successful deps.dev batch response | 16 MiB |

## Validation

- `go test ./internal/system ./internal/config ./internal/baseline ./internal/detectors/sbom ./internal/matchers/depsdev`
- `make generate`
- `make fmt-check`
- `make lint`
- `make test`
- `make build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added size limits for configuration, baseline, and SBOM files to prevent oversized inputs from being processed.
  * Added response-size limits for external vulnerability, licensing, and project-quality services.
  * Improved error handling by reporting HTTP status codes without exposing remote response bodies.
  * Added validation for excessive baseline entries and duplicate advisory identifiers.

* **Documentation**
  * Documented input limits, response handling, caching behavior, and known residual risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->