### PR TITLE
docs(ci): document benign SLSA generator annotations in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,18 @@ jobs:
     # tag as immutable (even if the bad release is later deleted). The
     # `publish` job uploads this provenance file itself, by release ID, to
     # avoid that entirely.
+    #
+    # Known benign annotations from this job (all internal to the generator at
+    # v2.1.0, its latest release — nothing here can configure them away):
+    #   - "Node.js 20 is deprecated ... forced to run on Node 24": the
+    #     generator's internal actions still declare node20; GitHub runs them
+    #     on Node 24 anyway. Upstream migration is tracked in
+    #     slsa-framework/slsa-github-generator#4490.
+    #   - "Restore cache failed: Dependencies file is not found ... go.sum":
+    #     the generator's own setup-go step enables caching but its builder
+    #     checkout has no go.sum at the expected path. Tracked upstream in
+    #     slsa-framework/slsa-github-generator#2863 (fix PRs #2864, #4441).
+    # Re-check both when bumping the generator past v2.1.0.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}


### PR DESCRIPTION
## Summary

Run https://github.com/bomly-dev/bomly-cli/actions/runs/31546516949 surfaced 3 warning annotations, all from the `provenance` job. Investigation shows every one originates **inside** the pinned `slsa-framework/slsa-github-generator@v2.1.0` reusable workflow, which is still the latest upstream release — nothing in our workflow can fix or suppress them:

- **Node.js 20 deprecation (×2)** — the generator's internal actions (`detect-workflow-js`, `compute-sha256`, `privacy-check`, and its pinned `checkout`/`setup-go`/`upload-artifact`) still declare `node20`; GitHub forces them onto Node 24, which works. Upstream migration is tracked in slsa-framework/slsa-github-generator#4490.
- **`Restore cache failed: ... go.sum`** — the generator's own `setup-go` step enables module caching, but its builder checkout has no `go.sum` at the path it inspects. Purely a missed cache, not a failure. Tracked upstream in slsa-framework/slsa-github-generator#2863 (fix PRs #2864 and #4441, both still open).

The generator must stay pinned to a full `vX.Y.Z` tag for `slsa-verifier` builder-identity resolution, so we cannot pin to a fixed commit on `main` either. This PR records all of that as a comment on the `provenance` job so the annotations aren't re-investigated, with a reminder to re-check when bumping past v2.1.0.

No behavioral change — comment only. `[skip release]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notes explaining known benign build annotations from the release process.
  * Included references to upstream issues and a reminder to review these notes when upgrading tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->