### PR TITLE
feat(sbom): emit package origin as download and repository locations

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -97,7 +97,7 @@ jobs:
           - name: ruby
             run: 'TestScan$/scan-bundler'
           - name: sbom
-            run: 'TestScan$/scan-sbom|TestDiff/(diff-sbom$|diff-sbom-detail-change$)|TestLiteScan/lite-scan-sbom|TestScanSBOMSyftJSONRejected$'
+            run: 'TestScan$/scan-sbom|TestDiff/(diff-sbom$|diff-sbom-detail-change$)|TestLiteScan/lite-scan-sbom|TestScanSBOMSyftJSONRejected$|TestScanSBOMExportDistribution$'
           - name: dotnet
             run: 'TestScan$/scan-nuget'
             dotnet: true

--- a/.github/workflows/update-smoke-goldens.yml
+++ b/.github/workflows/update-smoke-goldens.yml
@@ -121,7 +121,7 @@ jobs:
           - name: cpp
             run: 'TestScan$/scan-cpp-conan'
           - name: sbom
-            run: 'TestScan$/scan-sbom|TestDiff/(diff-sbom$|diff-sbom-detail-change$)|TestLiteScan/lite-scan-sbom|TestScanSBOMSyftJSONRejected$'
+            run: 'TestScan$/scan-sbom|TestDiff/(diff-sbom$|diff-sbom-detail-change$)|TestLiteScan/lite-scan-sbom|TestScanSBOMSyftJSONRejected$|TestScanSBOMExportDistribution$'
           - name: plugin
             run: 'TestPluginWorkflows'
           - name: container

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -166,6 +166,20 @@ inherit these checkout validation controls.
 
 Reachability data lives on `sdk.Vulnerability.Reachability` rather than on `Finding.Reachability` because `--analyze` must be useful without `--audit`. Matchers populate the OSV-aligned `Vulnerability` record on the PURL-keyed registry package; the analyzer enriches it in place; the output layer resolves the analyzer's annotation by `(Finding.PackageRef, Finding.VulnerabilityID)` when emitting SARIF and the JSON `Finding` projection. This keeps a single source of truth (the registry) and removes the per-manifest sync that the old graph-mutating model required.
 
+### Decision: SBOM distribution data is classified, not passed through
+
+`sdk.Dependency.ResolvedURL` is not a URL. Detectors write whatever their lockfile records: npm/pnpm/yarn/bun write the exact tarball, Bundler writes the `GEM remote:` registry root, Cargo writes a `registry+`/`sparse+`/`git+`-prefixed index or repo, swiftpm writes a repository, and uv, pipenv, pub, and npm link entries can all write a **local filesystem path**. Some private-registry URLs embed a token.
+
+`internal/sbom/locator.go` therefore classifies each value into artifact / VCS / registry-root / nothing before it can reach an SBOM, rather than mapping the field straight onto `PackageDownloadLocation`. Two rules are load-bearing:
+
+1. **An http(s) scheme is required, and credentials are rejected in every position.** This is what keeps build-machine directory layout and private-registry credentials out of a published document. Credentials travel in more places than userinfo: query parameter names and values, fragments, hostname labels, path segments, and the `@<revision>` suffix on a version-control locator. `containsCredential` scans whole components for issuer-prefixed tokens at token boundaries rather than splitting on delimiters — a split needs the exact delimiter set for every position, and each missing separator is a silent gap. The check is on the value, never on `Source` — uv's `path`/`editable` values arrive under non-`file` sources.
+
+   One subtlety worth stating, because getting it backwards leaks credentials: **parse before splitting a revision.** In a URL, `@` before the host is userinfo and `@` after the path is a revision, and the two are only distinguishable once parsed. Splitting `https://ghp_secret@github.com` on `@` first reads the secret as the host and `github.com` as the revision, which passes every later check and rebuilds the credential. `splitVCSRevision` is the single place that ordering is encoded.
+
+2. **A registry root never becomes a download location.** `https://rubygems.org/` is schema-valid and both validators accept it, so the failure would be silent and plausible: every consumer would read it as the artifact's origin. `NOASSERTION` is the honest answer.
+
+Unrecognized shapes degrade toward the weaker claim (registry root, then nothing) rather than toward the stronger one. `FuzzClassifyResolvedURL` asserts the safety property directly: a classified value is either empty or an absolute network URL with no credential in any position.
+
 ### Decision: external lookups use `Coordinates.EcosystemName()`, never the bare `Name`
 
 `Coordinates` stores identity as `Org` + `Name` following the PURL namespace/name split, so `Name` alone is `postcss` for both `postcss` and `@tailwindcss/postcss`. Anything that leaves the process under a name — Grype's DB search, the OSV name-keyed query, name-derived cache keys, SBOM component names, the bare specifiers `jsreach` matches imports against — must use `EcosystemName()`, which rebuilds the ecosystem-native form (`@org/name` for npm, `org:name` for the Maven family, `org/name` for Go, Composer, Swift, and GitHub Actions).

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -99,6 +99,48 @@ Both formats carry:
   knows fixed versions, each vulnerability carries a `recommendation`
   ("Upgrade <package> to <version>"). No guidance is invented when no fix is
   known. SPDX 2.3 has no equivalent field.
+- Where each package came from, when the lockfile records it (see below).
+
+### Where a package came from
+
+Lockfiles record very different things in the same field. Some name the exact
+file that was downloaded, some name only the registry the ecosystem fetches
+from, and some name a directory on the machine that ran the scan. Bomly sorts
+each value into one of three kinds — an exact package file, a source
+repository, or a registry root — and emits it accordingly. A value that fits
+none of them, such as a local path, is not published at all:
+
+| What the lockfile recorded | SPDX | CycloneDX |
+| --- | --- | --- |
+| The exact package file | `downloadLocation` | `distribution` reference |
+| A source repository | `downloadLocation` (`git+` form) | `vcs` reference |
+| Only a registry root | `NOASSERTION` | `distribution` reference, marked as a registry root |
+| A local path, or nothing usable | `NOASSERTION` | nothing |
+
+For a dependency pinned to a source repository, Bomly records the resolved
+commit when the lockfile has one, in preference to the branch or tag that was
+requested. A branch moves; the commit is what was actually locked.
+
+Two rules matter here:
+
+- **A registry root is never used as a download location.** `https://rubygems.org/`
+  is a valid URL, so a validator would accept it, but it is not where that gem
+  came from. Saying nothing is better than saying something false.
+- **Local filesystem paths are never written to an SBOM**, and neither are URLs
+  carrying a credential. Several lockfile formats record a directory on the
+  build machine, or a private-registry URL with a token in it — in the
+  `user:password@host` position, in a query parameter such as `?token=` on a
+  signed download link, or embedded in the host or path. Any of these is
+  dropped rather than published. One fragment is recognized rather than
+  dropped: Yarn appends the artifact's own checksum to each `resolved` URL
+  (`...-1.4.0.tgz#71ee51fa...`). That is a fixed-length digest, not a secret,
+  so it is stripped and the download location is kept.
+
+Coverage follows what each ecosystem actually records. npm, pnpm, yarn, and bun
+lockfiles name the exact package archive, so those get a real download location.
+Bundler, Cargo, pub, and most Python lockfiles record only a registry or index
+root, so those get a registry reference and `NOASSERTION`. Go modules, Maven,
+Gradle, NuGet, and Composer record no location at all.
 
 ### Document identity
 
@@ -153,8 +195,12 @@ in both formats (CycloneDX `metadata.manufacturer`, SPDX `PackageSupplier` on
 the package the document DESCRIBES). Supplier is not defaulted to anything
 when the field is unset, and per-component supplier and description data is
 never invented: those fields stay absent unless a data source actually
-provides them. Third-party CRA profile checks will flag the missing
-manufacturer/contact metadata until the `sbom` section is configured.
+provides them. Bomly does not derive them from deps.dev either — its
+`GetVersion` payload asserts neither supplier nor description — and guessing
+(for example treating a PURL namespace as a supplier) would put invented
+claims into a compliance document. Third-party CRA profile checks will flag
+the missing manufacturer/contact metadata until the `sbom` section is
+configured.
 
 When `--enrich` is set, components are enriched from the matching-stage package
 registry (keyed by PURL):
@@ -165,14 +211,18 @@ registry (keyed by PURL):
 - Vulnerabilities — CycloneDX as a first-class `vulnerabilities` array (ratings,
   CWEs, advisories, `affects`); SPDX as `SECURITY`/`advisory` external references.
 - End-of-life status (CycloneDX `bomly:eol*` properties, SPDX package comment).
+- The source repository resolved by the OpenSSF Scorecard matcher (CycloneDX
+  `vcs` external reference, SPDX `PackageSourceInfo`). A repository recorded by
+  the detector itself is more precise, so it wins when both are known.
 
 Reachability annotations and other Bomly-specific metadata are emitted in the JSON output (`--json` or `--format json`), not in the standard SBOM formats. See [Output formats](OUTPUT_FORMATS.md).
 
 ### Preservation and conversion limits
 
 Bomly preserves component identity (including PURL), dependency edges, roots,
-scope, package type, licenses, digests, CPEs, and the enrichment fields described
-above when the destination format has an equivalent representation. Encoding is
+scope, package type, licenses, digests, CPEs, download and repository
+locations, and the enrichment fields described above when the destination
+format has an equivalent representation. Encoding is
 deterministic when the scan timestamp and document identifiers are fixed.
 
 Some information necessarily becomes less specific during conversion:

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -136,11 +136,15 @@ Two rules matter here:
   (`...-1.4.0.tgz#71ee51fa...`). That is a fixed-length digest, not a secret,
   so it is stripped and the download location is kept.
 
-Coverage follows what each ecosystem actually records. npm, pnpm, yarn, and bun
-lockfiles name the exact package archive, so those get a real download location.
-Bundler, Cargo, pub, and most Python lockfiles record only a registry or index
-root, so those get a registry reference and `NOASSERTION`. Go modules, Maven,
-Gradle, NuGet, and Composer record no location at all.
+Coverage follows what each ecosystem actually records. npm, pnpm, Yarn Classic
+(v1), and bun lockfiles name the exact package archive, so those get a real
+download location; Yarn Berry records only resolution identifiers such as
+`react@npm:18.2.0`, so its packages are omitted. Bundler, pub, and most Python
+lockfiles record only a registry or index root, so those get a registry
+reference and `NOASSERTION` — as do Cargo's registry dependencies, while its
+`git+` dependencies follow the source-repository row above with their pinned
+revision. Go modules, Maven, Gradle, NuGet, and Composer record no location at
+all.
 
 ### Document identity
 
@@ -220,9 +224,13 @@ Reachability annotations and other Bomly-specific metadata are emitted in the JS
 ### Preservation and conversion limits
 
 Bomly preserves component identity (including PURL), dependency edges, roots,
-scope, package type, licenses, digests, CPEs, download and repository
-locations, and the enrichment fields described above when the destination
-format has an equivalent representation. Encoding is
+scope, package type, licenses, digests, CPEs, and the enrichment fields described
+above when the destination format has an equivalent representation. Download and
+repository locations are an export-time projection of what Bomly's own detectors
+and matchers observed: they are written when scanning a project, but they are not
+read back when ingesting an existing SBOM, so `--sbom` conversion does not carry
+a source document's `downloadLocation` or external references through to the
+output. Encoding is
 deterministic when the scan timestamp and document identifiers are fixed.
 
 Some information necessarily becomes less specific during conversion:

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -136,10 +136,12 @@ Two rules matter here:
   (`...-1.4.0.tgz#71ee51fa...`). That is a fixed-length digest, not a secret,
   so it is stripped and the download location is kept.
 
-Coverage follows what each ecosystem actually records. npm, pnpm, Yarn Classic
+Coverage follows what each ecosystem actually records. npm, Yarn Classic
 (v1), and bun lockfiles name the exact package archive, so those get a real
-download location; Yarn Berry records only resolution identifiers such as
-`react@npm:18.2.0`, so its packages are omitted. Bundler, pub, and most Python
+download location, and pnpm does too when its lockfile records the optional
+`tarball` field — recent pnpm versions often record only an integrity hash,
+and those packages are omitted. Yarn Berry records only resolution
+identifiers such as `react@npm:18.2.0`, so its packages are omitted as well. Bundler, pub, and most Python
 lockfiles record only a registry or index root, so those get a registry
 reference and `NOASSERTION` — as do Cargo's registry dependencies, while its
 `git+` dependencies follow the source-repository row above with their pinned

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -47,6 +47,9 @@ func (c cycloneDXCodec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, e
 		if props := cycloneDXEOLProperties(comp.EOL); len(props) > 0 {
 			component.Properties = &props
 		}
+		if refs := cycloneDXComponentReferences(comp); len(refs) > 0 {
+			component.ExternalReferences = &refs
+		}
 		components = append(components, component)
 	}
 	bom.Components = &components
