### PR TITLE
feat: treat syft-JSON SBOMs as any other unsupported format

### DIFF
--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -579,11 +579,11 @@ The embedded surface preserves the exact constructor shapes the CLI used in-tree
 
 Two nested-module designs were evaluated and abandoned before this: a committed `go.work` workspace with `components/<kind>/<name>/` modules plus a lockstep release train, and a variant consuming the same nested modules through root `replace` directives. Both kept the code in-repo but added machinery the ordinary-module model does not need — workspace/pinned-build split in CI, a replace-directive allowlist, a bespoke tagging script — and the replace-based variant broke remote `go install`. With external repositories, `go install github.com/bomly-dev/bomly-cli/cmd/bomly@latest` keeps working, Dependabot handles version bumps, and each component repository owns its tests, fuzz targets, and releases.
 
-### Decision: syft-JSON SBOM ingest is removed; sniffing is retained for the migration error
+### Decision: syft-JSON SBOM ingest is removed; treated as any unsupported format
 
 Syft's proprietary JSON SBOM format is no longer an accepted `--sbom` ingest input. It had exactly one consumer in the codebase — the SBOM ingest detector — while the syft detector itself always shells out with `-o spdx-json`. The lite build (`bomly_external_syft`) never actually ingested it either: its fallback re-ran the generic decoder, which returned a nil document for the syft target, so `ToGraph(nil)` hard-failed with an unhelpful `sbom document is nil` error. The change therefore unifies full and lite behavior on one explicit, actionable rejection; the compatibility impact is on full builds only, which previously decoded the format. Removing the decode path made `internal/detectors/sbom` build-tag-free and dropped its `anchore/syft` dependency.
 
-The boundary: `internal/sbom` **keeps** syft-JSON identification in `DetectJSONTarget` solely so `UnmarshalAutoJSON` can fail with the precise, actionable `ErrSyftJSONUnsupported` ("convert with: `syft convert <file> -o spdx-json`") instead of a generic unsupported-format error. Sniffing is not a step toward re-adding ingest; supported ingest formats are SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON.
+Follow-up simplification (same decision, second pass): the format-specific sniffing and the `syft convert` migration error were removed too. There is nothing special about syft-JSON — an unsupported format is an unsupported format, and the generic `ErrUnsupportedFormat` rejection covers it. This also deleted the last root-module import of `github.com/anchore/syft` (the `syftjson` decoder used only for identification), so the anchore tree now reaches the binary exclusively through the syft/grype component modules. Supported ingest formats are SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON.
 
 ## Build Modes
 

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -65,12 +65,7 @@ This is fast, offline, and useful for:
 - Re-running policy on an SBOM you produced in a previous CI step.
 - Diffing SBOMs across releases.
 
-Format is auto-detected by content. The supported ingest formats are SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON. Syft's own JSON format is not supported as ingest input — convert it first:
-
-```bash
-syft convert ./app.syft.json -o spdx-json > ./app.spdx.json
-bomly scan --sbom --path ./app.spdx.json
-```
+Format is auto-detected by content. The supported ingest formats are SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON; anything else is rejected as an unsupported format. Most SBOM producers, including Syft, can emit one of the supported formats directly (for example `syft <target> -o spdx-json`).
 
 ## Diffing SBOMs
 

