### PR TITLE
fix(release): name the real cause when npm refuses the OIDC exchange

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,18 @@ jobs:
             exit 0
           fi
 
-          npm publish --provenance --access public
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::No OIDC token endpoint in the environment. This job needs 'id-token: write'."
+            exit 1
+          fi
+
+          # npm reports a bare ENEEDAUTH when the OIDC exchange is refused,
+          # which reads as "no credentials" and sends you looking for a token
+          # that deliberately does not exist. Name the real cause instead.
+          if ! npm publish --provenance --access public; then
+            echo "::error::npm publish failed. If the error above is ENEEDAUTH, npm refused the OIDC exchange and there is no token to fall back on — by design. That means the trusted publisher for bomly-mcp is missing or does not match this workflow. Check https://www.npmjs.com/package/bomly-mcp/access and confirm ALL of: publisher='GitHub Actions', organization='bomly-dev', repository='bomly-cli', workflow filename='release.yml', environment='npm-publish', and 'Allow npm publish' ticked under Allowed actions. Every field must match exactly; a blank or wrong environment name is the usual culprit. See dev-docs/CI.md#mcp-registry-publishing."
+            exit 1
+          fi
 
   publish-mcp-registry:
     # Publishes the server entry in the official MCP Registry

--- a/dev-docs/CI.md
+++ b/dev-docs/CI.md
@@ -283,6 +283,25 @@ mcp-publisher publish
 
 Publishing under `io.github.bomly-dev/*` also requires being an **Owner** of the org, which the registry checks.
 
+### If publish-npm fails with ENEEDAUTH
+
+`ENEEDAUTH` from `npm publish` in this job does **not** mean a token is missing. There is deliberately no token. It means npm refused the OIDC exchange and fell back to looking for credentials that do not exist.
+
+The cause is almost always the trusted-publisher record on npmjs.com not matching the workflow. Check every field at `https://www.npmjs.com/package/bomly-mcp/access`:
+
+| Field | Must be |
+| --- | --- |
+| Publisher | GitHub Actions |
+| Organization | `bomly-dev` |
+| Repository | `bomly-cli` |
+| Workflow filename | `release.yml` |
+| Environment name | `npm-publish` |
+| Allowed actions | **`npm publish` ticked** (at least one must be) |
+
+All of them must match exactly. A blank or wrong environment name is the usual culprit, and an unticked "Allowed actions" makes the record inert. Saving the form requires clicking **Set up connection** — a filled-in but unsaved form looks identical to a saved one on reload.
+
+Things that are *not* the cause, ruled out on the v0.21.2 and v0.21.3 failures: npm version (the job upgrades to 11.19.0, well past the 11.5.1 floor), `id-token: write` (present), and the environment binding (GitHub recorded a `npm-publish` deployment for the tag both times).
+
 ### Notes
 
 - **npm version floor.** Trusted publishing needs npm >= 11.5.1, which is newer than the runner image's bundled npm. The job installs `npm@^11.5.1` explicitly rather than inheriting whatever the image ships.


### PR DESCRIPTION
Follow-up to the [v0.21.3 release failure](https://github.com/bomly-dev/bomly-cli/actions/runs/31268587581).

## Where we got to

The `sudo` fix from #370 worked. npm upgraded to **11.19.0**, the tarball packed correctly (7 files, LICENSE and NOTICE included), and then:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

That message is misleading here. **There is no token by design.** `ENEEDAUTH` means npm refused the OIDC exchange and had nothing to fall back on.

## What is already ruled out

Everything under our control was verified correct for that run:

| Checked | Result |
| --- | --- |
| npm version | 11.19.0, well past the 11.5.1 floor |
| `id-token: write` | present on the job |
| Environment binding | GitHub recorded a `npm-publish` deployment for `ref=v0.21.3` |
| Stale npmrc / leftover token | none — the job writes no npmrc |
| `working-directory` | `npm`, correct package |

So the remaining variable is the **trusted-publisher record on npmjs.com**, which CI cannot inspect and neither can I.

## What this PR changes

It does not fix the config — that is a change only you can make. It makes the next failure say so:

- Replaces the bare `npm publish` with one that, on failure, prints the five fields that must match and where to check them.
- Adds a separate guard for a genuinely missing OIDC endpoint, so "no `id-token: write`" and "npm rejected the exchange" stop looking identical.
- Documents the same in `dev-docs/CI.md`, including what has already been ruled out.

## What to check

At `https://www.npmjs.com/package/bomly-mcp/access`:

| Field | Must be |
| --- | --- |
| Publisher | GitHub Actions |
| Organization | `bomly-dev` |
| Repository | `bomly-cli` |
| Workflow filename | `release.yml` |
| Environment name | `npm-publish` |
| Allowed actions | **`npm publish` ticked** |

Two things worth ruling out specifically: an unticked **Allowed actions** makes the record inert, and the form only saves on **Set up connection** — an unsaved form looks identical to a saved one after a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)