@@ -259,6 +262,39 @@ func cycloneDXSecurityReferences(p Provenance) []cdx.ExternalReference {
 	if disclosure := strings.TrimSpace(p.VulnerabilityDisclosureURL); disclosure != "" {
 		refs = append(refs, cdx.ExternalReference{Type: cdx.ERTypeAdvisories, URL: disclosure, Comment: "Coordinated vulnerability disclosure policy"})
 	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+// cycloneDXComponentReferences builds the per-component external references
+// describing where the package came from.
+//
+// A registry root is emitted only when no exact artifact URL is known, and it
+// carries a comment saying so — it names where the ecosystem fetches from, not
+// where this package came from.
+func cycloneDXComponentReferences(component Component) []cdx.ExternalReference {
+	refs := make([]cdx.ExternalReference, 0, 2)
+
+	switch {
+	case component.ArtifactURL != "":
+		refs = append(refs, cdx.ExternalReference{Type: cdx.ERTypeDistribution, URL: component.ArtifactURL})
+	case component.RegistryURL != "":
+		refs = append(refs, cdx.ExternalReference{
+			Type:    cdx.ERTypeDistribution,
+			URL:     component.RegistryURL,
+			Comment: "Registry root; not the exact artifact location",
+		})
+	}
+
+	// VCSURL is detector-supplied and version-exact, so it wins over the
+	// scorecard repository. Emitting both would assert the same repository
+	// twice from two sources.
+	if vcs := firstNonEmpty(component.VCSURL, component.Repository); vcs != "" {
+		refs = append(refs, cdx.ExternalReference{Type: cdx.ERTypeVCS, URL: vcs})
+	}
+
 	if len(refs) == 0 {
 		return nil
 	}

--- a/internal/sbom/distribution_test.go
+++ b/internal/sbom/distribution_test.go
@@ -1,0 +1,333 @@
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-sdk"
+	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+)
+
+// graphWithResolvedURL builds a one-node graph carrying a detector-supplied
+// resolved URL, the shape every distribution assertion is derived from.
+func graphWithResolvedURL(t *testing.T, resolved string, source sdk.DependencySource, ecosystem sdk.Ecosystem) *sdk.Graph {
+	t.Helper()
+	g := sdk.New()
+	node := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name:      "pkg",
+			Version:   "1.0.0",
+			PURL:      "pkg:npm/pkg@1.0.0",
+			Ecosystem: ecosystem,
+		},
+		Source:      source,
+		ResolvedURL: resolved,
+	})
+	if err := g.AddNode(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+	return g
+}
+
+func spdxPackageFor(t *testing.T, g *sdk.Graph, opts BuildOptions) *v23.Package {
+	t.Helper()
+	out, err := MarshalDepGraphJSON(g, TargetSPDX23JSON, opts, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal spdx: %v", err)
+	}
+	var doc v23.Document
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal spdx: %v", err)
+	}
+	for _, p := range doc.Packages {
+		if p != nil && p.PackageName == "pkg" {
+			return p
+		}
+	}
+	t.Fatal("package not found in spdx output")
+	return nil
+}
+
+func cycloneDXComponentFor(t *testing.T, g *sdk.Graph, opts BuildOptions) cdx.Component {
+	t.Helper()
+	out, err := MarshalDepGraphJSON(g, TargetCycloneDX17JSON, opts, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal cyclonedx: %v", err)
+	}
+	var bom cdx.BOM
+	if err := json.Unmarshal(out, &bom); err != nil {
+		t.Fatalf("unmarshal cyclonedx: %v", err)
+	}
+	if bom.Components == nil {
+		t.Fatal("no components in cyclonedx output")
+	}
+	for _, comp := range *bom.Components {
+		if comp.Name == "pkg" {
+			return comp
+		}
+	}
+	t.Fatal("component not found in cyclonedx output")
+	return cdx.Component{}
+}
+
+func externalRefURL(comp cdx.Component, refType cdx.ExternalReferenceType) string {
+	if comp.ExternalReferences == nil {
+		return ""
+	}
+	for _, ref := range *comp.ExternalReferences {
+		if ref.Type == refType {
+			return ref.URL
+		}
+	}
+	return ""
+}
+
+func TestDistributionProjection(t *testing.T) {
+	cases := []struct {
+		name         string
+		resolved     string
+		source       sdk.DependencySource
+		ecosystem    sdk.Ecosystem
+		wantDownload string
+		wantDistRef  string
+		wantVCSRef   string
+	}{
+		{
+			name:         "npm tarball becomes a download location",
+			resolved:     "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+			source:       sdk.DependencySourceRegistry,
+			ecosystem:    sdk.EcosystemNPM,
+			wantDownload: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+			wantDistRef:  "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+		},
+		{
+			// The single most important regression case: a registry root is
+			// a valid URL that both validators accept, and reading it as the
+			// artifact's origin would be wrong.
+			name:         "rubygems registry root never becomes a download location",
+			resolved:     "https://rubygems.org/",
+			source:       sdk.DependencySourceRegistry,
+			ecosystem:    sdk.EcosystemRuby,
+			wantDownload: "NOASSERTION",
+			wantDistRef:  "https://rubygems.org/",
+		},
+		{
+			name:         "cargo registry index never becomes a download location",
+			resolved:     "registry+https://github.com/rust-lang/crates.io-index",
+			source:       sdk.DependencySourceRegistry,
+			ecosystem:    sdk.EcosystemRust,
+			wantDownload: "NOASSERTION",
+			wantDistRef:  "https://github.com/rust-lang/crates.io-index",
+		},
+		{
+			name:         "cargo git pin normalizes to the spdx vcs form",
+			resolved:     "git+https://github.com/a/b?rev=deadbeef",
+			source:       sdk.DependencySourceGit,
+			ecosystem:    sdk.EcosystemRust,
+			wantDownload: "git+https://github.com/a/b@deadbeef",
+			wantVCSRef:   "git+https://github.com/a/b@deadbeef",
+		},
+		{
+			name:         "uv editable local path is never emitted",
+			resolved:     "/Users/ahmed/dev/mylib",
+			source:       sdk.DependencySourceFile,
+			ecosystem:    sdk.EcosystemPython,
+			wantDownload: "NOASSERTION",
+		},
+		{
+			name:         "credential bearing url is never emitted",
+			resolved:     "https://tok:s3cret@nexus.corp/pkg-1.0.0.tgz",
+			source:       sdk.DependencySourceRegistry,
+			ecosystem:    sdk.EcosystemNPM,
+			wantDownload: "NOASSERTION",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graphWithResolvedURL(t, tc.resolved, tc.source, tc.ecosystem)
+
+			pkg := spdxPackageFor(t, g, BuildOptions{})
+			if pkg.PackageDownloadLocation != tc.wantDownload {
+				t.Fatalf("downloadLocation = %q, want %q", pkg.PackageDownloadLocation, tc.wantDownload)
+			}
+
+			comp := cycloneDXComponentFor(t, g, BuildOptions{})
+			if got := externalRefURL(comp, cdx.ERTypeDistribution); got != tc.wantDistRef {
+				t.Fatalf("distribution ref = %q, want %q", got, tc.wantDistRef)
+			}
+			if got := externalRefURL(comp, cdx.ERTypeVCS); got != tc.wantVCSRef {
+				t.Fatalf("vcs ref = %q, want %q", got, tc.wantVCSRef)
+			}
+		})
+	}
+}
+
+// TestDetectorRevisionPinsVCSLocator covers the detectors (bundler, pub, the
+// python family) that keep a git dependency's resolved commit in metadata
+// while leaving ResolvedURL as the bare remote. Without folding it in, the
+// export names a moving branch for a package whose commit is known.
+func TestDetectorRevisionPinsVCSLocator(t *testing.T) {
+	g := sdk.New()
+	node := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name: "pkg", Version: "1.0.0",
+			PURL: "pkg:gem/pkg@1.0.0", Ecosystem: sdk.EcosystemRuby,
+		},
+		Source:      sdk.DependencySourceGit,
+		ResolvedURL: "https://github.com/owner/repo",
+		Metadata:    map[string]any{"source_revision": "9f8e7d6c5b4a"},
+	})
+	if err := g.AddNode(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	pkg := spdxPackageFor(t, g, BuildOptions{})
+	if want := "git+https://github.com/owner/repo@9f8e7d6c5b4a"; pkg.PackageDownloadLocation != want {
+		t.Fatalf("downloadLocation = %q, want the detector-resolved commit pinned (%q)",
+			pkg.PackageDownloadLocation, want)
+	}
+}
+
+// TestUnsafeDetectorRevisionIsIgnored keeps an unusable metadata value from
+// producing a malformed locator.
+func TestUnsafeDetectorRevisionIsIgnored(t *testing.T) {
+	g := sdk.New()
+	node := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name: "pkg", Version: "1.0.0",
+			PURL: "pkg:gem/pkg@1.0.0", Ecosystem: sdk.EcosystemRuby,
+		},
+		Source:      sdk.DependencySourceGit,
+		ResolvedURL: "https://github.com/owner/repo",
+		Metadata:    map[string]any{"source_revision": "bad revision\x00"},
+	})
+	if err := g.AddNode(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	pkg := spdxPackageFor(t, g, BuildOptions{})
+	if want := "git+https://github.com/owner/repo"; pkg.PackageDownloadLocation != want {
+		t.Fatalf("downloadLocation = %q, want the unpinned repository (%q)",
+			pkg.PackageDownloadLocation, want)
+	}
+}
+
+// TestDistributionNeverLeaksLocalPaths asserts on the encoded bytes, the way a
+// consumer would see them. A path leak is the one genuinely dangerous failure
+// mode of this feature.
+func TestDistributionNeverLeaksLocalPaths(t *testing.T) {
+	secrets := []string{
+		"/Users/ahmed/secret-project",
+		"../../etc/passwd",
+		"file:///Users/ahmed/x",
+		"https://tok:s3cret@nexus.corp/a-1.0.tgz",
+	}
+	for _, secret := range secrets {
+		g := graphWithResolvedURL(t, secret, sdk.DependencySourceRegistry, sdk.EcosystemNPM)
+		for _, target := range []Target{TargetSPDX23JSON, TargetCycloneDX17JSON} {
+			out, err := MarshalDepGraphJSON(g, target, BuildOptions{}, EncodeOptions{})
+			if err != nil {
+				t.Fatalf("marshal %s: %v", target, err)
+			}
+			needle := secret
+			if idx := strings.Index(needle, "://"); idx >= 0 {
+				needle = needle[idx+3:]
+			}
+			if strings.Contains(string(out), needle) {
+				t.Fatalf("%s output leaked %q", target, secret)
+			}
+		}
+	}
+}
+
+func TestScorecardRepositoryProjection(t *testing.T) {
+	const purl = "pkg:npm/pkg@1.0.0"
+	g := graphWithResolvedURL(t, "", sdk.DependencySourceRegistry, sdk.EcosystemNPM)
+
+	registry := sdk.NewPackageRegistry()
+	pkg := registry.Ensure(purl)
+	pkg.Name, pkg.Version = "pkg", "1.0.0"
+	pkg.Scorecard = &sdk.PackageScorecard{Repository: "github.com/owner/repo"}
+
+	opts := BuildOptions{Registry: registry}
+	comp := cycloneDXComponentFor(t, g, opts)
+	if got := externalRefURL(comp, cdx.ERTypeVCS); got != "https://github.com/owner/repo" {
+		t.Fatalf("vcs ref = %q, want the normalized scorecard repository", got)
+	}
+
+	spdxPkg := spdxPackageFor(t, g, opts)
+	if want := "Source repository: https://github.com/owner/repo"; spdxPkg.PackageSourceInfo != want {
+		t.Fatalf("sourceInfo = %q, want %q", spdxPkg.PackageSourceInfo, want)
+	}
+}
+
+// TestScorecardRepositoryAbsentWithoutEnrichment covers the registry-less call
+// shape used by the benchmark, where every registry-sourced field must degrade
+// to omitted rather than panic or invent a value.
+func TestScorecardRepositoryAbsentWithoutEnrichment(t *testing.T) {
+	g := graphWithResolvedURL(t, "", sdk.DependencySourceRegistry, sdk.EcosystemNPM)
+
+	comp := cycloneDXComponentFor(t, g, BuildOptions{})
+	if comp.ExternalReferences != nil {
+		t.Fatalf("expected no external references, got %+v", *comp.ExternalReferences)
+	}
+	if spdxPkg := spdxPackageFor(t, g, BuildOptions{}); spdxPkg.PackageSourceInfo != "" {
+		t.Fatalf("expected no sourceInfo, got %q", spdxPkg.PackageSourceInfo)
+	}
+}
+
+// TestDetectorVCSWinsOverScorecardRepository keeps the two sources from each
+// asserting the same repository twice.
+func TestDetectorVCSWinsOverScorecardRepository(t *testing.T) {
+	const purl = "pkg:npm/pkg@1.0.0"
+	g := graphWithResolvedURL(t, "git+https://github.com/a/b?rev=deadbeef", sdk.DependencySourceGit, sdk.EcosystemNPM)
+
+	registry := sdk.NewPackageRegistry()
+	pkg := registry.Ensure(purl)
+	pkg.Name, pkg.Version = "pkg", "1.0.0"
+	pkg.Scorecard = &sdk.PackageScorecard{Repository: "github.com/owner/repo"}
+
+	comp := cycloneDXComponentFor(t, g, BuildOptions{Registry: registry})
+	vcsRefs := 0
+	for _, ref := range *comp.ExternalReferences {
+		if ref.Type == cdx.ERTypeVCS {
+			vcsRefs++
+			if ref.URL != "git+https://github.com/a/b@deadbeef" {
+				t.Fatalf("vcs ref = %q, want the detector-supplied pin", ref.URL)
+			}
+		}
+	}
+	if vcsRefs != 1 {
+		t.Fatalf("expected exactly one vcs reference, got %d", vcsRefs)
+	}
+}
+
+// TestSwiftPMRevisionKeyIsRead covers the detector that records its resolved
+// commit under "revision" rather than "source_revision". Reading only the
+// latter exported a reproducible SwiftPM pin as a moving repository.
+func TestSwiftPMRevisionKeyIsRead(t *testing.T) {
+	g := sdk.New()
+	node := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name: "swift-nio", Version: "2.0.0",
+			PURL: "pkg:swift/github.com/apple/swift-nio@2.0.0", Ecosystem: sdk.EcosystemSwift,
+		},
+		Source:      sdk.DependencySourceGit,
+		ResolvedURL: "https://github.com/apple/swift-nio",
+		Metadata:    map[string]any{"revision": "9f8e7d6c5b4a"},
+	})
+	if err := g.AddNode(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	out, err := MarshalDepGraphJSON(g, TargetSPDX23JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "git+https://github.com/apple/swift-nio@9f8e7d6c5b4a") {
+		t.Fatalf("swiftpm resolved revision was not pinned:\n%s", out)
+	}
+}