--- a/docs/SCAN_TARGETS.md
+++ b/docs/SCAN_TARGETS.md
@@ -186,7 +186,7 @@ bomly scan --sbom --path ./vendor.spdx.json
 bomly scan --sbom --path ./build/sbom.cdx.json
 ```
 
-SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON are auto-detected. Syft's own JSON format is not accepted; convert it first with `syft convert <file> -o spdx-json`. Useful when:
+SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON are auto-detected; any other format is rejected as unsupported. Useful when:
 
 - You produced an SBOM in a previous CI step and want to audit it.
 - A vendor sent you an SBOM and you want to evaluate it against your policy.

--- a/docs/detectors/sbom/sbom.md
+++ b/docs/detectors/sbom/sbom.md
@@ -79,5 +79,4 @@ bomly diff --sbom --base ./v1.0.cdx.json --head ./v1.1.cdx.json
 - **Vendor-specific extensions** (custom properties, non-standard package types) are passed through to the JSON output but are not used for policy decisions.
 - **SBOM ingest is exclusive** — combining `--sbom` with `--image` or `--url` is rejected with exit 4.
 - **Format versions other than SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON** are rejected. SPDX 3.0 ingest is tracked for follow-up.
-- **Syft's own JSON format is not ingested.** Bomly still recognizes it and tells you how to migrate: `syft convert <file> -o spdx-json`.
 - **Tag-Value SPDX** and **XML CycloneDX** are not currently ingested.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/anchore/packageurl-go v0.2.0
-	github.com/anchore/syft v1.51.0
 	github.com/bomly-dev/bomly-plugin-depsdev-license-matcher v0.1.0
 	github.com/bomly-dev/bomly-plugin-govulncheck-analyzer v0.1.0
 	github.com/bomly-dev/bomly-plugin-grype-matcher v0.1.0
@@ -36,6 +35,7 @@ require (
 require (
 	github.com/anchore/clio v0.1.1 // indirect
 	github.com/anchore/grype v0.117.0 // indirect
+	github.com/anchore/syft v1.51.0 // indirect
 	github.com/evanw/esbuild v0.28.1 // indirect
 	github.com/glebarez/sqlite v1.11.0 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect

--- a/internal/detectors/sbom/detector.go
+++ b/internal/detectors/sbom/detector.go
@@ -85,8 +85,6 @@ func (d Detector) ResolveGraph(_ context.Context, req sdk.DetectionRequest) (sdk
 	doc, target, err := sbom.UnmarshalAutoJSON(data)
 	if err != nil {
 		switch {
-		case errors.Is(err, sbom.ErrSyftJSONUnsupported):
-			return sdk.DetectionResult{}, fmt.Errorf("unsupported sbom file %q: %w", sbomPath, err)
 		case errors.Is(err, sbom.ErrMalformedJSON):
 			return sdk.DetectionResult{}, fmt.Errorf("parse sbom file %q: %w", sbomPath, err)
 		case errors.Is(err, sbom.ErrUnsupportedFormat):

--- a/internal/detectors/sbom/detector_test.go
+++ b/internal/detectors/sbom/detector_test.go
@@ -141,8 +141,8 @@ func TestDetectorResolveGraph_RejectsUnsupportedOrMalformedJSON(t *testing.T) {
 // runs identically under the default and bomly_external_syft build tags.
 func TestDetectorResolveGraph_RejectsSyftJSON(t *testing.T) {
 	syftJSON := []byte(`{"artifacts":[],"artifactRelationships":[],"source":{"type":"directory","target":"."},"descriptor":{"name":"syft","version":"1.0.0"},"schema":{"version":"16.0.34","url":"https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.34.json"}}`)
-	if target, err := sbom.DetectJSONTarget(syftJSON); err != nil || target != sbom.TargetSyftJSON {
-		t.Fatalf("fixture must sniff as syft json, got (%q, %v)", target, err)
+	if _, err := sbom.DetectJSONTarget(syftJSON); !errors.Is(err, sbom.ErrUnsupportedFormat) {
+		t.Fatalf("fixture must be an unsupported format, got %v", err)
 	}
 
 	path := filepath.Join(t.TempDir(), "input.syft.json")
@@ -151,13 +151,11 @@ func TestDetectorResolveGraph_RejectsSyftJSON(t *testing.T) {
 	}
 
 	_, err := (Detector{}).ResolveGraph(context.Background(), requestForSBOMPath(path))
-	if err == nil || !errors.Is(err, sbom.ErrSyftJSONUnsupported) {
-		t.Fatalf("ResolveGraph() error = %v, want wrapped sbom.ErrSyftJSONUnsupported", err)
+	if err == nil || !errors.Is(err, sbom.ErrUnsupportedFormat) {
+		t.Fatalf("ResolveGraph() error = %v, want wrapped sbom.ErrUnsupportedFormat", err)
 	}
-	for _, want := range []string{path, "syft convert <file> -o spdx-json"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("ResolveGraph() error %q missing %q", err.Error(), want)
-		}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("ResolveGraph() error %q missing the file path", err.Error())
 	}
 }
 

--- a/internal/sbom/codec.go
+++ b/internal/sbom/codec.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/anchore/syft/syft/format/syftjson"
 	"github.com/bomly-dev/bomly-sdk"
 )
 
@@ -15,11 +14,6 @@ var (
 	ErrUnsupportedTarget = errors.New("unsupported sbom target")
 	ErrUnsupportedFormat = errors.New("unsupported sbom format")
 	ErrMalformedJSON     = errors.New("malformed sbom json")
-
-	// ErrSyftJSONUnsupported reports that the input is a syft-format JSON SBOM,
-	// which Bomly no longer ingests. Detection is kept so callers can point the
-	// user at the conversion path instead of a generic format error.
-	ErrSyftJSONUnsupported = errors.New("syft JSON SBOMs are not supported; convert with: syft convert <file> -o spdx-json")
 )
 
 type codec interface {
@@ -63,10 +57,6 @@ func DetectJSONTarget(data []byte) (Target, error) {
 		return "", ErrMalformedJSON
 	}
 
-	if id, _ := syftjson.NewFormatDecoder().Identify(bytes.NewReader(trimmed)); id == syftjson.ID {
-		return TargetSyftJSON, nil
-	}
-
 	var sniff struct {
 		SPDXVersion string `json:"spdxVersion"`
 		BOMFormat   string `json:"bomFormat"`
@@ -102,10 +92,6 @@ func UnmarshalAutoJSON(data []byte) (*Document, Target, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	if target == TargetSyftJSON {
-		return nil, target, ErrSyftJSONUnsupported
-	}
-
 	doc, err := UnmarshalJSON(data, target)
 	if err != nil {
 		return nil, "", err

--- a/internal/sbom/codec_fuzz_test.go
+++ b/internal/sbom/codec_fuzz_test.go
@@ -45,7 +45,7 @@ func FuzzUnmarshalAutoJSON(f *testing.F) {
 			t.Fatalf("non-deterministic parse: (%q, %v) then (%q, %v)", target, err, target2, err2)
 		}
 		if err != nil {
-			for _, sentinel := range []error{ErrSyftJSONUnsupported, ErrMalformedJSON, ErrUnsupportedFormat} {
+			for _, sentinel := range []error{ErrMalformedJSON, ErrUnsupportedFormat} {
 				if errors.Is(err, sentinel) != errors.Is(err2, sentinel) {
 					t.Fatalf("non-deterministic error classification: %v then %v", err, err2)
 				}
@@ -55,13 +55,10 @@ func FuzzUnmarshalAutoJSON(f *testing.F) {
 		}
 
 		if err != nil {
-			if target == TargetSyftJSON && !errors.Is(err, ErrSyftJSONUnsupported) {
-				t.Fatalf("syft target must fail with ErrSyftJSONUnsupported, got %v", err)
-			}
 			return
 		}
-		if target == TargetSyftJSON {
-			t.Fatal("syft target must never parse successfully")
+		if target == "" {
+			t.Fatal("successful parse must report a concrete target")
 		}
 		if doc == nil {
 			t.Fatalf("successful %s parse returned nil document", target)

--- a/internal/sbom/model.go
+++ b/internal/sbom/model.go
@@ -15,7 +15,6 @@ const (
 	TargetCycloneDX15JSON Target = "cyclonedx-1.5+json"
 	TargetCycloneDX16JSON Target = "cyclonedx-1.6+json"
 	TargetCycloneDX17JSON Target = "cyclonedx-1.7+json"
-	TargetSyftJSON        Target = "syft+json"
 	defaultDocumentName          = "bomly-dependencies"
 	defaultToolName              = "bomly-cli"
 )

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -4,16 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/anchore/syft/syft/artifact"
-	syftfile "github.com/anchore/syft/syft/file"
-	"github.com/anchore/syft/syft/format/syftjson"
-	syftpkg "github.com/anchore/syft/syft/pkg"
-	syftsbom "github.com/anchore/syft/syft/sbom"
 	"github.com/bomly-dev/bomly-sdk"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
@@ -477,8 +471,8 @@ func TestDetectJSONTarget_DetectsSupportedFormats(t *testing.T) {
 	}
 
 	syftData := mustSyftJSONFixture(t)
-	if target, err := DetectJSONTarget(syftData); err != nil || target != TargetSyftJSON {
-		t.Fatalf("DetectJSONTarget(syft) = (%q, %v)", target, err)
+	if _, err := DetectJSONTarget(syftData); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("DetectJSONTarget(syft) must report an unsupported format, got %v", err)
 	}
 }
 
@@ -489,8 +483,8 @@ func TestUnmarshalAutoJSON_RejectsUnsupportedOrMalformedJSON(t *testing.T) {
 	if _, _, err := UnmarshalAutoJSON([]byte(`{"hello":`)); err == nil || !errors.Is(err, ErrMalformedJSON) {
 		t.Fatalf("expected malformed-json error, got %v", err)
 	}
-	if _, target, err := UnmarshalAutoJSON(mustSyftJSONFixture(t)); !errors.Is(err, ErrSyftJSONUnsupported) || target != TargetSyftJSON {
-		t.Fatalf("expected syft-json-unsupported error with syft target, got (%q, %v)", target, err)
+	if _, _, err := UnmarshalAutoJSON(mustSyftJSONFixture(t)); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("expected unsupported-format error for syft JSON, got %v", err)
 	}
 }
 
@@ -692,44 +686,18 @@ func idsOfPackages(packages []*sdk.Dependency) []string {
 
 func mustSyftJSONFixture(t *testing.T) []byte {
 	t.Helper()
-
-	app := syftpkg.Package{
-		Name:      "demo-app",
-		Version:   "1.0.0",
-		Type:      syftpkg.NpmPkg,
-		PURL:      "pkg:npm/demo-app@1.0.0",
-		Locations: syftfile.NewLocationSet(syftfile.NewLocation("package-lock.json")),
-	}
-	app.SetID()
-
-	dependency := syftpkg.Package{
-		Name:      "react",
-		Version:   "18.2.0",
-		Type:      syftpkg.NpmPkg,
-		PURL:      "pkg:npm/react@18.2.0",
-		Locations: syftfile.NewLocationSet(syftfile.NewLocation("package-lock.json")),
-		Licenses:  syftpkg.NewLicenseSet(syftpkg.NewLicense("MIT")),
-	}
-	dependency.SetID()
-
-	doc := syftsbom.SBOM{
-		Artifacts: syftsbom.Artifacts{
-			Packages: syftpkg.NewCollection(app, dependency),
-		},
-		Relationships: []artifact.Relationship{
-			{From: dependency, To: app, Type: artifact.DependencyOfRelationship},
-		},
-	}
-
-	encoder, err := syftjson.NewFormatEncoderWithConfig(syftjson.EncoderConfig{Pretty: true})
-	if err != nil {
-		t.Fatalf("new syft encoder: %v", err)
-	}
-	var out bytes.Buffer
-	if err := encoder.Encode(&out, doc); err != nil {
-		t.Fatalf("encode syft json: %v", err)
-	}
-	return []byte(strings.TrimSpace(out.String()))
+	// A representative syft-format JSON document. Bomly treats the format as
+	// unsupported, so a static fixture is all these tests need.
+	return []byte(`{
+  "artifacts": [
+    {"id": "a1", "name": "demo-app", "version": "1.0.0", "type": "npm", "purl": "pkg:npm/demo-app@1.0.0"},
+    {"id": "a2", "name": "react", "version": "18.2.0", "type": "npm", "purl": "pkg:npm/react@18.2.0"}
+  ],
+  "artifactRelationships": [{"parent": "a2", "child": "a1", "type": "dependency-of"}],
+  "source": {"type": "directory", "target": "."},
+  "descriptor": {"name": "syft", "version": "1.0.0"},
+  "schema": {"version": "16.0.34", "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.34.json"}
+}`)
 }
 
 // A PURL Bomly emitted must name an ecosystem Bomly recognises when it is read

--- a/internal/support/prose/detectors/sbom.md
+++ b/internal/support/prose/detectors/sbom.md
@@ -60,5 +60,4 @@ bomly diff --sbom --base ./v1.0.cdx.json --head ./v1.1.cdx.json
 - **Vendor-specific extensions** (custom properties, non-standard package types) are passed through to the JSON output but are not used for policy decisions.
 - **SBOM ingest is exclusive** — combining `--sbom` with `--image` or `--url` is rejected with exit 4.
 - **Format versions other than SPDX 2.3 JSON and CycloneDX 1.4–1.7 JSON** are rejected. SPDX 3.0 ingest is tracked for follow-up.
-- **Syft's own JSON format is not ingested.** Bomly still recognizes it and tells you how to migrate: `syft convert <file> -o spdx-json`.
 - **Tag-Value SPDX** and **XML CycloneDX** are not currently ingested.

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -539,13 +539,8 @@ func TestScanSBOMSyftJSONRejected(t *testing.T) {
 			if code != 3 {
 				t.Fatalf("expected exit 3 (resolution failure) for syft-JSON ingest, got %d\nstderr:\n%s", code, stderr)
 			}
-			for _, want := range []string{
-				"syft JSON SBOMs are not supported",
-				"syft convert <file> -o spdx-json",
-			} {
-				if !strings.Contains(stderr, want) {
-					t.Fatalf("expected stderr to contain %q, got:\n%s", want, stderr)
-				}
+			if !strings.Contains(stderr, "unsupported sbom format") && !strings.Contains(stderr, "detect sbom format") {
+				t.Fatalf("expected stderr to report an unsupported sbom format, got:\n%s", stderr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Per direction: there is nothing special about syft-JSON — an unsupported SBOM format is just an unsupported SBOM format.

- `DetectJSONTarget` no longer identifies syft-JSON; it falls through to the generic `ErrUnsupportedFormat` like any other unrecognized document. `TargetSyftJSON` and `ErrSyftJSONUnsupported` are deleted, along with the sbom detector's dedicated error branch and the "convert with `syft convert`" guidance in errors and docs.
- This removes the last root-module use of `github.com/anchore/syft` (the `syftjson` sniffer import plus the test-fixture encoder, replaced by a static JSON fixture). The module is now only an **indirect** dependency, arriving via the syft-detector and grype-matcher component repos.
- Docs updated (`docs/SBOM.md`, `docs/SCAN_TARGETS.md`, sbom detector prose + regenerated component doc, `dev-docs/ARCHITECTURE.md` decision entry).

Behavior change: scanning a syft-JSON SBOM still fails with exit code 3, but with the generic `unsupported sbom format` error instead of a syft-specific conversion hint.

## Testing

- `go test ./...` green (GOWORK=off)
- Full + lite builds green; `go vet`, `gofmt` clean
- `FuzzUnmarshalAutoJSON` 5s focused run green
- Smoke `TestScanSBOMSyftJSONRejected` updated and verified green against both the full and lite binaries
- `make generate` drift committed (sbom detector component doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
