### PR TITLE
docs: Module-first plugin authoring guides

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -7,13 +7,15 @@ Bomly plugins let you extend scans without changing the Bomly binary. Today, man
 - **auditors** that turn graph and registry data into findings or risk scores
 - **analyzers** that annotate vulnerabilities with reachability data during `--analyze`
 
-Each role has a serve entrypoint in the SDK: `sdk.ServeDetector`, `sdk.ServeMatcher`, `sdk.ServeAuditor`, and `sdk.ServeAnalyzer`.
+Every plugin packages its component as one `sdk.Module` and serves it from `main` with `sdk.ServeModule`. The same module can also be compiled into a host build, so a component is written once and runs in both execution modes. (The low-level per-role entrypoints `sdk.ServeDetector`, `sdk.ServeMatcher`, `sdk.ServeAuditor`, and `sdk.ServeAnalyzer` remain available for advanced cases.)
 
 ## Start Here
 
-Use this page when you want to install, trust, configure, package, or troubleshoot a managed plugin.
+Use this page when you want to install, trust, configure, package, or troubleshoot a managed plugin — and for the [authoring basics](#write-a-plugin) every plugin role shares.
 
-Use the implementation guides when you are writing one:
+**Writing a plugin? Start from the [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository** ("Use this template" on GitHub). It is a complete, working plugin with typed configuration, tests, the SDK conformance suite, CI, and a release workflow Bomly can install from.
+
+Then use the implementation guide for your role:
 
 - [How To Implement A Detector Plugin](plugins/how-to-implement-detector.md)
 - [How To Implement A Matcher Plugin](plugins/how-to-implement-matcher.md)
@@ -22,12 +24,12 @@ Use the implementation guides when you are writing one:
 
 Use the [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) for the Go types, runtime entrypoints, request/response payloads, graph model, package registry, and finding contract those guides use.
 
-Example plugin repositories live outside this repo so each plugin type can show a realistic package, release, and README:
+Real plugin repositories live outside this repo so each plugin type can show a realistic package, release, and README:
 
-- [Bun Lock Detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector) — detector example using `PackageManagerOther`
-- [ClearlyDefined License Matcher](https://github.com/bomly-dev/bomly-plugin-clearlydefined-matcher) — matcher example for license enrichment
-- [EOL Lifecycle Matcher](https://github.com/bomly-dev/bomly-plugin-eol-matcher) — matcher example for lifecycle metadata
-- [Meme Dependency Auditor](https://github.com/bomly-dev/bomly-plugin-meme-auditor) — auditor example that emits warning findings
+- [Bun Lock Detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector) — detector for a package manager Bomly does not model directly (`PackageManagerOther`)
+- [ClearlyDefined License Matcher](https://github.com/bomly-dev/bomly-plugin-clearlydefined-matcher) — matcher for license enrichment
+- [EOL Lifecycle Matcher](https://github.com/bomly-dev/bomly-plugin-eol-matcher) — matcher for lifecycle metadata
+- [Meme Dependency Auditor](https://github.com/bomly-dev/bomly-plugin-meme-auditor) — auditor that emits warning findings
 
 ## How Plugins Run
 
@@ -60,6 +62,77 @@ Bomly owns:
 
 Plugins do not get install hooks, post-install scripts, or automatic execution from repository checkouts.
 
+## Write A Plugin
+
+A plugin is written once as a **module** — the execution-neutral packaging of one component:
+
+```go
+sdk.Module{
+    Kind: sdk.PluginKindMatcher, // or Detector / Auditor / Analyzer
+    Matcher: &sdk.MatcherModule{
+        Descriptor: descriptor(), // static registration data
+        New: func(ctx context.Context, host sdk.HostContext) (sdk.Matcher, error) {
+            // construct the component; decode config from host
+        },
+    },
+}
+```
+
+The same module value can be compiled into a host build (embedded) or served as a managed plugin subprocess — the component code does not change between the two. `sdk.HostContext` is the only channel through which the component reaches host services, and both execution modes satisfy the same contract:
+
+- `Logger()` — a zap logger wired to the host's verbosity. Never log secrets.
+- `HTTPClient()` — an HTTP client provider that honors Bomly's proxy, no-proxy, and CA certificate settings.
+- `Runtime()` — the host core version and whether execution is embedded or managed.
+- `DecodeConfig(v)` — unmarshals the component's own `plugins.<kind>.<name>` configuration block (see [Configuration](#configuration-and-proxy-support)).
+
+Every role embeds a default-lifecycle helper (`sdk.BaseDetector`, `sdk.BaseMatcher`, `sdk.BaseAuditor`, `sdk.BaseAnalyzer`) that supplies always-ready, always-applicable implementations of `Ready(ctx, req) error` and `Applicable(ctx, req) (bool, error)`. Override `Ready` to report a missing prerequisite with a clear reason; override `Applicable` to skip requests the component should not handle. Honor the context everywhere.
+
+### Repository contract
+
+Follow the [template repository's](https://github.com/bomly-dev/bomly-plugin-template) shape:
+
+```text
+plugin/                  importable package exporting Module()
+cmd/<binary-name>/
+  main.go                one line: sdk.ServeModule(plugin.Module())
+bomly-plugin.json        package manifest; "id" must equal the descriptor name
+testdata/                fixtures for unit tests
+.github/workflows/       CI plus a release workflow producing platform archives
+go.mod                   pins a released github.com/bomly-dev/bomly-sdk version
+```
+
+Keeping the component in an importable `plugin/` package (not `package main`) is what makes the module reusable: the binary serves it, tests construct it directly, and a host build can embed it.
+
+`sdk.ServeModule` is the managed entrypoint. It validates the module, builds a managed `HostContext` (stderr logger, HTTP client provider from Bomly's environment, config decoding from the file the host passes), constructs the component lazily on first use, and speaks the plugin wire protocol. Only plugins that need the low-level wire surface directly should reach for the per-role `Serve<Kind>` entrypoints and `Served<Kind>` interfaces.
+
+## Test A Plugin
+
+Unit-test the component logic through `Module().New` with a small test `HostContext` stub (the template's `plugin/plugin_test.go` shows one), then run the SDK conformance suite:
+
+```go
+func TestConformance(t *testing.T) {
+    conformance.Test(t, conformance.Config{
+        Module:       plugin.Module(),
+        ManifestPath: "../bomly-plugin.json",
+        SampleConfig: json.RawMessage(`{"greeting":"hi"}`),
+    })
+}
+```
+
+The suite checks module and descriptor validity, JSON round-trip stability, construction through a `HostContext`, the Ready/Applicable lifecycle contract (including prompt return on a cancelled context), role capabilities such as the package-updates delta protocol, and — when `ManifestPath` is set — the manifest identity cross-check. To probe a built binary over the real managed transport, add `conformance.ProbeBinary(t, "bin/<name>", conformance.WithModule(plugin.Module()))`.
+
+The local development loop against Bomly:
+
+```bash
+go build -o ./bin/<binary-name> ./cmd/<binary-name>
+bomly plugins install ./bin/<binary-name> --dev
+bomly plugins enable <plugin-id>
+bomly scan ...                     # with the role's selector flag
+bomly plugins verify <plugin-id>   # manifest, checksum, binary, descriptor
+bomly plugins test <plugin-id>     # runtime readiness
+bomly plugins doctor <plugin-id>   # verify + test
+```
+
 ## Trust And Enablement
 
 Installed external plugins are disabled by default. They do not participate in scans until you enable them:
@@ -79,13 +152,13 @@ Repository-declared plugins are never executed automatically. The host must expl
 
 ## Try The Example Plugins
 
-Each example repo has a `bomly-plugin.json`, a small Go implementation, tests, and packaging notes.
+Each example repo has a `bomly-plugin.json`, a Go implementation, tests, and packaging notes. Check its README for the exact build command; the general workflow is:
 
 ```bash
 git clone git@github.com:bomly-dev/bomly-plugin-bun-lock-detector.git
 cd bomly-plugin-bun-lock-detector
 go test ./...
-go build -o ./bin/bomly-plugin-bun-lock-detector .
+go build -o ./bin/bomly-plugin-bun-lock-detector ./cmd/bomly-plugin-bun-lock-detector
 bomly plugins install ./bin/bomly-plugin-bun-lock-detector --dev
 bomly plugins enable bomly.examples.detector.bun-lock
 bomly scan --path ./my-bun-project --detectors bomly.examples.detector.bun-lock
@@ -195,7 +268,9 @@ All three are optional and older plugins that omit them keep working unchanged.
 
 A detector plugin may also explain which package-manager remediation strategies
 it understands. Add `RemediationCapabilities` to the detector descriptor and
-implement `sdk.ServedDetectorRemediationProvider`.
+implement the optional hints provider — `sdk.DetectorRemediationProvider` on a
+module's detector, or `sdk.ServedDetectorRemediationProvider` in the low-level
+served style.
 
 The provider runs after vulnerability enrichment. It receives the detector's
 own result and the enriched package registry. It may return occurrence-scoped
@@ -238,22 +313,32 @@ kind — but it is deprecated and reported with a warning. Kind-scoped blocks
 win when both are present. New configuration should always use the
 kind-scoped form.
 
-Plugins that declare a `ConfigSchema` in their descriptor get their
-configuration keys, descriptions, and defaults rendered by
-`bomly plugins info <plugin-id>`.
+Plugins that declare a `ConfigSchema` in their descriptor (build it from the
+config struct with `sdk.MustConfigSchemaFor`) get their configuration keys,
+descriptions, and defaults rendered by `bomly plugins info <plugin-id>`.
 
-External plugins can read only their own config through the SDK:
+A component reads only its own block, through the `HostContext` its module
+constructor receives:
 
 ```go
-type config struct {
-    APIBase string `json:"api_base"`
+type Config struct {
+    APIBase string `json:"apiBase" doc:"Service endpoint override" default:"https://api.example.com"`
 }
 
-var cfg config
-if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
-    return err
-}
+New: func(_ context.Context, host sdk.HostContext) (sdk.Matcher, error) {
+    matcher := &Matcher{}
+    if err := host.DecodeConfig(&matcher.config); err != nil {
+        return nil, fmt.Errorf("decode config: %w", err)
+    }
+    return matcher, nil
+},
 ```
+
+`DecodeConfig` has identical JSON semantics in both execution modes: embedded
+execution sources the block from the host config, managed execution from the
+config file the host passes to the subprocess. (Plugins written against the
+low-level served style read the same payload with
+`sdk.DecodePluginConfigFromEnv`.)
 
 Proxy settings can be configured with a direct proxy URL:
 
@@ -292,7 +377,7 @@ if err != nil {
 client := provider.Client(20 * time.Second)
 ```
 
-## Package Layout
+## Package And Release A Plugin
 
 An external plugin package includes a `bomly-plugin.json` manifest and one or more platform entrypoint binaries:
 
@@ -302,6 +387,10 @@ bin/
   bomly-plugin-example
 README.md
 ```
+
+The manifest's `entrypoint` field maps each `os/arch` platform to its binary name (Windows entries end in `.exe`). Keep the manifest `version` and the release tag in lockstep.
+
+For distribution, follow the template repository's release workflow: build each platform, package one archive per platform named `<name>_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows) containing the binary, `bomly-plugin.json`, `README.md`, and `LICENSE`, generate a `SHA256SUMS` file over the archives, and publish everything as a GitHub release. Users then install with `bomly plugins install github:<owner>/<repo>@v<version>`, and Bomly verifies the archive against `SHA256SUMS` automatically.
 
 Installed plugins are stored under:
 

--- a/docs/plugins/how-to-implement-analyzer.md
+++ b/docs/plugins/how-to-implement-analyzer.md
@@ -2,114 +2,127 @@
 
 An analyzer plugin runs code analysis after enrichment. Use an analyzer when you want to annotate vulnerabilities with reachability data — whether the scanned project can actually reach the vulnerable package or symbol — for a language the built-in analyzers do not cover, or with a technique they do not use.
 
-External analyzer plugins are served with `sdk.ServeAnalyzer`. They run when a scan passes `--analyze` (which requires `--enrich`), after matchers and before auditors.
+An analyzer is one `sdk.Module` with `Kind: sdk.PluginKindAnalyzer`. The same module can be compiled into a host build (embedded) or served as a managed plugin binary with `sdk.ServeModule` — you write the component once. Analyzers run when a scan passes `--analyze` (which requires `--enrich`), after matchers and before auditors. [Plugin basics](../PLUGINS.md#write-a-plugin) covers the module model, repository contract, configuration, testing, and release flow shared by every role; this guide covers what is specific to analyzers.
 
-The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents the `sdk.ServeAnalyzer` entrypoint, `sdk.ServedAnalyzer` interface, `sdk.AnalyzeRequest`, `sdk.AnalyzeResponse`, PURL-keyed package registry, and the `sdk.Reachability` annotation used below.
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents `sdk.Module`, `sdk.AnalyzerModule`, the `sdk.Analyzer` interface, `sdk.AnalyzeRequest`, `sdk.AnalyzeResult`, the PURL-keyed package registry, and the `sdk.Reachability` annotation used below.
 
-## Repository Layout
+## Start From The Template
 
-An analyzer plugin is an independent Go module that pins a released SDK version:
+Start from the [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository ("Use this template" on GitHub). It ships a working matcher; turning it into an analyzer means changing the module kind, the descriptor, and the role method — the layout, manifest, tests, and release workflow stay the same:
 
 ```text
-go.mod                      module example.com/bomly-plugin-myreach
-                            require github.com/bomly-dev/bomly-sdk v0.1.0
-analyzer/                   implementation package (analysis logic, tests)
-cmd/bomly-plugin-myreach/
-  main.go                   thin entrypoint calling sdk.ServeAnalyzer
-bomly-plugin.json           package manifest
-README.md
+plugin/                  importable package: descriptor, Config, Analyzer, Module()
+cmd/<binary-name>/
+  main.go                one line: sdk.ServeModule(plugin.Module())
+bomly-plugin.json        package manifest ("kind": "analyzer")
+testdata/                fixtures for unit tests
+.github/workflows/       CI and the release workflow
+go.mod                   pins a released github.com/bomly-dev/bomly-sdk version
 ```
 
-Keep the analysis logic in a normal library package so it is unit-testable without the plugin runtime, and keep `main.go` minimal:
+## The Module
 
 ```go
-package main
-
-import (
-    "example.com/bomly-plugin-myreach/analyzer"
-
-    "github.com/bomly-dev/bomly-sdk"
-)
-
-func main() {
-    sdk.ServeAnalyzer(analyzer.New())
-}
-```
-
-## Minimum Shape
-
-The implementation satisfies `sdk.ServedAnalyzer`:
-
-```go
-package analyzer
+package plugin
 
 import (
     "context"
+    "fmt"
 
-    "github.com/bomly-dev/bomly-sdk"
+    sdk "github.com/bomly-dev/bomly-sdk"
 )
 
-const pluginID = "myreach-analyzer"
+// Name must equal the "id" field in bomly-plugin.json.
+const Name = "com.example.myreach-analyzer"
 
-// Config is the plugin's configuration block. Advertising it through
-// ConfigSchema lets `bomly plugins info` document it.
+// Config is the analyzer's typed configuration block.
 type Config struct {
-    MaxDepth int `json:"max_depth" doc:"Maximum call-graph depth to explore" default:"10"`
+    MaxDepth int `json:"maxDepth" doc:"Maximum call-graph depth to explore" default:"10"`
 }
 
-type Analyzer struct{}
+// Analyzer annotates vulnerabilities with reachability. sdk.BaseAnalyzer
+// supplies default Ready/Applicable implementations. Override Ready when the
+// analysis needs a toolchain that can be missing.
+type Analyzer struct {
+    sdk.BaseAnalyzer
+    config Config
+}
 
-func New() *Analyzer { return &Analyzer{} }
-
-func (a *Analyzer) Descriptor(context.Context) (*sdk.AnalyzerDescriptor, error) {
-    return &sdk.AnalyzerDescriptor{
-        Name:        pluginID,
+func descriptor() sdk.AnalyzerDescriptor {
+    return sdk.AnalyzerDescriptor{
+        Name:        Name,
         DisplayName: "MyReach Analyzer",
         // SupportedLanguages is the analyzer's primary dispatch axis: Bomly
         // only runs the analyzer when the request's language matches (an
         // empty list reads as "all languages").
         SupportedLanguages: []sdk.Language{sdk.LanguageGo},
         // SupportedTiers communicates the precision you can deliver:
-        // TierSymbol (call-path level) or TierPackage (import level).
+        // sdk.TierSymbol (call-path level) or sdk.TierPackage (import level).
         SupportedTiers: []sdk.ReachabilityTier{sdk.TierPackage},
-        // Advertise optional protocol features. CapabilityPackageUpdates
-        // enables the registry-delta response contract described below.
+        // The analyzer can return package-update deltas (see below).
         Capabilities: []string{sdk.CapabilityPackageUpdates},
         ConfigSchema: sdk.MustConfigSchemaFor(Config{}),
+    }
+}
+
+func (a *Analyzer) Descriptor() sdk.AnalyzerDescriptor { return descriptor() }
+
+// Analyze annotates registry vulnerabilities with reachability.
+func (a *Analyzer) Analyze(ctx context.Context, req sdk.AnalyzeRequest) (sdk.AnalyzeResult, error) {
+    updated := annotateReachability(ctx, req) // your analysis; returns []*sdk.Package
+    stats := map[string]sdk.ReachabilityStats{Name: {Reachable: len(updated)}}
+
+    if req.AcceptPackageUpdates {
+        // Delta path: return only the packages you touched.
+        return sdk.AnalyzeResult{
+            PackageUpdates: updated,
+            AnalyzerRuns:   []string{Name},
+            AnalyzerStats:  stats,
+        }, nil
+    }
+
+    // Baseline path (protocol v1): return the full registry.
+    registry := sdk.ApplyPackageUpdates(req.Registry, updated)
+    return sdk.AnalyzeResult{
+        Registry:      registry,
+        AnalyzerRuns:  []string{Name},
+        AnalyzerStats: stats,
     }, nil
 }
 
-func (a *Analyzer) Ready(context.Context, *sdk.AnalyzeRequest) (*sdk.ReadyResponse, error) {
-    return &sdk.ReadyResponse{Ready: true}, nil
-}
-
-func (a *Analyzer) Applicable(context.Context, *sdk.AnalyzeRequest) (*sdk.ApplicableResponse, error) {
-    return &sdk.ApplicableResponse{Applicable: true}, nil
-}
-
-func (a *Analyzer) Analyze(ctx context.Context, req *sdk.AnalyzeRequest) (*sdk.AnalyzeResponse, error) {
-    updated := annotateReachability(ctx, req) // your analysis; returns []*sdk.Package
-    stats := map[string]sdk.ReachabilityStats{pluginID: {Reachable: len(updated)}}
-
-    if req.AcceptPackageUpdates {
-        // Modern hosts merge deltas: return only the packages you touched.
-        return &sdk.AnalyzeResponse{PackageUpdates: updated, AnalyzerStats: stats}, nil
+// Module packages the analyzer for both execution modes.
+func Module() sdk.Module {
+    return sdk.Module{
+        Kind: sdk.PluginKindAnalyzer,
+        Analyzer: &sdk.AnalyzerModule{
+            Descriptor: descriptor(),
+            New: func(_ context.Context, host sdk.HostContext) (sdk.Analyzer, error) {
+                analyzer := &Analyzer{}
+                if err := host.DecodeConfig(&analyzer.config); err != nil {
+                    return nil, fmt.Errorf("decode %s config: %w", Name, err)
+                }
+                return analyzer, nil
+            },
+        },
     }
-
-    // Older hosts expect the full registry back.
-    registry := sdk.ApplyPackageUpdates(req.Registry, updated)
-    return &sdk.AnalyzeResponse{Registry: registry, AnalyzerStats: stats}, nil
 }
 ```
 
-## What Each Hook Does
+The binary entrypoint stays one line:
 
-- `Descriptor` describes the component identity, supported languages, tiers, capabilities, and configuration schema.
-- `Ready` reports whether the analyzer can run in the current environment (toolchain present, source readable). Return `Ready: false` with a `Reason` instead of an error when the environment is simply missing something.
-- `Applicable` reports whether the analyzer should run for the current request (right language, project shape).
-- `Analyze` reads `sdk.AnalyzeRequest` and returns reachability annotations.
+```go
+func main() { sdk.ServeModule(plugin.Module()) }
+```
 
-All hooks receive a context. Honor cancellation: analysis can be expensive, and a cancelled scan should stop the analyzer promptly. Check `ctx.Err()` between phases and pass the context into any subprocess or HTTP call.
+## What Each Part Does
+
+- `Descriptor` is the analyzer's static registration: name (must equal the manifest `id`), supported languages, tiers, capabilities, and config schema.
+- `New` constructs the analyzer once per execution, with a `sdk.HostContext` for the logger, HTTP client, runtime info, and configuration.
+- `Ready(ctx, req) error` reports whether the analyzer can run right now — return `nil` when ready, or an error whose message explains the reason (toolchain missing, source unreadable). `sdk.BaseAnalyzer` embeds an always-ready default.
+- `Applicable(ctx, req) (bool, error)` reports whether the analyzer should run for this request (right language, right project shape).
+- `Analyze` does the work: run the analysis and return reachability annotations.
+
+All methods receive a context. Honor cancellation: analysis can be expensive, and a cancelled scan should stop the analyzer promptly. Check `ctx.Err()` between phases and pass the context into any subprocess or HTTP call.
 
 ## Reachability Semantics
 
@@ -118,24 +131,24 @@ Analyzers annotate `Vulnerability.Reachability` on packages in the PURL-keyed re
 ```go
 pkg, ok := req.Registry.Get("pkg:golang/example.com/mod@v1.2.3")
 if !ok {
-    return nil // nothing to annotate
+    return // nothing to annotate
 }
 for i := range pkg.Vulnerabilities {
     pkg.Vulnerabilities[i].Reachability = &sdk.Reachability{
         Status:   sdk.ReachabilityReachable,
         Tier:     sdk.TierPackage,
-        Analyzer: pluginID,
+        Analyzer: Name,
     }
 }
 ```
 
-Use the four statuses honestly: `reachable` when you found evidence, `unreachable` when the analysis completed and found none (state your tier — package-tier unreachable does not mean safe), `unknown` with a `Reason` when the analysis could not complete, and leave the annotation absent when the vulnerability is outside your scope.
+Use the statuses honestly: `sdk.ReachabilityReachable` when you found evidence, `sdk.ReachabilityUnreachable` when the analysis completed and found none (state your tier — package-tier unreachable does not mean safe), `sdk.ReachabilityUnknown` with a `Reason` when the analysis could not complete, and leave the annotation absent when the vulnerability is outside your scope.
 
 **Never fail the scan.** Analyzer failures degrade: if your toolchain is missing, a file does not parse, or an internal step errors, report `unknown` with a reason (or return an error, which Bomly downgrades to a pipeline warning) — but prefer returning partial results over returning an error. The scan must complete either way.
 
 ## Registry Deltas (`package-updates-v1`)
 
-Analyzers can return results in two shapes:
+Analyzers can respond in two shapes:
 
 - **Full registry** (protocol v1 baseline): return `Registry` with every package, annotated or not. Always works.
 - **Deltas**: return `PackageUpdates` containing only the packages you touched. The host merges them into its registry by PURL. Cheaper on the wire for large projects.
@@ -144,90 +157,56 @@ The rules:
 
 1. Advertise `sdk.CapabilityPackageUpdates` (`"package-updates-v1"`) in `Descriptor.Capabilities`.
 2. Return `PackageUpdates` **only when** `req.AcceptPackageUpdates` is true — that is the host telling you it understands deltas. Older hosts never set it, and you must fall back to returning the full registry for them.
-3. When `Registry` is non-nil in the response, it wins and `PackageUpdates` is ignored, so return one or the other.
+3. When `Registry` is non-nil in the result, it wins and `PackageUpdates` is ignored — return one or the other.
 
 `sdk.ApplyPackageUpdates` implements the same merge the host uses, which makes the legacy fallback a one-liner (see the `Analyze` example above) and is handy in tests.
 
-## Configuration
+## Configuration, HTTP, And Cache
 
-Per-analyzer config lives under the kind-scoped `plugins.analyzers.<name>` block:
+Declare a typed `Config` struct with `json`, `doc:`, and `default:` tags, advertise it with `ConfigSchema: sdk.MustConfigSchemaFor(Config{})`, and decode it in `New` with `host.DecodeConfig(&cfg)`. Users set the block under `plugins.analyzers.<name>`:
 
 ```yaml
 plugins:
   analyzers:
-    myreach-analyzer:
-      max_depth: 10
+    com.example.myreach-analyzer:
+      maxDepth: 10
 ```
 
-(The deprecated flat `plugins.<name>` form still works but emits a deprecation warning.)
+The same block reaches the component in both execution modes. See [Configuration in the plugin guide](../PLUGINS.md#configuration-and-proxy-support) for details and the deprecated flat form.
 
-Read it with:
+If the analyzer calls an external service, use `HostContext.HTTPClient()` so proxy settings work consistently, and document every endpoint in the README. If the analysis is deterministic for a fixed input (lockfile hash, toolchain version), add caching inside the plugin; cache failures are non-fatal — log a warning and continue.
+
+## Test It
+
+Unit-test the analysis logic and both response shapes, and run the SDK conformance suite (it exercises the package-updates contract for modules that advertise the capability):
 
 ```go
-var cfg Config
-if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
-    return nil, err
+func TestConformance(t *testing.T) {
+    conformance.Test(t, conformance.Config{
+        Module:       Module(),
+        ManifestPath: filepath.Join("..", "bomly-plugin.json"),
+        SampleConfig: json.RawMessage(`{"maxDepth":5}`),
+    })
 }
 ```
 
-Declare the same struct in `Descriptor.ConfigSchema` via `sdk.ConfigSchemaFor` (or `MustConfigSchemaFor`) so `bomly plugins info <name>` can render the configuration keys, docs, and defaults.
-
-If the analyzer calls an external service, use Bomly's SDK HTTP provider so proxy settings work consistently:
-
-```go
-provider, err := sdk.NewHTTPClientProviderFromEnv()
-if err != nil {
-    return nil, err
-}
-client := provider.Client(20 * time.Second)
-```
-
-If the analysis is deterministic for a fixed input (lockfile hash, toolchain version), add caching inside the plugin. Cache failures should be non-fatal: log a warning and continue without cached data.
-
-## Package And Install
-
-For development, build and install the binary directly:
+Local development loop:
 
 ```bash
 go build -o ./bin/bomly-plugin-myreach ./cmd/bomly-plugin-myreach
 bomly plugins install ./bin/bomly-plugin-myreach --dev
-bomly plugins enable myreach-analyzer
+bomly plugins enable com.example.myreach-analyzer
+bomly scan --path ./my-project --enrich --analyze --analyzers +com.example.myreach-analyzer --json
+bomly plugins verify com.example.myreach-analyzer
+bomly plugins test com.example.myreach-analyzer
+bomly plugins doctor com.example.myreach-analyzer
 ```
 
-For distribution, package a package-only `bomly-plugin.json` manifest (with `"kind": "analyzer"`) alongside per-platform binaries:
+`--analyzers +<name>` adds the analyzer to the default set; `--analyzers <name>` runs only it. The scan JSON records the analyzer under `metadata.analyzer_runs`, and annotated vulnerabilities carry your `reachability` block. See [Testing a plugin](../PLUGINS.md#test-a-plugin) for the shared workflow, including `conformance.ProbeBinary`.
 
-```text
-bomly-plugin.json
-bin/
-  bomly-plugin-myreach
-README.md
-```
+## Package And Release
 
-Publish one archive per platform (for example `bomly-plugin-myreach_linux_amd64.tar.gz`) plus a `SHA256SUMS` file so `github:owner/repo@tag` installs verify checksums automatically. The manifest contains package and install fields only. Bomly probes the binary at install time, verifies `descriptor.name == manifest.id`, and writes its own internal descriptor snapshot for plugin list, selectors, verification, and runtime registration.
-
-## Test It
-
-Check installation and runtime readiness:
-
-```bash
-bomly plugins verify myreach-analyzer
-bomly plugins test myreach-analyzer
-bomly plugins doctor myreach-analyzer
-```
-
-Run only this analyzer during a scan:
-
-```bash
-bomly scan --path ./my-project --enrich --analyze --analyzers myreach-analyzer --json
-```
-
-Or add it to the default analyzer set:
-
-```bash
-bomly scan --path ./my-project --enrich --analyze --analyzers +myreach-analyzer
-```
-
-The scan JSON records the analyzer under `metadata.analyzer_runs`, and annotated vulnerabilities carry your `reachability` block.
+Follow the template's release workflow: one archive per platform named `<name>_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows) containing the binary, `bomly-plugin.json`, `README.md`, and `LICENSE`, plus a `SHA256SUMS` file. The manifest's `entrypoint` map names the binary per platform, and `descriptor.Name` must equal the manifest `id`. See [Package and release](../PLUGINS.md#package-and-release-a-plugin).
 
 ## Implementation Checklist
 
@@ -236,9 +215,7 @@ The scan JSON records the analyzer under `metadata.analyzer_runs`, and annotated
 - Advertise `SupportedLanguages`, `SupportedTiers`, and `Capabilities` accurately.
 - Return `PackageUpdates` only when `req.AcceptPackageUpdates` is true; otherwise return the full registry.
 - Honor context cancellation in long-running analysis.
-- Document configuration through `ConfigSchema` and read it with `DecodePluginConfigFromEnv`.
-- Be explicit in your README about any network calls the analyzer makes; keep them behind configuration where possible.
-- Honor proxy settings through `sdk.NewHTTPClientProviderFromEnv`.
-- Wrap errors with useful context and avoid panics.
+- Make network calls through `HostContext.HTTPClient()` and document every endpoint.
+- Wrap errors with useful context; avoid panics.
 - Do not log secrets, tokens, or credentials.
-- Add unit tests for the analysis logic and the delta/full-registry response paths.
+- Add unit tests for the analysis logic and both response shapes, plus `conformance.Test`.

--- a/docs/plugins/how-to-implement-auditor.md
+++ b/docs/plugins/how-to-implement-auditor.md
@@ -2,75 +2,114 @@
 
 An auditor plugin evaluates the dependency graph and package registry after detection and optional enrichment. Use an auditor when you want to produce findings, risk scores, or policy-style decisions from data Bomly already has.
 
-External auditor plugins are served with `sdk.ServeAuditor`.
+An auditor is one `sdk.Module` with `Kind: sdk.PluginKindAuditor`. The same module can be compiled into a host build (embedded) or served as a managed plugin binary with `sdk.ServeModule` — you write the component once. [Plugin basics](../PLUGINS.md#write-a-plugin) covers the module model, repository contract, configuration, testing, and release flow shared by every role; this guide covers what is specific to auditors.
 
-The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents the `sdk.ServeAuditor` entrypoint, `sdk.ServedAuditor` interface, `sdk.AuditRequest`, `sdk.AuditResult`, reference-style findings, and risk-score types used below.
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents `sdk.Module`, `sdk.AuditorModule`, the `sdk.Auditor` interface, `sdk.AuditRequest`, `sdk.AuditResult`, reference-style findings, and the risk-score types used below.
 
-## Minimum Shape
+## Start From The Template
 
-Create a Go `main` package that imports the Bomly SDK:
+Start from the [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository ("Use this template" on GitHub). It ships a working matcher; turning it into an auditor means changing the module kind, the descriptor, and the role method — the layout, manifest, tests, and release workflow stay the same:
+
+```text
+plugin/                  importable package: descriptor, Config, Auditor, Module()
+cmd/<binary-name>/
+  main.go                one line: sdk.ServeModule(plugin.Module())
+bomly-plugin.json        package manifest ("kind": "auditor")
+testdata/                fixtures for unit tests
+.github/workflows/       CI and the release workflow
+go.mod                   pins a released github.com/bomly-dev/bomly-sdk version
+```
+
+## The Module
 
 ```go
-package main
+package plugin
 
 import (
     "context"
+    "fmt"
 
-    "github.com/bomly-dev/bomly-sdk"
+    sdk "github.com/bomly-dev/bomly-sdk"
 )
 
-const pluginID = "bomly.examples.auditor.meme-deps"
+// Name must equal the "id" field in bomly-plugin.json.
+const Name = "com.example.policy-auditor"
 
-type auditor struct{}
-
-
-func (a *auditor) Descriptor(context.Context) (*sdk.AuditorDescriptor, error) {
-    return &sdk.AuditorDescriptor{
-        Name:        pluginID,
-        DisplayName: "Meme Dependency Auditor",
-        Aliases:     []string{"meme-deps"},
-        Tags:        []string{"policy", "meme"},
-    }, nil
+// Config is the auditor's typed configuration block.
+type Config struct {
+    DeniedPackages []string `json:"deniedPackages" doc:"Package names that always fail policy"`
 }
 
-func (a *auditor) Ready(context.Context, *sdk.AuditRequest) (*sdk.ReadyResponse, error) {
-    return &sdk.ReadyResponse{Ready: true}, nil
+// Auditor evaluates scan data and emits findings. sdk.BaseAuditor supplies
+// default Ready/Applicable implementations (always ready, always applicable).
+type Auditor struct {
+    sdk.BaseAuditor
+    config Config
 }
 
-func (a *auditor) Applicable(context.Context, *sdk.AuditRequest) (*sdk.ApplicableResponse, error) {
-    return &sdk.ApplicableResponse{Applicable: true}, nil
-}
-
-func (a *auditor) Audit(ctx context.Context, req *sdk.AuditRequest) (*sdk.AuditResponse, error) {
-    finding := sdk.Finding{
-        ID:          "security-team-policy-example",
-        Kind:        sdk.FindingKindPackage,
-        PackageRef:  "pkg:npm/lodash@4.17.21",
-        PolicyStatus: sdk.FindingPolicyStatusWarn,
-        Title:       "Dependency has unusually high meme density",
-        Source:      pluginID,
+func descriptor() sdk.AuditorDescriptor {
+    return sdk.AuditorDescriptor{
+        Name:         Name,
+        DisplayName:  "Example Policy Auditor",
+        Aliases:      []string{"example-policy"},
+        Tags:         []string{"policy"},
+        ConfigSchema: sdk.MustConfigSchemaFor(Config{}),
     }
+}
 
-    return &sdk.AuditResponse{
+func (a *Auditor) Descriptor() sdk.AuditorDescriptor { return descriptor() }
+
+// Audit reads the graph and registry and returns findings and run metadata.
+func (a *Auditor) Audit(ctx context.Context, req sdk.AuditRequest) (sdk.AuditResult, error) {
+    finding := sdk.Finding{
+        ID:           "example-policy:pkg:npm/lodash@4.17.21",
+        RuleID:       "example-policy/denied-package",
+        Kind:         sdk.FindingKindPackage,
+        PackageRef:   "pkg:npm/lodash@4.17.21",
+        PolicyStatus: sdk.FindingPolicyStatusWarn,
+        Title:        "Package is on the internal deny list",
+        Source:       Name,
+    }
+    return sdk.AuditResult{
         Findings:        []sdk.Finding{finding},
-        AuditorRuns:     []string{pluginID},
-        AuditorFindings: map[string]int{pluginID: 1},
+        AuditorRuns:     []string{Name},
+        AuditorFindings: map[string]int{Name: 1},
     }, nil
 }
 
-func main() {
-    sdk.ServeAuditor(&auditor{})
+// Module packages the auditor for both execution modes.
+func Module() sdk.Module {
+    return sdk.Module{
+        Kind: sdk.PluginKindAuditor,
+        Auditor: &sdk.AuditorModule{
+            Descriptor: descriptor(),
+            New: func(_ context.Context, host sdk.HostContext) (sdk.Auditor, error) {
+                auditor := &Auditor{}
+                if err := host.DecodeConfig(&auditor.config); err != nil {
+                    return nil, fmt.Errorf("decode %s config: %w", Name, err)
+                }
+                return auditor, nil
+            },
+        },
+    }
 }
 ```
 
-The working example repo is [bomly-plugin-meme-auditor](https://github.com/bomly-dev/bomly-plugin-meme-auditor). It shows a small auditor that reads graph nodes and emits reference-style package findings.
+The binary entrypoint stays one line:
 
-## What Each Hook Does
+```go
+func main() { sdk.ServeModule(plugin.Module()) }
+```
 
-- `Descriptor` describes the component identity, display name, aliases, tags, and support.
-- `Ready` reports whether the plugin can run in the current environment.
-- `Applicable` reports whether the auditor should run for the current request.
-- `Audit` reads `sdk.AuditRequest` and returns findings, risk scores, and run metadata.
+## What Each Part Does
+
+- `Descriptor` is the auditor's static registration: name (must equal the manifest `id`), display name, aliases, tags, support, and config schema.
+- `New` constructs the auditor once per execution, with a `sdk.HostContext` for the logger, HTTP client, runtime info, and configuration.
+- `Ready(ctx, req) error` reports whether the auditor can run right now — return `nil` when ready, or an error explaining the reason (for example, a missing policy file). `sdk.BaseAuditor` embeds an always-ready default.
+- `Applicable(ctx, req) (bool, error)` reports whether the auditor should run for this request.
+- `Audit` does the work: evaluate the data and return findings, risk scores, and run metadata.
+
+Auditors run during `--audit`, which evaluates existing data. Do not make network calls from an auditor unless the plugin explicitly documents that behavior. Honor the context in long evaluations.
 
 ## Read Graph And Registry Data
 
@@ -80,111 +119,86 @@ Bomly gives auditors the same core scan data used by built-in auditors:
 - `req.Registry` contains package records keyed by PURL.
 - `req.BaselineGraph` may be present for diff-style workflows.
 - `req.Target` may be present when a command focuses on one dependency.
-- `req.DependencyDetailChanges` contains the canonical head-side dependency
-  detail transitions during a diff audit. It is empty for scans, explains, and
-  the base side of a diff. This optional protocol-v1 field may be absent when
-  an older core calls the plugin.
+- `req.DependencyDetailChanges` contains the canonical head-side dependency detail transitions during a diff audit. It is empty for scans, explains, and the base side of a diff. This optional protocol-v1 field may be absent when an older core calls the plugin.
 
-Auditors should emit reference-style findings that point at registry packages by PURL:
+## The Findings Contract
+
+Auditors emit **reference-style** findings that point at registry packages by PURL — they never copy full package or vulnerability records:
 
 ```go
 finding := sdk.Finding{
-    ID:              "GHSA-example",
+    ID:              "GHSA-example@pkg:npm/lodash@4.17.21",
+    RuleID:          "example-policy/known-vulnerability",
     Kind:            sdk.FindingKindVulnerability,
     PackageRef:      "pkg:npm/lodash@4.17.21",
     VulnerabilityID: "GHSA-example",
-    PolicyStatus:     sdk.FindingPolicyStatusFail,
-    Source:          pluginID,
+    PolicyStatus:    sdk.FindingPolicyStatusFail,
+    Source:          Name,
 }
 ```
 
-Do not copy full package or vulnerability records into findings. Keep the finding focused on the decision and references.
+- `Kind` categorizes the concern: `sdk.FindingKindVulnerability`, `sdk.FindingKindLicense`, `sdk.FindingKindPackage` — plugins may introduce new kinds, and consumers treat the list as open.
+- `PackageRef` is the offending package's PURL; `VulnerabilityID` names the advisory inside that package for vulnerability findings.
+- `RuleID` is the stable rule that produced the finding. Unlike `ID`, it must not contain package versions or project-specific occurrence data — baselines and suppressions key off it.
+- `PolicyStatus` drives evaluation: `sdk.FindingPolicyStatusFail` fails the policy gate, `sdk.FindingPolicyStatusWarn` is a visible warning, and `sdk.FindingPolicyStatusSuppressed` keeps a finding visible while excluding it from failure evaluation. Bomly's baseline and policy machinery may later resolve statuses on top of what the auditor emitted.
+- Use clear, actionable titles and `Reasons`.
 
-## Configuration And HTTP
+Auditors may also return `RiskScores` — normalized per-package scores referenced by PURL — and should always fill `AuditorRuns` and `AuditorFindings` so run metadata shows up in scan output.
 
-Per-plugin config lives under the kind-scoped `plugins.auditors.<name>` block (the deprecated flat `plugins.<plugin-id>` form still works with a warning):
+## Configuration
+
+Declare a typed `Config` struct with `json`, `doc:`, and `default:` tags, advertise it with `ConfigSchema: sdk.MustConfigSchemaFor(Config{})`, and decode it in `New` with `host.DecodeConfig(&cfg)`. Users set the block under `plugins.auditors.<name>`:
 
 ```yaml
 plugins:
   auditors:
-    bomly.examples.auditor.meme-deps:
-      extra_packages:
+    com.example.policy-auditor:
+      deniedPackages:
         - totally-not-suspicious
 ```
 
-Read it with:
-
-```go
-type config struct {
-    PolicyFile string `json:"policy_file"`
-}
-
-var cfg config
-if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
-    return nil, err
-}
-```
-
-Auditors should normally evaluate data already present in `req.Graph` and `req.Registry`. If an auditor intentionally calls an external service, document that behavior and use Bomly's SDK HTTP provider so proxy settings work consistently:
-
-```go
-provider, err := sdk.NewHTTPClientProviderFromEnv()
-if err != nil {
-    return nil, err
-}
-client := provider.Client(20 * time.Second)
-_ = client
-```
-
-## Package And Install
-
-For development, build and install the binary directly:
-
-```bash
-go build -o ./bin/bomly-plugin-meme-auditor .
-bomly plugins install ./bin/bomly-plugin-meme-auditor --dev
-bomly plugins enable bomly.examples.auditor.meme-deps
-```
-
-For distribution, package a package-only `bomly-plugin.json` manifest with the binary:
-
-```text
-bomly-plugin.json
-bin/
-  bomly-plugin-meme-auditor
-README.md
-```
-
-The manifest contains package and install fields only. Bomly probes the binary at install time, verifies `descriptor.name == manifest.id`, and writes its own internal descriptor snapshot for plugin list, selectors, verification, and runtime registration.
+The same block reaches the component in both execution modes. See [Configuration in the plugin guide](../PLUGINS.md#configuration-and-proxy-support) for details and the deprecated flat form.
 
 ## Test It
 
-Check installation and runtime readiness:
+Unit-test policy evaluation and finding construction, and run the SDK conformance suite:
 
-```bash
-bomly plugins verify bomly.examples.auditor.meme-deps
-bomly plugins test bomly.examples.auditor.meme-deps
-bomly plugins doctor bomly.examples.auditor.meme-deps
+```go
+func TestConformance(t *testing.T) {
+    conformance.Test(t, conformance.Config{
+        Module:       Module(),
+        ManifestPath: filepath.Join("..", "bomly-plugin.json"),
+        SampleConfig: json.RawMessage(`{"deniedPackages":["left-pad"]}`),
+    })
+}
 ```
 
-Run only this auditor:
+Local development loop:
 
 ```bash
-bomly scan --path ./my-project --audit --auditors bomly.examples.auditor.meme-deps --json
+go build -o ./bin/bomly-plugin-policy ./cmd/bomly-plugin-policy
+bomly plugins install ./bin/bomly-plugin-policy --dev
+bomly plugins enable com.example.policy-auditor
+bomly scan --path ./my-project --audit --auditors +com.example.policy-auditor --json
+bomly plugins verify com.example.policy-auditor
+bomly plugins test com.example.policy-auditor
+bomly plugins doctor com.example.policy-auditor
 ```
 
-Or add it to the default auditor set:
+`--auditors +<name>` adds the auditor to the default set; `--auditors <name>` runs only it. See [Testing a plugin](../PLUGINS.md#test-a-plugin) for the shared workflow, including `conformance.ProbeBinary`.
 
-```bash
-bomly scan --path ./my-project --audit --auditors +bomly.examples.auditor.meme-deps
-```
+## Package And Release
+
+Follow the template's release workflow: one archive per platform named `<name>_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows) containing the binary, `bomly-plugin.json`, `README.md`, and `LICENSE`, plus a `SHA256SUMS` file. The manifest's `entrypoint` map names the binary per platform, and `descriptor.Name` must equal the manifest `id`. See [Package and release](../PLUGINS.md#package-and-release-a-plugin).
 
 ## Implementation Checklist
 
-- Read `req.Graph` and `req.Registry`; emit reference-style findings.
-- Return `AuditorRuns` with the auditor ID.
-- Use actionable finding summaries and clear policy statuses.
+- Read `req.Graph` and `req.Registry`; emit reference-style findings — never inline package or vulnerability payloads.
+- Give every finding a stable `RuleID` free of versions and occurrence data.
+- Use actionable titles and clear policy statuses.
+- Return `AuditorRuns` and `AuditorFindings` with the auditor name.
 - Avoid external network calls unless the plugin explicitly documents them.
-- Wrap errors with useful context and avoid panics.
+- Honor context cancellation in long evaluations.
+- Wrap errors with useful context; avoid panics.
 - Do not log secrets, tokens, or credentials.
-- Add unit tests for policy evaluation and finding construction.
+- Add unit tests for policy evaluation and finding construction, plus `conformance.Test`.

--- a/docs/plugins/how-to-implement-detector.md
+++ b/docs/plugins/how-to-implement-detector.md
@@ -2,52 +2,79 @@
 
 A detector plugin turns project evidence into a Bomly dependency graph. Use a detector when Bomly needs a new way to read dependency data, such as a new package manager, a specialized manifest format, or an internal dependency source.
 
-External detector plugins are served with `sdk.ServeDetector`.
+A detector is one `sdk.Module` with `Kind: sdk.PluginKindDetector`. The same module can be compiled into a host build (embedded) or served as a managed plugin binary with `sdk.ServeModule` — you write the component once. [Plugin basics](../PLUGINS.md#write-a-plugin) covers the module model, repository contract, configuration, testing, and release flow shared by every role; this guide covers what is specific to detectors.
 
-The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents the `sdk.ServeDetector` entrypoint, `sdk.ServedDetector` interface, `sdk.DetectionRequest`, `sdk.DetectionResult`, graph helpers, coordinates, and package-manager support types used below.
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents `sdk.Module`, `sdk.DetectorModule`, the `sdk.Detector` interface, `sdk.DetectionRequest`, `sdk.DetectionResult`, graph helpers, and the package-manager support types used below.
 
-## Minimum Shape
+## Start From The Template
 
-Create a Go `main` package that imports the Bomly SDK:
+Start from the [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository ("Use this template" on GitHub). It ships a working matcher; turning it into a detector means changing the module kind, the descriptor, and the role method — the layout, manifest, tests, and release workflow stay the same:
+
+```text
+plugin/                  importable package: descriptor, Config, Detector, Module()
+cmd/<binary-name>/
+  main.go                one line: sdk.ServeModule(plugin.Module())
+bomly-plugin.json        package manifest ("kind": "detector")
+testdata/                fixtures for unit tests
+.github/workflows/       CI and the release workflow
+go.mod                   pins a released github.com/bomly-dev/bomly-sdk version
+```
+
+## The Module
+
+The component lives in an importable `plugin/` package that exports `Module()`:
 
 ```go
-package main
+package plugin
 
 import (
     "context"
+    "fmt"
 
-    "github.com/bomly-dev/bomly-sdk"
+    sdk "github.com/bomly-dev/bomly-sdk"
 )
 
-const pluginID = "bomly.examples.detector.bun-lock"
+// Name must equal the "id" field in bomly-plugin.json.
+const Name = "com.example.bun-lock-detector"
 
-type detector struct{}
+// Config is the detector's typed configuration block.
+type Config struct {
+    IncludeDev bool `json:"includeDev" doc:"Include devDependencies in the graph" default:"false"`
+}
 
+// Detector reads bun.lock evidence and returns a dependency graph.
+// sdk.BaseDetector supplies default Ready/Applicable implementations
+// (always ready, always applicable).
+type Detector struct {
+    sdk.BaseDetector
+    config Config
+}
 
-func (d *detector) Descriptor(context.Context) (*sdk.DetectorDescriptor, error) {
-    return &sdk.DetectorDescriptor{
-        Name:        pluginID,
+func descriptor() sdk.DetectorDescriptor {
+    return sdk.DetectorDescriptor{
+        Name:        Name,
         DisplayName: "Bun Lock Detector",
         Aliases:     []string{"bun-lock"},
         Tags:        []string{"dependency-detection", "bun"},
-    }, nil
+        // Directories recursive discovery must never descend into for this
+        // ecosystem (see "Discovery metadata" below).
+        IgnoredDirectories: []string{"node_modules"},
+        ConfigSchema:       sdk.MustConfigSchemaFor(Config{}),
+    }
 }
 
-func (d *detector) PackageManagerSupport(context.Context) ([]sdk.PackageManagerSupport, error) {
+func support() []sdk.PackageManagerSupport {
     return []sdk.PackageManagerSupport{
         sdk.Support(sdk.PackageManagerOther, "bun.lock", "bun.lockb", "package.json"),
-    }, nil
+    }
 }
 
-func (d *detector) Ready(context.Context, *sdk.DetectRequest) (*sdk.ReadyResponse, error) {
-    return &sdk.ReadyResponse{Ready: true}, nil
-}
+func (d *Detector) Descriptor() sdk.DetectorDescriptor { return descriptor() }
 
-func (d *detector) Applicable(context.Context, *sdk.DetectRequest) (*sdk.ApplicableResponse, error) {
-    return &sdk.ApplicableResponse{Applicable: true}, nil
-}
+func (d *Detector) PackageManagerSupport() []sdk.PackageManagerSupport { return support() }
 
-func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.DetectResponse, error) {
+// ResolveGraph reads the request and returns one or more manifest-scoped graphs.
+func (d *Detector) ResolveGraph(ctx context.Context, req sdk.DetectionRequest) (sdk.DetectionResult, error) {
     graph := sdk.New()
     dep := sdk.NewDependency(sdk.Dependency{
         Coordinates: sdk.Coordinates{
@@ -56,75 +83,84 @@ func (d *detector) Detect(ctx context.Context, req *sdk.DetectRequest) (*sdk.Det
             Version:   "3.0.1",
             PURL:      "pkg:npm/is-odd@3.0.1",
         },
-        FoundBy: pluginID,
+        FoundBy: Name,
     })
     if err := graph.AddNode(dep); err != nil {
-        return nil, err
+        return sdk.DetectionResult{}, fmt.Errorf("add node: %w", err)
     }
-    return &sdk.DetectResponse{
+    return sdk.DetectionResult{
         SubprojectInfo:      req.Subproject,
         RootExecutionTarget: req.ExecutionTarget,
-        Graphs: &sdk.GraphContainer{
-            Entries: []sdk.GraphEntry{{
-                Manifest: sdk.ManifestMetadata{Path: "package.json", Kind: sdk.ManifestKind("package.json")},
-                Graph:    graph,
-            }},
-        },
+        Graphs: sdk.SingleGraphContainer(graph, sdk.ManifestMetadata{
+            Path: "bun.lock",
+        }),
     }, nil
 }
 
-func main() {
-    sdk.ServeDetector(&detector{})
+// Module packages the detector for both execution modes.
+func Module() sdk.Module {
+    return sdk.Module{
+        Kind: sdk.PluginKindDetector,
+        Detector: &sdk.DetectorModule{
+            Descriptor: descriptor(),
+            Support:    support(),
+            New: func(_ context.Context, host sdk.HostContext) (sdk.Detector, error) {
+                detector := &Detector{}
+                if err := host.DecodeConfig(&detector.config); err != nil {
+                    return nil, fmt.Errorf("decode %s config: %w", Name, err)
+                }
+                return detector, nil
+            },
+        },
+    }
 }
 ```
 
-The working example repo is [bomly-plugin-bun-lock-detector](https://github.com/bomly-dev/bomly-plugin-bun-lock-detector). It demonstrates `sdk.PackageManagerOther` for a package manager Bomly does not model directly yet.
-
-## What Each Hook Does
-
-- `Descriptor` describes the component identity, display name, aliases, tags, support, and detector behavior.
-- `PackageManagerSupport` tells Bomly which package managers and evidence patterns can plan this detector.
-- `Ready` reports whether the plugin can run in the current environment.
-- `Applicable` reports whether the plugin should run for the current request.
-- `Detect` reads the request and returns a `sdk.DetectResponse` containing one or more manifest-scoped graphs.
-
-Detector plugins may also implement:
+The binary entrypoint stays one line:
 
 ```go
-func (d *detector) Install(context.Context, *sdk.DetectRequest) (*sdk.InstallResponse, error)
+package main
+
+import (
+    sdk "github.com/bomly-dev/bomly-sdk"
+
+    "example.com/bomly-plugin-bun-lock/plugin"
+)
+
+func main() { sdk.ServeModule(plugin.Module()) }
 ```
 
-Use `Install` only for install-first detectors that prepare dependencies before graph resolution. Do not install package managers themselves; Bomly assumes required package managers already exist.
+## What Each Part Does
 
-### Add optional remediation hints
+- `Descriptor` is the detector's static registration: name (must equal the manifest `id`), display name, aliases, tags, supported ecosystems and managers, discovery metadata, and config schema.
+- `Support` (or the `PackageManagerSupport` method) tells Bomly which package managers and evidence files can plan this detector — declared on the module so Bomly can plan without constructing the component.
+- `New` constructs the detector once per execution, with a `sdk.HostContext` for the logger, HTTP client, runtime info, and configuration.
+- `Ready(ctx, req) error` reports whether the detector can run right now. Return `nil` when ready; return an error whose message explains the reason (for example `fmt.Errorf("bun executable not found on PATH")`) when it cannot. `sdk.BaseDetector` embeds an always-ready default.
+- `Applicable(ctx, req) (bool, error)` reports whether the detector should run for this request (right project shape, right evidence present).
+- `ResolveGraph` does the work: read evidence, build graphs, return them.
 
-If the detector knows package-manager strategies, advertise them in its
-descriptor:
+Honor the context in every method: probing, parsing, and subprocess work should stop promptly when the scan is cancelled.
 
-```go
-RemediationCapabilities: []sdk.RemediationCapability{{
-    SupportedManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
-    Actions: []sdk.RemediationAction{
-        sdk.RemediationActionDirectBump,
-        sdk.RemediationActionTransitiveOverride,
-    },
-}},
-```
+## Detector Chains And Hand-Off
 
-Then optionally implement:
+Bomly plans detector chains per package manager and runs them first-success: when the planned primary detector reports not ready or not applicable, or fails, the next detector in the chain gets the request. Syft is typically the last fallback for ecosystems it covers.
 
-```go
-func (d *detector) RemediationHints(
-    ctx context.Context,
-    req *sdk.RemediationHintRequest,
-) (*sdk.RemediationHintResponse, error)
-```
+Hand off gracefully instead of failing hard:
 
-Return hints only for dependency IDs and manifest paths produced by that
-detector. Hints may list supported strategies and plain-language
-package-manager advice. They must not choose a fix version, edit files, run
-commands, or make network calls. Bomly validates the hints and chooses the
-final action. If the capability is absent, Bomly does not call this method.
+- Report a missing toolchain through `Ready` with a clear reason, not through a `ResolveGraph` error. The reason appears in scan output when a fallback is used (`FallbackReason` on the result the fallback produces).
+- Report "this project is not for me" through `Applicable`, not through an empty graph.
+- Reserve `ResolveGraph` errors for real failures on projects the detector should have handled.
+
+## Discovery Metadata
+
+Detector plugins participate in subproject discovery and scan planning through descriptor fields, aggregated across every registered detector exactly like the built-ins:
+
+- `PackageManagerSupport.EvidencePatterns` — file names (such as `bun.lock`) whose presence plans this detector for a directory.
+- `DetectorDescriptor.IgnoredDirectories` — directory basename globs recursive discovery (`--recursive`) must not descend into (a Node detector declares `node_modules`, a Maven detector declares `target`).
+- `DetectorDescriptor.IgnoredDirectoryMarkers` — file names that mark a directory as ignored regardless of its name (`pyvenv.cfg` marks a Python virtualenv).
+- `sdk.Support(...).WithMultiModule()` — declares that the detector natively expands nested workspace or reactor modules from a root manifest, so recursive discovery does not scan the same modules twice.
+
+All of these are optional; older plugins that omit them keep working.
 
 ## Build The Graph
 
@@ -140,67 +176,95 @@ child := sdk.NewDependency(sdk.Dependency{
 
 graph := sdk.New()
 if err := graph.AddNode(parent); err != nil {
-    return nil, err
+    return sdk.DetectionResult{}, err
 }
 if err := graph.AddNode(child); err != nil {
-    return nil, err
+    return sdk.DetectionResult{}, err
 }
 if err := graph.AddEdge(parent.ID, child.ID); err != nil {
-    return nil, err
+    return sdk.DetectionResult{}, err
 }
 ```
 
-Return `req.Subproject` and `req.ExecutionTarget` in the response so Bomly can keep the result tied to the planned scan target.
+Prefer canonical PURLs and fill `Coordinates` where possible — matchers enrich packages by PURL, and findings reference them the same way. Return `req.Subproject` and `req.ExecutionTarget` in the result so Bomly keeps it tied to the planned scan target. Use `DetectionResult.Warnings` for non-fatal problems worth surfacing (the graph is usable, but something about the project will degrade an install elsewhere).
 
-## Package And Install
+## Optional Capabilities
 
-For development, build and install the binary directly:
+**Install-first.** A detector that must prepare dependencies before reading them (for example, running a resolving install) implements `sdk.InstallFirstDetector` (`Install(ctx, req) error`) and sets `SupportsInstallFirst` in its descriptor. Do not install package managers themselves; Bomly assumes required package managers already exist.
 
-```bash
-go build -o ./bin/bomly-plugin-bun-lock-detector .
-bomly plugins install ./bin/bomly-plugin-bun-lock-detector --dev
-bomly plugins enable bomly.examples.detector.bun-lock
+**Remediation hints.** A detector that understands package-manager fix strategies can advertise them and contribute read-only evidence after vulnerability enrichment:
+
+```go
+// In the descriptor:
+RemediationCapabilities: []sdk.RemediationCapability{{
+    SupportedManagers: []sdk.PackageManager{sdk.PackageManagerNPM},
+    Actions: []sdk.RemediationAction{
+        sdk.RemediationActionDirectBump,
+        sdk.RemediationActionTransitiveOverride,
+    },
+}},
 ```
 
-For distribution, package a package-only `bomly-plugin.json` manifest with the binary:
+Then implement `sdk.DetectorRemediationProvider` on the detector:
 
-```text
-bomly-plugin.json
-bin/
-  bomly-plugin-bun-lock-detector
-README.md
+```go
+func (d *Detector) RemediationHints(ctx context.Context, req sdk.RemediationHintRequest) (sdk.RemediationHintResponse, error)
 ```
 
-The manifest contains package and install fields only: ID, kind, version, runtime, API version, Bomly version constraint, entrypoint, source, homepage, description, and license. Bomly probes the binary at install time, verifies `descriptor.name == manifest.id`, and writes its own internal descriptor snapshot for plugin list, selectors, verification, and runtime registration.
+Return hints only for dependency IDs and manifest paths this detector produced. Hints may name supported strategies and give plain-language package-manager advice. They must not choose a fix version, edit files, run commands, or make network calls — Bomly validates every hint and the central remediation component chooses the final action. Detectors without the capability are simply never asked.
+
+## Configuration
+
+Declare a typed `Config` struct with `json`, `doc:`, and `default:` tags, advertise it with `ConfigSchema: sdk.MustConfigSchemaFor(Config{})`, and decode it in `New` with `host.DecodeConfig(&cfg)`. Users set the block under `plugins.detectors.<name>`:
+
+```yaml
+plugins:
+  detectors:
+    com.example.bun-lock-detector:
+      includeDev: true
+```
+
+The same block reaches the component in both execution modes. See [Configuration in the plugin guide](../PLUGINS.md#configuration-and-proxy-support) for details and the deprecated flat form.
 
 ## Test It
 
-Check installation and runtime readiness:
+Unit-test parsing and graph construction against `testdata/` fixtures, and run the SDK conformance suite:
 
-```bash
-bomly plugins verify bomly.examples.detector.bun-lock
-bomly plugins test bomly.examples.detector.bun-lock
-bomly plugins doctor bomly.examples.detector.bun-lock
+```go
+func TestConformance(t *testing.T) {
+    conformance.Test(t, conformance.Config{
+        Module:       Module(),
+        ManifestPath: filepath.Join("..", "bomly-plugin.json"),
+    })
+}
 ```
 
-Run only this detector:
+Local development loop:
 
 ```bash
-bomly scan --path ./my-project --detectors bomly.examples.detector.bun-lock --json
+go build -o ./bin/bomly-plugin-bun-lock ./cmd/bomly-plugin-bun-lock
+bomly plugins install ./bin/bomly-plugin-bun-lock --dev
+bomly plugins enable com.example.bun-lock-detector
+bomly scan --path ./my-project --detectors com.example.bun-lock-detector --json
+bomly plugins verify com.example.bun-lock-detector
+bomly plugins test com.example.bun-lock-detector
+bomly plugins doctor com.example.bun-lock-detector
 ```
 
-Or add it to the default detector set:
+Use `--detectors +<name>` to add the detector to the default set instead of replacing it. See [Testing a plugin](../PLUGINS.md#test-a-plugin) for the shared workflow, including `conformance.ProbeBinary` for probing the built binary over the real managed transport.
 
-```bash
-bomly scan --path ./my-project --detectors +bomly.examples.detector.bun-lock
-```
+## Package And Release
+
+Follow the template's release workflow: one archive per platform named `<name>_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows) containing the binary, `bomly-plugin.json`, `README.md`, and `LICENSE`, plus a `SHA256SUMS` file. The manifest's `entrypoint` map names the binary per platform, and `descriptor.Name` must equal the manifest `id`. See [Package and release](../PLUGINS.md#package-and-release-a-plugin).
 
 ## Implementation Checklist
 
-- Declare accurate package-manager support and evidence patterns.
-- Wrap errors with useful context.
-- Avoid panics in normal flow.
-- Do not log secrets, tokens, or credentials.
-- Keep network calls explicit and explain them in the plugin README.
+- Declare accurate package-manager support, evidence patterns, and discovery metadata.
+- Report missing toolchains through `Ready` with a clear reason; hand off to the chain instead of failing.
+- Honor context cancellation in probing, parsing, and subprocesses.
+- Prefer canonical PURLs and filled `Coordinates`.
 - Keep remediation hints read-only and within the advertised capabilities.
-- Add local unit tests for parsing and graph construction.
+- Wrap errors with useful context; avoid panics.
+- Do not log secrets, tokens, or credentials.
+- Keep network calls explicit and document them in the plugin README.
+- Add unit tests for parsing and graph construction, plus `conformance.Test`.

--- a/docs/plugins/how-to-implement-matcher.md
+++ b/docs/plugins/how-to-implement-matcher.md
@@ -2,100 +2,141 @@
 
 A matcher plugin enriches packages after detection. Use a matcher when you want to add vulnerability data, license data, lifecycle information, health signals, or other package metadata to Bomly's package registry.
 
-External matcher plugins are served with `sdk.ServeMatcher`.
+A matcher is one `sdk.Module` with `Kind: sdk.PluginKindMatcher`. The same module can be compiled into a host build (embedded) or served as a managed plugin binary with `sdk.ServeModule` — you write the component once. [Plugin basics](../PLUGINS.md#write-a-plugin) covers the module model, repository contract, configuration, testing, and release flow shared by every role; this guide covers what is specific to matchers.
 
-The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents the `sdk.ServeMatcher` entrypoint, `sdk.ServedMatcher` interface, `sdk.MatchRequest`, `sdk.MatchResult`, PURL-keyed package registry, and enrichment types used below.
+The [Bomly SDK API reference](https://pkg.go.dev/github.com/bomly-dev/bomly-sdk) documents `sdk.Module`, `sdk.MatcherModule`, the `sdk.Matcher` interface, `sdk.MatchRequest`, `sdk.MatchResult`, the PURL-keyed package registry, and the enrichment types used below.
 
-## Minimum Shape
+## Start From The Template
 
-Create a Go `main` package that imports the Bomly SDK:
+The [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository *is* a matcher — a complete, working one that annotates every package with a configurable greeting. Click "Use this template" on GitHub, work through its rename checklist, and replace the `Match` logic. The layout:
+
+```text
+plugin/                  importable package: descriptor, Config, Matcher, Module()
+cmd/<binary-name>/
+  main.go                one line: sdk.ServeModule(plugin.Module())
+bomly-plugin.json        package manifest ("kind": "matcher")
+testdata/                fixture registry for unit tests
+.github/workflows/       CI and the release workflow
+go.mod                   pins a released github.com/bomly-dev/bomly-sdk version
+```
+
+## The Module
+
+This is the template's matcher, trimmed to the essentials:
 
 ```go
-package main
+package plugin
 
 import (
     "context"
+    "fmt"
 
-    "github.com/bomly-dev/bomly-sdk"
+    sdk "github.com/bomly-dev/bomly-sdk"
 )
 
-const pluginID = "clearlydefined-license-matcher"
+// Name must equal the "id" field in bomly-plugin.json.
+const Name = "com.example.license-matcher"
 
-type matcher struct{}
-
-
-func (m *matcher) Descriptor(context.Context) (*sdk.MatcherDescriptor, error) {
-    return &sdk.MatcherDescriptor{
-        Name:        pluginID,
-        DisplayName: "ClearlyDefined License Matcher",
-        Aliases:     []string{"clearlydefined", "licenses"},
-        Tags:        []string{"license-enrichment", "http", "cache"},
-        // Declare the ecosystems your matcher can actually enrich. Leave this
-        // empty only when the matcher works for every ecosystem — an empty
-        // list reads as "all". `bomly plugins list` and the generated docs
-        // show whatever you put here.
-        SupportedEcosystems: []sdk.Ecosystem{
-            sdk.EcosystemNPM,
-            sdk.EcosystemMaven,
-            sdk.EcosystemGo,
-        },
-    }, nil
+// Config is the matcher's typed configuration block.
+type Config struct {
+    APIBase string `json:"apiBase" doc:"Service endpoint override" default:"https://api.example.com"`
 }
 
-func (m *matcher) Ready(context.Context, *sdk.MatchRequest) (*sdk.ReadyResponse, error) {
-    return &sdk.ReadyResponse{Ready: true}, nil
+// Matcher enriches registry packages. sdk.BaseMatcher supplies default
+// Ready/Applicable implementations (always ready, always applicable).
+type Matcher struct {
+    sdk.BaseMatcher
+    config Config
+    host   sdk.HostContext
 }
 
-func (m *matcher) Applicable(context.Context, *sdk.MatchRequest) (*sdk.ApplicableResponse, error) {
-    return &sdk.ApplicableResponse{Applicable: true}, nil
+func descriptor() sdk.MatcherDescriptor {
+    return sdk.MatcherDescriptor{
+        Name:        Name,
+        DisplayName: "Example License Matcher",
+        Aliases:     []string{"example-licenses"},
+        Tags:        []string{"license-enrichment", "http"},
+        // Declare the ecosystems the matcher can actually enrich. An empty
+        // list reads as "all ecosystems".
+        SupportedEcosystems: []sdk.Ecosystem{sdk.EcosystemNPM, sdk.EcosystemGo},
+        // The matcher can return package-update deltas (see below).
+        Capabilities: []string{sdk.CapabilityPackageUpdates},
+        ConfigSchema: sdk.MustConfigSchemaFor(Config{}),
+    }
 }
 
-func (m *matcher) Match(ctx context.Context, req *sdk.MatchRequest) (*sdk.MatchResponse, error) {
-    registry := req.Registry
-    if registry == nil {
-        registry = sdk.NewPackageRegistry()
+func (m *Matcher) Descriptor() sdk.MatcherDescriptor { return descriptor() }
+
+// Match runs once per scan with the full package registry.
+func (m *Matcher) Match(ctx context.Context, req sdk.MatchRequest) (sdk.MatchResult, error) {
+    stats := sdk.MatcherStats{Name: Name, DisplayName: "Example License Matcher"}
+    if req.Registry == nil {
+        return sdk.MatchResult{MatcherStats: stats}, nil
     }
 
-    pkg := registry.Ensure("pkg:npm/lodash@4.17.21")
-    pkg.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
-    pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
-        ID:     "GHSA-example",
-        Source: "example-feed",
-    })
+    if req.AcceptPackageUpdates {
+        // Delta path: return only the packages we touched. Each update is a
+        // sparse Package carrying the PURL (the merge key) plus the new data.
+        var updates []*sdk.Package
+        for _, pkg := range req.Registry.All() {
+            update := &sdk.Package{Coordinates: sdk.Coordinates{PURL: pkg.PURL}}
+            update.Licenses = []sdk.PackageLicense{{SPDXExpression: "MIT"}}
+            updates = append(updates, update)
+        }
+        stats.MatchedPackages = len(updates)
+        stats.Licenses = len(updates)
+        return sdk.MatchResult{PackageUpdates: updates, MatcherStats: stats}, nil
+    }
 
-    return &sdk.MatchResponse{
-        Registry: registry,
-        MatcherStats: sdk.MatcherStats{
-            Name: pluginID,
-            DisplayName: "ClearlyDefined License Matcher",
-            MatchedPackages: 1,
-            Licenses: 1,
-            Vulnerabilities: 1,
-        },
-    }, nil
+    // Baseline path (protocol v1): enrich in place, echo the full registry.
+    for _, pkg := range req.Registry.All() {
+        pkg.Licenses = append(pkg.Licenses, sdk.PackageLicense{SPDXExpression: "MIT"})
+        stats.MatchedPackages++
+        stats.Licenses++
+    }
+    return sdk.MatchResult{Registry: req.Registry, MatcherStats: stats}, nil
 }
 
-func main() {
-    sdk.ServeMatcher(&matcher{})
+// Module packages the matcher for both execution modes.
+func Module() sdk.Module {
+    return sdk.Module{
+        Kind: sdk.PluginKindMatcher,
+        Matcher: &sdk.MatcherModule{
+            Descriptor: descriptor(),
+            New: func(_ context.Context, host sdk.HostContext) (sdk.Matcher, error) {
+                matcher := &Matcher{host: host}
+                if err := host.DecodeConfig(&matcher.config); err != nil {
+                    return nil, fmt.Errorf("decode %s config: %w", Name, err)
+                }
+                return matcher, nil
+            },
+        },
+    }
 }
 ```
 
-The working example repo is [bomly-plugin-clearlydefined-matcher](https://github.com/bomly-dev/bomly-plugin-clearlydefined-matcher). It shows a standalone HTTP matcher with plugin-local cache and proxy-aware SDK HTTP clients.
+The binary entrypoint stays one line:
 
-## What Each Hook Does
+```go
+func main() { sdk.ServeModule(plugin.Module()) }
+```
 
-- `Descriptor` describes the component identity, display name, aliases, tags, and support.
-- `Ready` reports whether the plugin can run in the current environment.
-- `Applicable` reports whether the matcher should run for the current request.
-- `Match` reads `sdk.MatchRequest` and returns a `sdk.MatchResponse` with the enriched registry.
+## What Each Part Does
+
+- `Descriptor` is the matcher's static registration: name (must equal the manifest `id`), display name, aliases, tags, supported ecosystems, capabilities, and config schema.
+- `New` constructs the matcher once per execution, with a `sdk.HostContext` for the logger, HTTP client, runtime info, and configuration.
+- `Ready(ctx, req) error` reports whether the matcher can run right now — return `nil` when ready, or an error explaining the reason (a missing token, an unreachable endpoint). `sdk.BaseMatcher` embeds an always-ready default; override it when your matcher depends on something that can be absent.
+- `Applicable(ctx, req) (bool, error)` reports whether the matcher should run for this request (for example, only certain ecosystems).
+- `Match` does the work: enrich registry packages and return the result with `MatcherStats`.
+
+Matchers only run during explicit enrichment (`--enrich`). Honor the context: pass it into every HTTP call so a cancelled scan stops promptly.
 
 ## Use The Registry
 
 Bomly separates dependency instances from package records:
 
-- `req.Graph` contains dependency nodes and edges.
-- `req.Registry` contains canonical package records keyed by PURL.
-- Matchers enrich registry packages and return the updated registry.
+- `req.Graph` contains dependency nodes and edges — identity and structure.
+- `req.Registry` contains canonical package records keyed by PURL. Matchers enrich each package once per PURL, no matter how many dependency instances point at it.
 
 Use `Ensure` when a package may already exist:
 
@@ -104,98 +145,95 @@ pkg := req.Registry.Ensure("pkg:npm/lodash@4.17.21")
 pkg.Licenses = append(pkg.Licenses, sdk.PackageLicense{SPDXExpression: "MIT"})
 pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
     ID:     "GHSA-example",
-    Source: "security-team",
+    Source: "example-feed",
 })
 ```
 
-Prefer canonical PURLs. Auditors and output rendering use PURLs to connect findings, vulnerabilities, and packages.
+Prefer canonical PURLs. Auditors and output rendering use PURLs to connect findings, vulnerabilities, and packages. Enrich packages; do not rewrite graph identity.
+
+## Registry Deltas (`package-updates-v1`)
+
+Matchers can respond in two shapes:
+
+- **Full registry** (protocol v1 baseline): return `Registry` with every package, enriched or not. Always works.
+- **Deltas**: return `PackageUpdates` containing only the packages you touched. The host merges them into its registry by PURL. Cheaper on the wire for large projects.
+
+The rules:
+
+1. Advertise `sdk.CapabilityPackageUpdates` in `Descriptor.Capabilities`.
+2. Return `PackageUpdates` **only when** `req.AcceptPackageUpdates` is true — that is the host telling you it understands deltas. Older hosts never set it, and you must fall back to the full-registry shape for them.
+3. When `Registry` is non-nil in the result, it wins and `PackageUpdates` is ignored — return one or the other.
+
+`sdk.ApplyPackageUpdates` implements the same merge the host uses; it is handy in tests and for building a full-registry fallback from the delta path.
+
+## Degrade, Don't Fail
+
+Enrichment failures should not sink a scan. If the upstream service is down or a response does not parse, prefer returning partial results — the packages you did enrich, with `UnmatchedPackages` counted in `MatcherStats` — over returning an error. Report a completely unavailable dependency (missing token, unreachable endpoint) through `Ready` with a clear reason instead of failing mid-`Match`. Cache lookups that fail are non-fatal: log a warning and continue without the cache.
 
 ## Configuration, HTTP, And Cache
 
-Per-plugin config lives under the kind-scoped `plugins.matchers.<name>` block (the deprecated flat `plugins.<plugin-id>` form still works with a warning):
+Declare a typed `Config` struct with `json`, `doc:`, and `default:` tags, advertise it with `ConfigSchema: sdk.MustConfigSchemaFor(Config{})`, and decode it in `New` with `host.DecodeConfig(&cfg)`. Users set the block under `plugins.matchers.<name>`:
 
 ```yaml
 plugins:
   matchers:
-    clearlydefined-license-matcher:
-      api_base: https://api.clearlydefined.io
+    com.example.license-matcher:
+      apiBase: https://api.example.com
 ```
 
-Read it with:
+The same block reaches the component in both execution modes. See [Configuration in the plugin guide](../PLUGINS.md#configuration-and-proxy-support) for details and the deprecated flat form.
+
+Make outbound calls through `HostContext.HTTPClient()` so Bomly's proxy, no-proxy, and CA settings apply consistently:
 
 ```go
-type config struct {
-    APIBase string `json:"api_base"`
-}
-
-var cfg config
-if err := sdk.DecodePluginConfigFromEnv(&cfg); err != nil {
-    return nil, err
-}
+client := m.host.HTTPClient().Client(20 * time.Second)
 ```
 
-If the matcher calls an external service, use Bomly's SDK HTTP provider so proxy settings work consistently:
-
-```go
-provider, err := sdk.NewHTTPClientProviderFromEnv()
-if err != nil {
-    return nil, err
-}
-client := provider.Client(20 * time.Second)
-_ = client
-```
-
-If the matcher produces deterministic output for a fixed input and service version, add caching inside the plugin. Cache failures should be non-fatal: log a warning and continue without cached data.
-
-## Package And Install
-
-For development, build and install the binary directly:
-
-```bash
-go build -o ./bin/bomly-plugin-clearlydefined-matcher .
-bomly plugins install ./bin/bomly-plugin-clearlydefined-matcher --dev
-bomly plugins enable clearlydefined-license-matcher
-```
-
-For distribution, package a package-only `bomly-plugin.json` manifest with the binary:
-
-```text
-bomly-plugin.json
-bin/
-  bomly-plugin-clearlydefined-matcher
-README.md
-```
-
-The manifest contains package and install fields only. Bomly probes the binary at install time, verifies `descriptor.name == manifest.id`, and writes its own internal descriptor snapshot for plugin list, selectors, verification, and runtime registration.
+Document every endpoint the matcher talks to in its README. If the matcher produces deterministic output for a fixed input and service version, add caching inside the plugin; cache failures are non-fatal.
 
 ## Test It
 
-Check installation and runtime readiness:
+Unit-test the mapping from service responses into registry package data, cover both the full-registry and delta paths, and run the SDK conformance suite:
 
-```bash
-bomly plugins verify clearlydefined-license-matcher
-bomly plugins test clearlydefined-license-matcher
-bomly plugins doctor clearlydefined-license-matcher
+```go
+func TestConformance(t *testing.T) {
+    conformance.Test(t, conformance.Config{
+        Module:       Module(),
+        ManifestPath: filepath.Join("..", "bomly-plugin.json"),
+        SampleConfig: json.RawMessage(`{"apiBase":"https://example.test"}`),
+    })
+}
 ```
 
-Run only this matcher during enrichment:
+The template's `plugin/plugin_test.go` shows a minimal test `HostContext` stub and fixture-registry loading.
+
+Local development loop:
 
 ```bash
-bomly scan --path ./my-project --enrich --matchers clearlydefined-license-matcher --json
+go build -o ./bin/bomly-plugin-example ./cmd/bomly-plugin-example
+bomly plugins install ./bin/bomly-plugin-example --dev
+bomly plugins enable com.example.license-matcher
+bomly scan --path ./my-project --enrich --matchers +com.example.license-matcher --json
+bomly plugins verify com.example.license-matcher
+bomly plugins test com.example.license-matcher
+bomly plugins doctor com.example.license-matcher
 ```
 
-Or add it to the default matcher set:
+`--matchers +<name>` adds the matcher to the default set; `--matchers <name>` runs only it. See [Testing a plugin](../PLUGINS.md#test-a-plugin) for the shared workflow, including `conformance.ProbeBinary`.
 
-```bash
-bomly scan --path ./my-project --enrich --matchers +clearlydefined-license-matcher
-```
+## Package And Release
+
+Follow the template's release workflow: one archive per platform named `<name>_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows) containing the binary, `bomly-plugin.json`, `README.md`, and `LICENSE`, plus a `SHA256SUMS` file. The manifest's `entrypoint` map names the binary per platform, and `descriptor.Name` must equal the manifest `id`. See [Package and release](../PLUGINS.md#package-and-release-a-plugin).
 
 ## Implementation Checklist
 
-- Enrich `req.Registry`; do not replace graph identity.
-- Return `MatcherStats` with the matcher ID and useful counts.
-- Keep external network calls behind explicit enrichment.
-- Honor proxy settings through the SDK HTTP provider.
-- Wrap errors with useful context and avoid panics.
+- Enrich `req.Registry` by PURL; do not rewrite graph identity.
+- Return `MatcherStats` with the matcher name and useful counts.
+- Advertise `SupportedEcosystems` and `Capabilities` accurately.
+- Return `PackageUpdates` only when `req.AcceptPackageUpdates` is true; otherwise return the full registry.
+- Degrade to partial results on upstream failures; report hard unavailability through `Ready`.
+- Make network calls through `HostContext.HTTPClient()` and document every endpoint.
+- Honor context cancellation in HTTP calls and long loops.
+- Wrap errors with useful context; avoid panics.
 - Do not log secrets, tokens, or credentials.
-- Add unit tests for mapping service responses into registry package data.
+- Add unit tests for response mapping plus both response shapes, and `conformance.Test`.


### PR DESCRIPTION
Rewrites the plugin authoring documentation around the Module/ServeModule model (plan milestone M5).

## What changed

**Four how-to guides restructured to one consistent Module-first shape** (`docs/plugins/how-to-implement-{detector,matcher,auditor,analyzer}.md`):

- Start From The Template — every guide starts from the [bomly-plugin-template](https://github.com/bomly-dev/bomly-plugin-template) repository, which is the canonical, excerpt-worthy example: importable `plugin/` package exporting `Module()`, one-line `cmd/<name>/main.go` calling `sdk.ServeModule`, `bomly-plugin.json`, conformance tests, CI, and the platform-archive release workflow.
- The Module — role module struct (`DetectorModule` / `MatcherModule` / `AuditorModule` / `AnalyzerModule`), descriptor identity (name = manifest id), typed `New(ctx, HostContext)` factory, embedded `sdk.Base*` lifecycle defaults.
- Configuration — typed config struct with `json`/`doc:`/`default:` tags, decoded via `HostContext.DecodeConfig`, advertised with `sdk.MustConfigSchemaFor`; same `plugins.<kind>.<name>` block embedded or managed.
- Role specifics — detector: evidence patterns, discovery metadata, chain hand-off through `Ready`/`Applicable`, install-first, read-only remediation hints; matcher/analyzer: the `package-updates-v1` delta contract and non-fatal degradation; analyzer: annotate-never-fail reachability semantics; auditor: reference-style findings, stable `RuleID`, policy statuses.
- Testing, packaging, security — `conformance.Test` / `ProbeBinary`, the dev install loop, archive naming + `SHA256SUMS`, no secrets in logs, network via `HostContext.HTTPClient()`.

**`docs/PLUGINS.md`** now carries the shared authoring material so the guides do not repeat it four times: a new "Write A Plugin" section (module model, `HostContext` contract, repository contract, `ServeModule` as THE entrypoint with the low-level `Serve<Kind>` adapters noted for advanced cases), a "Test A Plugin" section, and an extended "Package And Release A Plugin" section. The configuration and remediation-hints sections teach the module-style APIs; the served-style equivalents remain as compatibility notes only.

Every SDK symbol referenced in the guides was verified against the pinned `bomly-dev/bomly-sdk` release via `go doc`. Relative links and anchors across the touched files were checked; `make generate` produces no drift (guides are hand-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
