### PR TITLE
fix(security): resolve code scanning alerts 228/229 by removing the source_ref input

### DIFF
--- a/.github/workflows/update-smoke-goldens.yml
+++ b/.github/workflows/update-smoke-goldens.yml
@@ -1,13 +1,14 @@
 name: Update Smoke Goldens
 
+# Goldens are regenerated from the ref the workflow is dispatched on: pick the
+# branch in the "Run workflow" dropdown. Running the dispatched ref's own code
+# (instead of checking out a ref supplied via an input) keeps the executed code
+# and the run's cache scope on the same branch, so a dispatch from a feature
+# branch can never write into the default branch's Actions cache scope
+# (CodeQL actions/cache-poisoning/poisonable-step).
 on:
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: Git ref to regenerate golden files from
-        required: true
-        default: main
-        type: string
       base_ref:
         description: Base branch for the pull request
         required: true
@@ -18,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: update-smoke-goldens-${{ github.event.inputs.source_ref }}
+  group: update-smoke-goldens-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -32,13 +33,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.source_ref }}
 
-      # This workflow executes code from an arbitrary source_ref while its
-      # cache scope is the trusted ref the dispatch ran on (normally main), so
-      # it must never WRITE caches: a poisoned entry would be served to every
-      # trusted workflow. Keep setup-go's cache off; the daily smoke.yml run
+      # Dispatches usually run on short-lived feature branches whose cache
+      # scope is branch-local, so writing caches here would only create
+      # throwaway entries. Keep setup-go's cache off; the daily smoke.yml run
       # on main is the only writer of the shared caches.
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -133,12 +131,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.source_ref }}
 
-      # cache: false for the same reason as the build job — this job runs
-      # source_ref code inside the trusted-branch cache scope and must never
-      # write caches.
+      # cache: false for the same reason as the build job — the daily
+      # smoke.yml run on main is the only writer of the shared caches.
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -227,10 +222,9 @@ jobs:
           </settings>
           XML
 
-      # Restore-only, never save: this job executes code from an arbitrary
-      # source_ref while the cache scope is the trusted ref the dispatch ran
-      # on, so saving here would let that code poison caches served to every
-      # trusted workflow. The daily smoke.yml run on main saves these rolling
+      # Restore-only, never save: dispatches usually run on feature branches,
+      # so entries saved here would be branch-scoped throwaways. The daily
+      # smoke.yml run on main saves these rolling
       # caches (unique key per run, prefix restore); we only read the newest
       # one. Java derives user.home from passwd, not $HOME, so every bomly
       # invocation shares the runner-level ~/.m2 despite the harness's
@@ -324,8 +318,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.source_ref }}
 
       - name: Download regenerated goldens
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -361,7 +353,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF: ${{ github.ref_name }}
           BASE_REF: ${{ inputs.base_ref }}
           RUN_ID: ${{ github.run_id }}
           FAILED_SLICES: ${{ steps.failures.outputs.failed }}

--- a/dev-docs/CI.md
+++ b/dev-docs/CI.md
@@ -10,7 +10,7 @@ its own minimal CI in its own repository.
 |-------------------------|----------------------------------|----------------------------------------------------------------------|
 | `CI`                    | Pull requests, pushes to `main`  | Lint, `go test ./...`, full and lite builds, npm wrapper tests, go.mod/go.sum tidy-drift and no-`replace` checks |
 | `Smoke`                 | Pull requests (labeled), nightly | End-to-end smoke slices driving the built binary against pinned public repositories |
-| `Update Smoke Goldens`  | Manual dispatch                  | Regenerates smoke golden files per slice and opens a PR with the drift |
+| `Update Smoke Goldens`  | Manual dispatch on the branch to regenerate from | Regenerates smoke golden files per slice and opens a PR with the drift |
 | `Fuzz`                  | Nightly schedule, manual dispatch | Native Go fuzzing over the `scripts/run-fuzz.sh` target list; uploads minimized failures as artifacts |
 | `CodeQL`                | Pull requests, pushes, schedule  | Static analysis for Go and JavaScript                                |
 | `SBOM Interoperability` | Schedule, manual dispatch        | Binary-driven SBOM export/ingest checks against third-party tools    |


### PR DESCRIPTION
## Summary

Closes code scanning alerts [228](https://github.com/bomly-dev/bomly-cli/security/code-scanning/228) and [229](https://github.com/bomly-dev/bomly-cli/security/code-scanning/229) (`actions/cache-poisoning/poisonable-step`), which remained open after #405.

## Why #405 did not close them

The CodeQL query fires on the *pattern*: a privileged `workflow_dispatch` run that checks out code from the untrusted `inputs.source_ref` and then executes it (`make build`, `pip install`) while holding the dispatch ref's (normally `main`'s) Actions cache scope. #405 disabled the workflow's own cache writes, but the input-driven checkout + execution remained, so CodeQL kept reporting both alerts on `main` (verified: the `/language:actions` analysis on 510ff73, after #405 merged, still returned 2 results).

## Fix

Remove the `source_ref` input entirely. The workflow now checks out and runs the ref it is **dispatched on**, so:

- there is no untrusted-input checkout for the query to flag, and
- the executed code and the run's cache scope always belong to the same branch — a dispatch from a feature branch cannot write into `main`'s cache scope by construction.

The cache posture from #405 (setup caches off, restore-only Maven/Gradle caches fed by the daily `smoke.yml` run on `main`) is kept, with comments updated to the new rationale.

## Usage change

To regenerate goldens for a branch, pick that branch in the **Run workflow** dropdown instead of typing `source_ref`. The `base_ref` input for the PR base is unchanged. No scripts or docs referenced the old input; `dev-docs/CI.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)