### PR TITLE
fix(release): npm upgrade needs sudo, and only when actually too old

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,13 +273,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Upgrade npm for trusted publishing
-        # Trusted publishing needs npm >= 11.5.1. The runner image bundles an
-        # older npm with its Node, so pin an explicit floor rather than
-        # inheriting whatever the image happens to ship this month.
+      - name: Ensure npm supports trusted publishing
+        # Trusted publishing needs npm >= 11.5.1, which the runner image has
+        # not always bundled. Upgrade only when the shipped npm is too old, so
+        # this becomes a no-op once the image catches up.
+        #
+        # `sudo` is required: npm's global prefix on the runner is /usr/local,
+        # which the `runner` user cannot write to. Without it this fails with
+        # EACCES on /usr/local/share/man — which is exactly how the v0.21.2
+        # release lost its npm and registry publish.
         run: |
           set -euo pipefail
-          npm install -g npm@^11.5.1
+          required=11.5.1
+          current="$(npm --version)"
+          if printf '%s\n%s\n' "$required" "$current" | sort -V -C; then
+            echo "npm ${current} already supports trusted publishing."
+          else
+            echo "npm ${current} is older than ${required}; upgrading."
+            sudo npm install -g "npm@^${required}"
+          fi
           npm --version
 
       - name: Stamp the release version into npm/package.json


### PR DESCRIPTION
The [v0.21.2 release](https://github.com/bomly-dev/bomly-cli/actions/runs/31209631748) published correctly but lost its npm and MCP Registry publish.

## What happened

`publish-npm` failed on its **first** step:

```
npm error code EACCES
npm error path /usr/local/share/man/man5
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man5'
```

npm's global prefix on the runner is `/usr/local`, which the `runner` user cannot write to. `npm install -g` needs `sudo`. `publish-mcp-registry` was then skipped behind it.

Everything user-facing was unaffected — the GitHub release, Homebrew/Scoop/WinGet PRs, checksums, cosign signature and SLSA provenance all completed, because both publish jobs sit downstream of `publish`. npm and the registry are simply still on 0.21.1.

## The fix

Two changes to the same step:

1. **`sudo`** on the global install.
2. **Only upgrade when the shipped npm is actually below 11.5.1.** The step was unconditional on the assumption the image ships an older npm. That will stop being true, and an unconditional global install is slower and one more thing to break. It now compares with `sort -V -C` and no-ops when npm is new enough.

Boundary verified across `10.9.8 / 11.4.0 / 11.5.0 / 11.5.1 / 11.5.2 / 12.0.0` — upgrades below 11.5.1, no-ops at and above it. YAML and the step's shell body both syntax-checked, and the body was dry-run locally.

## Getting 0.21.2 onto npm

Re-running the failed job **will not work** — a re-run uses the workflow file from the `v0.21.2` tag, which still has the bug.

Two options once this merges:

- **Do nothing.** The next release publishes normally. npm and the registry stay on 0.21.1, which installs and runs fine; they are just one patch behind.
- **Publish 0.21.2 by hand** — the release assets it needs are already live:
  ```bash
  cd npm && npm publish --access public   # from a checkout at v0.21.2
  mcp-publisher login github --token "$(gh auth token)" && mcp-publisher publish
  ```

## Note

This is the failure I argued a rehearsal release wasn't worth cutting. The containment reasoning held — nothing user-facing broke — but the step was broken from the start, and a dry run would have caught it before a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clearer error response when an alert type is missing or invalid.
  * Error details now include the supported alert type identifiers to help resolve configuration issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->