--- a/internal/sbom/distribution_test.go
+++ b/internal/sbom/distribution_test.go
@@ -331,3 +331,28 @@ func TestSwiftPMRevisionKeyIsRead(t *testing.T) {
 		t.Fatalf("swiftpm resolved revision was not pinned:\n%s", out)
 	}
 }
+
+// TestOpaqueTokenRevisionIsNotPinned covers the metadata path: a Pipenv or
+// Poetry ref carrying an entitlement-style token reaches source_revision, and
+// pinning it would publish the token after the "@".
+func TestOpaqueTokenRevisionIsNotPinned(t *testing.T) {
+	g := sdk.New()
+	node := sdk.NewDependencyWithID("pkg@1.0.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name: "pkg", Version: "1.0.0",
+			PURL: "pkg:pypi/pkg@1.0.0", Ecosystem: sdk.EcosystemPython,
+		},
+		Source:      sdk.DependencySourceGit,
+		ResolvedURL: "https://github.com/owner/repo",
+		Metadata:    map[string]any{"source_revision": "Xk9mPq2Lr8Tn4Vw7Yz"},
+	})
+	if err := g.AddNode(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	pkg := spdxPackageFor(t, g, BuildOptions{})
+	if want := "git+https://github.com/owner/repo"; pkg.PackageDownloadLocation != want {
+		t.Fatalf("downloadLocation = %q, want the unpinned repository (%q)",
+			pkg.PackageDownloadLocation, want)
+	}
+}

