### PR TITLE
docs: clarify that file-only -o SBOM runs print nothing without --format

### DIFF
--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -131,6 +131,7 @@ bomly:
   script:
     - |
       bomly scan --enrich --audit --fail-on high \
+        --format text \
         -o spdx=sbom.spdx.json \
         -o cyclonedx=sbom.cdx.json
   artifacts:
@@ -219,6 +220,7 @@ jobs:
           command: |
             curl -fsSL https://bomly.dev/install.sh | BOMLY_VERSION=v0.14.2 sh
             bomly scan --enrich --audit --fail-on high \
+              --format text \
               -o spdx=sbom.spdx.json \
               -o cyclonedx=sbom.cdx.json
       - save_cache:

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -225,7 +225,7 @@ Supported targets:
 A single scan can produce:
 
 - A human report on stdout.
-- A JSON document piped to a file.
+- A JSON document written to a file.
 - A SARIF document for a CI panel.
 - One or more SBOM artifacts.
 
@@ -233,13 +233,14 @@ Example:
 
 ```bash
 bomly scan --enrich --audit --fail-on high \
-  --json \
-  -o markdown=summary.md \
+  --format text \
+  -o json=bomly.json \
   -o sarif=bomly.sarif \
   -o spdx=sbom.spdx.json \
-  -o cyclonedx=sbom.cdx.json \
-  > bomly.json
+  -o cyclonedx=sbom.cdx.json
 ```
+
+`--format text` keeps the terminal report on stdout. Without it (and with every `-o` naming a file), a successful run writes the files and prints nothing.
 
 Detector and matcher work runs once. All outputs derive from the same in-memory graph.
 

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -47,6 +47,7 @@ Constraints:
 
 - At most one `-o` may omit `=<path>`. Two stdout outputs would collide.
 - `-o spdx=` (empty path) is an error.
+- When every `-o` names a file and `--format` is not set, a successful run writes the files and prints nothing — add `--format text` if you also want the terminal report.
 - `--format spdx`, `--format cyclonedx`, `-o spdx`, and `-o cyclonedx` are supported by `scan` only.
 - Paths are resolved relative to the current working directory.
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -53,7 +53,7 @@ With `--fail-on high`, this run passes: the only *introduced* finding is medium,
 bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json
 ```
 
-Both files are written in one pass from the same resolved graph. Use `--format spdx` (or `cyclonedx`) to stream a single SBOM to stdout instead. Details: [SBOM formats](SBOM.md).
+Both files are written in one pass from the same resolved graph, and a successful run prints nothing — add `--format text` if you also want the terminal report in the build log. Use `--format spdx` (or `cyclonedx`) to stream a single SBOM to stdout instead. Details: [SBOM formats](SBOM.md).
 
 ## Triage vulnerabilities by reachability
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -59,7 +59,7 @@ bomly scan --enrich --audit --analyze --fail-on low --fail-on reachable
 ```bash
 bomly scan --json                                   # shortcut for --format json
 bomly scan --enrich --audit --fail-on high --format sarif
-bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json  # write SBOM files; prints nothing — add --format text to keep the report
+bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json  # write SBOM files; prints nothing — add --format text to also print a report
 bomly scan --interactive                            # open the TUI instead of printing a report
 ```
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -59,7 +59,7 @@ bomly scan --enrich --audit --analyze --fail-on low --fail-on reachable
 ```bash
 bomly scan --json                                   # shortcut for --format json
 bomly scan --enrich --audit --fail-on high --format sarif
-bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json  # extra artifacts alongside the report
+bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json  # write SBOM files; prints nothing — add --format text to keep the report
 bomly scan --interactive                            # open the TUI instead of printing a report
 ```
 


### PR DESCRIPTION
## Summary

Resolves the ambiguity from #316's follow-up question: is `bomly scan -o spdx=sbom.spdx.json -o cyclonedx=sbom.cdx.json` (no `--format`) printing nothing on success a bug or intended?

**It is intended.** The early return in `internal/cli/scan_cmd.go` (`allOutputsAreSBOM(outputSpecs) && Format == ""`) deliberately suppresses the primary report when every `-o` spec is a file-target SBOM and no explicit `--format` is set, and `TestRoot_ScanCommand_WritesMultipleSBOMFormatsToFiles` locks it in (`expected no stdout when writing files`). The docs wave-2 pass (#354) already aligned README, GETTING_STARTED, and the OUTPUT_FORMATS `-o` section with this; this PR fixes the remaining stragglers that still implied the report prints alongside bare `-o`:

- **docs/commands/scan.md** — the `-o spdx=... -o cyclonedx=...` example was annotated "extra artifacts alongside the report"; now says it prints nothing and to add `--format text` to keep the report.
- **docs/OUTPUT_FORMATS.md** (Combining outputs) — the bullets promised "a human report on stdout" but the example (`--json ... > bomly.json`) never produced one. The example now uses `--format text` + `-o json=bomly.json` so every promised output actually appears, with a note about the silent bare-`-o` form.
- **docs/SBOM.md** — added the silent-on-success rule to the constraints list.
- **docs/CI_INTEGRATION.md** — the GitLab and CircleCI recipes gate on `--fail-on high` but printed nothing to the job log, so a policy failure was an unexplained exit 2; added `--format text`. (The GitHub Actions and Jenkins recipes already use `--format sarif`.)
- **docs/USE_CASES.md** — the SBOM-publish recipe now notes the silence.

## Verification

- Built the CLI and ran it on a minimal Go module fixture: bare `-o spdx= -o cyclonedx=` → exit 0, 0 bytes on stdout and stderr; adding `--format text -o json=` → text report on stdout plus all three files written (confirms the updated OUTPUT_FORMATS example is a valid flag combination).
- `go test ./internal/cli/ -run TestRoot_ScanCommand_WritesMultipleSBOM` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `bomly scan` handles terminal reports and file outputs.
  * Documented using `--format text` to display a human-readable report alongside JSON, SARIF, SPDX, or CycloneDX files.
  * Clarified that runs writing only to files complete silently unless text output is explicitly enabled.
  * Updated CI, SBOM generation, command reference, and output-combination examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->