### PR TITLE
chore: pin bomly-sdk v0.9.1, and describe how releases actually happen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,7 +334,9 @@ Any new user-visible feature needs a smoke case under `test/smoke/` — follow t
 
 ## Release
 
-Draft releases are created automatically after merges to `main` from commit prefixes: `feat:` → minor, other → patch, `type!:`/`BREAKING CHANGE:` → major, `[skip release]` → none. Squash titles count. Publishing runs GoReleaser with signed checksums and SLSA provenance; see `dev-docs/RELEASE_CHECKLIST.md`.
+Releases are cut deliberately, never by merging. Run the **Auto Version** workflow from `main` and choose the bump (`patch` / `minor` / `major`); it rewrites `var version` in `cmd/bomly/main.go`, commits, and pushes the `vX.Y.Z` tag. Pushing that tag is what triggers **Release**, which runs GoReleaser with signed checksums and SLSA provenance; see `dev-docs/RELEASE_CHECKLIST.md`.
+
+Nothing about a merge to `main` starts a release, and no commit prefix chooses the bump — a `feat!:` squash title does not make the next release major. The person dispatching the workflow picks that, so choosing it is a decision, not a consequence.
 
 ## Reference Docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,9 @@ Any new user-visible feature needs a smoke case under `test/smoke/` — follow t
 
 ## Release
 
-Draft releases are created automatically after merges to `main` from commit prefixes: `feat:` → minor, other → patch, `type!:`/`BREAKING CHANGE:` → major, `[skip release]` → none. Squash titles count. Publishing runs GoReleaser with signed checksums and SLSA provenance; see `dev-docs/RELEASE_CHECKLIST.md`.
+Releases are cut deliberately, never by merging. Run the **Auto Version** workflow from `main` and choose the bump (`patch` / `minor` / `major`); it rewrites `var version` in `cmd/bomly/main.go`, commits, and pushes the `vX.Y.Z` tag. Pushing that tag is what triggers **Release**, which runs GoReleaser with signed checksums and SLSA provenance; see `dev-docs/RELEASE_CHECKLIST.md`.
+
+Nothing about a merge to `main` starts a release, and no commit prefix chooses the bump — a `feat!:` squash title does not make the next release major. The person dispatching the workflow picks that, so choosing it is a decision, not a consequence.
 
 ## Reference Docs
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bomly-dev/bomly-plugin-pyreach-analyzer v0.2.0
 	github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0
 	github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0
-	github.com/bomly-dev/bomly-sdk v0.9.0
+	github.com/bomly-dev/bomly-sdk v0.9.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0 h1:VOK4+GfVGukbccabjD
 github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0/go.mod h1:3ux1Su5UCCKeF+wtttQrlw7r+B7sc6UXrK98Ybuq5gw=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0 h1:UlKwTqp+ZWu25leky9J6NITCKDdePpdgJQl/8dInApg=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0/go.mod h1:NVVrSMHkjC3VEDPtCI7+1c4tWBzwI1eve8tynO1pRoM=
-github.com/bomly-dev/bomly-sdk v0.9.0 h1:6oKp6TXNFl9dSpwRHzmaahtLHB1Rqv5PnmDIsNvXNKY=
-github.com/bomly-dev/bomly-sdk v0.9.0/go.mod h1:7RJLUANK8xHMZ5/r45zYxGyKUHC8yQiVem22yM0MyZw=
+github.com/bomly-dev/bomly-sdk v0.9.1 h1:CqZiJamcaRU//7aq2zF65CxLrGST9wLc1OZDtIePtyw=
+github.com/bomly-dev/bomly-sdk v0.9.1/go.mod h1:7RJLUANK8xHMZ5/r45zYxGyKUHC8yQiVem22yM0MyZw=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=


### PR DESCRIPTION
Two small, unrelated things that both belong on top of the union merge.

## The pin

`bomly-sdk` v0.9.1 carries the three fixes that followed the union release, two of them against defects filed from this repo's review of v0.9.0:

| | |
| --- | --- |
| [#40](https://github.com/bomly-dev/bomly-sdk/pull/40) | `PropagateScopes` stands down when the root is absent, instead of stamping every unscoped dependency runtime (closes [#38](https://github.com/bomly-dev/bomly-sdk/issues/38)) |
| [#41](https://github.com/bomly-dev/bomly-sdk/pull/41) | a generic fallback identity keeps its ecosystem when reconstructed from the package URL alone (closes [#37](https://github.com/bomly-dev/bomly-sdk/issues/37)) |
| [#42](https://github.com/bomly-dev/bomly-sdk/pull/42) | the component descriptor name is bounded (closes [#32](https://github.com/bomly-dev/bomly-sdk/issues/32)) |

The CLI reaches #40 on every Python lockfile graph through `detectorkit.PropagateScopes`.

**No golden moves.** Both behavioural fixes address shapes the fixtures do not produce — a caller holding a pre-promotion root ID, and a fallback identity round-tripped through its own purl. Verified with the full smoke suite including the Python cases, which need pipenv, poetry and uv locally.

## The release description

`CLAUDE.md` and `AGENTS.md` described something this repository does not do:

> Draft releases are created automatically after merges to `main` from commit prefixes: `feat:` → minor, other → patch, `type!:`/`BREAKING CHANGE:` → major …

Nothing does that. `release.yml` fires only on a pushed `v*.*.*` tag, and `auto-version.yml` is `workflow_dispatch` with the bump as an explicit dropdown. A merge to `main` starts nothing.

This is not cosmetic: the old text says a `feat!:` squash title makes the next release major, and the union merge landed with exactly that prefix — which reads as an imminent v1.0.0 that was never going to happen. The corrected text matches the workflows and states that the bump is a decision someone makes, not a consequence of a commit title.

## Verification

`make verify SMOKE=1` green: fmt, lint, vet on every build-tag variant, `go test ./...`, generated-doc drift, and the full networked smoke suite with zero golden drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release guidance to explain the manual release process.
  - Releases are now initiated through the Auto Version workflow from the main branch.
  - Release creators select the version increment, generate the version tag, and trigger publishing.
  - Merging changes or using commit prefixes no longer automatically starts or determines a release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->