--- a/internal/sbom/locator.go
+++ b/internal/sbom/locator.go
@@ -1,0 +1,584 @@
+package sbom
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+// LocatorKind classifies what a detector-supplied resolved URL actually points
+// at. Detectors record wildly different things in the same field — an npm
+// lockfile records a tarball URL, a Gemfile.lock records the registry root, a
+// uv lock can record a local directory — so the kind must be decided per value
+// rather than per ecosystem.
+type LocatorKind int
+
+const (
+	// LocatorNone means nothing publishable could be asserted. Local
+	// filesystem paths and credential-bearing URLs land here.
+	LocatorNone LocatorKind = iota
+	// LocatorArtifact is a concrete downloadable file.
+	LocatorArtifact
+	// LocatorVCS is a source-control location.
+	LocatorVCS
+	// LocatorRegistryRoot is a registry or index root: it says where the
+	// ecosystem fetches from, not where this package came from.
+	LocatorRegistryRoot
+)
+
+// Locator is the classified form of a resolved URL, ready for projection into
+// an SBOM. URL is empty whenever Kind is LocatorNone.
+type Locator struct {
+	Kind LocatorKind
+	URL  string
+}
+
+// artifactExtensions are the archive suffixes that mark a URL path as a
+// concrete package artifact rather than a registry endpoint. The list is an
+// allowlist on purpose: an unrecognized path shape degrades to a registry
+// root, which is never used as a download location.
+var artifactExtensions = []string{
+	".tgz", ".tar.gz", ".tar.bz2", ".tar.xz", ".tar", ".zip",
+	".whl", ".gem", ".crate", ".jar", ".nupkg", ".egg", ".conda",
+}
+
+// metadataKeySourceRevision is the Dependency.Metadata key several detectors
+// (ruby, pub, and the python family) use to record the commit a git
+// dependency resolved to, separately from the repository URL.
+// Detectors do not agree on one key: ruby, pub, and the python family write
+// "source_revision", while swiftpm writes "revision".
+var metadataRevisionKeys = []string{"source_revision", "revision"}
+
+// sourceRevisionFrom returns a detector-recorded resolved commit, or "".
+func sourceRevisionFrom(metadata map[string]any) string {
+	for _, key := range metadataRevisionKeys {
+		revision, _ := metadata[key].(string)
+		revision = strings.TrimSpace(revision)
+		if isSafeRevision(revision) {
+			return revision
+		}
+	}
+	return ""
+}
+
+// pinLocator attaches a detector-recorded revision to a VCS locator that does
+// not already carry one.
+//
+// Bundler, pub, and the python detectors keep the resolved commit in metadata
+// while leaving ResolvedURL as the bare remote, so without this the export
+// would name a moving branch for a dependency whose commit is actually known.
+func pinLocator(locator Locator, revision string) Locator {
+	if locator.Kind != LocatorVCS || revision == "" || strings.Contains(locator.URL, "@") {
+		return locator
+	}
+	return Locator{Kind: LocatorVCS, URL: locator.URL + "@" + revision}
+}
+
+// hasCredentialPath reports whether any path segment looks like a secret.
+//
+// looksLikeCredential is applied to query names and values, revisions, mail
+// addresses, and URN segments, but a token can just as easily sit in the path:
+// "https://repo.example/download/ghp_abcd1234/pkg.tgz" has no userinfo, no
+// query, and no fragment, so every other gate passes it.
+func hasCredentialPath(parsed *url.URL) bool {
+	path := parsed.Path
+	if decoded, err := url.PathUnescape(path); err == nil {
+		path = decoded
+	}
+	return containsCredential(path)
+}
+
+// hasCredentialHost reports whether any hostname label looks like a secret.
+//
+// Userinfo, path, query, fragment, and revision positions are all gated, but
+// a token can sit in the host too: "https://ghp_abcd1234.repo.example/a.tgz"
+// has a nil User, a clean path, and no query, so every other check passes it.
+func hasCredentialHost(parsed *url.URL) bool {
+	return containsCredential(parsed.Hostname())
+}
+
+// classifyResolvedURL decides what raw points at, given the detector's own
+// source classification and the package ecosystem.
+//
+// The function is deliberately conservative: it emits nothing unless the value
+// is an unambiguous http(s) URL, and it prefers the weaker LocatorRegistryRoot
+// over LocatorArtifact whenever the path shape is not recognizably an archive.
+// An SBOM that omits a download location is correct; one that points at the
+// wrong place, or at the developer's home directory, is not.
+func classifyResolvedURL(raw string, source sdk.DependencySource, ecosystem sdk.Ecosystem) Locator {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Locator{}
+	}
+
+	// Cargo records the raw Cargo.lock `source` string, which carries its own
+	// scheme prefix. The prefix is a stronger signal than anything else here.
+	hint := LocatorNone
+	vcsTool := ""
+	switch {
+	case strings.HasPrefix(raw, "registry+"):
+		raw, hint = strings.TrimPrefix(raw, "registry+"), LocatorRegistryRoot
+	case strings.HasPrefix(raw, "sparse+"):
+		raw, hint = strings.TrimPrefix(raw, "sparse+"), LocatorRegistryRoot
+	default:
+		// Any recognized version-control tool prefix, not just git+: an SPDX
+		// downloadLocation of "svn+https://…" is a valid VCS location, and
+		// leaving it prefixed makes the transport gate reject it outright.
+		// The tool is carried through so normalization does not silently
+		// rewrite the asserted version-control system as Git.
+		if prefix, rest, isVCS := splitVCSToolPrefix(raw); isVCS {
+			raw, hint, vcsTool = rest, LocatorVCS, prefix
+		}
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return Locator{}
+	}
+
+	// The scheme gate is what keeps local filesystem layout out of published
+	// SBOMs. Several detectors put bare paths in this field (uv `editable`
+	// and `path`, pipenv `path`, pub `path`, npm link entries), and they do
+	// not consistently carry DependencySourceFile, so the check must be on
+	// the value rather than on source.
+	// Detector-derived values stay HTTP-only: nothing asserts what they are,
+	// so the narrowest gate is right. A value the source document declared a
+	// download location may also use the network transports the external
+	// reference gate accepts.
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return Locator{}
+	}
+	if parsed.Host == "" {
+		return Locator{}
+	}
+
+	// A lockfile pointing at a private registry can embed a token. Publishing
+	// it in an SBOM would leak a live credential, so drop the value entirely
+	// rather than try to strip the userinfo and emit the rest.
+	if parsed.User != nil || hasCredentialHost(parsed) {
+		return Locator{}
+	}
+
+	switch source {
+	case sdk.DependencySourceFile, sdk.DependencySourceProject, sdk.DependencySourceWorkspace:
+		return Locator{}
+	}
+
+	// Every VCS form is classified before the query and fragment gate below.
+	// normalizeVCS discards both and keeps only a character-checked revision,
+	// so it is safe on values the gate would otherwise reject — and a git
+	// dependency legitimately pins its revision that way
+	// ("https://host/repo.git?rev=<sha>"). Gating first would silently drop
+	// those pins.
+	if hint == LocatorVCS {
+		return normalizeVCS(parsed, vcsTool)
+	}
+	if hint != LocatorRegistryRoot {
+		// Swift package identity is the repository URL, so swiftpm records a
+		// repo even for `kind: registry` pins. Without this the extension
+		// check below would demote them to registry roots.
+		if ecosystem == sdk.EcosystemSwift {
+			return normalizeVCS(parsed, vcsTool)
+		}
+		if source == sdk.DependencySourceGit || strings.HasSuffix(parsed.Path, ".git") {
+			return normalizeVCS(parsed, vcsTool)
+		}
+	}
+
+	// The path is checked here rather than above because every VCS branch has
+	// already returned: those go through normalizeVCS, which separates the
+	// "@<revision>" suffix and then checks what remains, so a bad revision
+	// costs only the revision instead of the whole repository.
+	if hasCredentialPath(parsed) {
+		return Locator{}
+	}
+
+	// Credentials also travel outside userinfo: signed and private-registry
+	// URLs carry them as query parameters or fragments
+	// ("...?token=<secret>", "...?X-Amz-Signature=..."). A detector-supplied
+	// value has nothing asserting the URL is a download location, so any
+	// query disqualifies it — a benign parameter cannot be told apart from a
+	// credential, and omitting is cheap.
+	if parsed.RawQuery != "" {
+		return Locator{}
+	}
+
+	// A fragment is rejected on the same grounds, with one exception: Yarn
+	// v1 appends the artifact's own checksum to every `resolved` URL
+	// ("...-1.4.0.tgz#71ee51fa..."). That is a fixed-format digest, not a
+	// secret, and rejecting it would drop the download location for every
+	// package in a Yarn lockfile. Strip it and keep the URL; anything that
+	// is not digest-shaped is still treated as a secret.
+	if parsed.Fragment != "" {
+		if !isChecksumFragment(parsed.Fragment) {
+			return Locator{}
+		}
+		clean := *parsed
+		clean.Fragment = ""
+		parsed = &clean
+	}
+
+	if hint == LocatorRegistryRoot {
+		return Locator{Kind: LocatorRegistryRoot, URL: parsed.String()}
+	}
+
+	if isConcreteArtifactPath(parsed.Path) {
+		return Locator{Kind: LocatorArtifact, URL: parsed.String()}
+	}
+	return Locator{Kind: LocatorRegistryRoot, URL: parsed.String()}
+}
+
+// isChecksumFragment reports whether a URL fragment is a bare hex digest of a
+// standard length, the form Yarn v1 and some registries append to an artifact
+// URL.
+//
+// The length allowlist is what keeps this from becoming a hole: an arbitrary
+// hex-looking secret of some other length is still rejected as a credential.
+func isChecksumFragment(fragment string) bool {
+	switch len(fragment) {
+	case 32, 40, 64, 96, 128: // md5, sha1, sha256, sha384, sha512
+	default:
+		return false
+	}
+	for _, r := range fragment {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isConcreteArtifactPath reports whether the final path segment names a
+// package archive.
+func isConcreteArtifactPath(path string) bool {
+	idx := strings.LastIndex(path, "/")
+	last := strings.ToLower(path[idx+1:])
+	if last == "" {
+		return false
+	}
+	for _, ext := range artifactExtensions {
+		if strings.HasSuffix(last, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeVCS renders parsed in the SPDX 2.3 version-control form,
+// "<tool>+<transport>://<host><path>[@<revision>]".
+//
+// That grammar has no query component, so a cargo value such as
+// "git+https://host/a/b?rev=abc" cannot be passed through as-is: the revision
+// is moved to the "@" suffix and the query is dropped.
+func normalizeVCS(parsed *url.URL, tool string) Locator {
+	// The fragment carries the resolved commit and the query carries what was
+	// requested, so "?branch=main#abc123" locked abc123. Preferring the
+	// fragment records the immutable commit rather than a moving branch, and
+	// matches the precedence uvSourceRevision already applies when the same
+	// lockfile value is parsed for detection.
+	//
+	// A fragment must be commit-shaped, not merely character-safe: an access
+	// token such as "#ghp_abcd1234" passes isSafeRevision and would then be
+	// republished after the "@". A query value is held to the looser rule
+	// because its key names it a revision.
+	// An already-rendered "@<revision>" lives in the path, where url.Parse
+	// leaves it untouched. Splitting it off here is what stops a token from
+	// riding through on a value that was normalized once already: this
+	// function is reached from paths that never call validatedVCSLocator.
+	parsed, pathRevision, ok := splitVCSRevision(parsed.String())
+	if !ok {
+		return Locator{}
+	}
+
+	revision := strings.TrimSpace(parsed.Fragment)
+	if !isCommitFragment(revision) {
+		revision = ""
+	}
+	if revision == "" {
+		revision = pathRevision
+	}
+	if revision == "" {
+		for _, key := range []string{"rev", "tag", "branch"} {
+			if value := strings.TrimSpace(parsed.Query().Get(key)); value != "" {
+				revision = value
+				break
+			}
+		}
+	}
+
+	clean := *parsed
+	clean.RawQuery = ""
+	clean.Fragment = ""
+
+	// A repository location needs a path: "https://host" alone identifies no
+	// repository. Requiring one also removes an ambiguity in the SPDX form —
+	// with an empty path, the "@<revision>" suffix would re-parse as URL
+	// userinfo ("git+https://host@rev" reads as user "host", host "rev").
+	if path := strings.Trim(clean.Path, "/"); path == "" {
+		return Locator{}
+	}
+
+	base := strings.TrimSuffix(clean.String(), "/")
+	if tool == "" {
+		tool = "git+"
+	}
+	out := tool + base
+	if isSafeRevision(revision) {
+		out += "@" + revision
+	}
+	return Locator{Kind: LocatorVCS, URL: out}
+}
+
+// isCommitFragment reports whether a URL fragment looks like a git object
+// name.
+//
+// Fragments on a version-control URL carry the resolved commit by convention
+// (uv and cargo both write one), so requiring bare hex is faithful to the
+// format and, unlike the looser isSafeRevision, excludes credential shapes:
+// "ghp_abcd1234" and "github_pat_11ABC_xyz" both fail on their underscores
+// and non-hex letters.
+func isCommitFragment(fragment string) bool {
+	if len(fragment) < 4 || len(fragment) > 64 {
+		return false
+	}
+	for _, r := range fragment {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// credentialPrefixes are issuer prefixes used by common access-token formats.
+// No legitimate git tag, branch, or commit begins with one.
+var credentialPrefixes = []string{
+	"ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_", // GitHub
+	"glpat-", "gldt-", // GitLab
+	"npm_",                                      // npm
+	"pypi-",                                     // PyPI
+	"xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-", // Slack
+	"sk_live_", "pk_live_", "sk-", // Stripe, OpenAI
+	"akia", "asia", // AWS access key ids
+	"aiza",               // Google
+	"hf_",                // Hugging Face
+	"dop_v1_", "doo_v1_", // DigitalOcean
+	"shpat_", "shpss_", // Shopify
+}
+
+// credentialBodyMinimum is how many token characters must follow an issuer
+// prefix before the value is treated as a real secret. A bare "ghp_" is a
+// prefix, not a credential, and rejecting it would discard ordinary URLs.
+const credentialBodyMinimum = 8
+
+// containsCredential reports whether text contains a recognizable access token
+// at a token boundary.
+//
+// This scans rather than splitting on delimiters. Splitting needs the exact
+// delimiter set for every position a token might sit in, and each missing
+// separator is a silent gap; a boundary-aware scan has no such gaps and is the
+// same check wherever it is applied — path, host, or query.
+//
+// The boundary requirement is what keeps it from firing on ordinary text: the
+// prefix must start the value or follow a non-token character, so "task-runner"
+// does not match the "sk-" prefix.
+func containsCredential(text string) bool {
+	lowered := strings.ToLower(text)
+	for _, prefix := range credentialPrefixes {
+		for offset := 0; ; {
+			idx := strings.Index(lowered[offset:], prefix)
+			if idx < 0 {
+				break
+			}
+			at := offset + idx
+			offset = at + 1
+
+			if at > 0 && isTokenRune(rune(lowered[at-1])) {
+				continue // mid-word, not a token boundary
+			}
+			body := 0
+			for _, r := range lowered[at+len(prefix):] {
+				if !isTokenRune(r) {
+					break
+				}
+				body++
+			}
+			if body >= credentialBodyMinimum {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isTokenRune reports whether a rune can appear inside an access token.
+func isTokenRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	case r == '_', r == '-':
+		return true
+	}
+	return false
+}
+
+// looksLikeCredential reports whether a value carries a recognizable
+// access-token prefix.
+//
+// A revision reaches an SBOM verbatim after the "@", and unlike a URL fragment
+// it cannot simply be required to be hex: tags and branches are legitimate
+// here, and they use the same character set a token does. Matching known
+// issuer prefixes is therefore the check available, and it is deliberately
+// narrow — a bespoke or unrecognized secret format would still pass. The
+// stronger guarantee lives on the fragment path, which requires bare hex.
+func looksLikeCredential(value string) bool {
+	return containsCredential(strings.TrimSpace(value))
+}
+
+// isSafeRevision reports whether revision is a plausible git revision that can
+// be appended to an SPDX version-control locator verbatim.
+//
+// The value originates in a lockfile, so it may contain anything at all; a
+// control character or a space would produce an unparseable locator. An
+// unsafe revision is dropped rather than escaped, leaving the still-correct
+// repository URL without a pinned revision.
+func isSafeRevision(revision string) bool {
+	if revision == "" || len(revision) > 256 {
+		return false
+	}
+	if looksLikeCredential(revision) {
+		return false
+	}
+	for _, r := range revision {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.', r == '_', r == '-', r == '/', r == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeRepositoryURL renders a scheme-less canonical repository
+// identifier, such as the "github.com/owner/repo" the OpenSSF Scorecard
+// matcher records, as an absolute https URL.
+//
+// CycloneDX external reference URLs are iri-reference typed, so a scheme-less
+// value would validate but be read as a relative reference. Returns "" when
+// the value does not look like a host-qualified repository.
+func normalizeRepositoryURL(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || strings.ContainsAny(repo, " \t\r\n") {
+		return ""
+	}
+	if strings.Contains(repo, "://") {
+		parsed, err := url.Parse(repo)
+		if err != nil || parsed.User != nil || parsed.Host == "" {
+			return ""
+		}
+		if parsed.RawQuery != "" || parsed.Fragment != "" {
+			return ""
+		}
+		switch strings.ToLower(parsed.Scheme) {
+		case "http", "https":
+			// The scheme-less branch below requires an owner/repo path;
+			// an absolute URL has to clear the same bar or it names no
+			// repository at all.
+			if strings.Trim(parsed.Path, "/") == "" || hasCredentialPath(parsed) || hasCredentialHost(parsed) {
+				return ""
+			}
+			return parsed.String()
+		default:
+			return ""
+		}
+	}
+	if strings.ContainsAny(repo, "?#") {
+		return ""
+	}
+
+	host, rest, ok := strings.Cut(repo, "/")
+	if !ok || !isHostname(host) || strings.TrimSpace(rest) == "" {
+		return ""
+	}
+
+	// Re-parse rather than trusting the shape check: the path may still hold
+	// something url.Parse rejects, such as an invalid percent-escape.
+	candidate := "https://" + repo
+	parsed, err := url.Parse(candidate)
+	if err != nil || parsed.Host != host || parsed.User != nil || hasCredentialPath(parsed) || hasCredentialHost(parsed) {
+		return ""
+	}
+	return candidate
+}
+
+// splitVCSRevision parses a version-control URL and separates any trailing
+// "@<revision>" that is already rendered into its path.
+//
+// Parsing has to happen first. "@" before the host is userinfo — a credential
+// — while "@" after the path is a revision, and the two are only
+// distinguishable once the URL is parsed. Splitting on "@" beforehand reads
+// "https://ghp_secret@github.com" as host "ghp_secret" with revision
+// "github.com", which passes every later check and reconstructs the original
+// credential.
+//
+// ok is false when the URL is unsafe to publish at all.
+func splitVCSRevision(raw string) (parsed *url.URL, revision string, ok bool) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.User != nil || parsed.Host == "" || hasCredentialHost(parsed) {
+		return nil, "", false
+	}
+	// Separate the revision before checking the path. "@" is a path delimiter
+	// for the credential scan, so leaving a "@<revision>" suffix in place
+	// would reject the whole locator for a bad revision instead of dropping
+	// just that revision and keeping the repository.
+	if idx := strings.LastIndex(parsed.Path, "@"); idx >= 0 {
+		revision = parsed.Path[idx+1:]
+		clean := *parsed
+		clean.Path = parsed.Path[:idx]
+		parsed = &clean
+	}
+	if hasCredentialPath(parsed) {
+		return nil, "", false
+	}
+	return parsed, revision, true
+}
+
+// vcsToolPrefixes are the version-control tool prefixes SPDX and CycloneDX
+// use ahead of a transport. Assuming every repository reference is Git would
+// drop the others outright.
+var vcsToolPrefixes = []string{"git+", "svn+", "hg+", "bzr+"}
+
+// splitVCSToolPrefix separates a recognized tool prefix from a locator,
+// returning the prefix (with its "+") and the remainder.
+func splitVCSToolPrefix(locator string) (prefix, rest string, ok bool) {
+	lowered := strings.ToLower(locator)
+	for _, candidate := range vcsToolPrefixes {
+		if strings.HasPrefix(lowered, candidate) {
+			return candidate, locator[len(candidate):], true
+		}
+	}
+	return "", locator, false
+}
+
+// isHostname reports whether value looks like a dotted DNS hostname.
+func isHostname(value string) bool {
+	if !strings.Contains(value, ".") || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sbom/locator.go
+++ b/internal/sbom/locator.go
@@ -69,7 +69,11 @@ func sourceRevisionFrom(metadata map[string]any) string {
 // while leaving ResolvedURL as the bare remote, so without this the export
 // would name a moving branch for a dependency whose commit is actually known.
 func pinLocator(locator Locator, revision string) Locator {
-	if locator.Kind != LocatorVCS || revision == "" || strings.Contains(locator.URL, "@") {
+	if locator.Kind != LocatorVCS || revision == "" {
+		return locator
+	}
+	_, existingRevision, ok := splitVCSRevision(locator.URL)
+	if !ok || existingRevision != "" {
 		return locator
 	}
 	return Locator{Kind: LocatorVCS, URL: locator.URL + "@" + revision}
@@ -152,7 +156,7 @@ func classifyResolvedURL(raw string, source sdk.DependencySource, ecosystem sdk.
 	default:
 		return Locator{}
 	}
-	if parsed.Host == "" {
+	if parsed.Hostname() == "" {
 		return Locator{}
 	}
 
@@ -551,7 +555,7 @@ func normalizeRepositoryURL(repo string) string {
 	}
 	if strings.Contains(repo, "://") {
 		parsed, err := url.Parse(repo)
-		if err != nil || parsed.User != nil || parsed.Host == "" {
+		if err != nil || parsed.User != nil || parsed.Hostname() == "" {
 			return ""
 		}
 		if parsed.RawQuery != "" || parsed.Fragment != "" {
@@ -602,7 +606,7 @@ func normalizeRepositoryURL(repo string) string {
 // ok is false when the URL is unsafe to publish at all.
 func splitVCSRevision(raw string) (parsed *url.URL, revision string, ok bool) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || parsed.User != nil || parsed.Host == "" || hasCredentialHost(parsed) {
+	if err != nil || parsed.User != nil || parsed.Hostname() == "" || hasCredentialHost(parsed) {
 		return nil, "", false
 	}
 	// Separate the revision before checking the path. "@" is a path delimiter

--- a/internal/sbom/locator.go
+++ b/internal/sbom/locator.go
@@ -86,7 +86,7 @@ func hasCredentialPath(parsed *url.URL) bool {
 	if decoded, err := url.PathUnescape(path); err == nil {
 		path = decoded
 	}
-	return containsCredential(path)
+	return containsCredential(path) || hasOpaqueSecretRun(path)
 }
 
 // hasCredentialHost reports whether any hostname label looks like a secret.
@@ -95,7 +95,7 @@ func hasCredentialPath(parsed *url.URL) bool {
 // a token can sit in the host too: "https://ghp_abcd1234.repo.example/a.tgz"
 // has a nil User, a clean path, and no query, so every other check passes it.
 func hasCredentialHost(parsed *url.URL) bool {
-	return containsCredential(parsed.Hostname())
+	return containsCredential(parsed.Hostname()) || hasOpaqueSecretRun(parsed.Hostname())
 }
 
 // classifyResolvedURL decides what raw points at, given the detector's own
@@ -358,15 +358,22 @@ func isCommitFragment(fragment string) bool {
 
 // credentialPrefixes are issuer prefixes used by common access-token formats.
 // No legitimate git tag, branch, or commit begins with one.
+// Matching is case-sensitive: issuers fix the casing of their prefixes, and
+// folding case is what made ordinary words collide ("asia-packages" is not an
+// AWS key, but lowercased it matched "ASIA"). Generic prefixes that also occur
+// in real path segments (a bare "sk-") are narrowed to their issuer-specific
+// forms; secrets with no recognizable prefix are handled by the opaque-shape
+// check below.
 var credentialPrefixes = []string{
 	"ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_", // GitHub
 	"glpat-", "gldt-", // GitLab
 	"npm_",                                      // npm
 	"pypi-",                                     // PyPI
 	"xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-", // Slack
-	"sk_live_", "pk_live_", "sk-", // Stripe, OpenAI
-	"akia", "asia", // AWS access key ids
-	"aiza",               // Google
+	"sk_live_", "pk_live_", // Stripe
+	"sk-proj-", "sk-ant-", // OpenAI, Anthropic
+	"AKIA", "ASIA", // AWS access key ids
+	"AIza",               // Google
 	"hf_",                // Hugging Face
 	"dop_v1_", "doo_v1_", // DigitalOcean
 	"shpat_", "shpss_", // Shopify
@@ -389,21 +396,20 @@ const credentialBodyMinimum = 8
 // prefix must start the value or follow a non-token character, so "task-runner"
 // does not match the "sk-" prefix.
 func containsCredential(text string) bool {
-	lowered := strings.ToLower(text)
 	for _, prefix := range credentialPrefixes {
 		for offset := 0; ; {
-			idx := strings.Index(lowered[offset:], prefix)
+			idx := strings.Index(text[offset:], prefix)
 			if idx < 0 {
 				break
 			}
 			at := offset + idx
 			offset = at + 1
 
-			if at > 0 && isTokenRune(rune(lowered[at-1])) {
+			if at > 0 && isTokenRune(rune(text[at-1])) {
 				continue // mid-word, not a token boundary
 			}
 			body := 0
-			for _, r := range lowered[at+len(prefix):] {
+			for _, r := range text[at+len(prefix):] {
 				if !isTokenRune(r) {
 					break
 				}
@@ -412,6 +418,42 @@ func containsCredential(text string) bool {
 			if body >= credentialBodyMinimum {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// hasOpaqueSecretRun reports whether text contains a maximal token run shaped
+// like an opaque credential with no recognizable issuer prefix — a JWT
+// segment, an entitlement token embedded in a download path, or similar.
+//
+// The prefix list cannot be complete, and origin metadata is optional, so an
+// unrecognizable-but-secret-shaped run is dropped rather than published. The
+// shape is deliberately narrow to keep legitimate values: a run must be long
+// and mix all three character classes (upper, lower, digit), which package
+// names (lowercase), version strings (short runs), and content hashes
+// (single-case hex) never produce. A bespoke all-lowercase secret still
+// passes; omission-preferred is a mitigation, not a guarantee.
+func hasOpaqueSecretRun(text string) bool {
+	for _, run := range strings.FieldsFunc(text, func(r rune) bool {
+		return !isTokenRune(r)
+	}) {
+		if len(run) < 16 {
+			continue
+		}
+		var hasUpper, hasLower, hasDigit bool
+		for _, r := range run {
+			switch {
+			case r >= 'A' && r <= 'Z':
+				hasUpper = true
+			case r >= 'a' && r <= 'z':
+				hasLower = true
+			case r >= '0' && r <= '9':
+				hasDigit = true
+			}
+		}
+		if hasUpper && hasLower && hasDigit {
+			return true
 		}
 	}
 	return false

--- a/internal/sbom/locator.go
+++ b/internal/sbom/locator.go
@@ -116,6 +116,7 @@ func classifyResolvedURL(raw string, source sdk.DependencySource, ecosystem sdk.
 	// scheme prefix. The prefix is a stronger signal than anything else here.
 	hint := LocatorNone
 	vcsTool := ""
+	gitArchive := false
 	switch {
 	case strings.HasPrefix(raw, "registry+"):
 		raw, hint = strings.TrimPrefix(raw, "registry+"), LocatorRegistryRoot
@@ -184,7 +185,15 @@ func classifyResolvedURL(raw string, source sdk.DependencySource, ecosystem sdk.
 			return normalizeVCS(parsed, vcsTool)
 		}
 		if source == sdk.DependencySourceGit || strings.HasSuffix(parsed.Path, ".git") {
-			return normalizeVCS(parsed, vcsTool)
+			// A git-sourced dependency can still resolve to an archive: Yarn
+			// stores the codeload tarball for a GitHub selector. Rendering
+			// that endpoint in git+ syntax would invent a repository that is
+			// not cloneable, so an archive-shaped path stays an artifact and
+			// falls through to the gates below.
+			if !pathContainsArchive(parsed.Path) {
+				return normalizeVCS(parsed, vcsTool)
+			}
+			gitArchive = true
 		}
 	}
 
@@ -225,7 +234,7 @@ func classifyResolvedURL(raw string, source sdk.DependencySource, ecosystem sdk.
 		return Locator{Kind: LocatorRegistryRoot, URL: parsed.String()}
 	}
 
-	if isConcreteArtifactPath(parsed.Path) {
+	if isConcreteArtifactPath(parsed.Path) || gitArchive {
 		return Locator{Kind: LocatorArtifact, URL: parsed.String()}
 	}
 	return Locator{Kind: LocatorRegistryRoot, URL: parsed.String()}
@@ -251,6 +260,21 @@ func isChecksumFragment(fragment string) bool {
 		}
 	}
 	return true
+}
+
+// pathContainsArchive reports whether any path segment is archive-shaped —
+// either carrying a package-archive extension or being one outright, the way
+// codeload URLs embed "tar.gz" as its own segment before the revision.
+func pathContainsArchive(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		lowered := strings.ToLower(segment)
+		for _, ext := range artifactExtensions {
+			if strings.HasSuffix(lowered, ext) || lowered == strings.TrimPrefix(ext, ".") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isConcreteArtifactPath reports whether the final path segment names a
@@ -494,7 +518,12 @@ func isSafeRevision(revision string) bool {
 	if revision == "" || len(revision) > 256 {
 		return false
 	}
-	if looksLikeCredential(revision) {
+	// A revision is republished after the "@", so it needs both gates: the
+	// issuer-prefix scan and the opaque-shape check. A Pipenv or Poetry ref
+	// carrying an entitlement-style token has no recognizable prefix but is
+	// exactly the shape hasOpaqueSecretRun rejects. The cost of a false
+	// positive is an unpinned repository, which is the safe direction.
+	if looksLikeCredential(revision) || hasOpaqueSecretRun(revision) {
 		return false
 	}
 	for _, r := range revision {
@@ -580,7 +609,14 @@ func splitVCSRevision(raw string) (parsed *url.URL, revision string, ok bool) {
 	// for the credential scan, so leaving a "@<revision>" suffix in place
 	// would reject the whole locator for a bad revision instead of dropping
 	// just that revision and keeping the repository.
-	if idx := strings.LastIndex(parsed.Path, "@"); idx >= 0 {
+	// Only the SPDX locator form ".../repo@rev" is split: the "@" must sit
+	// inside the final segment (not open one, the way a scoped name like
+	// "/@core" does) and the suffix must not span segments. A literal "@" in
+	// a repository path such as "/teams/@core/library" is part of the
+	// repository, and splitting there would export "/teams" at revision
+	// "core/library" — a repository that does not exist.
+	if idx := strings.LastIndex(parsed.Path, "@"); idx > 0 &&
+		parsed.Path[idx-1] != '/' && !strings.Contains(parsed.Path[idx+1:], "/") {
 		revision = parsed.Path[idx+1:]
 		clean := *parsed
 		clean.Path = parsed.Path[:idx]

--- a/internal/sbom/locator_fuzz_test.go
+++ b/internal/sbom/locator_fuzz_test.go
@@ -38,6 +38,7 @@ func FuzzClassifyResolvedURL(f *testing.F) {
 		"workspace:*",
 		"git@github.com:a/b.git",
 		"https://",
+		"https://:8080/pkg.tgz",
 		// Regression: a host-only URL with a fragment once produced
 		// "git+http://0@0", whose "@<revision>" suffix re-parses as userinfo.
 		"http://0#0",
@@ -99,6 +100,7 @@ func FuzzNormalizeRepositoryURL(f *testing.F) {
 		"%./0",
 		// Regression: a scheme with no host once produced the bare "http:".
 		"http://",
+		"https://:8080/a/b",
 	} {
 		f.Add(seed)
 	}

--- a/internal/sbom/locator_fuzz_test.go
+++ b/internal/sbom/locator_fuzz_test.go
@@ -1,0 +1,119 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/bomly-dev/bomly-sdk"
+	"github.com/bomly-dev/bomly-sdk/testkit"
+)
+
+// FuzzClassifyResolvedURL exercises the resolved-URL classifier, which runs
+// over values taken verbatim from untrusted lockfiles (npm `resolved`, uv
+// `editable`/`path`, Cargo.lock `source`, Gemfile.lock `GEM remote:`, and so
+// on).
+//
+// The invariant under test is a safety property, not just an absence of
+// panics: a classified value is either nothing at all or an absolute http(s)
+// URL with no embedded credentials. That is what keeps local filesystem paths
+// and private-registry tokens out of published SBOMs.
+func FuzzClassifyResolvedURL(f *testing.F) {
+	for _, seed := range []string{
+		"https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+		"https://files.pythonhosted.org/packages/x/req-2.31.0-py3-none-any.whl",
+		"https://rubygems.org/",
+		"https://pypi.org/simple",
+		"registry+https://github.com/rust-lang/crates.io-index",
+		"sparse+https://index.crates.io/",
+		"git+https://github.com/a/b?rev=deadbeef",
+		"git+https://github.com/a/b#cafebabe",
+		"https://github.com/apple/swift-nio.git",
+		"https://registry.npmjs.org/@babel/core/-/core-7.0.0.tgz",
+		"https://tok:s3cret@nexus.corp/a/b-1.0.tgz",
+		"/Users/ahmed/dev/mylib",
+		"../vendor/foo",
+		".",
+		`C:\src\lib`,
+		"file:///tmp/x.tgz",
+		"link:../pkg",
+		"workspace:*",
+		"git@github.com:a/b.git",
+		"https://",
+		// Regression: a host-only URL with a fragment once produced
+		// "git+http://0@0", whose "@<revision>" suffix re-parses as userinfo.
+		"http://0#0",
+		// Regression: a control character in the fragment once reached the
+		// revision suffix and produced an unparseable locator.
+		"http://0/0#\x02",
+		"::::",
+		"",
+		"   ",
+		"\x00\uFFFD",
+		"%%%%",
+		"https://host/%2e%2e/%2e%2e/etc/passwd",
+	} {
+		f.Add(seed)
+	}
+
+	sources := []sdk.DependencySource{
+		sdk.DependencySourceRegistry, sdk.DependencySourceGit, sdk.DependencySourceURL,
+		sdk.DependencySourceFile, sdk.DependencySourceProject, sdk.DependencySourceWorkspace, "",
+	}
+	ecosystems := []sdk.Ecosystem{
+		sdk.EcosystemNPM, sdk.EcosystemPython, sdk.EcosystemRust,
+		sdk.EcosystemRuby, sdk.EcosystemSwift, sdk.EcosystemUnknown,
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		if len(raw) > testkit.MaxFuzzInputSize {
+			return
+		}
+		for _, source := range sources {
+			for _, ecosystem := range ecosystems {
+				got := classifyResolvedURL(raw, source, ecosystem)
+				assertPublishableLocator(t, got, raw)
+
+				if again := classifyResolvedURL(raw, source, ecosystem); again != got {
+					t.Fatalf("nondeterministic classification of %q: %+v vs %+v", raw, got, again)
+				}
+			}
+		}
+	})
+}
+
+// FuzzNormalizeRepositoryURL exercises the scorecard repository renderer,
+// whose input is an API-supplied repository identifier.
+func FuzzNormalizeRepositoryURL(f *testing.F) {
+	for _, seed := range []string{
+		"github.com/kubernetes/kubernetes",
+		"https://github.com/a/b",
+		"github.com",
+		"not-a-host",
+		"/Users/ahmed/repo",
+		"has space/repo",
+		"ftp://github.com/a/b",
+		"https://tok:sec@github.com/a/b",
+		"",
+		"\x00",
+		// Regression: a dot-containing but non-hostname prefix once produced
+		// "https://%./0", which is an invalid percent-escape.
+		"%./0",
+		// Regression: a scheme with no host once produced the bare "http:".
+		"http://",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		if len(raw) > testkit.MaxFuzzInputSize {
+			return
+		}
+		got := normalizeRepositoryURL(raw)
+		if got == "" {
+			return
+		}
+		assertPublishableLocator(t, Locator{Kind: LocatorVCS, URL: got}, raw)
+		if again := normalizeRepositoryURL(raw); again != got {
+			t.Fatalf("nondeterministic normalization of %q: %q vs %q", raw, got, again)
+		}
+	})
+}

--- a/internal/sbom/locator_test.go
+++ b/internal/sbom/locator_test.go
@@ -119,6 +119,7 @@ func TestClassifyResolvedURL(t *testing.T) {
 		{"empty", "", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"whitespace", "   ", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"scheme only", "https://", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"port without hostname", "https://:8080/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"colons", "::::", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 	}
 
@@ -203,6 +204,36 @@ func assertPublishableLocator(t *testing.T, got Locator, input string) {
 	if parsed.User != nil {
 		t.Fatalf("emitted locator with userinfo %q for input %q", got.URL, input)
 	}
+	if parsed.Hostname() == "" {
+		t.Fatalf("emitted locator without a hostname %q for input %q", got.URL, input)
+	}
+}
+
+func TestPinLocatorDistinguishesPathAtFromRevision(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "literal at path is pinned",
+			url:  "git+https://git.example.com/teams/@core/library",
+			want: "git+https://git.example.com/teams/@core/library@9f8e7d6c",
+		},
+		{
+			name: "existing revision is preserved",
+			url:  "git+https://git.example.com/teams/library@deadbeef",
+			want: "git+https://git.example.com/teams/library@deadbeef",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pinLocator(Locator{Kind: LocatorVCS, URL: tc.url}, "9f8e7d6c")
+			if got.URL != tc.want {
+				t.Fatalf("url = %q, want %q", got.URL, tc.want)
+			}
+		})
+	}
 }
 
 func TestNormalizeRepositoryURL(t *testing.T) {
@@ -218,6 +249,7 @@ func TestNormalizeRepositoryURL(t *testing.T) {
 		{"/Users/ahmed/repo", ""},
 		{"has space/repo", ""},
 		{"ftp://github.com/a/b", ""},
+		{"https://:8080/a/b", ""},
 		{"https://tok:sec@github.com/a/b", ""},
 	}
 	for _, tc := range cases {

--- a/internal/sbom/locator_test.go
+++ b/internal/sbom/locator_test.go
@@ -54,6 +54,17 @@ func TestClassifyResolvedURL(t *testing.T) {
 		{"token in hostname label", "https://ghp_abcd1234.repo.example/a.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"token in path segment", "https://repo.example/download/ghp_abcd1234/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"percent-encoded token in path", "https://repo.example/download/%67hp_abcd1234/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		// Secrets with no recognizable issuer prefix: the opaque-shape check
+		// (long single run mixing upper, lower, and digits) catches them.
+		{"jwt segment in path", "https://repo.example/download/eyJhbGciOiJIUzI1NiJ9/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"opaque entitlement token in path", "https://dl.example.io/Xk9mPq2Lr8Tn4Vw7Yz/owner/pkg-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"aws key id in path", "https://repo.example/AKIAIOSFODNN7EXAMPLE/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		// Prefix matching is case-sensitive, so ordinary words that lowercase
+		// into an issuer prefix are not secrets.
+		{"asia as an ordinary word survives", "https://mirror.example/asia-packages/pkg-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorArtifact, "https://mirror.example/asia-packages/pkg-1.0.tgz"},
+		// Mixed-case artifact names split at the extension dot, so no single
+		// run reaches the opaque threshold.
+		{"mixed-case wheel survives", "https://files.pythonhosted.org/packages/ab/cd/Django-4.2-py3-none-any.whl", sdk.DependencySourceURL, sdk.EcosystemPython, LocatorArtifact, "https://files.pythonhosted.org/packages/ab/cd/Django-4.2-py3-none-any.whl"},
 		{"username only", "https://tok@nexus.corp/a/b-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"query token", "https://nexus.corp/a/b-1.0.tgz?token=s3cret", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
 		{"presigned signature", "https://s3.amazonaws.com/b/a-1.0.tgz?X-Amz-Signature=deadbeef", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},

--- a/internal/sbom/locator_test.go
+++ b/internal/sbom/locator_test.go
@@ -1,0 +1,204 @@
+package sbom
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+func TestClassifyResolvedURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		source    sdk.DependencySource
+		ecosystem sdk.Ecosystem
+		wantKind  LocatorKind
+		wantURL   string
+	}{
+		// Artifacts: the npm family is the cleanest case.
+		{"npm tarball", "https://registry.npmjs.org/react/-/react-18.2.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorArtifact, "https://registry.npmjs.org/react/-/react-18.2.0.tgz"},
+		{"python wheel", "https://files.pythonhosted.org/packages/x/req-2.31.0-py3-none-any.whl", sdk.DependencySourceURL, sdk.EcosystemPython, LocatorArtifact, "https://files.pythonhosted.org/packages/x/req-2.31.0-py3-none-any.whl"},
+		{"python sdist", "https://files.pythonhosted.org/packages/x/req-2.31.0.tar.gz", sdk.DependencySourceURL, sdk.EcosystemPython, LocatorArtifact, "https://files.pythonhosted.org/packages/x/req-2.31.0.tar.gz"},
+		{"gem artifact", "https://rubygems.org/gems/rake-13.0.6.gem", sdk.DependencySourceRegistry, sdk.EcosystemRuby, LocatorArtifact, "https://rubygems.org/gems/rake-13.0.6.gem"},
+
+		// Registry roots must never become a download location.
+		{"rubygems root", "https://rubygems.org/", sdk.DependencySourceRegistry, sdk.EcosystemRuby, LocatorRegistryRoot, "https://rubygems.org/"},
+		{"pypi simple index", "https://pypi.org/simple", sdk.DependencySourceRegistry, sdk.EcosystemPython, LocatorRegistryRoot, "https://pypi.org/simple"},
+		{"pub root", "https://pub.dev", sdk.DependencySourceRegistry, sdk.EcosystemDart, LocatorRegistryRoot, "https://pub.dev"},
+		{"cargo registry prefix", "registry+https://github.com/rust-lang/crates.io-index", sdk.DependencySourceRegistry, sdk.EcosystemRust, LocatorRegistryRoot, "https://github.com/rust-lang/crates.io-index"},
+		{"cargo sparse prefix", "sparse+https://index.crates.io/", sdk.DependencySourceRegistry, sdk.EcosystemRust, LocatorRegistryRoot, "https://index.crates.io/"},
+
+		// VCS, including the SPDX grammar normalization.
+		{"cargo git with rev", "git+https://github.com/a/b?rev=deadbeef", sdk.DependencySourceGit, sdk.EcosystemRust, LocatorVCS, "git+https://github.com/a/b@deadbeef"},
+		{"cargo git with fragment", "git+https://github.com/a/b#cafebabe", sdk.DependencySourceGit, sdk.EcosystemRust, LocatorVCS, "git+https://github.com/a/b@cafebabe"},
+		{"cargo git with tag", "git+https://github.com/a/b?tag=v1.2.3", sdk.DependencySourceGit, sdk.EcosystemRust, LocatorVCS, "git+https://github.com/a/b@v1.2.3"},
+		{"git suffix path", "https://github.com/apple/swift-nio.git", sdk.DependencySourceGit, sdk.EcosystemSwift, LocatorVCS, "git+https://github.com/apple/swift-nio.git"},
+		{"swiftpm registry kind still vcs", "https://github.com/apple/swift-nio", sdk.DependencySourceRegistry, sdk.EcosystemSwift, LocatorVCS, "git+https://github.com/apple/swift-nio"},
+
+		// Local filesystem paths must never be emitted.
+		{"absolute posix path", "/Users/ahmed/dev/mylib", sdk.DependencySourceFile, sdk.EcosystemPython, LocatorNone, ""},
+		{"absolute path with non-file source", "/home/runner/work/x/y", sdk.DependencySourceURL, sdk.EcosystemPython, LocatorNone, ""},
+		{"relative path", "../vendor/foo", sdk.DependencySourceFile, sdk.EcosystemPython, LocatorNone, ""},
+		{"uv editable dot", ".", sdk.DependencySourceFile, sdk.EcosystemPython, LocatorNone, ""},
+		{"windows path", `C:\src\lib`, sdk.DependencySourceFile, sdk.EcosystemNPM, LocatorNone, ""},
+		{"file scheme", "file:///tmp/x.tgz", sdk.DependencySourceFile, sdk.EcosystemNPM, LocatorNone, ""},
+		{"npm link specifier", "link:../pkg", sdk.DependencySourceWorkspace, sdk.EcosystemNPM, LocatorNone, ""},
+		{"npm workspace specifier", "workspace:*", sdk.DependencySourceWorkspace, sdk.EcosystemNPM, LocatorNone, ""},
+		{"npm link local dir", "https://registry.npmjs.org/a/-/a-1.0.0.tgz", sdk.DependencySourceWorkspace, sdk.EcosystemNPM, LocatorNone, ""},
+		{"scp style git", "git@github.com:a/b.git", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorNone, ""},
+
+		// Credentials must never reach an SBOM, in userinfo or anywhere else.
+		{"userinfo token", "https://tok:s3cret@nexus.corp/a/b-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"token in hostname label", "https://ghp_abcd1234.repo.example/a.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"token in path segment", "https://repo.example/download/ghp_abcd1234/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"percent-encoded token in path", "https://repo.example/download/%67hp_abcd1234/pkg.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"username only", "https://tok@nexus.corp/a/b-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"query token", "https://nexus.corp/a/b-1.0.tgz?token=s3cret", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"presigned signature", "https://s3.amazonaws.com/b/a-1.0.tgz?X-Amz-Signature=deadbeef", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"fragment secret", "https://nexus.corp/a/b-1.0.tgz#s3cret", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"hex fragment of odd length is still a secret", "https://nexus.corp/a/b-1.0.tgz#deadbeef", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		// Yarn v1 appends the artifact's own sha1 to every resolved URL.
+		// Treating that as a secret would drop the download location for
+		// every package in a Yarn lockfile.
+		{"yarn checksum fragment is stripped", "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#ceeba79ee36dfa7612b1ede82a3e37b2a30def1c", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorArtifact, "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz"},
+		{"sha256 fragment is stripped", "https://reg.example/a/b-1.0.tgz#" + strings.Repeat("a", 64), sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorArtifact, "https://reg.example/a/b-1.0.tgz"},
+		{"registry root with query", "https://nexus.corp/?apiKey=s3cret", sdk.DependencySourceRegistry, sdk.EcosystemRuby, LocatorNone, ""},
+		// A VCS locator is exempt only because normalizeVCS discards the query
+		// and keeps a character-checked revision. Every VCS form must be
+		// classified before the gate, not just the cargo "git+" prefix.
+		{"vcs query keeps only the revision", "git+https://github.com/a/b?rev=deadbeef&token=s3cret", sdk.DependencySourceGit, sdk.EcosystemRust, LocatorVCS, "git+https://github.com/a/b@deadbeef"},
+		{"git source pin without prefix", "https://github.com/a/b?rev=deadbeef", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/a/b@deadbeef"},
+		{"dot-git path pin", "https://host/repo.git?rev=deadbeef", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorVCS, "git+https://host/repo.git@deadbeef"},
+		{"swift pin with revision", "https://github.com/apple/swift-nio?tag=2.0.0", sdk.DependencySourceRegistry, sdk.EcosystemSwift, LocatorVCS, "git+https://github.com/apple/swift-nio@2.0.0"},
+		{"git source drops a credential query", "https://github.com/a/b?token=s3cret", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/a/b"},
+		// The fragment is the resolved commit and the query is what was
+		// requested, so the immutable commit wins over a moving branch. This
+		// is the shape uv records: "?rev=main#abc123".
+		{"resolved commit beats requested branch", "https://github.com/a/b?branch=main#abc123", sdk.DependencySourceGit, sdk.EcosystemPython, LocatorVCS, "git+https://github.com/a/b@abc123"},
+		{"resolved commit beats requested rev", "https://github.com/example/git-helper?rev=main#abc123", sdk.DependencySourceGit, sdk.EcosystemPython, LocatorVCS, "git+https://github.com/example/git-helper@abc123"},
+		// A fragment must be commit-shaped, not merely character-safe: an
+		// access token passes isSafeRevision and would be republished.
+		{"pat fragment is not a revision", "https://github.com/org/repo#ghp_abcd1234", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
+		{"fine-grained pat fragment is not a revision", "https://github.com/org/repo#github_pat_11ABCDEFGHIJKLMNOP", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
+		{"non-hex fragment is not a revision", "https://github.com/org/repo#release-candidate", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
+		{"named query revision still allows tags", "https://github.com/org/repo?tag=v1.2.3", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo@v1.2.3"},
+		// A query key names its value a revision, so tags and branches are
+		// legitimate there — but a recognizable token is not.
+		{"token in rev query is rejected", "https://github.com/org/repo?rev=ghp_abcd1234", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
+		{"token in branch query is rejected", "https://github.com/org/repo?branch=glpat-Abc123XYZ789def", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
+		{"underscored branch still allowed", "https://github.com/org/repo?branch=release_candidate", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo@release_candidate"},
+		{"requested rev used when no commit resolved", "https://github.com/a/b?rev=v1.2.3", sdk.DependencySourceGit, sdk.EcosystemPython, LocatorVCS, "git+https://github.com/a/b@v1.2.3"},
+
+		// Degenerate input.
+		{"empty", "", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"whitespace", "   ", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"scheme only", "https://", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+		{"colons", "::::", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorNone, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyResolvedURL(tc.raw, tc.source, tc.ecosystem)
+			if got.Kind != tc.wantKind {
+				t.Fatalf("kind = %v, want %v (url %q)", got.Kind, tc.wantKind, got.URL)
+			}
+			if got.URL != tc.wantURL {
+				t.Fatalf("url = %q, want %q", got.URL, tc.wantURL)
+			}
+		})
+	}
+}
+
+// TestClassifyResolvedURLNeverEmitsLocalPaths is the invariant that matters
+// most: whatever a lockfile contains, a classified value is either empty or an
+// absolute http(s)/git+http(s) URL. A regression here leaks the developer's or
+// CI runner's directory layout into a published SBOM.
+func TestClassifyResolvedURLNeverEmitsLocalPaths(t *testing.T) {
+	inputs := []string{
+		"/Users/ahmed/secret-project/lib", "../../etc/passwd", "./local", ".",
+		`C:\Users\ahmed\proj`, "file:///Users/ahmed/x", "link:../a", "workspace:^1",
+		"git@github.com:a/b.git", "ssh://git@github.com/a/b.git", "", "   ",
+		"https://user:pass@host/a.tgz",
+	}
+	for _, in := range inputs {
+		for _, source := range []sdk.DependencySource{
+			sdk.DependencySourceRegistry, sdk.DependencySourceGit, sdk.DependencySourceURL,
+			sdk.DependencySourceFile, sdk.DependencySourceProject, sdk.DependencySourceWorkspace, "",
+		} {
+			got := classifyResolvedURL(in, source, sdk.EcosystemNPM)
+			assertPublishableLocator(t, got, in)
+		}
+	}
+}
+
+// assertPublishableLocator enforces the emit-or-nothing contract shared by the
+// table test and the fuzz target.
+func assertPublishableLocator(t *testing.T, got Locator, input string) {
+	t.Helper()
+	if got.Kind == LocatorNone {
+		if got.URL != "" {
+			t.Fatalf("LocatorNone carried url %q for input %q", got.URL, input)
+		}
+		return
+	}
+	if got.URL == "" {
+		t.Fatalf("kind %v carried an empty url for input %q", got.Kind, input)
+	}
+	switch {
+	case strings.HasPrefix(got.URL, "https://"), strings.HasPrefix(got.URL, "http://"):
+	default:
+		// The classifier deliberately keeps the asserted version-control tool
+		// rather than rewriting everything to git+, so accept every prefix it
+		// can produce. Hard-coding git+ here would fail `make fuzz` on valid
+		// behavior.
+		matched := false
+		for _, prefix := range vcsToolPrefixes {
+			if strings.HasPrefix(got.URL, prefix+"https://") || strings.HasPrefix(got.URL, prefix+"http://") ||
+				strings.HasPrefix(got.URL, prefix+"git://") {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("emitted an out-of-vocabulary locator %q for input %q", got.URL, input)
+		}
+	}
+	// Check userinfo structurally rather than by looking for "@": scoped npm
+	// packages ("/@babel/core/") and VCS revisions ("@deadbeef") both contain
+	// one legitimately.
+	bare := got.URL
+	for _, prefix := range vcsToolPrefixes {
+		bare = strings.TrimPrefix(bare, prefix)
+	}
+	parsed, err := url.Parse(bare)
+	if err != nil {
+		t.Fatalf("emitted unparseable locator %q for input %q", got.URL, input)
+	}
+	if parsed.User != nil {
+		t.Fatalf("emitted locator with userinfo %q for input %q", got.URL, input)
+	}
+}
+
+func TestNormalizeRepositoryURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"github.com/kubernetes/kubernetes", "https://github.com/kubernetes/kubernetes"},
+		{"gitlab.com/org/repo", "https://gitlab.com/org/repo"},
+		{"https://github.com/a/b", "https://github.com/a/b"},
+		{"", ""},
+		{"   ", ""},
+		{"not-a-host", ""},
+		{"github.com", ""},
+		{"github.com/", ""},
+		{"/Users/ahmed/repo", ""},
+		{"has space/repo", ""},
+		{"ftp://github.com/a/b", ""},
+		{"https://tok:sec@github.com/a/b", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeRepositoryURL(tc.in); got != tc.want {
+			t.Fatalf("normalizeRepositoryURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/sbom/locator_test.go
+++ b/internal/sbom/locator_test.go
@@ -62,6 +62,19 @@ func TestClassifyResolvedURL(t *testing.T) {
 		// Prefix matching is case-sensitive, so ordinary words that lowercase
 		// into an issuer prefix are not secrets.
 		{"asia as an ordinary word survives", "https://mirror.example/asia-packages/pkg-1.0.tgz", sdk.DependencySourceRegistry, sdk.EcosystemNPM, LocatorArtifact, "https://mirror.example/asia-packages/pkg-1.0.tgz"},
+		// A git-sourced dependency that resolved to an archive is the
+		// downloaded artifact, not a cloneable repository: rendering the
+		// codeload endpoint in git+ syntax would invent a repo.
+		{"git-sourced codeload tarball stays an artifact", "https://codeload.github.com/user/repo/tar.gz/9f8e7d6c5b4a", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorArtifact, "https://codeload.github.com/user/repo/tar.gz/9f8e7d6c5b4a"},
+		{"git-sourced tgz stays an artifact", "https://host.example/archives/pkg-1.0.0.tgz", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorArtifact, "https://host.example/archives/pkg-1.0.0.tgz"},
+		// A literal "@" opening a path segment is a scoped name, not the SPDX
+		// revision marker; splitting there would export a repo that does not
+		// exist.
+		{"literal @ in repository path survives", "https://git.example.com/teams/@core/library", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://git.example.com/teams/@core/library"},
+		{"spdx revision form still splits", "https://git.example.com/teams/library@9f8e7d6c", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://git.example.com/teams/library@9f8e7d6c"},
+		// An opaque mixed-case token is not a revision, whatever field the
+		// lockfile carried it in.
+		{"opaque token revision is dropped", "https://github.com/org/repo?rev=Xk9mPq2Lr8Tn4Vw7Yz", sdk.DependencySourceGit, sdk.EcosystemNPM, LocatorVCS, "git+https://github.com/org/repo"},
 		// Mixed-case artifact names split at the extension dot, so no single
 		// run reaches the opaque threshold.
 		{"mixed-case wheel survives", "https://files.pythonhosted.org/packages/ab/cd/Django-4.2-py3-none-any.whl", sdk.DependencySourceURL, sdk.EcosystemPython, LocatorArtifact, "https://files.pythonhosted.org/packages/ab/cd/Django-4.2-py3-none-any.whl"},

--- a/internal/sbom/model.go
+++ b/internal/sbom/model.go
@@ -135,6 +135,18 @@ type Component struct {
 	Digests         []Digest
 	Vulnerabilities []Vulnerability
 	EOL             *EOL
+
+	// Where the package came from, classified from the detector- or
+	// matcher-supplied resolved URL. At most one of ArtifactURL and VCSURL is
+	// set; RegistryURL is the weaker fallback naming a registry or index
+	// root, and is deliberately never used as a download location.
+	ArtifactURL string
+	VCSURL      string
+	RegistryURL string
+
+	// Repository is a canonical source repository resolved by the OpenSSF
+	// Scorecard matcher during enrichment, rendered as an absolute https URL.
+	Repository string
 }
 
 // Dependency describes one package relationship list in the intermediate SBOM model.

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -44,7 +44,7 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 			PackageName:               c.NameOrID(),
 			PackageSPDXIdentifier:     spdxID,
 			PackageVersion:            c.Version,
-			PackageDownloadLocation:   "NOASSERTION",
+			PackageDownloadLocation:   spdxDownloadLocation(c),
 			FilesAnalyzed:             false,
 			PackageComment:            spdxPackageComment(c),
 			PackageLicenseDeclared:    spdxLicenseValue(c.Licenses),
@@ -53,6 +53,7 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 			PackageChecksums:          spdxChecksums(c.Digests),
 			PackageExternalReferences: spdxExternalReferences(c),
 			PrimaryPackagePurpose:     spdxPrimaryPackagePurpose(c.Type),
+			PackageSourceInfo:         spdxSourceInfo(c),
 		}
 		if _, isRoot := rootComponents[c.ID]; isRoot || IsProjectRootComponent(c) {
 			if doc.Provenance.Manufacturer != "" {
@@ -426,6 +427,48 @@ func spdxCopyrightValue(value string) string {
 		return ""
 	}
 	return value
+}
+
+// spdxSourceInfoPrefix marks a source repository inside the free-text
+// PackageSourceInfo field so a reader can recover it deterministically.
+const spdxSourceInfoPrefix = "Source repository: "
+
+// spdxDownloadLocation renders where the package was obtained.
+//
+// A registry root is deliberately not used: "https://rubygems.org/" is a
+// syntactically valid URL that validators accept, and every consumer would
+// read it as the artifact's origin, which is false. NOASSERTION is the honest
+// answer when only a registry root is known.
+func spdxDownloadLocation(component Component) string {
+	if location := firstNonEmpty(component.ArtifactURL, component.VCSURL); location != "" {
+		return location
+	}
+	return "NOASSERTION"
+}
+
+// spdxSourceInfo renders the source repository into SPDX's free-text origin
+// field.
+//
+// PackageSourceInfo is defined as free text about the origin of the package,
+// which is what a source repository is. PackageHomePage is a different claim
+// (the package's home page) that Bomly does not know, and SPDX 2.3 has no
+// version-control external-reference category.
+func spdxSourceInfo(component Component) string {
+	// Suppress only when the VCS locator itself became the download location,
+	// which would make one package assert the same repository twice.
+	if component.VCSURL != "" && component.ArtifactURL == "" {
+		return ""
+	}
+	repo := strings.TrimSpace(component.Repository)
+	if repo == "" && component.ArtifactURL != "" {
+		// Keep the version-control form intact: stripping "git+" would fold a
+		// pinned revision into the URL path.
+		repo = component.VCSURL
+	}
+	if repo == "" {
+		return ""
+	}
+	return spdxSourceInfoPrefix + repo
 }
 
 func spdxExternalReferences(component Component) []*v23.PackageExternalReference {

--- a/internal/sbom/transform.go
+++ b/internal/sbom/transform.go
@@ -47,6 +47,10 @@ func FromDepGraph(g *sdk.Graph, opts BuildOptions) (*Document, error) {
 			Licenses:       componentLicenses(sdk.DetectionLicenses(pkg)),
 			Digests:        componentDigests(pkg.Digests),
 		}
+		applyLocator(&component, pinLocator(
+			classifyResolvedURL(pkg.ResolvedURL, pkg.Source, pkg.Ecosystem),
+			sourceRevisionFrom(pkg.Metadata),
+		))
 		enrichComponentFromRegistry(&component, opts.Registry, pkg.PURL)
 		components = append(components, component)
 		depsByRef[pkg.ID] = nil
@@ -290,6 +294,31 @@ func enrichComponentFromRegistry(component *Component, registry *sdk.PackageRegi
 			Cycle:         pkg.EOL.Cycle,
 			LatestVersion: pkg.EOL.LatestVersion,
 		}
+	}
+	if pkg.Scorecard != nil && component.Repository == "" {
+		// Fill a gap only: the scorecard repository is matcher-derived and
+		// must not displace a more specific detector-supplied location.
+		component.Repository = normalizeRepositoryURL(pkg.Scorecard.Repository)
+	}
+	// The registry copy of ResolvedURL is normally the detection value echoed
+	// back, so it only fills a gap a matcher supplied. Source is not carried
+	// on Package, so classification here is shape-driven only.
+	if component.ArtifactURL == "" && component.VCSURL == "" && component.RegistryURL == "" {
+		applyLocator(component, classifyResolvedURL(pkg.ResolvedURL, "", pkg.Ecosystem))
+	}
+}
+
+// applyLocator projects a classified resolved URL onto a component. A
+// LocatorNone leaves the component untouched, so an unpublishable value simply
+// results in no assertion.
+func applyLocator(component *Component, locator Locator) {
+	switch locator.Kind {
+	case LocatorArtifact:
+		component.ArtifactURL = locator.URL
+	case LocatorVCS:
+		component.VCSURL = locator.URL
+	case LocatorRegistryRoot:
+		component.RegistryURL = locator.URL
 	}
 }
 

--- a/scripts/run-fuzz.sh
+++ b/scripts/run-fuzz.sh
@@ -31,6 +31,8 @@ targets=(
   "github.com/bomly-dev/bomly-cli/internal/detectors/swiftpm FuzzDepGraphFromSwiftResolved"
   "github.com/bomly-dev/bomly-cli/internal/sbom FuzzUnmarshalAutoJSON"
   "github.com/bomly-dev/bomly-cli/internal/sbom FuzzNormalizeSPDXLicenseExpression"
+  "github.com/bomly-dev/bomly-cli/internal/sbom FuzzClassifyResolvedURL"
+  "github.com/bomly-dev/bomly-cli/internal/sbom FuzzNormalizeRepositoryURL"
   "github.com/bomly-dev/bomly-cli/internal/baseline FuzzLoad"
   "github.com/bomly-dev/bomly-cli/internal/engine FuzzConsolidateVulnerabilities"
   "github.com/bomly-dev/bomly-cli/internal/plugin FuzzPluginPathSanitizers"

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -615,14 +615,15 @@ func TestScanSBOMExportDistribution(t *testing.T) {
 		if strings.Contains(rendered, dir) {
 			t.Fatalf("%s output leaked the output directory %q", name, dir)
 		}
+		// os.TempDir() is deliberately absent: on Linux it is the bare
+		// "/tmp", which legitimately appears in npm package URLs such as
+		// registry.npmjs.org/tmp/-/tmp-0.0.33.tgz. The anchored markers
+		// below cover a leaked absolute temp path.
 		for _, marker := range []string{
-			"file://", "bomly-git-", os.TempDir(),
+			"file://", "bomly-git-",
 			`"/Users/`, `"/home/`, `"/var/folders/`, `"/private/`,
 			`:"/tmp/`, `":/tmp/`,
 		} {
-			if marker == "" {
-				continue
-			}
 			if strings.Contains(rendered, marker) {
 				t.Fatalf("%s output leaked a local path or clone directory (%q)", name, marker)
 			}

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -511,6 +511,125 @@ func TestExplain(t *testing.T) {
 	}
 }
 
+// TestScanSBOMExportDistribution covers SBOM *export* end to end, which the
+// golden-backed cases above do not: they all emit `--format json`, so nothing
+// asserted the SPDX/CycloneDX bytes themselves.
+//
+// The case is deliberately property-asserting rather than golden-backed. An
+// SBOM document carries four volatile fields (documentNamespace, serialNumber,
+// created/timestamp, tool version) that normalizeJSON is not written for, so a
+// golden would flap on every run.
+//
+// It is pinned to bomly-dev/example-javascript-npm because npm lockfiles record
+// the exact package archive — the one ecosystem family where the artifact path
+// actually fires. The leak assertion is the important one: no scan-machine path
+// may ever reach a published SBOM.
+func TestScanSBOMExportDistribution(t *testing.T) {
+	t.Parallel()
+	requireTool(t, "npm")
+
+	dir := t.TempDir()
+	spdxPath := filepath.Join(dir, "out.spdx.json")
+	cdxPath := filepath.Join(dir, "out.cdx.json")
+
+	_, stderr, code := runBomly(t,
+		"scan", "--url", "https://github.com/bomly-dev/example-javascript-npm", "--ref", "v1.0.0",
+		"--detectors", "npm",
+		"-o", "spdx="+spdxPath, "-o", "cyclonedx="+cdxPath,
+	)
+	if code != 0 {
+		t.Fatalf("bomly exited %d\nstderr:\n%s", code, stderr)
+	}
+
+	spdxRaw, err := os.ReadFile(spdxPath)
+	if err != nil {
+		t.Fatalf("read spdx: %v", err)
+	}
+	cdxRaw, err := os.ReadFile(cdxPath)
+	if err != nil {
+		t.Fatalf("read cyclonedx: %v", err)
+	}
+
+	var spdxDoc struct {
+		Packages []struct {
+			Name             string `json:"name"`
+			DownloadLocation string `json:"downloadLocation"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(spdxRaw, &spdxDoc); err != nil {
+		t.Fatalf("unmarshal spdx: %v", err)
+	}
+
+	registryDownloads := 0
+	for _, pkg := range spdxDoc.Packages {
+		switch {
+		case pkg.DownloadLocation == "NOASSERTION":
+		case strings.HasPrefix(pkg.DownloadLocation, "https://"):
+			registryDownloads++
+		default:
+			t.Fatalf("package %q has a download location that is neither NOASSERTION nor https: %q",
+				pkg.Name, pkg.DownloadLocation)
+		}
+	}
+	if registryDownloads == 0 {
+		t.Fatal("expected npm packages to carry registry download locations, got none")
+	}
+
+	var cdxDoc struct {
+		Components []struct {
+			Name               string `json:"name"`
+			ExternalReferences []struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			} `json:"externalReferences"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(cdxRaw, &cdxDoc); err != nil {
+		t.Fatalf("unmarshal cyclonedx: %v", err)
+	}
+	distributions := 0
+	for _, comp := range cdxDoc.Components {
+		for _, ref := range comp.ExternalReferences {
+			if ref.Type == "distribution" {
+				distributions++
+				if !strings.HasPrefix(ref.URL, "https://") {
+					t.Fatalf("component %q distribution reference is not https: %q", comp.Name, ref.URL)
+				}
+			}
+		}
+	}
+	if distributions == 0 {
+		t.Fatal("expected npm components to carry distribution references, got none")
+	}
+
+	// Nothing about the machine that ran the scan may appear in either
+	// document.
+	//
+	// Checking only `dir` would be too weak: that is the output directory
+	// passed to -o, while a --url scan clones the repository into a separate
+	// bomly-git-* temp directory. A detector leaking that clone path would go
+	// unnoticed. Assert on the shape of any local path instead, so the check
+	// covers paths this test never sees.
+	for name, raw := range map[string][]byte{"spdx": spdxRaw, "cyclonedx": cdxRaw} {
+		rendered := string(raw)
+		if strings.Contains(rendered, dir) {
+			t.Fatalf("%s output leaked the output directory %q", name, dir)
+		}
+		for _, marker := range []string{
+			"file://", "bomly-git-", os.TempDir(),
+			`"/Users/`, `"/home/`, `"/var/folders/`, `"/private/`,
+			`:"/tmp/`, `":/tmp/`,
+		} {
+			if marker == "" {
+				continue
+			}
+			if strings.Contains(rendered, marker) {
+				t.Fatalf("%s output leaked a local path or clone directory (%q)", name, marker)
+			}
+		}
+	}
+}
+
 // TestScanSBOMSyftJSONRejected locks in the syft-JSON ingest removal end to
 // end: `--sbom` on a syft-format JSON file must exit 3 (resolution failure —
 // the detector cannot produce a graph) with the actionable conversion hint,


### PR DESCRIPTION
Addresses the buildable subset of #380. Replaces #391, which grew far past this scope and is closed in its favor — see that PR for the full review history.

## Why not supplier/description

#380 asked for per-component `supplier` and `description` sourced from deps.dev. Probing the live API across npm, PyPI, Maven, NuGet, Cargo, and Go shows `GetVersion` asserts **neither** field — only `links[]` and `registries[]`. Real supplier/description live in registry-native metadata, which means new allowed network hosts (a CLAUDE.md non-negotiable) and likely a new `bomly-plugin-*` repo. Those stay deferred; the docs now say so explicitly.

## What this ships (export only)

Origin information Bomly already collects and then dropped at the export boundary:

| Lockfile records | SPDX | CycloneDX |
| --- | --- | --- |
| Exact package file | `downloadLocation` (was hardcoded `NOASSERTION`) | `distribution` |
| Source repository | `downloadLocation` (`git+` form, pinned commit) | `vcs` |
| Registry root only | `NOASSERTION` | `distribution`, marked as a root |
| Local path / unusable | `NOASSERTION` | nothing |

Plus the OpenSSF Scorecard repository (`vcs` / `PackageSourceInfo`) during `--enrich`, and detector-resolved commits (bundler/pub/python `source_revision`, swiftpm `revision`) folded into the locator so reproducible pins don't export as moving branches.

## The classifier

`ResolvedURL` is not a URL — npm records tarballs, Bundler records the registry root, Cargo prefixes its source string, uv/pipenv/pub/npm-link can record **local filesystem paths**, and private-registry URLs can embed tokens. `internal/sbom/locator.go` classifies every value before it can reach a document. Two mutation-verified rules:

1. **A registry root never becomes a download location** — that failure is schema-valid and silently wrong.
2. **No local path or credential is ever published** — a boundary-aware token scan covers userinfo, host labels, path segments, query, fragment, and revision suffixes, rather than splitting on delimiters.

Both `FuzzClassifyResolvedURL` and `FuzzNormalizeRepositoryURL` are registered in `scripts/run-fuzz.sh`.

## Deliberately excluded

The SBOM-**ingest** preservation work from #391 (carrying a third party's supplier/description/references through re-export). It touches every field across both formats plus merge semantics, and review showed it isn't settled. It moves to its own issue with the #391 review history as input. Decoders in this PR are untouched from main.

## Verification

- `make test`, `make fuzz` targets, `make generate` (no drift)
- `spdxlib.ValidateDocument` + official CycloneDX 1.7 schema on real scans across npm/yarn/ruby/python — all valid, **zero scan-machine paths in any output**
- npm: 136 real download locations; yarn: 379 (checksum fragments recognized as digests, not secrets); Bundler/uv correctly abstain
- Re-ingesting Bomly's own output still yields `NOASSERTION`, never the registry root
- New smoke case `TestScanSBOMExportDistribution`, registered in both slice matrices

No new CLI flag, so no MCP or plugin-command surface is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SBOM exports now include package download, repository, registry, and version-control references in SPDX and CycloneDX formats.
  * Added safeguards to exclude local paths, credentials, malformed URLs, and unsafe locations from exported SBOMs.
  * Improved package-origin mapping for registries, Git repositories, Cargo, Yarn, SwiftPM, and detector metadata.

* **Documentation**
  * Expanded SBOM documentation and architecture guidance for URL classification and package-origin metadata.

* **Tests**
  * Added comprehensive distribution, safety, fuzz, and end-to-end export coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->