### PR TITLE
fix(detectors): union scopes when duplicate nodes fold

### DIFF
--- a/internal/detectors/ensure_node.go
+++ b/internal/detectors/ensure_node.go
@@ -18,14 +18,22 @@ import (
 // this rather than calling Graph.AddNode after a Node lookup, so a detector
 // added later inherits the shared behavior instead of having to know about it.
 //
-// EnsureNode deliberately merges nothing. Records that genuinely differ are
-// different occurrences and belong in distinct nodes under distinct IDs (the
-// caller decides identity); records that are the same need nothing merged.
+// When it folds, the survivor takes the union of both records' scopes. Scopes
+// answer "where is this package reachable?", so one package listed in two
+// dependency groups is reachable at both -- a manifest's develop entry does
+// not stop being a develop dependency because the default group named the
+// package first. Everything else on the discarded record is dropped: records
+// that genuinely differ are different occurrences and belong in distinct
+// nodes under distinct IDs (the caller decides identity, EnsureOccurrence is
+// the shared rule for resolution-qualified identity).
 func EnsureNode(g *sdk.Graph, node *sdk.Dependency) (*sdk.Dependency, error) {
 	if g == nil || node == nil {
 		return nil, nil
 	}
 	if existing, ok := g.Node(node.ID); ok {
+		for _, scope := range node.Scopes {
+			existing.AddScope(scope)
+		}
 		return existing, nil
 	}
 	if err := g.AddNode(node); err != nil {
@@ -69,14 +77,16 @@ func OccurrenceID(baseID, qualifier string) string {
 // hand-written shape one review round at a time before it was centralized;
 // route new sites through here.
 func EnsureOccurrence(g *sdk.Graph, node *sdk.Dependency, qualifier string) (*sdk.Dependency, error) {
-	surviving, err := EnsureNode(g, node)
-	if err != nil || surviving == node || surviving == nil {
-		return surviving, err
+	if g == nil || node == nil {
+		return nil, nil
 	}
-	if strings.TrimSpace(surviving.ResolvedURL) == strings.TrimSpace(node.ResolvedURL) {
-		return surviving, nil
+	// Decide identity before inserting: a record that stays a distinct
+	// occurrence must not fold anything -- not even scopes -- onto the node
+	// it collided with.
+	if existing, ok := g.Node(node.ID); ok &&
+		strings.TrimSpace(existing.ResolvedURL) != strings.TrimSpace(node.ResolvedURL) {
+		node.ID = OccurrenceID(node.ID, qualifier)
 	}
-	node.ID = OccurrenceID(node.ID, qualifier)
 	return EnsureNode(g, node)
 }
 

--- a/internal/detectors/ensure_node_test.go
+++ b/internal/detectors/ensure_node_test.go
@@ -110,3 +110,59 @@ func TestEnsureNode(t *testing.T) {
 		t.Fatalf("EnsureNode(nil node) = %v, %v; want a no-op", surviving, err)
 	}
 }
+
+func scopedDependency(scope sdk.Scope, resolvedURL string) *sdk.Dependency {
+	return sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython,
+		Name:    "requests",
+		Version: "2.31.0"}, ResolvedURL: resolvedURL, Scopes: sdk.ScopesOf(scope),
+	})
+}
+
+// One package listed in two dependency groups is reachable at both scopes.
+// The fold is where the second group's record disappears, so the fold is
+// where its scope must survive.
+func TestEnsureNodeUnionsScopesOnFold(t *testing.T) {
+	g := sdk.New()
+	runtime := scopedDependency(sdk.ScopeRuntime, "")
+	if _, err := detectors.EnsureNode(g, runtime); err != nil {
+		t.Fatalf("EnsureNode(runtime) error = %v", err)
+	}
+
+	surviving, err := detectors.EnsureNode(g, scopedDependency(sdk.ScopeDevelopment, ""))
+	if err != nil || surviving != runtime {
+		t.Fatalf("EnsureNode(duplicate) = %v, %v; want the existing node", surviving, err)
+	}
+	if !surviving.HasScope(sdk.ScopeRuntime) || !surviving.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("surviving scopes = %v; want the union of both records' scopes", surviving.Scopes)
+	}
+}
+
+// A record that stays a distinct occurrence merges nothing: its scope belongs
+// to its own node, not to the node it collided with.
+func TestEnsureOccurrenceScopes(t *testing.T) {
+	g := sdk.New()
+	first := scopedDependency(sdk.ScopeRuntime, "https://a.example/requests-2.31.0.tar.gz")
+	if _, err := detectors.EnsureOccurrence(g, first, "a"); err != nil {
+		t.Fatalf("EnsureOccurrence(first) error = %v", err)
+	}
+
+	other := scopedDependency(sdk.ScopeDevelopment, "https://b.example/requests-2.31.0.tar.gz")
+	occurrence, err := detectors.EnsureOccurrence(g, other, "b")
+	if err != nil || occurrence == first {
+		t.Fatalf("EnsureOccurrence(conflicting resolution) = %v, %v; want a distinct occurrence", occurrence, err)
+	}
+	if first.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("first occurrence scopes = %v; a distinct occurrence must not leak its scope", first.Scopes)
+	}
+	if !occurrence.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("new occurrence scopes = %v; want its own scope kept", occurrence.Scopes)
+	}
+
+	folded, err := detectors.EnsureOccurrence(g, scopedDependency(sdk.ScopeDevelopment, "https://a.example/requests-2.31.0.tar.gz"), "a")
+	if err != nil || folded != first {
+		t.Fatalf("EnsureOccurrence(same resolution) = %v, %v; want a fold into the first occurrence", folded, err)
+	}
+	if !first.HasScope(sdk.ScopeRuntime) || !first.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("first occurrence scopes = %v; want the union after folding", first.Scopes)
+	}
+}

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -286,7 +286,7 @@ func depGraphFromGoListWithScope(raw []byte, rootModule string, directRequires [
 		}
 		if !currentModule.Main {
 			currentNode := packageFromModuleNode(currentModule, mergedScope, directLines, sumDigests)
-			if err := addOrMergeModuleNode(depsGraph, currentNode, mergedScope); err != nil {
+			if err := addOrMergeModuleNode(depsGraph, currentNode); err != nil {
 				return nil, err
 			}
 		}
@@ -357,7 +357,7 @@ func enqueueImportedPackages(depsGraph *sdk.Graph, rootID string, from moduleNod
 		}
 		if !to.Main {
 			pkg := packageFromModuleNode(to, scope, directLines, sumDigests)
-			if err := addOrMergeModuleNode(depsGraph, pkg, scope); err != nil {
+			if err := addOrMergeModuleNode(depsGraph, pkg); err != nil {
 				return err
 			}
 			if from.Path != to.Path || from.Version != to.Version {
@@ -567,11 +567,8 @@ func appendUniqueModule(modules []moduleRef, seen map[string]struct{}, ref modul
 	return append(modules, ref)
 }
 
-func addOrMergeModuleNode(depsGraph *sdk.Graph, node *sdk.Dependency, scope sdk.Scope) error {
-	surviving, err := detectors.EnsureNode(depsGraph, node)
-	if err != nil {
-		return err
-	}
-	surviving.AddScope(scope)
-	return nil
+func addOrMergeModuleNode(depsGraph *sdk.Graph, node *sdk.Dependency) error {
+	// The node carries its scope; the shared helper unions scopes on fold.
+	_, err := detectors.EnsureNode(depsGraph, node)
+	return err
 }

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -477,9 +477,7 @@ func depGraphFromGradleOutput(raw []byte, rootName string, modules []gradleModul
 			if refNode != nil {
 				stack = stack[:depth+1]
 				parentID := stack[len(stack)-1]
-				if existing, ok := currentGraph.Node(refNode.ID); ok {
-					existing.AddScope(currentScope)
-				} else if err := currentGraph.AddNode(refNode); err != nil && !errors.Is(err, sdk.ErrNodeAlreadyExist) {
+				if _, err := detectors.EnsureNode(currentGraph, refNode); err != nil {
 					return gradleParseResult{}, fmt.Errorf("add project reference node %q: %w", refNode.ID, err)
 				}
 				if err := currentGraph.AddEdge(parentID, refNode.ID); err != nil {
@@ -496,12 +494,8 @@ func depGraphFromGradleOutput(raw []byte, rootName string, modules []gradleModul
 		}
 		stack = stack[:depth+1]
 		parentID := stack[len(stack)-1]
-		surviving, err := detectors.EnsureNode(currentGraph, node)
-		if err != nil {
+		if _, err := detectors.EnsureNode(currentGraph, node); err != nil {
 			return gradleParseResult{}, err
-		}
-		if surviving != node {
-			surviving.AddScope(node.PrimaryScope())
 		}
 		if err := currentGraph.AddEdge(parentID, node.ID); err != nil {
 			return gradleParseResult{}, fmt.Errorf("add dependency %q -> %q: %w", parentID, node.ID, err)

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -401,12 +401,8 @@ func depGraphFromMavenTGF(raw []byte) (*sdk.Graph, error) {
 				return nil, err
 			}
 			tgfPackages[id] = node
-			surviving, err := detectors.EnsureNode(tgfGraph, node)
-			if err != nil {
+			if _, err := detectors.EnsureNode(tgfGraph, node); err != nil {
 				return nil, err
-			}
-			if surviving != node {
-				surviving.AddScope(node.PrimaryScope())
 			}
 		case looksLikeTGFEdgeLine(line):
 			fields := strings.Fields(line)

--- a/internal/detectors/node/common.go
+++ b/internal/detectors/node/common.go
@@ -203,9 +203,6 @@ func DepGraphFromNPMNode(root *NPMListNode) (*sdk.Graph, error) {
 			if surviving == nil {
 				continue
 			}
-			if surviving != node {
-				surviving.AddScope(node.PrimaryScope())
-			}
 			if err := depsGraph.AddEdge(current.parentID, surviving.ID); err != nil {
 				return nil, fmt.Errorf("add dependency %q -> %q: %w", current.parentID, surviving.ID, err)
 			}
@@ -349,15 +346,10 @@ func splitYarnTreeName(value string) (string, string, error) {
 
 // AddNodeIfMissing adds a package to a graph or merges scope into the existing package.
 func AddNodeIfMissing(depsGraph *sdk.Graph, node *sdk.Dependency) error {
-	surviving, err := detectors.EnsureNode(depsGraph, node)
-	if err != nil {
-		return err
-	}
-	if surviving != node {
-		// A package reached twice carries both scopes.
-		surviving.AddScope(node.PrimaryScope())
-	}
-	return nil
+	// A package reached twice carries both scopes; the shared helper unions
+	// them on fold.
+	_, err := detectors.EnsureNode(depsGraph, node)
+	return err
 }
 
 // PackageJSONManifest is the subset of package.json used by Node detectors.

--- a/internal/detectors/node/npm/npm_lockfile_parser.go
+++ b/internal/detectors/node/npm/npm_lockfile_parser.go
@@ -263,9 +263,6 @@ func depGraphFromNPMLockfile(projectPath string) (npmLockfileGraphs, error) {
 		if err != nil {
 			return npmLockfileGraphs{}, err
 		}
-		if surviving != pkgNode {
-			surviving.AddScope(pkgNode.PrimaryScope())
-		}
 		pathToID[packagePath] = surviving.ID
 		if member {
 			// The descriptor must track whatever node now represents this

--- a/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
@@ -153,9 +153,6 @@ func depGraphFromPNPMLockfile(projectPath string) (pnpmLockfileGraphs, error) {
 		if err != nil {
 			return pnpmLockfileGraphs{}, err
 		}
-		if surviving != pkgNode {
-			surviving.AddScope(pkgNode.PrimaryScope())
-		}
 		resolved := resolvedPackage{id: surviving.ID, name: name, version: node.NormalizeVersionToken(version)}
 		byKey[key] = resolved
 		byName[name] = append(byName[name], resolved)

--- a/internal/detectors/node/yarn/yarn_lockfile_parser.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser.go
@@ -93,9 +93,6 @@ func depGraphFromYarnLockfile(projectPath string) (*sdk.Graph, error) {
 		if err != nil {
 			return "", err
 		}
-		if surviving != pkgNode {
-			surviving.AddScope(pkgNode.PrimaryScope())
-		}
 		entryNodeByIndex[idx] = surviving.ID
 		return surviving.ID, nil
 	}

--- a/internal/detectors/python/detector_test.go
+++ b/internal/detectors/python/detector_test.go
@@ -327,6 +327,44 @@ func TestDepGraphFromPipfileLock(t *testing.T) {
 	}
 }
 
+// A package listed in both the default and develop groups is reachable at
+// both scopes; folding the duplicate record must not drop the second group's
+// scope (https://github.com/bomly-dev/bomly-cli/issues/400).
+func TestDepGraphFromPipfileLockPackageInBothGroupsKeepsBothScopes(t *testing.T) {
+	path := t.TempDir() + "/Pipfile.lock"
+	raw := []byte(`{
+  "default": {
+    "requests": {"version": "==2.2.1"}
+  },
+  "develop": {
+    "requests": {"version": "==2.2.1"},
+    "pytest": {"version": "==9.0.3"}
+  }
+}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write Pipfile.lock: %v", err)
+	}
+
+	g, err := depGraphFromPipfileLock(path, "")
+	if err != nil {
+		t.Fatalf("depGraphFromPipfileLock() error = %v", err)
+	}
+	shared, ok := g.Node("requests@2.2.1")
+	if !ok {
+		t.Fatalf("expected requests package, got %s", g.PrettyString())
+	}
+	if !shared.HasScope(sdk.ScopeRuntime) || !shared.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("requests scopes = %v; want both the default and develop group scopes", shared.Scopes)
+	}
+	devOnly, ok := g.Node("pytest@9.0.3")
+	if !ok {
+		t.Fatalf("expected pytest package, got %s", g.PrettyString())
+	}
+	if devOnly.HasScope(sdk.ScopeRuntime) || !devOnly.HasScope(sdk.ScopeDevelopment) {
+		t.Fatalf("pytest scopes = %v; want the develop group scope only", devOnly.Scopes)
+	}
+}
+
 func TestFilterPythonToolPackagesRemovesUndeclaredTools(t *testing.T) {
 	g := sdk.New()
 	root := sdk.NewDependency(sdk.Dependency{Coordinates: sdk.Coordinates{Ecosystem: sdk.EcosystemPython, Name: "root"}})


### PR DESCRIPTION
Fixes #400.

## What

When one package appears twice in a manifest, the duplicate node folds and its scopes went with it — a `Pipfile.lock` package listed in both `default` and `develop` kept only the scope of whichever group was processed first. Four detectors (node, gomod, gradle, maven) hand-merged scopes at their own fold sites; ten others silently dropped them.

## How

- `detectors.EnsureNode` (the fold point centralized in #397, called `AddNodeFolding` in the issue) now unions the incoming record's scopes onto the survivor. Scopes answer "where is this package reachable?", so a fold takes the union; everything else on the discarded record is still dropped.
- `EnsureOccurrence` now decides fold-vs-distinct-occurrence **before** inserting, so a record that stays a distinct occurrence (conflicting `ResolvedURL`) never leaks its scope onto the node it collided with. Same identity semantics as before, restated without the double insert.
- Deleted the per-detector merges the helper now subsumes: gomod's `addOrMergeModuleNode` scope parameter, maven's and gradle's post-fold `AddScope(PrimaryScope())`, gradle's hand-rolled lookup-then-`AddScope` for project references, and the four node-family sites (npm list tree, npm/pnpm/yarn lockfile parsers). Every one of those nodes already carries its scope via `sdk.ScopesOf` at construction. Edge-time scope propagation (composer/cargo/mix/nuget/etc. marking scopes on lookups driven by manifest sections) is a different mechanism and is untouched.

## Behavior change

Duplicate-node scope semantics change for every detector using the helper: a package reachable at more than one scope now carries all of them, not just the first-seen one. The previously hand-merging detectors are unchanged in effect (their nodes carried a single scope, and union ⊇ `PrimaryScope` merge).

## Tests

- `TestEnsureNodeUnionsScopesOnFold` — fold unions scopes.
- `TestEnsureOccurrenceScopes` — distinct occurrence keeps its own scope and leaks nothing; same-resolution fold unions.
- `TestDepGraphFromPipfileLockPackageInBothGroupsKeepsBothScopes` — the issue's reproduction: `requests` in both groups carries runtime + development, `pytest` stays development-only.
- `make test` passes with no golden drift. Smoke goldens may move where a real-repo package is reachable at more than one scope — if the smoke run flags drift, dispatch **Update Smoke Goldens** after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)