### PR TITLE
docs(ci): record the read:org gotcha for manual registry publishing

### DIFF
--- a/dev-docs/CI.md
+++ b/dev-docs/CI.md
@@ -270,6 +270,19 @@ Two jobs at the end of `release.yml` publish the `bomly-mcp` npm wrapper and the
    gh variable set PUBLISH_MCP_REGISTRY -R bomly-dev/bomly-cli --body true
    ```
 
+### Publishing the registry entry by hand
+
+Rarely needed — the release workflow does it — but useful for a first listing or a fix-up:
+
+```bash
+mcp-publisher login github --token "$(gh auth token)"
+mcp-publisher publish
+```
+
+**Use `--token`, not the bare interactive `mcp-publisher login github`.** The interactive OAuth flow does not request the `read:org` scope, so the registry cannot read your organization role and grants only your personal namespace (`io.github.<user>/*`). Publishing then fails with a 403 naming the wrong namespace. The error suggests making your org membership public; that alone does **not** fix it. A token carrying `read:org` does — and the `gh` CLI's own token already has it.
+
+Publishing under `io.github.bomly-dev/*` also requires being an **Owner** of the org, which the registry checks.
+
 ### Notes
 
 - **npm version floor.** Trusted publishing needs npm >= 11.5.1, which is newer than the runner image's bundled npm. The job installs `npm@^11.5.1` explicitly rather than inheriting whatever the image ships.


### PR DESCRIPTION
`io.github.bomly-dev/bomly-cli` **0.21.1 is now live** in the official MCP Registry. This documents the one thing that cost time getting there.

Publishing the first entry by hand failed twice with:

```
403 Forbidden ... You have permission to publish: io.github.bomly-guy/*.
Attempting to publish: io.github.bomly-dev/bomly-cli.
If you're trying to publish to a GitHub organization, you may need to make
your organization membership public...
```

**That suggestion is a red herring.** Membership was made public, a fresh token was minted afterwards, and it still carried only `io.github.bomly-guy/*`.

The real cause: the interactive `mcp-publisher login github` flow does not request the `read:org` scope, so the registry cannot read the publisher's organization role and falls back to the personal namespace. Passing a token that has `read:org` fixes it immediately — and the `gh` CLI's own token already carries it:

```bash
mcp-publisher login github --token "$(gh auth token)"
```

Token claims before and after:

```
before: [{"action":"publish","resource":"io.github.bomly-guy/*"}]
after:  [{"action":"publish","resource":"io.github.bomly-guy/*"},
         {"action":"publish","resource":"io.github.bomly-dev/*"}]
```

Adds a short "Publishing the registry entry by hand" section to `dev-docs/CI.md` so the next person does not re-derive this. Does not touch the CI path, which uses OIDC and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)