### PR TITLE
fix(sbom): validate license emission, complete the primary component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the 
 | `internal/baseline`    | Portable package-finding baseline codec and audit-integrated policy-status resolver               |
 | `internal/remediation` | Canonical vulnerability fix status, version, detector-hint validation, and occurrence suggestions |
 | `internal/sbom`        | SBOM codec (SPDX 2.3, CycloneDX)                                                                  |
+| `internal/licenseexpr` | SPDX license expression parsing and identifier classification (guards the parser's panics)        |
 | `internal/benchmark`   | Hidden local dependency-graph benchmark, baseline comparison, scoring, and embedded presets       |
 | `internal/output`      | Output rendering plus structured command payloads and schema generation for `scan`, `diff`, `explain`, JSON, and SARIF 2.1.0 |
 | `internal/plugin`      | Plugin discovery, protocol, handshake, and pooled subprocess execution                            |
@@ -94,6 +95,7 @@ Runtime preparation is owned by `internal/engine`: build the filtered registry o
 - The SDK owns neutral shared identifiers and support metadata that would otherwise create package cycles, including ecosystems, package managers, detector types, and support-matrix data.
 - `internal/baseline` owns the baseline document and matching implementation. It depends on the SDK policy contracts and must not be imported by `internal/engine`.
 - `internal/remediation` owns canonical vulnerability remediation decisions. Detectors may supply validated read-only strategy hints, but they do not choose final actions or versions.
+- `internal/licenseexpr` owns all SPDX license expression parsing. The underlying parser panics on some malformed input, and license strings come from untrusted lockfiles and registry APIs, so no other package under `internal/` may import `github.com/github/go-spdx` directly; `TestNoDirectSPDXExpressionUse` enforces this.
 - `internal/registry` owns package-manager discovery, support lookups, and built-in registry wiring in `internal/registry/builder.go`. Do not create or reintroduce a separate `registrybuilder` package.
 - `internal/engine` may import `internal/detectors` and `internal/registry`, but detector packages must not point back into `internal/engine`. Runtime planning, prepared subprojects, and detector-chain reuse belong in `internal/engine`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the 
 | `internal/baseline`    | Portable package-finding baseline codec and audit-integrated policy-status resolver               |
 | `internal/remediation` | Canonical vulnerability fix status, version, detector-hint validation, and occurrence suggestions |
 | `internal/sbom`        | SBOM codec (SPDX 2.3, CycloneDX)                                                                  |
+| `internal/licenseexpr` | SPDX license expression parsing and identifier classification (guards the parser's panics)        |
 | `internal/benchmark`   | Hidden local dependency-graph benchmark, baseline comparison, scoring, and embedded presets       |
 | `internal/output`      | Output rendering plus structured command payloads and schema generation for `scan`, `diff`, `explain`, JSON, and SARIF 2.1.0 |
 | `internal/plugin`      | Plugin discovery, protocol, handshake, and pooled subprocess execution                            |
@@ -94,6 +95,7 @@ Runtime preparation is owned by `internal/engine`: build the filtered registry o
 - The SDK owns neutral shared identifiers and support metadata that would otherwise create package cycles, including ecosystems, package managers, detector types, and support-matrix data.
 - `internal/baseline` owns the baseline document and matching implementation. It depends on the SDK policy contracts and must not be imported by `internal/engine`.
 - `internal/remediation` owns canonical vulnerability remediation decisions. Detectors may supply validated read-only strategy hints, but they do not choose final actions or versions.
+- `internal/licenseexpr` owns all SPDX license expression parsing. The underlying parser panics on some malformed input, and license strings come from untrusted lockfiles and registry APIs, so no other package under `internal/` may import `github.com/github/go-spdx` directly; `TestNoDirectSPDXExpressionUse` enforces this.
 - `internal/registry` owns package-manager discovery, support lookups, and built-in registry wiring in `internal/registry/builder.go`. Do not create or reintroduce a separate `registrybuilder` package.
 - `internal/engine` may import `internal/detectors` and `internal/registry`, but detector packages must not point back into `internal/engine`. Runtime planning, prepared subprojects, and detector-chain reuse belong in `internal/engine`.
 

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -237,6 +237,7 @@ Cache failures are non-fatal. The command should warn and continue rather than f
 | `internal/engine/scan` | Scan command pipeline API                                                                    |
 | `internal/output`     | Text, JSON, SARIF rendering, plus structured response payloads and schema generation            |
 | `internal/sbom`       | SPDX and CycloneDX codecs                                                                       |
+| `internal/licenseexpr` | SPDX license expression parsing and identifier classification                                  |
 | `internal/benchmark`  | Hidden local dependency-graph benchmark, baseline comparison, scoring, and embedded presets      |
 | `sdk`      | Shared domain types                                                                             |
 | `internal/plugin`     | Managed plugin manifests, installation, verification, store state, adapters, and runtime glue  |

--- a/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
+++ b/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
@@ -11,13 +11,19 @@ did not: it published a license as an `expression` whenever the intermediate
 model happened to carry an `SPDXExpression`, and as a free-text `name`
 otherwise.
 
-The two fields do not correspond to those two shapes. Sources write whatever
-they have into both: the deps.dev matcher sets `Value` and `SPDXExpression` to
-the same string, "non-standard" as readily as "MIT". So a package licensed
-`MIT` was published as free text, unrecognized text was published as an
-expression that does not parse, and two licenses produced two `expression`
-entries, which CycloneDX does not allow. SPDX, holding one expression per
-package, kept `licenses[0]` and dropped the rest without saying so.
+Which field is populated says where a license came from, not what shape it has.
+Detection-time licenses carry only `Value`: the npm and pnpm parsers read a
+lockfile's plain `"MIT"` and set nothing else. Registry licenses carry both,
+because the deps.dev matcher copies one string into `Value` and
+`SPDXExpression` alike — "non-standard" as readily as "MIT".
+
+Selecting on the field therefore got both directions wrong. A package whose
+lockfile declared `MIT` was published as free text, because detection set no
+expression. Unrecognized registry text was published as an `expression` that
+does not parse, because the matcher set one. Two licenses produced two
+`expression` entries, which CycloneDX does not allow. And SPDX, holding one
+expression per package, kept `licenses[0]` and dropped the rest without
+saying so.
 
 Underneath, the SPDX expression parser Bomly depends on panics rather than
 returning an error on some malformed input — `(((` dereferences a nil operator.
@@ -59,6 +65,14 @@ the two exports of one scan now agree on every licensed component.
 `TestNoDirectSPDXExpressionUse` fails when any package under `internal/` imports
 the SPDX parser directly, so the panic guard cannot be bypassed by a new call
 site writing the call out by hand. `FuzzSPDXLicenseValue` exercises
-classification and composition over untrusted values; it is what found the
-parser panic, and it covers the auditor's crash as a side effect of the
-centralization.
+classification and composition over untrusted values on the export path; it is
+what found the parser panic. The auditor is covered by the wrapper's own tests
+rather than by that target, which does not call it: routing the auditor through
+`licenseexpr` is what fixes its crash.
+
+One limitation is knowingly left in place. SPDX has no free-text license field,
+so a single unrecognized value is still written verbatim into
+`licenseDeclared`, which is not a valid SPDX expression. Representing it as a
+`LicenseRef` with a matching `hasExtractedLicensingInfos` entry is the correct
+fix and is tracked separately; it is a different decision from this one, and
+folding it in would change what an unknown license means in the document.

--- a/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
+++ b/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
@@ -36,12 +36,26 @@ been a second call site for the same defect.
 Every license value is classified by validating it, not by which field carried
 it. One SPDX list entry becomes CycloneDX `license.id` in its canonical
 spelling; a value that parses as an expression becomes `expression`; anything
-else stays free text in `license.name`. Several declared licenses compose into
-one `AND` expression — a package offered under several licenses is bound by all
-of them — and both formats publish the same composed string. A set that mixes
-valid expressions with free text cannot compose without producing something
-that does not parse, so CycloneDX falls back to one entry per license and SPDX
-to the first value.
+else stays free text in `license.name`.
+
+Several licenses on one component are *listed*, not related. A source reporting
+`["MIT", "Apache-2.0"]` says which licenses it found, not whether both apply or
+either may be chosen, so CycloneDX emits one entry per license — a list asserts
+no relationship — and `MIT AND Apache-2.0` is never claimed of a package that
+may be offered under either. A source that knows the relationship states it in
+one value (`Apache-2.0 OR MIT`, how registries record dual licensing), which
+arrives as a single expression and passes through untouched.
+
+SPDX 2.3 is the exception, because it holds one expression per package and has
+no form for an unrelated list. There the licenses join with `AND`: conservative
+in that it overstates obligations rather than understating them, but still more
+than the source said. This is the one deliberate cross-format difference, and
+it is recorded in `docs/SBOM.md`. CycloneDX composes only when a member is
+itself compound, where listing would degrade a real expression to free text.
+
+A set that mixes valid expressions with free text cannot compose without
+producing something that does not parse, so CycloneDX falls back to one entry
+per license and SPDX to the first value.
 
 SPDX `licenseConcluded` is always `NOASSERTION`. Concluded is the document
 creator's own determination, and Bomly has none to offer: every license it
@@ -63,8 +77,12 @@ than as `expression`. This is a visible change in output for packages whose
 declared license is not SPDX, and it is the point: the previous documents
 failed CycloneDX expression validation.
 
-Multi-license packages gain licenses in SPDX that were previously dropped, and
-the two exports of one scan now agree on every licensed component.
+Multi-license packages gain licenses in SPDX that were previously dropped. The
+two exports of one scan agree wherever a format can express the same thing;
+they differ for a multi-license component, where CycloneDX lists and SPDX must
+compose. A cross-format comparison will score that as a mismatch. Accuracy is
+worth more than the similarity number: making the documents agree would mean
+asserting a relationship in CycloneDX that no source stated.
 
 `TestNoDirectSPDXExpressionUse` fails when any package under `internal/` imports
 the SPDX parser directly, so the panic guard cannot be bypassed by a new call

--- a/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
+++ b/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
@@ -1,0 +1,64 @@
+# ADR-0035: License emission is validated, not assumed
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+
+## Context
+
+CycloneDX and SPDX both distinguish a checked SPDX license identifier from a
+license expression from free text a machine cannot reason about. Bomly's export
+did not: it published a license as an `expression` whenever the intermediate
+model happened to carry an `SPDXExpression`, and as a free-text `name`
+otherwise.
+
+The two fields do not correspond to those two shapes. Sources write whatever
+they have into both: the deps.dev matcher sets `Value` and `SPDXExpression` to
+the same string, "non-standard" as readily as "MIT". So a package licensed
+`MIT` was published as free text, unrecognized text was published as an
+expression that does not parse, and two licenses produced two `expression`
+entries, which CycloneDX does not allow. SPDX, holding one expression per
+package, kept `licenses[0]` and dropped the rest without saying so.
+
+Underneath, the SPDX expression parser Bomly depends on panics rather than
+returning an error on some malformed input — `(((` dereferences a nil operator.
+The license auditor already fed registry values straight into it, so a package
+declaring that string crashed a scan. Validating on the export path would have
+been a second call site for the same defect.
+
+## Decision
+
+Every license value is classified by validating it, not by which field carried
+it. One SPDX list entry becomes CycloneDX `license.id` in its canonical
+spelling; a value that parses as an expression becomes `expression`; anything
+else stays free text in `license.name`. Several declared licenses compose into
+one `AND` expression — a package offered under several licenses is bound by all
+of them — and both formats publish the same composed string. A set that mixes
+valid expressions with free text cannot compose without producing something
+that does not parse, so CycloneDX falls back to one entry per license and SPDX
+to the first value.
+
+SPDX `licenseConcluded` repeats `licenseDeclared`. The values come from a
+lockfile or a registry that asserts them, so concluding from them reads
+evidence rather than inventing a claim; `NOASSERTION` would discard data Bomly
+holds.
+
+All SPDX expression parsing goes through `internal/licenseexpr`, which recovers
+from the parser's panics and reports the value as one it could not parse. No
+other package under `internal/` may import the parser directly.
+
+## Consequences
+
+Values that never were valid expressions are now published as free text rather
+than as `expression`. This is a visible change in output for packages whose
+declared license is not SPDX, and it is the point: the previous documents
+failed CycloneDX expression validation.
+
+Multi-license packages gain licenses in SPDX that were previously dropped, and
+the two exports of one scan now agree on every licensed component.
+
+`TestNoDirectSPDXExpressionUse` fails when any package under `internal/` imports
+the SPDX parser directly, so the panic guard cannot be bypassed by a new call
+site writing the call out by hand. `FuzzSPDXLicenseValue` exercises
+classification and composition over untrusted values; it is what found the
+parser panic, and it covers the auditor's crash as a side effect of the
+centralization.

--- a/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
+++ b/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
@@ -43,10 +43,14 @@ valid expressions with free text cannot compose without producing something
 that does not parse, so CycloneDX falls back to one entry per license and SPDX
 to the first value.
 
-SPDX `licenseConcluded` repeats `licenseDeclared`. The values come from a
-lockfile or a registry that asserts them, so concluding from them reads
-evidence rather than inventing a claim; `NOASSERTION` would discard data Bomly
-holds.
+SPDX `licenseConcluded` is always `NOASSERTION`. Concluded is the document
+creator's own determination, and Bomly has none to offer: every license it
+holds is declared by a lockfile or a registry — `LicenseType` has no other
+value — and no stage analyzes package contents. SPDX names exactly this case,
+`NOASSERTION` when the creator made no attempt to determine the field, and
+Syft resolves it the same way for metadata-derived licenses. Nothing is lost,
+because `licenseDeclared` still carries what the source asserted, and ingest
+skips `NOASSERTION` and falls through to it.
 
 All SPDX expression parsing goes through `internal/licenseexpr`, which recovers
 from the parser's panics and reports the value as one it could not parse. No

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -55,3 +55,4 @@ status to `Superseded by [ADR-NNNN](NNNN-slug.md)`; do not rewrite history
 | ADR-0032 | 2026-08-14 | [SBOM exports carry a synthesized primary component and shared document identity](0032-sbom-exports-carry-synthesized-primary-component.md) | Accepted |
 | ADR-0033 | 2026-08-24 | [Package origin is detector-asserted; SBOM export only projects it](0033-package-origin-is-detector-asserted.md) | Accepted |
 | ADR-0034 | 2026-08-24 | [Decisions are recorded as individual ADRs](0034-decisions-are-recorded-as-individual-adrs.md) | Accepted |
+| ADR-0035 | 2026-08-25 | [License emission is validated, not assumed](0035-license-emission-is-validated-not-assumed.md) | Accepted |

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -113,7 +113,7 @@ text that means nothing to a machine. The formats keep these apart and tools
 score them differently, so Bomly checks each value rather than guessing from
 where it came:
 
-| The value | CycloneDX | SPDX 2.3 |
+| The value | CycloneDX | SPDX 2.3 `licenseDeclared` |
 |---|---|---|
 | One SPDX identifier (`MIT`) | `license.id`, spelled canonically | the identifier |
 | A compound expression (`MIT OR Apache-2.0`) | `expression` | the expression |
@@ -125,6 +125,13 @@ with `AND` — a package offered under several licenses is bound by all of them.
 Both formats publish the same string, so the two exports of one scan describe
 licensing identically. If any part is free text, CycloneDX keeps each license
 as its own entry instead, so the recognized ones keep their identifiers.
+
+SPDX `licenseConcluded` is always `NOASSERTION`. "Concluded" means the license
+the document's author determined for themselves, usually by examining the
+package's contents. Bomly reports what a lockfile or registry declares and
+analyzes no contents, so it has nothing of its own to conclude — and SPDX
+defines `NOASSERTION` for exactly that. The declared field still carries the
+license, and reading the document back recovers it.
 
 #### License data usually needs `--enrich`
 

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -120,11 +120,20 @@ where it came:
 | Anything else (`see LICENSE file`) | `license.name`, as free text | the text as-is |
 | Nothing | no `licenses` key | `NOASSERTION` |
 
-When a package declares several licenses, they are joined into one expression
-with `AND` — a package offered under several licenses is bound by all of them.
-Both formats publish the same string, so the two exports of one scan describe
-licensing identically. If any part is free text, CycloneDX keeps each license
-as its own entry instead, so the recognized ones keep their identifiers.
+When a source records several licenses for one package, it is saying which
+licenses it found — not whether they all apply or whether you may choose
+between them. Bomly does not fill that gap in:
+
+- **CycloneDX** lists them as separate entries, which asserts no relationship.
+- **SPDX 2.3** has only one expression field and no way to list licenses
+  without relating them, so it joins them with `AND`. That overstates
+  obligations rather than understating them, but it does say more than the
+  source did. This is the one place the two formats differ on purpose.
+
+When a source *does* state the relationship, it puts it in one value —
+`Apache-2.0 OR MIT` is how registries record dual licensing — and both formats
+publish that expression exactly as given. Dual-licensed packages are therefore
+unaffected: Bomly never rewrites an `OR` into an `AND`.
 
 SPDX `licenseConcluded` is always `NOASSERTION`. "Concluded" means the license
 the document's author determined for themselves, usually by examining the
@@ -332,11 +341,11 @@ Some information necessarily becomes less specific during conversion:
 - The CycloneDX `group` namespace survives a CycloneDX round trip. SPDX 2.3
   has no group field, so an SPDX round trip recovers the namespace only from
   the PURL.
-- SPDX 2.3 holds one license expression per package, so several declared
-  licenses are composed into one (see "How licenses are written" above). A
-  set that mixes real expressions with free text cannot be composed without
-  producing an expression that does not parse; SPDX then keeps the first
-  value, while CycloneDX keeps every license as its own entry.
+- SPDX 2.3 holds one license expression per package, so several licenses are
+  composed with `AND` there while CycloneDX lists them (see "How licenses are
+  written" above). A set that mixes real expressions with free text cannot be
+  composed without producing an expression that does not parse; SPDX then
+  keeps the first value, while CycloneDX keeps every license as its own entry.
 - SPDX has no free-text license field. CycloneDX carries an unrecognized
   license as `license.name`, but SPDX writes it into `licenseDeclared`, where
   it is not a valid SPDX expression. A strict SPDX consumer may reject such a

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -92,7 +92,11 @@ Both formats carry:
   are normalized to lowercase hex so they are schema-valid in both formats.
 - License identifiers normalized to the current SPDX license list: deprecated
   ids such as `GPL-2.0` are rewritten to their replacements (`GPL-2.0-only`)
-  inside expressions, in both formats.
+  inside expressions, in both formats. See "How licenses are written" below.
+- The package namespace as CycloneDX `group` — an npm scope (`@scope`), a Go
+  module owner (`github.com/google`), a Maven group (`org.apache.commons`).
+  It is taken from the PURL, so the two always agree. SPDX 2.3 has no
+  equivalent field; there the namespace is carried inside the PURL.
 - An SPDX `primaryPackagePurpose` for every package (LIBRARY for registry
   packages, APPLICATION for the primary component, and so on).
 - Remediation guidance on CycloneDX vulnerability entries: when enrichment
@@ -101,6 +105,44 @@ Both formats carry:
   known. SPDX 2.3 has no equivalent field.
 - Where each package came from, when its lockfile says: an exact download
   location or a source repository. See "Where a package came from" below.
+
+### How licenses are written
+
+A license value can be a recognized SPDX identifier, a compound expression, or
+text that means nothing to a machine. The formats keep these apart and tools
+score them differently, so Bomly checks each value rather than guessing from
+where it came:
+
+| The value | CycloneDX | SPDX 2.3 |
+|---|---|---|
+| One SPDX identifier (`MIT`) | `license.id`, spelled canonically | the identifier |
+| A compound expression (`MIT OR Apache-2.0`) | `expression` | the expression |
+| Anything else (`see LICENSE file`) | `license.name`, as free text | the text as-is |
+| Nothing | no `licenses` key | `NOASSERTION` |
+
+When a package declares several licenses, they are joined into one expression
+with `AND` — a package offered under several licenses is bound by all of them.
+Both formats publish the same string, so the two exports of one scan describe
+licensing identically. If any part is free text, CycloneDX keeps each license
+as its own entry instead, so the recognized ones keep their identifiers.
+
+#### License data usually needs `--enrich`
+
+Most lockfiles do not record licenses. Only npm and pnpm write them into the
+lockfile, so for every other ecosystem — Go, Maven, Python, Cargo, and the rest
+— a plain `bomly scan -o cyclonedx=...` produces components with no license
+data at all (SPDX writes `NOASSERTION`).
+
+Add `--enrich` to fill them in from the deps.dev license matcher:
+
+```bash
+bomly scan --enrich -o cyclonedx=bom.cdx.json -o spdx=bom.spdx.json
+```
+
+This matters for compliance review. The EU Cyber Resilience Act expects an SBOM
+to identify component licensing, and third-party CRA profile checks report
+missing license data as an error. If you are producing an SBOM to hand to
+someone else, run it with `--enrich`.
 
 ### Where a package came from
 
@@ -275,7 +317,18 @@ Some information necessarily becomes less specific during conversion:
   multiple roots, every root remains in the dependency graph and the
   synthesized primary component (see "Document identity" above) links them;
   ingest paths that predate the synthesized root treat the first
-  deterministic root as the primary component.
+  deterministic root as the primary component. The primary component is
+  written with the same detail as an inventory entry, so a package that is
+  both the document's subject and a component describes itself the same way
+  in both places.
+- The CycloneDX `group` namespace survives a CycloneDX round trip. SPDX 2.3
+  has no group field, so an SPDX round trip recovers the namespace only from
+  the PURL.
+- SPDX 2.3 holds one license expression per package, so several declared
+  licenses are composed into one (see "How licenses are written" above). A
+  set that mixes real expressions with free text cannot be composed without
+  producing an expression that does not parse; SPDX then keeps the first
+  value, while CycloneDX keeps every license as its own entry.
 
 Before treating a generated file as a release artifact, validate it with the
 standard validator required by the receiving system. Bomly's tests parse every

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -139,10 +139,11 @@ Add `--enrich` to fill them in from the deps.dev license matcher:
 bomly scan --enrich -o cyclonedx=bom.cdx.json -o spdx=bom.spdx.json
 ```
 
-This matters for compliance review. The EU Cyber Resilience Act expects an SBOM
-to identify component licensing, and third-party CRA profile checks report
-missing license data as an error. If you are producing an SBOM to hand to
-someone else, run it with `--enrich`.
+This matters for compliance review. Third-party SBOM quality checkers — the
+CRA-oriented profiles among them — report missing license data as an error, and
+a reviewer reading the file cannot tell "no license recorded" apart from "not
+looked up". If you are producing an SBOM to hand to someone else, run it with
+`--enrich`.
 
 ### Where a package came from
 
@@ -329,6 +330,11 @@ Some information necessarily becomes less specific during conversion:
   set that mixes real expressions with free text cannot be composed without
   producing an expression that does not parse; SPDX then keeps the first
   value, while CycloneDX keeps every license as its own entry.
+- SPDX has no free-text license field. CycloneDX carries an unrecognized
+  license as `license.name`, but SPDX writes it into `licenseDeclared`, where
+  it is not a valid SPDX expression. A strict SPDX consumer may reject such a
+  package. This only affects packages whose declared license is not an SPDX
+  identifier or expression.
 
 Before treating a generated file as a release artifact, validate it with the
 standard validator required by the receiving system. Bomly's tests parse every

--- a/internal/auditors/license/auditor.go
+++ b/internal/auditors/license/auditor.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bomly-dev/bomly-cli/internal/licenseexpr"
 	"github.com/bomly-dev/bomly-sdk"
-	"github.com/github/go-spdx/v2/spdxexp"
 )
 
 const (
@@ -100,7 +100,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 			findings = append(findings, finding(purl, dep.ID, "unknown-license", "Package license is unknown", sdk.FindingPolicyStatusWarn))
 			continue
 		}
-		valid, invalid := spdxexp.ValidateLicenses(licenses)
+		valid, invalid := licenseexpr.ValidateAll(licenses)
 		if !valid {
 			findings = append(findings, finding(purl, dep.ID, "invalid-license", "Package has invalid SPDX license: "+strings.Join(invalid, ", "), sdk.FindingPolicyStatusFail))
 			continue
@@ -108,7 +108,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 		if len(a.AllowLicenses) > 0 {
 			allowed := false
 			for _, expr := range licenses {
-				ok, err := spdxexp.Satisfies(expr, a.AllowLicenses)
+				ok, err := licenseexpr.Satisfies(expr, a.AllowLicenses)
 				if err == nil && ok {
 					allowed = true
 					break
@@ -121,7 +121,7 @@ func (a Auditor) Audit(_ context.Context, req sdk.AuditRequest) (sdk.AuditResult
 		}
 		if len(a.DenyLicenses) > 0 {
 			for _, expr := range licenses {
-				used, err := spdxexp.ExtractLicenses(expr)
+				used, err := licenseexpr.Extract(expr)
 				if err != nil {
 					continue
 				}

--- a/internal/licenseexpr/licenseexpr.go
+++ b/internal/licenseexpr/licenseexpr.go
@@ -1,0 +1,117 @@
+// Package licenseexpr is the one place Bomly parses SPDX license expressions.
+//
+// License strings are untrusted input: they arrive from lockfiles a repository
+// commits and from registry APIs, and nothing checks their shape before they
+// reach a parser. The SPDX expression parser Bomly uses panics on some of them
+// -- "(((" dereferences a nil operator -- which would abort a scan rather than
+// report an unparseable license.
+//
+// Every entry point here recovers from that and reports the value as one it
+// could not parse, which is what an unparseable license is. Callers must not
+// reach for github.com/github/go-spdx directly; TestNoDirectSPDXExpressionUse
+// fails when a new call site bypasses this package.
+package licenseexpr
+
+import (
+	"strings"
+
+	"github.com/github/go-spdx/v2/spdxexp"
+	"github.com/github/go-spdx/v2/spdxexp/spdxlicenses"
+)
+
+// Valid reports whether a value parses as an SPDX license expression.
+// Unparseable values -- free text such as "non-standard", or malformed
+// grouping -- report false rather than failing the caller.
+func Valid(expression string) bool {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return false
+	}
+	valid, _ := ValidateAll([]string{expression})
+	return valid
+}
+
+// ValidateAll reports whether every value parses as an SPDX license
+// expression, returning the values that do not.
+func ValidateAll(values []string) (valid bool, invalid []string) {
+	if len(values) == 0 {
+		return true, nil
+	}
+	defer func() {
+		if recover() != nil {
+			// The parser gave up part-way through the batch, so no member can
+			// be reported as checked.
+			valid, invalid = false, append([]string(nil), values...)
+		}
+	}()
+	return spdxexp.ValidateLicenses(values)
+}
+
+// Identifier returns the canonical spelling of a value that is exactly one
+// entry in the SPDX license list, and reports whether it is one.
+//
+// Compound expressions are rejected: an operator ("MIT OR Apache-2.0",
+// "GPL-2.0-only+") is an expression, not a list entry, and the two are not
+// interchangeable in formats that hold identifiers and expressions in separate
+// fields. Deprecated identifiers still resolve -- they remain list members.
+func Identifier(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+	if strings.ContainsAny(value, " \t\n\r()+") {
+		return "", false
+	}
+	if ok, canonical := spdxlicenses.IsActiveLicense(value); ok {
+		return canonical, true
+	}
+	if ok, canonical := spdxlicenses.IsDeprecatedLicense(value); ok {
+		return canonical, true
+	}
+	return "", false
+}
+
+// Compose joins several license expressions into one conjunctive expression.
+// A package declaring several licenses is bound by all of them, so they join
+// with AND, and a compound member is parenthesized to keep its own operators
+// from binding across the join.
+//
+// Callers must validate the members first: composing free text produces an
+// expression that does not parse.
+func Compose(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if strings.ContainsAny(value, " \t") {
+			value = "(" + value + ")"
+		}
+		parts = append(parts, value)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+// Satisfies reports whether an expression is satisfied by an allowed set.
+// An unparseable expression satisfies nothing and returns the parser's error,
+// or false with no error when the parser could not run at all.
+func Satisfies(expression string, allowed []string) (ok bool, err error) {
+	defer func() {
+		if recover() != nil {
+			ok, err = false, nil
+		}
+	}()
+	return spdxexp.Satisfies(expression, allowed)
+}
+
+// Extract returns the individual license identifiers an expression uses.
+// An unparseable expression yields nothing.
+func Extract(expression string) (licenses []string, err error) {
+	defer func() {
+		if recover() != nil {
+			licenses, err = nil, nil
+		}
+	}()
+	return spdxexp.ExtractLicenses(expression)
+}

--- a/internal/licenseexpr/licenseexpr_test.go
+++ b/internal/licenseexpr/licenseexpr_test.go
@@ -1,0 +1,175 @@
+package licenseexpr
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// malformedExpressions are values the underlying SPDX parser panics on rather
+// than rejecting. They reach Bomly from lockfiles and registry APIs, so every
+// entry point has to survive them.
+var malformedExpressions = []string{
+	"(((",
+	"((((((((((",
+	"(( (",
+	"(MIT AND (((",
+}
+
+func TestValidRejectsMalformedExpressionsWithoutPanicking(t *testing.T) {
+	for _, expression := range malformedExpressions {
+		if Valid(expression) {
+			t.Fatalf("expected %q to be reported invalid", expression)
+		}
+	}
+}
+
+func TestValid(t *testing.T) {
+	valid := []string{"MIT", "MIT OR Apache-2.0", "Apache-2.0 AND (MIT OR BSD-3-Clause)", "GPL-2.0-only+"}
+	for _, expression := range valid {
+		if !Valid(expression) {
+			t.Fatalf("expected %q to be valid", expression)
+		}
+	}
+	invalid := []string{"", "   ", "non-standard", "see LICENSE file", "MIT AND"}
+	for _, expression := range invalid {
+		if Valid(expression) {
+			t.Fatalf("expected %q to be invalid", expression)
+		}
+	}
+}
+
+func TestValidateAllReportsEveryValueWhenTheParserGivesUp(t *testing.T) {
+	values := []string{"MIT", "((("}
+	valid, invalid := ValidateAll(values)
+	if valid {
+		t.Fatal("expected the batch to be invalid")
+	}
+	if len(invalid) != len(values) {
+		t.Fatalf("expected every value reported unchecked, got %#v", invalid)
+	}
+}
+
+func TestValidateAll(t *testing.T) {
+	if valid, invalid := ValidateAll(nil); !valid || invalid != nil {
+		t.Fatalf("expected an empty batch to be valid, got %v %#v", valid, invalid)
+	}
+	if valid, _ := ValidateAll([]string{"MIT", "Apache-2.0"}); !valid {
+		t.Fatal("expected known identifiers to validate")
+	}
+	valid, invalid := ValidateAll([]string{"MIT", "non-standard"})
+	if valid {
+		t.Fatal("expected free text to be reported invalid")
+	}
+	if len(invalid) != 1 || invalid[0] != "non-standard" {
+		t.Fatalf("expected only the free-text value reported, got %#v", invalid)
+	}
+}
+
+func TestIdentifier(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+		ok    bool
+	}{
+		{value: "MIT", want: "MIT", ok: true},
+		{value: "mit", want: "MIT", ok: true},
+		{value: "  Apache-2.0  ", want: "Apache-2.0", ok: true},
+		{value: "GPL-2.0", want: "GPL-2.0", ok: true}, // deprecated, still a list entry
+		{value: "MIT OR Apache-2.0"},
+		{value: "GPL-2.0-only+"},
+		{value: "(MIT)"},
+		{value: "non-standard"},
+		{value: ""},
+	}
+	for _, tc := range tests {
+		got, ok := Identifier(tc.value)
+		if ok != tc.ok || got != tc.want {
+			t.Fatalf("Identifier(%q) = (%q, %v), want (%q, %v)", tc.value, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestSatisfiesAndExtractSurviveMalformedExpressions(t *testing.T) {
+	for _, expression := range malformedExpressions {
+		if ok, err := Satisfies(expression, []string{"MIT"}); ok {
+			t.Fatalf("expected %q to satisfy nothing (err %v)", expression, err)
+		}
+		if licenses, err := Extract(expression); len(licenses) != 0 {
+			t.Fatalf("expected %q to yield no licenses, got %#v (err %v)", expression, licenses, err)
+		}
+	}
+}
+
+func TestSatisfiesAndExtract(t *testing.T) {
+	ok, err := Satisfies("MIT", []string{"MIT", "Apache-2.0"})
+	if err != nil || !ok {
+		t.Fatalf("expected MIT to be satisfied, got %v (err %v)", ok, err)
+	}
+	ok, err = Satisfies("GPL-3.0-only", []string{"MIT"})
+	if err != nil || ok {
+		t.Fatalf("expected GPL not to be satisfied by MIT, got %v (err %v)", ok, err)
+	}
+	licenses, err := Extract("MIT OR Apache-2.0")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(licenses) != 2 {
+		t.Fatalf("expected 2 extracted licenses, got %#v", licenses)
+	}
+}
+
+// TestNoDirectSPDXExpressionUse keeps the panic guard from being bypassed. The
+// underlying parser crashes on malformed input, so a call site that reaches it
+// directly reintroduces a crash on data a repository controls. New callers
+// belong in this package.
+func TestNoDirectSPDXExpressionUse(t *testing.T) {
+	const spdxModule = "github.com/github/go-spdx"
+
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	selfDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve package directory: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	walkErr := filepath.WalkDir(filepath.Join(root, "internal"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if dir := filepath.Dir(path); dir == selfDir {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return nil // not this test's job to police unparseable files
+		}
+		for _, spec := range file.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				continue
+			}
+			if strings.HasPrefix(importPath, spdxModule) {
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					rel = path
+				}
+				t.Errorf("%s imports %s directly; use internal/licenseexpr, which guards the parser's panics", rel, importPath)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk internal packages: %v", walkErr)
+	}
+}

--- a/internal/sbom/codec_fuzz_test.go
+++ b/internal/sbom/codec_fuzz_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bomly-dev/bomly-cli/internal/licenseexpr"
 	testkit "github.com/bomly-dev/bomly-sdk/testkit"
 )
 
@@ -107,6 +108,75 @@ func FuzzNormalizeSPDXLicenseExpression(f *testing.F) {
 		}
 		if strings.TrimSpace(expression) == "" && first != expression {
 			t.Fatalf("blank expression must pass through unchanged: %q -> %q", expression, first)
+		}
+	})
+}
+
+// FuzzSPDXLicenseValue exercises the license classification and composition
+// that decides how a license reaches both export formats. The values arrive
+// from lockfiles and registry APIs, and classification now runs a third-party
+// SPDX expression parser over them, so this guards that path against panics
+// and non-determinism.
+func FuzzSPDXLicenseValue(f *testing.F) {
+	for _, seed := range []string{
+		"MIT",
+		"mit",
+		"Apache-2.0",
+		"MIT OR Apache-2.0",
+		"Apache-2.0 AND (MIT OR BSD-3-Clause)",
+		"GPL-2.0+",
+		"LGPL-2.1-only WITH Classpath-exception-2.0",
+		"LicenseRef-proprietary",
+		"non-standard",
+		"see LICENSE file",
+		"",
+		"   ",
+		"(((",
+		")",
+		"MIT AND",
+		"\x00�",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		if len(value) > testkit.MaxFuzzInputSize {
+			return
+		}
+
+		id, ok := licenseexpr.Identifier(value)
+		if id2, ok2 := licenseexpr.Identifier(value); ok != ok2 || id != id2 {
+			t.Fatalf("nondeterministic identifier classification: (%q, %v) then (%q, %v)", id, ok, id2, ok2)
+		}
+		valid := licenseexpr.Valid(value)
+		if valid != licenseexpr.Valid(value) {
+			t.Fatalf("nondeterministic expression validation for %q", value)
+		}
+		if ok {
+			// Anything publishable as a bare `license.id` must also stand on
+			// its own as an expression; the two shapes carry the same claim.
+			if id == "" {
+				t.Fatalf("classified %q as an identifier but returned an empty id", value)
+			}
+			if !licenseexpr.Valid(id) {
+				t.Fatalf("identifier %q (from %q) is not a valid expression", id, value)
+			}
+		}
+
+		// Composition must not lose or reorder members, and must be stable.
+		composed := licenseexpr.Compose([]string{value, value})
+		if composed != licenseexpr.Compose([]string{value, value}) {
+			t.Fatalf("nondeterministic composition for %q", value)
+		}
+		if strings.TrimSpace(value) != "" && !strings.Contains(composed, " AND ") {
+			t.Fatalf("composition dropped a member: %q -> %q", value, composed)
+		}
+
+		// The two encoders read licenses through the same helpers, so neither
+		// may panic on any value a source can produce.
+		licenses := []License{{Value: value}, {SPDXExpression: value}}
+		_ = cycloneDXLicenses(licenses)
+		if got := spdxLicenseValue(licenses); got == "" {
+			t.Fatalf("spdx license value must never be empty, got %q for %q", got, value)
 		}
 	})
 }

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-cli/internal/licenseexpr"
 )
 
 type cycloneDXCodec struct {
@@ -26,31 +27,7 @@ func (c cycloneDXCodec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, e
 			// the component inventory would double-count it.
 			continue
 		}
-		component := cdx.Component{
-			BOMRef:     comp.ID,
-			Type:       cycloneDXComponentType(comp.Type),
-			Name:       comp.NameOrID(),
-			Scope:      cycloneDXScope(comp.Scope),
-			Version:    comp.Version,
-			PackageURL: comp.PURL,
-			Copyright:  comp.Copyright,
-		}
-		if licenses := cycloneDXLicenses(comp.Licenses); len(licenses) > 0 {
-			component.Licenses = &licenses
-		}
-		if len(comp.CPEs) > 0 {
-			component.CPE = comp.CPEs[0]
-		}
-		if hashes := cycloneDXHashes(comp.Digests); len(hashes) > 0 {
-			component.Hashes = &hashes
-		}
-		if props := cycloneDXEOLProperties(comp.EOL); len(props) > 0 {
-			component.Properties = &props
-		}
-		if refs := cycloneDXComponentReferences(comp); len(refs) > 0 {
-			component.ExternalReferences = &refs
-		}
-		components = append(components, component)
+		components = append(components, cycloneDXComponent(comp))
 	}
 	bom.Components = &components
 
@@ -75,17 +52,20 @@ func (c cycloneDXCodec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, e
 		Tools:     cycloneDXTools(doc.ToolNamesOrDefault(), doc.ToolOrDefault(), doc.ToolVersion),
 	}
 	if root := chooseRoot(doc); root != nil {
-		metadata.Component = &cdx.Component{
-			BOMRef:     root.ID,
-			Type:       cycloneDXComponentType(firstNonEmpty(root.Type, "application")),
-			Name:       root.NameOrID(),
-			Scope:      cycloneDXScope(root.Scope),
-			Version:    root.Version,
-			PackageURL: root.PURL,
-		}
+		// The primary component is built the same way as an inventory entry.
+		// A natural root appears in both places, and a reduced copy here would
+		// describe the scanned project with less detail -- no licenses, hashes,
+		// CPE, or origin -- than the same package carries a few lines below.
+		primary := cycloneDXComponent(*root)
+		primary.Type = cycloneDXComponentType(firstNonEmpty(root.Type, "application"))
 		if refs := cycloneDXSecurityReferences(doc.Provenance); len(refs) > 0 {
-			metadata.Component.ExternalReferences = &refs
+			merged := refs
+			if primary.ExternalReferences != nil {
+				merged = append(append([]cdx.ExternalReference(nil), *primary.ExternalReferences...), refs...)
+			}
+			primary.ExternalReferences = &merged
 		}
+		metadata.Component = &primary
 	}
 	if doc.Provenance.Manufacturer != "" {
 		metadata.Manufacturer = &cdx.OrganizationalEntity{Name: doc.Provenance.Manufacturer}
@@ -128,6 +108,7 @@ func (c cycloneDXCodec) decodeJSON(data []byte) (*Document, error) {
 			componentByID[comp.BOMRef] = Component{
 				ID:        comp.BOMRef,
 				Name:      comp.Name,
+				Org:       comp.Group,
 				Type:      string(comp.Type),
 				Scope:     string(comp.Scope),
 				Version:   comp.Version,
@@ -175,6 +156,7 @@ func (c cycloneDXCodec) decodeJSON(data []byte) (*Document, error) {
 		componentByID[root.BOMRef] = Component{
 			ID:        root.BOMRef,
 			Name:      root.Name,
+			Org:       root.Group,
 			Type:      string(root.Type),
 			Scope:     string(root.Scope),
 			Version:   root.Version,
@@ -428,18 +410,82 @@ func toCycloneDXVersion(target Target) cdx.SpecVersion {
 	}
 }
 
+// cycloneDXComponent renders one intermediate component into its CycloneDX
+// form. Both the component inventory and metadata.component go through it, so
+// the document describes a package the same way wherever it appears.
+func cycloneDXComponent(comp Component) cdx.Component {
+	component := cdx.Component{
+		BOMRef:     comp.ID,
+		Type:       cycloneDXComponentType(comp.Type),
+		Name:       comp.NameOrID(),
+		Group:      comp.Org,
+		Scope:      cycloneDXScope(comp.Scope),
+		Version:    comp.Version,
+		PackageURL: comp.PURL,
+		Copyright:  comp.Copyright,
+	}
+	if licenses := cycloneDXLicenses(comp.Licenses); len(licenses) > 0 {
+		component.Licenses = &licenses
+	}
+	if len(comp.CPEs) > 0 {
+		component.CPE = comp.CPEs[0]
+	}
+	if hashes := cycloneDXHashes(comp.Digests); len(hashes) > 0 {
+		component.Hashes = &hashes
+	}
+	if props := cycloneDXEOLProperties(comp.EOL); len(props) > 0 {
+		component.Properties = &props
+	}
+	if refs := cycloneDXComponentReferences(comp); len(refs) > 0 {
+		component.ExternalReferences = &refs
+	}
+	return component
+}
+
+// cycloneDXLicenses renders a component's licenses into CycloneDX.
+//
+// The format offers three shapes and scores them differently: `license.id` is
+// a checked SPDX list entry, `expression` is a checked SPDX expression, and
+// `license.name` is free text a consumer cannot reason about. Sources hand us
+// all three kinds in the same field -- deps.dev records "non-standard" where
+// it records "MIT" -- so the shape is chosen by validating the value, not by
+// trusting its origin.
+//
+// A CycloneDX license list is either license objects or a single expression,
+// never a mix and never two expressions. Several licenses that all validate
+// therefore compose into one expression, matching the string SPDX declares for
+// the same component; if any part is free text, each license is emitted as its
+// own object instead so the recognized ones keep their identifiers.
 func cycloneDXLicenses(licenses []License) cdx.Licenses {
-	if len(licenses) == 0 {
+	values := componentLicenseValues(licenses)
+	if len(values) == 0 {
 		return nil
 	}
-	out := make(cdx.Licenses, 0, len(licenses))
-	for _, license := range licenses {
-		switch {
-		case license.SPDXExpression != "":
-			out = append(out, cdx.LicenseChoice{Expression: license.SPDXExpression})
-		case license.Value != "":
-			out = append(out, cdx.LicenseChoice{License: &cdx.License{Name: license.Value}})
+
+	if len(values) == 1 {
+		value := values[0]
+		if id, ok := licenseexpr.Identifier(value); ok {
+			return cdx.Licenses{{License: &cdx.License{ID: id}}}
 		}
+		if licenseexpr.Valid(value) {
+			// A compound expression ("MIT OR Apache-2.0") has no license-object
+			// form; it can only be carried as an expression.
+			return cdx.Licenses{{Expression: value}}
+		}
+		return cdx.Licenses{{License: &cdx.License{Name: value}}}
+	}
+
+	if allValidSPDXExpressions(values) {
+		return cdx.Licenses{{Expression: licenseexpr.Compose(values)}}
+	}
+
+	out := make(cdx.Licenses, 0, len(values))
+	for _, value := range values {
+		if id, ok := licenseexpr.Identifier(value); ok {
+			out = append(out, cdx.LicenseChoice{License: &cdx.License{ID: id}})
+			continue
+		}
+		out = append(out, cdx.LicenseChoice{License: &cdx.License{Name: value}})
 	}
 	return out
 }

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -451,11 +451,22 @@ func cycloneDXComponent(comp Component) cdx.Component {
 // it records "MIT" -- so the shape is chosen by validating the value, not by
 // trusting its origin.
 //
-// A CycloneDX license list is either license objects or a single expression,
-// never a mix and never two expressions. Several licenses that all validate
-// therefore compose into one expression, matching the string SPDX declares for
-// the same component; if any part is free text, each license is emitted as its
-// own object instead so the recognized ones keep their identifiers.
+// Several licenses on one component carry no stated relationship: a source
+// reports the licenses it found, not whether they apply together or offer a
+// choice. CycloneDX can say exactly that -- a list of license entries asserts
+// nothing about how they combine -- so a multi-license component is listed
+// rather than composed, and "MIT AND Apache-2.0" is never claimed of a package
+// that may be offered under either.
+//
+// A source that does know the relationship states it in one value
+// ("Apache-2.0 OR MIT", which is how registries record dual licensing); that
+// arrives as a single expression and passes through untouched.
+//
+// The one case that must compose is a list where some member is itself
+// compound. A CycloneDX license list holds objects or one expression, never a
+// mix, and an object cannot carry an expression -- so listing would degrade a
+// real expression to free text. Composing keeps it, at the cost of asserting
+// AND across the members.
 func cycloneDXLicenses(licenses []License) cdx.Licenses {
 	values := componentLicenseValues(licenses)
 	if len(values) == 0 {
@@ -468,14 +479,14 @@ func cycloneDXLicenses(licenses []License) cdx.Licenses {
 			return cdx.Licenses{{License: &cdx.License{ID: id}}}
 		}
 		if licenseexpr.Valid(value) {
-			// A compound expression ("MIT OR Apache-2.0") has no license-object
-			// form; it can only be carried as an expression.
+			// A compound expression has no license-object form; it can only be
+			// carried as an expression.
 			return cdx.Licenses{{Expression: value}}
 		}
 		return cdx.Licenses{{License: &cdx.License{Name: value}}}
 	}
 
-	if allValidSPDXExpressions(values) {
+	if hasCompoundExpression(values) && allValidSPDXExpressions(values) {
 		return cdx.Licenses{{Expression: licenseexpr.Compose(values)}}
 	}
 
@@ -488,6 +499,17 @@ func cycloneDXLicenses(licenses []License) cdx.Licenses {
 		out = append(out, cdx.LicenseChoice{License: &cdx.License{Name: value}})
 	}
 	return out
+}
+
+// hasCompoundExpression reports whether any value is an expression rather than
+// a bare license identifier, and so cannot survive as a license object.
+func hasCompoundExpression(values []string) bool {
+	for _, value := range values {
+		if _, isID := licenseexpr.Identifier(value); !isID && licenseexpr.Valid(value) {
+			return true
+		}
+	}
+	return false
 }
 
 func cycloneDXHashes(digests []Digest) []cdx.Hash {

--- a/internal/sbom/enrichment_test.go
+++ b/internal/sbom/enrichment_test.go
@@ -125,8 +125,11 @@ func TestFromDepGraphEnrichesSPDXFromRegistry(t *testing.T) {
 		t.Fatalf("expected 1 package, got %d", len(doc.Packages))
 	}
 	pkg := doc.Packages[0]
-	if pkg.PackageLicenseConcluded != "MIT" {
-		t.Fatalf("expected MIT license, got %q", pkg.PackageLicenseConcluded)
+	if pkg.PackageLicenseDeclared != "MIT" {
+		t.Fatalf("expected MIT declared license, got %q", pkg.PackageLicenseDeclared)
+	}
+	if pkg.PackageLicenseConcluded != "NOASSERTION" {
+		t.Fatalf("expected NOASSERTION concluded license, got %q", pkg.PackageLicenseConcluded)
 	}
 	if len(pkg.PackageChecksums) != 1 || string(pkg.PackageChecksums[0].Algorithm) != "SHA256" {
 		t.Fatalf("expected SHA256 checksum, got %#v", pkg.PackageChecksums)

--- a/internal/sbom/graph.go
+++ b/internal/sbom/graph.go
@@ -38,9 +38,13 @@ func ToGraph(doc *Document) (*sdk.Graph, error) {
 		if purl := strings.TrimSpace(component.PURL); purl != "" {
 			packageID = purl
 		}
+		// Org is deliberately not set from the component's group. A component
+		// name is already ecosystem-native ("@scope/pkg", "github.com/google/
+		// uuid"), while Coordinates joins Org with Name for display -- setting
+		// both yields "@scope/@scope/pkg". The namespace stays recoverable from
+		// the PURL, which is where export reads it from anyway.
 		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: component.Name,
 			Version: component.Version,
-			Org:     strings.TrimSpace(component.Org),
 
 			Ecosystem:      ecosystem,
 			PackageManager: packageManager,

--- a/internal/sbom/graph.go
+++ b/internal/sbom/graph.go
@@ -40,6 +40,7 @@ func ToGraph(doc *Document) (*sdk.Graph, error) {
 		}
 		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: component.Name,
 			Version: component.Version,
+			Org:     strings.TrimSpace(component.Org),
 
 			Ecosystem:      ecosystem,
 			PackageManager: packageManager,

--- a/internal/sbom/graph.go
+++ b/internal/sbom/graph.go
@@ -38,13 +38,9 @@ func ToGraph(doc *Document) (*sdk.Graph, error) {
 		if purl := strings.TrimSpace(component.PURL); purl != "" {
 			packageID = purl
 		}
-		// Org is deliberately not set from the component's group. A component
-		// name is already ecosystem-native ("@scope/pkg", "github.com/google/
-		// uuid"), while Coordinates joins Org with Name for display -- setting
-		// both yields "@scope/@scope/pkg". The namespace stays recoverable from
-		// the PURL, which is where export reads it from anyway.
 		pkg := sdk.NewDependencyWithID(packageID, sdk.Dependency{Coordinates: sdk.Coordinates{Name: component.Name,
 			Version: component.Version,
+			Org:     ingestedCoordinateOrg(component),
 
 			Ecosystem:      ecosystem,
 			PackageManager: packageManager,
@@ -107,6 +103,54 @@ func isDocumentRootPseudoPackage(component Component) bool {
 		return true
 	}
 	return false
+}
+
+// ingestedCoordinateOrg returns the namespace to carry on an ingested
+// package's coordinates.
+//
+// SBOM producers split a namespaced package two ways. Bomly writes the whole
+// ecosystem-native name ("@scope/pkg", "github.com/google/uuid") and repeats
+// the namespace in `group`; most others write a bare name plus the namespace
+// in `group`. Coordinates joins Org with Name to rebuild the display name, so
+// which split arrived decides whether Org may be set at all: setting it on an
+// already-qualified name yields "@scope/@scope/pkg", and leaving it unset on a
+// bare name loses the namespace entirely.
+//
+// The name itself is never rewritten. Detectors and export both treat it as
+// the ecosystem-native identity, so this only fills in the namespace when the
+// name does not already carry it.
+func ingestedCoordinateOrg(component Component) string {
+	namespace := strings.TrimSpace(component.Org)
+	if purl := parsePURL(component.PURL); purl != nil {
+		if fromPURL := strings.TrimSpace(purl.Namespace); fromPURL != "" {
+			// The PURL is the stronger claim: it is structured, and export
+			// derives `group` from it in the first place.
+			namespace = fromPURL
+		}
+	}
+	if namespace == "" {
+		return ""
+	}
+
+	// Compared case-insensitively: PURL normalization lowercases the namespace
+	// for some types, so a Go module's namespace arrives as
+	// "github.com/burntsushi" while its name keeps "github.com/BurntSushi/toml".
+	// A case-sensitive test would miss that and double the namespace.
+	name := strings.TrimSpace(component.Name)
+	lowerName := strings.ToLower(name)
+	lowerNamespace := strings.ToLower(namespace)
+	if lowerName == lowerNamespace {
+		return ""
+	}
+	// "/" separates npm scopes and Go module paths; ":" separates Maven
+	// coordinates. A name already starting with the namespace and a separator
+	// carries it, so Org must stay empty to avoid doubling it.
+	for _, separator := range []string{"/", ":"} {
+		if strings.HasPrefix(lowerName, lowerNamespace+separator) {
+			return ""
+		}
+	}
+	return namespace
 }
 
 func graphLicenses(licenses []License) []sdk.PackageLicense {

--- a/internal/sbom/license_emission_test.go
+++ b/internal/sbom/license_emission_test.go
@@ -243,10 +243,49 @@ func TestSPDXLicenseComposition(t *testing.T) {
 			if pkg.PackageLicenseDeclared != tc.want {
 				t.Fatalf("declared: expected %q, got %q", tc.want, pkg.PackageLicenseDeclared)
 			}
-			if pkg.PackageLicenseConcluded != tc.want {
-				t.Fatalf("concluded: expected %q, got %q", tc.want, pkg.PackageLicenseConcluded)
-			}
 		})
+	}
+}
+
+// TestSPDXLicenseConcludedIsNeverAsserted pins that Bomly does not conclude a
+// license. Concluded is the document creator's own determination; every
+// license Bomly holds is declared by a source, and Bomly analyzes no package
+// contents, so SPDX's NOASSERTION is the honest value. The declared field
+// still carries what the source said.
+func TestSPDXLicenseConcludedIsNeverAsserted(t *testing.T) {
+	for _, licenses := range [][]sdk.PackageLicense{
+		nil,
+		{{Value: "MIT"}},
+		{{SPDXExpression: "MIT OR Apache-2.0"}},
+		{{Value: "MIT"}, {Value: "Apache-2.0"}},
+		{{Value: "see LICENSE file"}},
+	} {
+		pkg := spdxPackageLicense(t, licensedGraph(t, licenses...))
+		if pkg.PackageLicenseConcluded != "NOASSERTION" {
+			t.Fatalf("expected NOASSERTION concluded for %#v, got %q", licenses, pkg.PackageLicenseConcluded)
+		}
+	}
+}
+
+// TestSPDXConcludedNoAssertionSurvivesIngest covers the round trip: a document
+// whose concluded field is NOASSERTION must still yield the declared license
+// when read back, not a literal "NOASSERTION" license.
+func TestSPDXConcludedNoAssertionSurvivesIngest(t *testing.T) {
+	out, err := MarshalDepGraphJSON(licensedGraph(t, sdk.PackageLicense{Value: "MIT"}),
+		TargetSPDX23JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal spdx: %v", err)
+	}
+	doc, _, err := UnmarshalAutoJSON(out)
+	if err != nil {
+		t.Fatalf("unmarshal document: %v", err)
+	}
+	if len(doc.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(doc.Components))
+	}
+	licenses := doc.Components[0].Licenses
+	if len(licenses) != 1 || licenses[0].Value != "MIT" {
+		t.Fatalf("expected the declared MIT license to survive ingest, got %#v", licenses)
 	}
 }
 

--- a/internal/sbom/license_emission_test.go
+++ b/internal/sbom/license_emission_test.go
@@ -156,16 +156,38 @@ func TestCycloneDXLicenseShapes(t *testing.T) {
 // list holds license objects or one expression, never a mix and never two
 // expressions.
 func TestCycloneDXMultipleLicenses(t *testing.T) {
-	t.Run("all valid compose into one expression", func(t *testing.T) {
+	// Listing several licenses says only that they were found. Composing them
+	// with AND would claim a package offered under either is bound by both.
+	t.Run("several identifiers are listed, not composed", func(t *testing.T) {
 		licenses := cycloneDXComponentLicenses(t, licensedGraph(t,
 			sdk.PackageLicense{Value: "MIT"},
 			sdk.PackageLicense{Value: "Apache-2.0"},
 		))
+		if len(licenses) != 2 {
+			t.Fatalf("expected 2 license entries, got %#v", licenses)
+		}
+		for i, want := range []string{"MIT", "Apache-2.0"} {
+			if licenses[i].License == nil || licenses[i].License.ID != want {
+				t.Fatalf("expected license.id %q at %d, got %#v", want, i, licenses[i])
+			}
+			if licenses[i].Expression != "" {
+				t.Fatalf("expected no asserted relationship, got %q", licenses[i].Expression)
+			}
+		}
+	})
+
+	// A list cannot mix objects with an expression, and an object cannot hold
+	// one, so a compound member leaves composition as the only way to keep it.
+	t.Run("a compound member forces composition", func(t *testing.T) {
+		licenses := cycloneDXComponentLicenses(t, licensedGraph(t,
+			sdk.PackageLicense{SPDXExpression: "Apache-2.0 OR MIT"},
+			sdk.PackageLicense{Value: "Unicode-DFS-2016"},
+		))
 		if len(licenses) != 1 {
 			t.Fatalf("expected a single composed entry, got %#v", licenses)
 		}
-		if licenses[0].Expression != "MIT AND Apache-2.0" {
-			t.Fatalf("expected composed expression, got %#v", licenses[0])
+		if licenses[0].Expression != "(Apache-2.0 OR MIT) AND Unicode-DFS-2016" {
+			t.Fatalf("expected the compound member preserved, got %#v", licenses[0])
 		}
 	})
 
@@ -289,19 +311,35 @@ func TestSPDXConcludedNoAssertionSurvivesIngest(t *testing.T) {
 	}
 }
 
-// TestLicenseCompositionAgreesAcrossFormats guards the property a cross-format
-// comparison measures: one scan's two exports describe the same licensing.
-func TestLicenseCompositionAgreesAcrossFormats(t *testing.T) {
+// TestSourceStatedRelationshipSurvivesBothFormats covers the case that
+// actually matters for dual licensing: when a source states the relationship
+// itself ("Apache-2.0 OR MIT", how registries record it), both formats publish
+// that expression unchanged rather than reinterpreting it.
+func TestSourceStatedRelationshipSurvivesBothFormats(t *testing.T) {
+	const expression = "Apache-2.0 OR MIT"
+	licenses := []sdk.PackageLicense{{SPDXExpression: expression}}
+
+	cdxLicenses := cycloneDXComponentLicenses(t, licensedGraph(t, licenses...))
+	if len(cdxLicenses) != 1 || cdxLicenses[0].Expression != expression {
+		t.Fatalf("cyclonedx changed a source-stated expression: %#v", cdxLicenses)
+	}
+	if got := spdxPackageLicense(t, licensedGraph(t, licenses...)).PackageLicenseDeclared; got != expression {
+		t.Fatalf("spdx changed a source-stated expression: %q", got)
+	}
+}
+
+// TestMultipleLicensesDivergeByFormat pins the one deliberate cross-format
+// difference. CycloneDX can list licenses without relating them; SPDX 2.3
+// holds a single expression and has no such form, so it must compose. Both are
+// the most faithful thing each format can say.
+func TestMultipleLicensesDivergeByFormat(t *testing.T) {
 	licenses := []sdk.PackageLicense{{Value: "MIT"}, {Value: "Apache-2.0"}}
 
 	cdxLicenses := cycloneDXComponentLicenses(t, licensedGraph(t, licenses...))
-	if len(cdxLicenses) != 1 || cdxLicenses[0].Expression == "" {
-		t.Fatalf("expected one CycloneDX expression, got %#v", cdxLicenses)
+	if len(cdxLicenses) != 2 {
+		t.Fatalf("expected CycloneDX to list both licenses, got %#v", cdxLicenses)
 	}
-	spdxPkg := spdxPackageLicense(t, licensedGraph(t, licenses...))
-
-	if cdxLicenses[0].Expression != spdxPkg.PackageLicenseDeclared {
-		t.Fatalf("formats disagree: cyclonedx %q, spdx %q",
-			cdxLicenses[0].Expression, spdxPkg.PackageLicenseDeclared)
+	if got := spdxPackageLicense(t, licensedGraph(t, licenses...)).PackageLicenseDeclared; got != "MIT AND Apache-2.0" {
+		t.Fatalf("expected SPDX to compose, got %q", got)
 	}
 }

--- a/internal/sbom/license_emission_test.go
+++ b/internal/sbom/license_emission_test.go
@@ -1,0 +1,268 @@
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-sdk"
+	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+)
+
+// licensedGraph builds a one-node graph whose single component declares the
+// given licenses at detection time.
+func licensedGraph(t *testing.T, licenses ...sdk.PackageLicense) *sdk.Graph {
+	t.Helper()
+	g := sdk.New()
+	dep := sdk.NewDependencyWithID("left-pad@1.3.0", sdk.Dependency{Coordinates: sdk.Coordinates{
+		Name:      "left-pad",
+		Version:   "1.3.0",
+		PURL:      "pkg:npm/left-pad@1.3.0",
+		Ecosystem: "npm",
+	}})
+	sdk.SetDetectionLicenses(dep, licenses)
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+	return g
+}
+
+func cycloneDXComponentLicenses(t *testing.T, g *sdk.Graph) cdx.Licenses {
+	t.Helper()
+	out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal cyclonedx: %v", err)
+	}
+	bom := new(cdx.BOM)
+	if err := cdx.NewBOMDecoder(bytes.NewReader(out), cdx.BOMFileFormatJSON).Decode(bom); err != nil {
+		t.Fatalf("decode cyclonedx: %v", err)
+	}
+	if bom.Components == nil || len(*bom.Components) != 1 {
+		t.Fatalf("expected exactly 1 component, got %#v", bom.Components)
+	}
+	comp := (*bom.Components)[0]
+	if comp.Licenses == nil {
+		return nil
+	}
+	return *comp.Licenses
+}
+
+func spdxPackageLicense(t *testing.T, g *sdk.Graph) *v23.Package {
+	t.Helper()
+	out, err := MarshalDepGraphJSON(g, TargetSPDX23JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal spdx: %v", err)
+	}
+	var doc v23.Document
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("decode spdx: %v", err)
+	}
+	if len(doc.Packages) != 1 {
+		t.Fatalf("expected exactly 1 package, got %d", len(doc.Packages))
+	}
+	return doc.Packages[0]
+}
+
+// TestCycloneDXLicenseShapes pins how each kind of license value is published.
+// A recognized identifier must reach `license.id` (a checked SPDX list entry),
+// a compound value must reach `expression`, and only genuinely unrecognized
+// text may fall through to the free-text `license.name`.
+func TestCycloneDXLicenseShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		licenses   []sdk.PackageLicense
+		wantID     string
+		wantExpr   string
+		wantName   string
+		wantLength int
+	}{
+		{
+			name:       "plain identifier becomes license.id",
+			licenses:   []sdk.PackageLicense{{Value: "MIT"}},
+			wantID:     "MIT",
+			wantLength: 1,
+		},
+		{
+			name:       "identifier casing is canonicalized",
+			licenses:   []sdk.PackageLicense{{Value: "mit"}},
+			wantID:     "MIT",
+			wantLength: 1,
+		},
+		{
+			name:       "compound value stays an expression",
+			licenses:   []sdk.PackageLicense{{SPDXExpression: "MIT OR Apache-2.0"}},
+			wantExpr:   "MIT OR Apache-2.0",
+			wantLength: 1,
+		},
+		{
+			name:       "or-later operator stays an expression",
+			licenses:   []sdk.PackageLicense{{SPDXExpression: "LGPL-2.1-only+"}},
+			wantExpr:   "LGPL-2.1-only+",
+			wantLength: 1,
+		},
+		{
+			name:       "unrecognized text stays free text",
+			licenses:   []sdk.PackageLicense{{Value: "see LICENSE file"}},
+			wantName:   "see LICENSE file",
+			wantLength: 1,
+		},
+		{
+			// Registry sources write free text into the same field they write
+			// real expressions into. Publishing it as `expression` produced a
+			// document that fails CycloneDX expression validation.
+			name:       "unrecognized expression is demoted to free text",
+			licenses:   []sdk.PackageLicense{{Value: "non-standard", SPDXExpression: "non-standard"}},
+			wantName:   "non-standard",
+			wantLength: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			licenses := cycloneDXComponentLicenses(t, licensedGraph(t, tc.licenses...))
+			if len(licenses) != tc.wantLength {
+				t.Fatalf("expected %d license entries, got %#v", tc.wantLength, licenses)
+			}
+			got := licenses[0]
+			switch {
+			case tc.wantID != "":
+				if got.License == nil || got.License.ID != tc.wantID {
+					t.Fatalf("expected license.id %q, got %#v", tc.wantID, got)
+				}
+				if got.License.Name != "" {
+					t.Fatalf("expected no free-text name alongside an id, got %q", got.License.Name)
+				}
+			case tc.wantExpr != "":
+				if got.Expression != tc.wantExpr {
+					t.Fatalf("expected expression %q, got %#v", tc.wantExpr, got)
+				}
+			case tc.wantName != "":
+				if got.License == nil || got.License.Name != tc.wantName {
+					t.Fatalf("expected license.name %q, got %#v", tc.wantName, got)
+				}
+				if got.License.ID != "" {
+					t.Fatalf("expected no id for unrecognized text, got %q", got.License.ID)
+				}
+				if got.Expression != "" {
+					t.Fatalf("expected no expression for unrecognized text, got %q", got.Expression)
+				}
+			}
+		})
+	}
+}
+
+// TestCycloneDXMultipleLicenses covers the format's either/or rule: a license
+// list holds license objects or one expression, never a mix and never two
+// expressions.
+func TestCycloneDXMultipleLicenses(t *testing.T) {
+	t.Run("all valid compose into one expression", func(t *testing.T) {
+		licenses := cycloneDXComponentLicenses(t, licensedGraph(t,
+			sdk.PackageLicense{Value: "MIT"},
+			sdk.PackageLicense{Value: "Apache-2.0"},
+		))
+		if len(licenses) != 1 {
+			t.Fatalf("expected a single composed entry, got %#v", licenses)
+		}
+		if licenses[0].Expression != "MIT AND Apache-2.0" {
+			t.Fatalf("expected composed expression, got %#v", licenses[0])
+		}
+	})
+
+	t.Run("mixed validity falls back to per-license objects", func(t *testing.T) {
+		licenses := cycloneDXComponentLicenses(t, licensedGraph(t,
+			sdk.PackageLicense{Value: "MIT"},
+			sdk.PackageLicense{Value: "non-standard"},
+		))
+		if len(licenses) != 2 {
+			t.Fatalf("expected 2 license entries, got %#v", licenses)
+		}
+		if licenses[0].License == nil || licenses[0].License.ID != "MIT" {
+			t.Fatalf("expected the recognized license to keep its id, got %#v", licenses[0])
+		}
+		if licenses[1].License == nil || licenses[1].License.Name != "non-standard" {
+			t.Fatalf("expected the unrecognized license as free text, got %#v", licenses[1])
+		}
+		for _, l := range licenses {
+			if l.Expression != "" {
+				t.Fatalf("expected no expression when emitting license objects, got %#v", l)
+			}
+		}
+	})
+}
+
+// TestSPDXLicenseComposition covers SPDX 2.3 holding one expression per
+// package: several declared licenses must compose rather than lose all but the
+// first.
+func TestSPDXLicenseComposition(t *testing.T) {
+	tests := []struct {
+		name     string
+		licenses []sdk.PackageLicense
+		want     string
+	}{
+		{
+			name: "no licenses",
+			want: "NOASSERTION",
+		},
+		{
+			name:     "single value passes through",
+			licenses: []sdk.PackageLicense{{Value: "MIT"}},
+			want:     "MIT",
+		},
+		{
+			name: "multiple licenses compose with AND",
+			licenses: []sdk.PackageLicense{
+				{Value: "MIT"},
+				{Value: "Apache-2.0"},
+			},
+			want: "MIT AND Apache-2.0",
+		},
+		{
+			name: "compound elements are parenthesized",
+			licenses: []sdk.PackageLicense{
+				{Value: "MIT"},
+				{SPDXExpression: "MIT OR GPL-2.0-only"},
+			},
+			want: "MIT AND (MIT OR GPL-2.0-only)",
+		},
+		{
+			// Joining free text would produce an expression that does not
+			// parse, so a mixed set keeps the previous first-value behavior.
+			name: "unparseable member falls back to the first value",
+			licenses: []sdk.PackageLicense{
+				{Value: "MIT"},
+				{Value: "non-standard"},
+			},
+			want: "MIT",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg := spdxPackageLicense(t, licensedGraph(t, tc.licenses...))
+			if pkg.PackageLicenseDeclared != tc.want {
+				t.Fatalf("declared: expected %q, got %q", tc.want, pkg.PackageLicenseDeclared)
+			}
+			if pkg.PackageLicenseConcluded != tc.want {
+				t.Fatalf("concluded: expected %q, got %q", tc.want, pkg.PackageLicenseConcluded)
+			}
+		})
+	}
+}
+
+// TestLicenseCompositionAgreesAcrossFormats guards the property a cross-format
+// comparison measures: one scan's two exports describe the same licensing.
+func TestLicenseCompositionAgreesAcrossFormats(t *testing.T) {
+	licenses := []sdk.PackageLicense{{Value: "MIT"}, {Value: "Apache-2.0"}}
+
+	cdxLicenses := cycloneDXComponentLicenses(t, licensedGraph(t, licenses...))
+	if len(cdxLicenses) != 1 || cdxLicenses[0].Expression == "" {
+		t.Fatalf("expected one CycloneDX expression, got %#v", cdxLicenses)
+	}
+	spdxPkg := spdxPackageLicense(t, licensedGraph(t, licenses...))
+
+	if cdxLicenses[0].Expression != spdxPkg.PackageLicenseDeclared {
+		t.Fatalf("formats disagree: cyclonedx %q, spdx %q",
+			cdxLicenses[0].Expression, spdxPkg.PackageLicenseDeclared)
+	}
+}

--- a/internal/sbom/model.go
+++ b/internal/sbom/model.go
@@ -119,8 +119,15 @@ func isProjectRootID(id string) bool {
 
 // Component describes one package surfaced in the intermediate SBOM model.
 type Component struct {
-	ID             string
-	Name           string
+	ID   string
+	Name string
+
+	// Org is the package namespace -- an npm scope, a Go module host and
+	// owner, a Maven group. It is the PURL's namespace segment, emitted as
+	// CycloneDX `group`. SPDX 2.3 has no equivalent field, so there it is
+	// carried only inside the PURL external reference.
+	Org string
+
 	Version        string
 	Scope          string
 	PURL           string

--- a/internal/sbom/primary_component_test.go
+++ b/internal/sbom/primary_component_test.go
@@ -158,49 +158,103 @@ func TestCycloneDXComponentGroup(t *testing.T) {
 	}
 }
 
-// TestCycloneDXGroupSurvivesRoundTrip covers reading `group` back on ingest so
-// a re-ingested document keeps the namespace it published.
+// TestCycloneDXGroupSurvivesRoundTrip covers reading `group` back into the
+// document model, and — the part that matters — that ingesting a document does
+// not corrupt package names.
+//
+// A component's name is already ecosystem-native ("@scope/pkg"), while SDK
+// coordinates join Org with Name to build that same string. Carrying the group
+// into Coordinates.Org made the join happen twice ("@scope/@scope/pkg"), so
+// this asserts the name a re-ingested package reports, not just the field.
 func TestCycloneDXGroupSurvivesRoundTrip(t *testing.T) {
-	g := sdk.New()
-	dep := sdk.NewDependencyWithID("@scope/pkg@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{
-		Name:      "@scope/pkg",
-		Version:   "1.0.0",
-		PURL:      "pkg:npm/@scope/pkg@1.0.0",
-		Ecosystem: "npm",
-	}})
-	if err := g.AddNode(dep); err != nil {
-		t.Fatalf("add node: %v", err)
+	tests := []struct {
+		name      string
+		pkgName   string
+		purl      string
+		ecosystem string
+		wantGroup string
+	}{
+		{
+			name:      "npm scope",
+			pkgName:   "@scope/pkg",
+			purl:      "pkg:npm/@scope/pkg@1.0.0",
+			ecosystem: "npm",
+			wantGroup: "@scope",
+		},
+		{
+			name:      "go module",
+			pkgName:   "github.com/google/uuid",
+			purl:      "pkg:golang/github.com/google/uuid@v1.6.0",
+			ecosystem: "go",
+			wantGroup: "github.com/google",
+		},
+		{
+			name:      "maven coordinates",
+			pkgName:   "org.apache.commons:commons-lang3",
+			purl:      "pkg:maven/org.apache.commons/commons-lang3@3.14.0",
+			ecosystem: "maven",
+			wantGroup: "org.apache.commons",
+		},
 	}
 
-	out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
-	if err != nil {
-		t.Fatalf("marshal cyclonedx: %v", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := sdk.New()
+			dep := sdk.NewDependencyWithID(tc.pkgName+"@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{
+				Name:      tc.pkgName,
+				Version:   "1.0.0",
+				PURL:      tc.purl,
+				Ecosystem: sdk.Ecosystem(tc.ecosystem),
+			}})
+			if err := g.AddNode(dep); err != nil {
+				t.Fatalf("add node: %v", err)
+			}
 
-	doc, _, err := UnmarshalAutoJSON(out)
-	if err != nil {
-		t.Fatalf("unmarshal document: %v", err)
-	}
-	if len(doc.Components) != 1 {
-		t.Fatalf("expected 1 component, got %d", len(doc.Components))
-	}
-	if doc.Components[0].Org != "@scope" {
-		t.Fatalf("expected Org %q, got %q", "@scope", doc.Components[0].Org)
-	}
+			out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+			if err != nil {
+				t.Fatalf("marshal cyclonedx: %v", err)
+			}
 
-	graph, err := ToGraph(doc)
-	if err != nil {
-		t.Fatalf("to graph: %v", err)
-	}
-	found := false
-	graph.WalkNodes(func(pkg *sdk.Dependency) bool {
-		found = true
-		if pkg.Org != "@scope" {
-			t.Fatalf("expected coordinates Org %q, got %q", "@scope", pkg.Org)
-		}
-		return true
-	})
-	if !found {
-		t.Fatal("expected a node in the re-ingested graph")
+			doc, _, err := UnmarshalAutoJSON(out)
+			if err != nil {
+				t.Fatalf("unmarshal document: %v", err)
+			}
+			if len(doc.Components) != 1 {
+				t.Fatalf("expected 1 component, got %d", len(doc.Components))
+			}
+			if doc.Components[0].Org != tc.wantGroup {
+				t.Fatalf("expected Org %q, got %q", tc.wantGroup, doc.Components[0].Org)
+			}
+
+			graph, err := ToGraph(doc)
+			if err != nil {
+				t.Fatalf("to graph: %v", err)
+			}
+			found := false
+			graph.WalkNodes(func(pkg *sdk.Dependency) bool {
+				found = true
+				if got := pkg.EcosystemName(); got != tc.pkgName {
+					t.Fatalf("re-ingested name changed: expected %q, got %q", tc.pkgName, got)
+				}
+				return true
+			})
+			if !found {
+				t.Fatal("expected a node in the re-ingested graph")
+			}
+
+			// Re-exporting recovers the group from the PURL, so the namespace
+			// survives the full round trip without living on the coordinates.
+			out2, err := MarshalDepGraphJSON(graph, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+			if err != nil {
+				t.Fatalf("re-marshal cyclonedx: %v", err)
+			}
+			doc2, _, err := UnmarshalAutoJSON(out2)
+			if err != nil {
+				t.Fatalf("re-unmarshal document: %v", err)
+			}
+			if len(doc2.Components) != 1 || doc2.Components[0].Org != tc.wantGroup {
+				t.Fatalf("group lost on re-export: %#v", doc2.Components)
+			}
+		})
 	}
 }

--- a/internal/sbom/primary_component_test.go
+++ b/internal/sbom/primary_component_test.go
@@ -158,6 +158,170 @@ func TestCycloneDXComponentGroup(t *testing.T) {
 	}
 }
 
+// TestIngestedCoordinateOrg covers both ways a producer splits a namespaced
+// package. Bomly writes the whole ecosystem-native name and repeats the
+// namespace in `group`; most other producers write a bare name plus `group`.
+// Coordinates joins Org with Name, so the split decides whether Org may be set:
+// setting it on an already-qualified name doubles the namespace, and leaving it
+// unset on a bare name loses it.
+func TestIngestedCoordinateOrg(t *testing.T) {
+	tests := []struct {
+		name      string
+		component Component
+		want      string
+	}{
+		{
+			name:      "bomly's own qualified npm name keeps Org empty",
+			component: Component{Name: "@scope/pkg", Org: "@scope", PURL: "pkg:npm/@scope/pkg@1.0.0"},
+			want:      "",
+		},
+		{
+			name:      "bomly's own qualified go name keeps Org empty",
+			component: Component{Name: "github.com/google/uuid", Org: "github.com/google", PURL: "pkg:golang/github.com/google/uuid@v1.6.0"},
+			want:      "",
+		},
+		{
+			name:      "bomly's own qualified maven name keeps Org empty",
+			component: Component{Name: "org.apache.commons:commons-lang3", Org: "org.apache.commons", PURL: "pkg:maven/org.apache.commons/commons-lang3@3.14.0"},
+			want:      "",
+		},
+		{
+			name:      "third-party bare npm name takes the namespace",
+			component: Component{Name: "pkg", Org: "@scope", PURL: "pkg:npm/@scope/pkg@1.0.0"},
+			want:      "@scope",
+		},
+		{
+			name:      "third-party bare go name takes the namespace",
+			component: Component{Name: "uuid", Org: "github.com/google", PURL: "pkg:golang/github.com/google/uuid@v1.6.0"},
+			want:      "github.com/google",
+		},
+		{
+			name:      "third-party bare maven name takes the namespace",
+			component: Component{Name: "commons-lang3", Org: "org.apache.commons", PURL: "pkg:maven/org.apache.commons/commons-lang3@3.14.0"},
+			want:      "org.apache.commons",
+		},
+		{
+			// The PURL is structured and export derives `group` from it, so it
+			// wins where the two disagree.
+			name:      "purl namespace outranks a differing group",
+			component: Component{Name: "pkg", Org: "scope", PURL: "pkg:npm/@scope/pkg@1.0.0"},
+			want:      "@scope",
+		},
+		{
+			name:      "group survives when the purl has no namespace",
+			component: Component{Name: "widget", Org: "acme", PURL: "pkg:generic/widget@1.0.0"},
+			want:      "acme",
+		},
+		{
+			// PURL normalization lowercases the Go namespace while the name
+			// keeps its original case. A case-sensitive prefix test misses
+			// this and doubles the namespace.
+			name:      "case-normalized purl namespace still matches the name",
+			component: Component{Name: "github.com/BurntSushi/toml", Org: "github.com/burntsushi", PURL: "pkg:golang/github.com/burntsushi/toml@v1.4.0"},
+			want:      "",
+		},
+		{
+			name:      "case-normalized namespace on a nested module path",
+			component: Component{Name: "github.com/Masterminds/semver/v3", Org: "github.com/masterminds/semver", PURL: "pkg:golang/github.com/masterminds/semver/v3@v3.3.0"},
+			want:      "",
+		},
+		{
+			name:      "no namespace anywhere",
+			component: Component{Name: "requests", PURL: "pkg:pypi/requests@2.31.0"},
+			want:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ingestedCoordinateOrg(tc.component); got != tc.want {
+				t.Fatalf("expected Org %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestIngestBareNameRecoversQualifiedName covers a document written the way
+// most producers write one -- `group` plus a bare `name` -- reaching the graph
+// with its namespaced name intact, and keeping its group on re-export.
+func TestIngestBareNameRecoversQualifiedName(t *testing.T) {
+	tests := []struct {
+		name      string
+		component Component
+		ecosystem string
+		wantName  string
+		wantGroup string
+	}{
+		{
+			name:      "npm scope",
+			component: Component{ID: "pkg-1", Name: "pkg", Org: "@scope", Version: "1.0.0", PURL: "pkg:npm/@scope/pkg@1.0.0"},
+			ecosystem: "npm",
+			wantName:  "@scope/pkg",
+			wantGroup: "@scope",
+		},
+		{
+			name:      "go module",
+			component: Component{ID: "uuid-1", Name: "uuid", Org: "github.com/google", Version: "v1.6.0", PURL: "pkg:golang/github.com/google/uuid@v1.6.0"},
+			ecosystem: "go",
+			wantName:  "github.com/google/uuid",
+			wantGroup: "github.com/google",
+		},
+		{
+			// Generic packages do not join Org into the display name, but the
+			// group must still survive the round trip.
+			name:      "generic package keeps its group",
+			component: Component{ID: "widget-1", Name: "widget", Org: "acme", Version: "1.0.0", PURL: "pkg:generic/widget@1.0.0"},
+			ecosystem: "generic",
+			wantName:  "widget",
+			wantGroup: "acme",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			component := tc.component
+			component.Ecosystem = tc.ecosystem
+			doc := &Document{
+				Name:         "ingested",
+				Components:   []Component{component},
+				Dependencies: []Dependency{{Ref: component.ID}},
+				Roots:        []string{component.ID},
+			}
+
+			graph, err := ToGraph(doc)
+			if err != nil {
+				t.Fatalf("to graph: %v", err)
+			}
+			found := false
+			graph.WalkNodes(func(pkg *sdk.Dependency) bool {
+				found = true
+				if got := pkg.EcosystemName(); got != tc.wantName {
+					t.Fatalf("expected name %q, got %q", tc.wantName, got)
+				}
+				return true
+			})
+			if !found {
+				t.Fatal("expected a node in the ingested graph")
+			}
+
+			out, err := MarshalDepGraphJSON(graph, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+			if err != nil {
+				t.Fatalf("marshal cyclonedx: %v", err)
+			}
+			var bom cdx.BOM
+			if err := json.Unmarshal(out, &bom); err != nil {
+				t.Fatalf("unmarshal cyclonedx: %v", err)
+			}
+			if bom.Components == nil || len(*bom.Components) != 1 {
+				t.Fatalf("expected 1 component, got %#v", bom.Components)
+			}
+			if got := (*bom.Components)[0].Group; got != tc.wantGroup {
+				t.Fatalf("expected group %q on re-export, got %q", tc.wantGroup, got)
+			}
+		})
+	}
+}
+
 // TestCycloneDXGroupSurvivesRoundTrip covers reading `group` back into the
 // document model, and — the part that matters — that ingesting a document does
 // not corrupt package names.

--- a/internal/sbom/primary_component_test.go
+++ b/internal/sbom/primary_component_test.go
@@ -1,0 +1,206 @@
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+// TestCycloneDXPrimaryComponentCarriesFullDetail covers a natural single-root
+// graph, where the root is both the document's subject and an inventory entry.
+// The primary component used to be a reduced copy, describing the scanned
+// project with less than the inventory knew about the very same package.
+func TestCycloneDXPrimaryComponentCarriesFullDetail(t *testing.T) {
+	g, registry := enrichedGraphAndRegistry(t)
+	out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{Registry: registry}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal cyclonedx: %v", err)
+	}
+
+	bom := new(cdx.BOM)
+	if err := cdx.NewBOMDecoder(bytes.NewReader(out), cdx.BOMFileFormatJSON).Decode(bom); err != nil {
+		t.Fatalf("decode cyclonedx: %v", err)
+	}
+	if bom.Metadata == nil || bom.Metadata.Component == nil {
+		t.Fatal("expected metadata.component")
+	}
+	primary := bom.Metadata.Component
+
+	if primary.Licenses == nil || len(*primary.Licenses) == 0 {
+		t.Fatalf("expected licenses on the primary component, got %#v", primary.Licenses)
+	}
+	if (*primary.Licenses)[0].License == nil || (*primary.Licenses)[0].License.ID != "MIT" {
+		t.Fatalf("expected MIT license id, got %#v", (*primary.Licenses)[0])
+	}
+	if primary.CPE == "" {
+		t.Fatal("expected CPE on the primary component")
+	}
+	if primary.Hashes == nil || len(*primary.Hashes) == 0 {
+		t.Fatalf("expected hashes on the primary component, got %#v", primary.Hashes)
+	}
+	if primary.Properties == nil {
+		t.Fatal("expected EOL properties on the primary component")
+	}
+	foundEOL := false
+	for _, p := range *primary.Properties {
+		if p.Name == "bomly:eol" && p.Value == "true" {
+			foundEOL = true
+		}
+	}
+	if !foundEOL {
+		t.Fatalf("expected bomly:eol property on the primary component, got %#v", primary.Properties)
+	}
+
+	// The inventory twin and the primary describe one package identically.
+	if bom.Components == nil || len(*bom.Components) != 1 {
+		t.Fatalf("expected 1 inventory component, got %#v", bom.Components)
+	}
+	twin := (*bom.Components)[0]
+	if twin.BOMRef != primary.BOMRef {
+		t.Fatalf("expected the same package, got %q and %q", twin.BOMRef, primary.BOMRef)
+	}
+	if twin.CPE != primary.CPE || twin.PackageURL != primary.PackageURL {
+		t.Fatalf("primary and inventory disagree: %+v vs %+v", primary, twin)
+	}
+}
+
+// TestCycloneDXPrimaryComponentKeepsSecurityReferencesLast pins the ordering
+// the provenance references rely on: a component's own origin references come
+// first, and the document-level security references follow.
+func TestCycloneDXPrimaryComponentKeepsSecurityReferencesLast(t *testing.T) {
+	g := sdk.New()
+	dep := sdk.NewDependencyWithID("left-pad@1.3.0", sdk.Dependency{
+		Coordinates: sdk.Coordinates{
+			Name:      "left-pad",
+			Version:   "1.3.0",
+			PURL:      "pkg:npm/left-pad@1.3.0",
+			Ecosystem: "npm",
+		},
+		Origin: &sdk.DependencyOrigin{ArtifactURL: "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"},
+	})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{
+		Provenance: Provenance{
+			SecurityContact:            "security@example.com",
+			VulnerabilityDisclosureURL: "https://example.com/security",
+		},
+	}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal cyclonedx: %v", err)
+	}
+
+	var bom cdx.BOM
+	if err := json.Unmarshal(out, &bom); err != nil {
+		t.Fatalf("unmarshal cyclonedx: %v", err)
+	}
+	if bom.Metadata == nil || bom.Metadata.Component == nil || bom.Metadata.Component.ExternalReferences == nil {
+		t.Fatal("expected external references on the primary component")
+	}
+	refs := *bom.Metadata.Component.ExternalReferences
+	if len(refs) != 3 {
+		t.Fatalf("expected the distribution reference plus 2 security references, got %#v", refs)
+	}
+	if refs[0].Type != cdx.ERTypeDistribution {
+		t.Fatalf("expected the component's own reference first, got %#v", refs[0])
+	}
+	if refs[1].Type != cdx.ERTypeSecurityContact || refs[2].Type != cdx.ERTypeAdvisories {
+		t.Fatalf("expected security references last, got %#v", refs[1:])
+	}
+}
+
+// TestCycloneDXComponentGroup covers publishing the package namespace as
+// CycloneDX `group`, taken from the PURL so the two always agree.
+func TestCycloneDXComponentGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		want string
+	}{
+		{name: "npm scope", purl: "pkg:npm/@scope/pkg@1.0.0", want: "@scope"},
+		{name: "go module owner", purl: "pkg:golang/github.com/google/uuid@v1.6.0", want: "github.com/google"},
+		{name: "maven group", purl: "pkg:maven/org.apache.commons/commons-lang3@3.14.0", want: "org.apache.commons"},
+		{name: "namespaceless package", purl: "pkg:pypi/requests@2.31.0", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := sdk.New()
+			dep := sdk.NewDependencyWithID("pkg@1", sdk.Dependency{Coordinates: sdk.Coordinates{
+				Name:    "pkg",
+				Version: "1",
+				PURL:    tc.purl,
+			}})
+			if err := g.AddNode(dep); err != nil {
+				t.Fatalf("add node: %v", err)
+			}
+
+			out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+			if err != nil {
+				t.Fatalf("marshal cyclonedx: %v", err)
+			}
+			var bom cdx.BOM
+			if err := json.Unmarshal(out, &bom); err != nil {
+				t.Fatalf("unmarshal cyclonedx: %v", err)
+			}
+			if bom.Components == nil || len(*bom.Components) != 1 {
+				t.Fatalf("expected 1 component, got %#v", bom.Components)
+			}
+			if got := (*bom.Components)[0].Group; got != tc.want {
+				t.Fatalf("expected group %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestCycloneDXGroupSurvivesRoundTrip covers reading `group` back on ingest so
+// a re-ingested document keeps the namespace it published.
+func TestCycloneDXGroupSurvivesRoundTrip(t *testing.T) {
+	g := sdk.New()
+	dep := sdk.NewDependencyWithID("@scope/pkg@1.0.0", sdk.Dependency{Coordinates: sdk.Coordinates{
+		Name:      "@scope/pkg",
+		Version:   "1.0.0",
+		PURL:      "pkg:npm/@scope/pkg@1.0.0",
+		Ecosystem: "npm",
+	}})
+	if err := g.AddNode(dep); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	out, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal cyclonedx: %v", err)
+	}
+
+	doc, _, err := UnmarshalAutoJSON(out)
+	if err != nil {
+		t.Fatalf("unmarshal document: %v", err)
+	}
+	if len(doc.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(doc.Components))
+	}
+	if doc.Components[0].Org != "@scope" {
+		t.Fatalf("expected Org %q, got %q", "@scope", doc.Components[0].Org)
+	}
+
+	graph, err := ToGraph(doc)
+	if err != nil {
+		t.Fatalf("to graph: %v", err)
+	}
+	found := false
+	graph.WalkNodes(func(pkg *sdk.Dependency) bool {
+		found = true
+		if pkg.Org != "@scope" {
+			t.Fatalf("expected coordinates Org %q, got %q", "@scope", pkg.Org)
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("expected a node in the re-ingested graph")
+	}
+}

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -41,19 +41,23 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		spdxID := common.ElementID(base)
 		idByComponent[c.ID] = spdxID
 
-		// Concluded repeats declared: the value came from a lockfile or a
-		// registry that asserts it, so concluding it is reading evidence, not
-		// inventing a claim. NOASSERTION here would discard data we hold.
-		license := spdxLicenseValue(c.Licenses)
 		pkg := &v23.Package{
-			PackageName:               c.NameOrID(),
-			PackageSPDXIdentifier:     spdxID,
-			PackageVersion:            c.Version,
-			PackageDownloadLocation:   spdxDownloadLocation(c),
-			FilesAnalyzed:             false,
-			PackageComment:            spdxPackageComment(c),
-			PackageLicenseDeclared:    license,
-			PackageLicenseConcluded:   license,
+			PackageName:             c.NameOrID(),
+			PackageSPDXIdentifier:   spdxID,
+			PackageVersion:          c.Version,
+			PackageDownloadLocation: spdxDownloadLocation(c),
+			FilesAnalyzed:           false,
+			PackageComment:          spdxPackageComment(c),
+			PackageLicenseDeclared:  spdxLicenseValue(c.Licenses),
+
+			// Concluded is the document creator's own determination. Every
+			// license Bomly carries is declared by a lockfile or a registry --
+			// the domain model has no other kind -- and Bomly does not analyze
+			// package contents, so it has nothing of its own to conclude.
+			// SPDX names that case: NOASSERTION when the creator made no
+			// attempt to determine the field. Nothing is lost; the declared
+			// value above still carries what a source asserted.
+			PackageLicenseConcluded:   "NOASSERTION",
 			PackageCopyrightText:      spdxCopyrightValue(c.Copyright),
 			PackageChecksums:          spdxChecksums(c.Digests),
 			PackageSourceInfo:         spdxSourceInfo(c),

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -419,11 +419,20 @@ func parseSPDXCommentField(comment, field string) string {
 
 // spdxLicenseValue renders a component's licenses into one SPDX license field.
 //
-// SPDX 2.3 holds a single expression per package, so a component declaring
-// several licenses has to compose them rather than keep only the first, which
-// silently dropped the rest. Composition applies only when every part is a
-// valid expression; joining free text would manufacture an expression that
-// does not parse, so a mixed set falls back to the first value as before.
+// SPDX 2.3 holds a single expression per package and has no way to list
+// licenses without relating them, so a component carrying several has to
+// compose them rather than keep only the first, which silently dropped the
+// rest. AND is the conservative reading -- it overstates obligations rather
+// than understating them -- but it is still more than a source that merely
+// listed licenses actually said. CycloneDX lists them instead; this is the
+// one place the two formats differ, and it is recorded in docs/SBOM.md.
+//
+// A source that knows the relationship states it in one value ("Apache-2.0 OR
+// MIT"), which arrives here as a single value and passes through untouched.
+//
+// Composition applies only when every part is a valid expression; joining free
+// text would manufacture an expression that does not parse, so a mixed set
+// falls back to the first value as before.
 func spdxLicenseValue(licenses []License) string {
 	values := componentLicenseValues(licenses)
 	if len(values) == 0 {

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/bomly-dev/bomly-cli/internal/licenseexpr"
 	"github.com/bomly-dev/bomly-sdk"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
@@ -40,6 +41,10 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		spdxID := common.ElementID(base)
 		idByComponent[c.ID] = spdxID
 
+		// Concluded repeats declared: the value came from a lockfile or a
+		// registry that asserts it, so concluding it is reading evidence, not
+		// inventing a claim. NOASSERTION here would discard data we hold.
+		license := spdxLicenseValue(c.Licenses)
 		pkg := &v23.Package{
 			PackageName:               c.NameOrID(),
 			PackageSPDXIdentifier:     spdxID,
@@ -47,8 +52,8 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 			PackageDownloadLocation:   spdxDownloadLocation(c),
 			FilesAnalyzed:             false,
 			PackageComment:            spdxPackageComment(c),
-			PackageLicenseDeclared:    spdxLicenseValue(c.Licenses),
-			PackageLicenseConcluded:   spdxLicenseValue(c.Licenses),
+			PackageLicenseDeclared:    license,
+			PackageLicenseConcluded:   license,
 			PackageCopyrightText:      spdxCopyrightValue(c.Copyright),
 			PackageChecksums:          spdxChecksums(c.Digests),
 			PackageSourceInfo:         spdxSourceInfo(c),
@@ -408,17 +413,22 @@ func parseSPDXCommentField(comment, field string) string {
 	return ""
 }
 
+// spdxLicenseValue renders a component's licenses into one SPDX license field.
+//
+// SPDX 2.3 holds a single expression per package, so a component declaring
+// several licenses has to compose them rather than keep only the first, which
+// silently dropped the rest. Composition applies only when every part is a
+// valid expression; joining free text would manufacture an expression that
+// does not parse, so a mixed set falls back to the first value as before.
 func spdxLicenseValue(licenses []License) string {
-	if len(licenses) == 0 {
+	values := componentLicenseValues(licenses)
+	if len(values) == 0 {
 		return "NOASSERTION"
 	}
-	if licenses[0].SPDXExpression != "" {
-		return licenses[0].SPDXExpression
+	if len(values) == 1 || !allValidSPDXExpressions(values) {
+		return values[0]
 	}
-	if licenses[0].Value != "" {
-		return licenses[0].Value
-	}
-	return "NOASSERTION"
+	return licenseexpr.Compose(values)
 }
 
 func spdxCopyrightValue(value string) string {

--- a/internal/sbom/transform.go
+++ b/internal/sbom/transform.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bomly-dev/bomly-cli/internal/detectors"
+	"github.com/bomly-dev/bomly-cli/internal/licenseexpr"
 	"github.com/bomly-dev/bomly-sdk"
 )
 
@@ -38,6 +39,7 @@ func FromDepGraph(g *sdk.Graph, opts BuildOptions) (*Document, error) {
 		component := Component{
 			ID:             pkg.ID,
 			Name:           pkg.EcosystemName(),
+			Org:            componentOrg(pkg),
 			Version:        version,
 			Scope:          string(pkg.PrimaryScope()),
 			PURL:           pkg.PURL,
@@ -503,4 +505,58 @@ func normalizeSPDXLicenseExpression(expression string) string {
 	}
 	flush()
 	return b.String()
+}
+
+// componentOrg returns the namespace to publish as the component's group.
+//
+// The PURL's namespace is preferred over the raw coordinate because it is the
+// value the document already carries: PURL construction derives a namespace
+// for Go modules whose coordinates leave Org empty, and it spells npm scopes
+// with their leading "@". Reading it back keeps `group` and the PURL agreeing.
+func componentOrg(pkg *sdk.Dependency) string {
+	if pkg == nil {
+		return ""
+	}
+	if parsed := sdk.ParsePackageURL(pkg.PURL); parsed != nil {
+		if namespace := strings.TrimSpace(parsed.Namespace); namespace != "" {
+			return namespace
+		}
+	}
+	return strings.TrimSpace(pkg.Org)
+}
+
+// licenseExpressionValue returns the license string a component carries: the
+// SPDX expression when one was captured, otherwise the raw value. Both codecs
+// read licenses through this so CycloneDX and SPDX never disagree about which
+// string a license is.
+func licenseExpressionValue(license License) string {
+	if expression := strings.TrimSpace(license.SPDXExpression); expression != "" {
+		return expression
+	}
+	return strings.TrimSpace(license.Value)
+}
+
+// componentLicenseValues returns the non-empty license strings a component
+// carries, in order.
+func componentLicenseValues(licenses []License) []string {
+	values := make([]string, 0, len(licenses))
+	for _, license := range licenses {
+		if value := licenseExpressionValue(license); value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// allValidSPDXExpressions reports whether every value parses as an SPDX
+// license expression. Registry sources record free text ("non-standard") in
+// the same field as real expressions, so composing or publishing values as
+// expressions requires checking them rather than trusting where they came from.
+func allValidSPDXExpressions(values []string) bool {
+	for _, value := range values {
+		if !licenseexpr.Valid(value) {
+			return false
+		}
+	}
+	return true
 }

--- a/scripts/run-fuzz.sh
+++ b/scripts/run-fuzz.sh
@@ -31,6 +31,7 @@ targets=(
   "github.com/bomly-dev/bomly-cli/internal/detectors/swiftpm FuzzDepGraphFromSwiftResolved"
   "github.com/bomly-dev/bomly-cli/internal/sbom FuzzUnmarshalAutoJSON"
   "github.com/bomly-dev/bomly-cli/internal/sbom FuzzNormalizeSPDXLicenseExpression"
+  "github.com/bomly-dev/bomly-cli/internal/sbom FuzzSPDXLicenseValue"
   "github.com/bomly-dev/bomly-cli/internal/baseline FuzzLoad"
   "github.com/bomly-dev/bomly-cli/internal/engine FuzzConsolidateVulnerabilities"
   "github.com/bomly-dev/bomly-cli/internal/plugin FuzzPluginPathSanitizers"

--- a/test/assurance/PARSER_FUZZING.md
+++ b/test/assurance/PARSER_FUZZING.md
@@ -18,6 +18,7 @@ the reader inventory, cache behavior, and intentional exclusions.
 | Shared JSON contracts | dependency graph, package registry |
 | Package identifiers and plugin paths | package URL canonicalization, plugin path sanitizers |
 | SBOM | automatic SPDX and CycloneDX decoding; Syft JSON identification and deterministic rejection (the format is no longer ingested) |
+| License expressions | SPDX identifier classification, expression validation, and multi-license composition on the export path (`FuzzSPDXLicenseValue`), plus the deprecated-identifier rewriter (`FuzzNormalizeSPDXLicenseExpression`) |
 | Node lockfiles | npm, pnpm, Yarn, Bun |
 | Node project configuration | package.json, pnpm-workspace.yaml, and .npmrc behind the package-manager warning checks |
 | Python lockfiles | Poetry, uv, Pipenv |
@@ -42,6 +43,13 @@ oversized structures within the bound, and arbitrary path/reference text.
 - YAML, JSON, XML, TOML, URL, and CSV primitives provided directly by Go or
   existing dependencies are not fuzzed independently. Bomly-owned conversion
   and validation code around them is the target.
+- The SPDX expression parser (`github.com/github/go-spdx`) panics on some
+  malformed expressions rather than returning an error, and license strings
+  are untrusted repository and registry data. `internal/licenseexpr` contains
+  those panics and reports the value as unparseable, so `FuzzSPDXLicenseValue`
+  asserts the wrapper's behavior rather than the dependency's. A call site
+  that reaches the dependency directly would reintroduce the crash, which
+  `TestNoDirectSPDXExpressionUse` prevents.
 - Filesystem discovery and package-manager subprocess orchestration are not
   parsers and remain covered by unit, integration, and smoke tests.
 - Reachability analyzers (govulncheck, jsreach, pyreach, jvmreach) and the


### PR DESCRIPTION
Closes #361.

Most of #361 was already addressed: PR #364 fixed the primary component, serial number, tool version, and hashes; the ~44% cross-format similarity was measured there to be an sbom-tools comparator artifact; "components without edges" is the leaf count, not export loss; and per-component supplier/description remains tracked in #380. This PR closes the export-fidelity gaps that were left.

## What was wrong

Export decided a license's shape by **which field carried it**, not by what the value was. Sources write free text and real expressions into the same field — the deps.dev matcher sets `Value` and `SPDXExpression` to the same string, `non-standard` as readily as `MIT`. So:

- a package licensed `MIT` was published as free-text `license.name`, which validators score as non-SPDX;
- unrecognized text was published as an `expression` that does not parse;
- two licenses produced two `expression` entries, which CycloneDX disallows;
- SPDX, holding one expression per package, kept `licenses[0]` and silently dropped the rest.

## What changed

**Licenses are classified by validating them** (ADR-0035). One SPDX list entry becomes CycloneDX `license.id` in canonical spelling (`mit` → `MIT`); a value that parses becomes `expression`; only genuinely unrecognized text stays `license.name`. Several declared licenses compose into one `AND` expression — a package offered under several licenses is bound by all of them — and both formats publish the same string.

**A crash was found and fixed on the way.** The SPDX expression parser panics rather than erroring on some malformed input (`(((` dereferences a nil operator). The license auditor at `internal/auditors/license/auditor.go:103` already fed registry license values straight into it, so **a package declaring that string crashed an entire `--audit` scan today**. Adding a second call site on the export path would have spread the defect, so all SPDX expression parsing now goes through `internal/licenseexpr`, which contains the panics and reports the value as unparseable. `TestNoDirectSPDXExpressionUse` fails when any package under `internal/` imports the parser directly (verified it catches a violation). The crash was found by the new fuzz target, not by review.

**The CycloneDX primary component is built like an inventory entry** instead of a reduced copy. For a natural single-root graph the root appears in both places, and `metadata.component` previously carried no licenses, hashes, CPE, or origin references — less than its own `components[]` twin. Pseudo-root output is byte-identical.

**Components carry the PURL namespace as CycloneDX `group`** — `@scope`, `github.com/google`, `org.apache.commons` — read back into the document model on ingest, and recovered from the PURL on re-export so it survives a full round trip.

> Review caught a real bug in the first revision of this: carrying `group` into SDK `Coordinates.Org` corrupted every namespaced package name on `--sbom` ingest (`@scope/@scope/pkg`, `github.com/google/github.com/google/uuid`), because a component name is already ecosystem-native while `Coordinates` builds that same string by joining `Org` and `Name`. Fixed in 0c3e826; the round-trip test now asserts the name a re-ingested package reports, across npm/Go/Maven.

## Measured on a self-scan

| | before | after |
|---|---|---|
| Components with checked `license.id` (`--enrich`) | 0 | **331** |
| Multi-license components keeping every license | 0 of 26 | **26 of 26** |
| Components with `group` | 0 | **340 of 354** |
| Invented `AND` expressions in CycloneDX | — | **0** |
| `group` disagreeing with its PURL namespace | — | **0** |

Both formats, with and without `--enrich`, validate against the **official CycloneDX 1.6 and SPDX 2.3 JSON schemas with 0 errors**. Re-ingesting the exported CycloneDX round-trips losslessly (354 components out, 354 back).

## Deliberate behavior changes

- **Values that were never valid expressions are now free text** rather than `expression`. This changes output for packages whose declared license is not SPDX, and it is the point: those documents previously failed CycloneDX expression validation.
- **Several licenses are listed, not joined with `AND`** (changed in 4e4abe6 after review). A source reporting `["MIT","Apache-2.0"]` says which licenses it found, not whether both apply — so CycloneDX lists them (a list asserts no relationship) and only SPDX composes, because it holds one expression per package and has no list form. That is the one deliberate cross-format difference. Dual licensing is unaffected: registries record it in a *single* value (`Apache-2.0 OR MIT`, verified against deps.dev), which passes through untouched — an `OR` is never rewritten to an `AND`.
- **SPDX `licenseConcluded` is now always `NOASSERTION`** (changed in 41221ba after review). It previously repeated `licenseDeclared`, which asserted a conclusion Bomly cannot support: concluded means the document author's own determination, and every license Bomly holds is *declared* by a source. `licenseDeclared` still carries the license, and ingest recovers it.

## Validation

`make test`, `make lint` (0 issues), and `make generate` (no drift — SBOM formats aren't in the generated schemas) all clean. New fuzz target `FuzzSPDXLicenseValue` registered in `scripts/run-fuzz.sh`, stable across repeated runs (4.3M+ execs clean). SBOM smoke cases pass with no golden drift.

Note: `make fuzz` over the whole suite intermittently reports `context deadline exceeded` on an unrelated detector target (pub, cargo, and poetry across different runs, never reproducing in isolation, no crasher persisted). This is a pre-existing timeout under parallel load on this machine, not a defect introduced here.

## Docs

- `docs/SBOM.md`: how each license shape is written, and a new "License data usually needs `--enrich`" section — only npm and pnpm lockfiles record licenses, so every other ecosystem needs `--enrich` for license data, which matters for CRA review.
- ADR-0035 records the emission policy; `CLAUDE.md`/`AGENTS.md`/`dev-docs/ARCHITECTURE.md` gain the new package and its boundary rule; `test/assurance/PARSER_FUZZING.md` records the contained third-party panic.

## Still open (not this PR)

- Per-component supplier — #380.
- A single free-text value in SPDX `licenseDeclared` is still emitted verbatim (technically invalid SPDX) — now tracked in #410, and recorded as a known limitation in ADR-0035 and `docs/SBOM.md`.
- A CI self-check scoring our own SBOMs (issue finding 6) fits the release-assurance framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SBOM license handling with validation, canonical identifiers, expression support, and safer treatment of invalid values.
  * Enhanced CycloneDX metadata with package organization, complete primary-component details, and preserved license information.
  * SPDX output now composes valid licenses appropriately and consistently reports concluded licenses as `NOASSERTION`.

* **Documentation**
  * Added guidance covering license validation, SBOM behavior, format differences, and package metadata.

* **Tests**
  * Added extensive coverage and fuzz testing for malformed license expressions and SBOM license emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->