### PR TITLE
feat(engine): apply package-update deltas from embedded components

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -98,6 +98,10 @@ func (e *Engine) Analyze(ctx context.Context, req sdk.AnalyzeRequest) (sdk.Analy
 		return sdk.AnalyzeResult{Registry: req.Registry}, nil
 	}
 
+	// The engine understands AnalyzeResult.PackageUpdates deltas, so advertise
+	// it to every analyzer, embedded or external.
+	req.AcceptPackageUpdates = true
+
 	aggregated := sdk.AnalyzeResult{
 		Registry:      req.Registry,
 		AnalyzerStats: make(map[string]sdk.ReachabilityStats),
@@ -126,9 +130,18 @@ func (e *Engine) Analyze(ctx context.Context, req sdk.AnalyzeRequest) (sdk.Analy
 			continue
 		}
 		aggregated.AnalyzerRuns = append(aggregated.AnalyzerRuns, label)
-		if result.Registry != nil {
+		// A returned registry wins over deltas, mirroring the external-plugin
+		// transport adapter (internal/plugin/registry.go externalAnalyzer.Analyze),
+		// which resolves PackageUpdates into a full Registry before the engine
+		// sees the result — so external plugin deltas are never applied twice.
+		switch {
+		case result.Registry != nil:
 			aggregated.Registry = result.Registry
 			req.Registry = result.Registry
+		case len(result.PackageUpdates) > 0:
+			updated := sdk.ApplyPackageUpdates(req.Registry, result.PackageUpdates)
+			aggregated.Registry = updated
+			req.Registry = updated
 		}
 		for analyzerName, stats := range result.AnalyzerStats {
 			aggregated.AnalyzerStats[analyzerName] = stats
@@ -164,6 +177,10 @@ func (e *Engine) Match(ctx context.Context, req sdk.MatchRequest) (MatchResult, 
 		return result, fmt.Errorf("%w for ecosystem %q, and package manager %q", ErrNoMatcher, req.Ecosystem, req.PackageManager)
 	}
 
+	// The engine understands MatchResult.PackageUpdates deltas, so advertise
+	// it to every matcher, embedded or external.
+	req.AcceptPackageUpdates = true
+
 	aggregated := MatchResult{
 		Registry: req.Registry,
 	}
@@ -191,9 +208,18 @@ func (e *Engine) Match(ctx context.Context, req sdk.MatchRequest) (MatchResult, 
 			continue
 		}
 		aggregated.MatcherStats = append(aggregated.MatcherStats, matcherStats(descriptor, result.MatcherStats))
-		if result.Registry != nil {
+		// A returned registry wins over deltas, mirroring the external-plugin
+		// transport adapter (internal/plugin/registry.go externalMatcher.Match),
+		// which resolves PackageUpdates into a full Registry before the engine
+		// sees the result — so external plugin deltas are never applied twice.
+		switch {
+		case result.Registry != nil:
 			aggregated.Registry = result.Registry
 			req.Registry = result.Registry
+		case len(result.PackageUpdates) > 0:
+			updated := sdk.ApplyPackageUpdates(req.Registry, result.PackageUpdates)
+			aggregated.Registry = updated
+			req.Registry = updated
 		}
 	}
 	finalizeMatchResult(&aggregated)

--- a/internal/engine/package_updates_test.go
+++ b/internal/engine/package_updates_test.go
@@ -1,0 +1,230 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+// deltaMatcher is a fake matcher whose Match behavior is fully controlled by
+// the test through the match func, so tests can return PackageUpdates deltas,
+// full registries, or zero-value results.
+type deltaMatcher struct {
+	name  string
+	match func(req MatchRequest) (sdk.MatchResult, error)
+}
+
+func (m deltaMatcher) Descriptor() MatcherDescriptor {
+	return MatcherDescriptor{Name: m.name}
+}
+
+func (m deltaMatcher) Ready(context.Context, MatchRequest) error { return nil }
+
+func (m deltaMatcher) Applicable(context.Context, MatchRequest) (bool, error) {
+	return true, nil
+}
+
+func (m deltaMatcher) Match(_ context.Context, req MatchRequest) (sdk.MatchResult, error) {
+	return m.match(req)
+}
+
+// deltaAnalyzer is the analyzer twin of deltaMatcher.
+type deltaAnalyzer struct {
+	name    string
+	analyze func(req sdk.AnalyzeRequest) (sdk.AnalyzeResult, error)
+}
+
+func (a deltaAnalyzer) Descriptor() sdk.AnalyzerDescriptor {
+	return sdk.AnalyzerDescriptor{Name: a.name}
+}
+
+func (a deltaAnalyzer) Ready(context.Context, sdk.AnalyzeRequest) error { return nil }
+
+func (a deltaAnalyzer) Applicable(context.Context, sdk.AnalyzeRequest) (bool, error) {
+	return true, nil
+}
+
+func (a deltaAnalyzer) Analyze(_ context.Context, req sdk.AnalyzeRequest) (sdk.AnalyzeResult, error) {
+	return a.analyze(req)
+}
+
+func TestEngineMatch_AppliesPackageUpdateDeltas(t *testing.T) {
+	const purl = "pkg:npm/react@18.2.0"
+	registry := newTestRegistry()
+
+	var sawAccept bool
+	registry.registerMatcher(deltaMatcher{
+		name: "delta",
+		match: func(req MatchRequest) (sdk.MatchResult, error) {
+			sawAccept = req.AcceptPackageUpdates
+			return sdk.MatchResult{
+				PackageUpdates: []*sdk.Package{{
+					Coordinates: sdk.Coordinates{PURL: purl},
+					Licenses:    []sdk.PackageLicense{{SPDXExpression: "MIT"}},
+				}},
+				MatcherStats: sdk.MatcherStats{Licenses: 1},
+			}, nil
+		},
+	})
+
+	var secondSawUpdate bool
+	registry.registerMatcher(deltaMatcher{
+		name: "observer",
+		match: func(req MatchRequest) (sdk.MatchResult, error) {
+			if pkg, ok := req.Registry.Get(purl); ok && len(pkg.Licenses) == 1 {
+				secondSawUpdate = true
+			}
+			// Zero-value result: the effective registry must be preserved.
+			return sdk.MatchResult{}, nil
+		},
+	})
+
+	result, err := NewEngine(registry).Match(context.Background(), MatchRequest{
+		Graph:    sdk.New(),
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if !sawAccept {
+		t.Fatal("expected the engine to set AcceptPackageUpdates on matcher requests")
+	}
+	if !secondSawUpdate {
+		t.Fatal("expected the second matcher to observe the delta-updated registry")
+	}
+	if result.Registry == nil {
+		t.Fatal("expected a registry on the aggregated result")
+	}
+	pkg, ok := result.Registry.Get(purl)
+	if !ok {
+		t.Fatalf("expected delta package %q in the final registry", purl)
+	}
+	if values := pkg.LicenseValues(); len(values) != 1 || values[0] != "MIT" {
+		t.Fatalf("expected delta enrichment to land, got %#v", values)
+	}
+	if len(result.MatcherStats) != 2 {
+		t.Fatalf("expected stats from both matchers, got %#v", result.MatcherStats)
+	}
+}
+
+func TestEngineMatch_ReturnedRegistryWinsOverPackageUpdates(t *testing.T) {
+	const kept = "pkg:npm/kept@1.0.0"
+	const ignored = "pkg:npm/ignored@1.0.0"
+	registry := newTestRegistry()
+
+	full := sdk.NewPackageRegistry()
+	full.Ensure(kept)
+	registry.registerMatcher(deltaMatcher{
+		name: "both",
+		match: func(MatchRequest) (sdk.MatchResult, error) {
+			// Returning both mirrors nothing a well-behaved component should
+			// do, but the adapter semantics are explicit: Registry wins.
+			return sdk.MatchResult{
+				Registry:       full,
+				PackageUpdates: []*sdk.Package{{Coordinates: sdk.Coordinates{PURL: ignored}}},
+			}, nil
+		},
+	})
+
+	result, err := NewEngine(registry).Match(context.Background(), MatchRequest{
+		Graph:    sdk.New(),
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if result.Registry != full {
+		t.Fatal("expected the returned registry to win over deltas")
+	}
+	if _, ok := result.Registry.Get(ignored); ok {
+		t.Fatal("expected PackageUpdates to be ignored when a registry is returned")
+	}
+	if _, ok := result.Registry.Get(kept); !ok {
+		t.Fatal("expected returned registry contents to be preserved")
+	}
+}
+
+func TestEngineAnalyze_AppliesPackageUpdateDeltas(t *testing.T) {
+	const purl = "pkg:golang/example.com/mod@v1.0.0"
+	registry := newTestRegistry()
+
+	var sawAccept bool
+	registry.RegisterAnalyzer(deltaAnalyzer{
+		name: "delta",
+		analyze: func(req sdk.AnalyzeRequest) (sdk.AnalyzeResult, error) {
+			sawAccept = req.AcceptPackageUpdates
+			return sdk.AnalyzeResult{
+				PackageUpdates: []*sdk.Package{{Coordinates: sdk.Coordinates{PURL: purl}}},
+				AnalyzerStats: map[string]sdk.ReachabilityStats{
+					"delta": {Reachable: 1},
+				},
+			}, nil
+		},
+	})
+
+	var secondSawUpdate bool
+	registry.RegisterAnalyzer(deltaAnalyzer{
+		name: "observer",
+		analyze: func(req sdk.AnalyzeRequest) (sdk.AnalyzeResult, error) {
+			_, secondSawUpdate = req.Registry.Get(purl)
+			// Zero-value result: the effective registry must be preserved.
+			return sdk.AnalyzeResult{}, nil
+		},
+	})
+
+	result, err := NewEngine(registry).Analyze(context.Background(), sdk.AnalyzeRequest{
+		Graph:    sdk.New(),
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if !sawAccept {
+		t.Fatal("expected the engine to set AcceptPackageUpdates on analyzer requests")
+	}
+	if !secondSawUpdate {
+		t.Fatal("expected the second analyzer to observe the delta-updated registry")
+	}
+	if result.Registry == nil {
+		t.Fatal("expected a registry on the aggregated result")
+	}
+	if _, ok := result.Registry.Get(purl); !ok {
+		t.Fatalf("expected delta package %q in the final registry", purl)
+	}
+	if result.AnalyzerStats["delta"].Reachable != 1 {
+		t.Fatalf("expected analyzer stats to aggregate, got %#v", result.AnalyzerStats)
+	}
+}
+
+func TestEngineAnalyze_ReturnedRegistryWinsOverPackageUpdates(t *testing.T) {
+	const kept = "pkg:npm/kept@1.0.0"
+	const ignored = "pkg:npm/ignored@1.0.0"
+	registry := newTestRegistry()
+
+	full := sdk.NewPackageRegistry()
+	full.Ensure(kept)
+	registry.RegisterAnalyzer(deltaAnalyzer{
+		name: "both",
+		analyze: func(sdk.AnalyzeRequest) (sdk.AnalyzeResult, error) {
+			return sdk.AnalyzeResult{
+				Registry:       full,
+				PackageUpdates: []*sdk.Package{{Coordinates: sdk.Coordinates{PURL: ignored}}},
+			}, nil
+		},
+	})
+
+	result, err := NewEngine(registry).Analyze(context.Background(), sdk.AnalyzeRequest{
+		Graph:    sdk.New(),
+		Registry: sdk.NewPackageRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if result.Registry != full {
+		t.Fatal("expected the returned registry to win over deltas")
+	}
+	if _, ok := result.Registry.Get(ignored); ok {
+		t.Fatal("expected PackageUpdates to be ignored when a registry is returned")
+	}
+}


### PR DESCRIPTION
## Gap

`sdk.MatchResult.PackageUpdates` / `sdk.AnalyzeResult.PackageUpdates` deltas were honored only by the managed-plugin transport adapters (`internal/plugin/registry.go` `externalMatcher.Match` / `externalAnalyzer.Analyze`). An embedded matcher or analyzer that returned deltas instead of a full registry had its enrichment silently dropped by the engine — the loop only consumed `result.Registry`.

## What changed

`Engine.Match` and `Engine.Analyze` (`internal/engine/engine.go`) now:

- set `AcceptPackageUpdates = true` on the request before invoking components — placed in the engine methods (the single funnel every request-construction path goes through, including `pipeline.go`), so every caller gets it;
- mirror the adapter semantics exactly after each result:
  - a returned `Registry` wins and deltas are ignored;
  - otherwise non-empty `PackageUpdates` are applied via `sdk.ApplyPackageUpdates` and the resulting registry threads to the aggregated result and to subsequent components in the same run, identically to how a returned registry threads;
  - a zero-value result preserves the effective registry;
- stats handling is unchanged (matcher stats append, analyzer stats merge).

No double-apply for external plugins: their adapter resolves deltas into a full `Registry` before the engine sees the result — noted in a code comment at both apply sites.

## Tests

`internal/engine/package_updates_test.go`:

- fake matcher returning only `PackageUpdates`: enrichment lands in the final registry, stats aggregate, and a second matcher observes the updated registry (that second matcher also covers the zero-value-result case);
- fake analyzer likewise;
- fakes returning BOTH `Registry` and `PackageUpdates`: the registry wins (adapter semantics) for both kinds;
- `AcceptPackageUpdates` asserted visible to components.

## Why now

This unlocks per-wave delta adoption in the component-extraction program: embedded components can move to the delta contract before they are extracted, and behave identically after extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
