### PR TITLE
feat(sbom): unrecognized licenses export as LicenseRef, not free text (phase 2.4 + SDK v0.9.2)

### DIFF
--- a/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
+++ b/dev-docs/adr/0035-license-emission-is-validated-not-assumed.md
@@ -53,9 +53,11 @@ than the source said. This is the one deliberate cross-format difference, and
 it is recorded in `docs/SBOM.md`. CycloneDX composes only when a member is
 itself compound, where listing would degrade a real expression to free text.
 
-A set that mixes valid expressions with free text cannot compose without
-producing something that does not parse, so CycloneDX falls back to one entry
-per license and SPDX to the first value.
+A set that mixes valid expressions with free text cannot compose while the
+free text stays free text, so CycloneDX falls back to one entry per license.
+SPDX no longer falls back at all: the unrecognized member becomes a
+`LicenseRef-*`, which is a valid expression element, so the set composes
+whole. See the note below.
 
 SPDX `licenseConcluded` is always `NOASSERTION`. Concluded is the document
 creator's own determination, and Bomly has none to offer: every license it
@@ -92,9 +94,39 @@ what found the parser panic. The auditor is covered by the wrapper's own tests
 rather than by that target, which does not call it: routing the auditor through
 `licenseexpr` is what fixes its crash.
 
-One limitation is knowingly left in place. SPDX has no free-text license field,
-so a single unrecognized value is still written verbatim into
-`licenseDeclared`, which is not a valid SPDX expression. Representing it as a
-`LicenseRef` with a matching `hasExtractedLicensingInfos` entry is the correct
-fix and is tracked separately; it is a different decision from this one, and
-folding it in would change what an unknown license means in the document.
+One limitation was knowingly left in place, and has since been resolved --
+see the note below.
+
+
+## Note (2026-09-05): the SPDX free-text limitation is resolved
+
+This ADR recorded that SPDX has no free-text license field, so an unrecognized
+value was written verbatim into `licenseDeclared` where it is not a valid
+expression, and that representing it as a `LicenseRef` was the correct fix but
+a separate decision. That decision is taken: bomly-cli#410.
+
+An unrecognized value now mints a `LicenseRef-*` and the original text travels
+with the document in `hasExtractedLicensingInfos`. Unlike `NOASSERTION` this
+loses nothing -- ingest reads the text back -- and unlike the old behavior the
+field holds something SPDX defines.
+
+It also retires the mixed-validity fallback this ADR described. A `LicenseRef`
+is a valid expression element, so a set mixing recognized and unrecognized
+values composes whole instead of keeping the first value and dropping the
+rest. That fallback was the quieter half of the defect: it dropped licenses a
+source had actually declared, and said so only in a comment.
+
+Minting is `bomly-sdk/spdxkit`'s, not this repository's. The identifier has to
+be deterministic, collision-free across components assembled without
+coordination, and confined to the characters the SPDX idstring grammar allows;
+`MintLicenseRef` answers all three by hashing the whitespace-normalized text.
+What stays here is the policy this ADR is about -- which values are classified
+how, and that classification is by validation rather than by the field a value
+arrived in.
+
+The body above refers to `internal/licenseexpr`, the CLI-local wrapper that
+contained the parser's panics when this was decided. That package is gone
+(bomly-cli#428): `bomly-sdk/spdxkit` carries the same six functions and the
+same panic guard, and no package under `internal/` may import the parser
+directly. Read those references as naming the kit. The decision this ADR
+records is unchanged -- only where the code that implements it lives.

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -117,7 +117,7 @@ where it came:
 |---|---|---|
 | One SPDX identifier (`MIT`) | `license.id`, spelled canonically | the identifier |
 | A compound expression (`MIT OR Apache-2.0`) | `expression` | the expression |
-| Anything else (`see LICENSE file`) | `license.name`, as free text | the text as-is |
+| Anything else (`see LICENSE file`) | `license.name`, as free text | a `LicenseRef-*` identifier, with the original text in `hasExtractedLicensingInfos` |
 | Nothing | no `licenses` key | `NOASSERTION` |
 
 When a source records several licenses for one package, it is saying which
@@ -343,14 +343,9 @@ Some information necessarily becomes less specific during conversion:
   the PURL.
 - SPDX 2.3 holds one license expression per package, so several licenses are
   composed with `AND` there while CycloneDX lists them (see "How licenses are
-  written" above). A set that mixes real expressions with free text cannot be
-  composed without producing an expression that does not parse; SPDX then
-  keeps the first value, while CycloneDX keeps every license as its own entry.
-- SPDX has no free-text license field. CycloneDX carries an unrecognized
-  license as `license.name`, but SPDX writes it into `licenseDeclared`, where
-  it is not a valid SPDX expression. A strict SPDX consumer may reject such a
-  package. This only affects packages whose declared license is not an SPDX
-  identifier or expression.
+  written" above). Every license is kept either way: a value SPDX cannot hold
+  verbatim becomes a `LicenseRef-*`, which is a valid expression element, so a
+  mixed set composes rather than losing its members.
 
 Before treating a generated file as a release artifact, validate it with the
 standard validator required by the receiving system. Bomly's tests parse every

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bomly-dev/bomly-plugin-pyreach-analyzer v0.2.0
 	github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0
 	github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0
-	github.com/bomly-dev/bomly-sdk v0.9.1
+	github.com/bomly-dev/bomly-sdk v0.9.2
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0 h1:VOK4+GfVGukbccabjD
 github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0/go.mod h1:3ux1Su5UCCKeF+wtttQrlw7r+B7sc6UXrK98Ybuq5gw=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0 h1:UlKwTqp+ZWu25leky9J6NITCKDdePpdgJQl/8dInApg=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0/go.mod h1:NVVrSMHkjC3VEDPtCI7+1c4tWBzwI1eve8tynO1pRoM=
-github.com/bomly-dev/bomly-sdk v0.9.1 h1:CqZiJamcaRU//7aq2zF65CxLrGST9wLc1OZDtIePtyw=
-github.com/bomly-dev/bomly-sdk v0.9.1/go.mod h1:7RJLUANK8xHMZ5/r45zYxGyKUHC8yQiVem22yM0MyZw=
+github.com/bomly-dev/bomly-sdk v0.9.2 h1:nVOdoEV5pKzv/4Pze1WXyfdS6o/wnLTBA1Y+VRxvcVw=
+github.com/bomly-dev/bomly-sdk v0.9.2/go.mod h1:Ulgp/NHlOLmbUvbKpuXylPf74LdCA54gpg+syK90Do8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/internal/engine/consolidation/consolidation_test.go
+++ b/internal/engine/consolidation/consolidation_test.go
@@ -7,9 +7,16 @@ import (
 	"github.com/bomly-dev/bomly-sdk"
 )
 
-// Two spellings of one Python package name -- case and separators -- mint the
-// same identity, so the second insertion folds into the first and the
-// consumer's edges point at one node.
+// Two spellings of one Python package -- name case and separators, and a
+// release-candidate version written in a different case -- mint the same
+// identity, so the second insertion folds into the first and the consumer's
+// edges point at one node.
+//
+// The version half came back with bomly-sdk v0.9.2, which canonicalizes a
+// PyPI version per PEP 440 before minting. It was briefly untrue: v0.9.0
+// stopped lowercasing every version containing a letter, which was right --
+// that rule corrupted Maven's "1.0-SNAPSHOT" -- and cost this fold until the
+// ecosystem-correct rule replaced the blanket one.
 //
 // Normalization moved into the constructor with ADR-0041, which is why this
 // case no longer builds two nodes and then collapses them: the second node
@@ -17,7 +24,7 @@ import (
 func TestEquivalentPythonSpellingsFoldOnInsertion(t *testing.T) {
 	g := sdk.New()
 	root := testnodes.Ref("app", "1.0.0")
-	pyA := testnodes.Dep(sdk.Coordinates{Ecosystem: "python", Name: "Requests_Toolbelt", Version: "1.0.0rc1"})
+	pyA := testnodes.Dep(sdk.Coordinates{Ecosystem: "python", Name: "Requests_Toolbelt", Version: "1.0.0RC1"})
 	pyB := testnodes.Dep(sdk.Coordinates{Ecosystem: "python", Name: "requests-toolbelt", Version: "1.0.0rc1"})
 
 	const want = "pkg:pypi/requests-toolbelt@1.0.0rc1"
@@ -49,38 +56,6 @@ func TestEquivalentPythonSpellingsFoldOnInsertion(t *testing.T) {
 	}
 	if len(deps) != 1 || deps[0].NodeID() != want {
 		t.Fatalf("root dependencies = %#v, want the one folded package", deps)
-	}
-}
-
-// Version case is NOT folded, and this pins that rather than leaving it
-// unstated.
-//
-// Identity spelling is packageurl-go's to decide (it is the library that owns
-// canonical package URLs), and it case-folds a version for exactly one type,
-// huggingface. The SDK used to lowercase every version containing a letter,
-// which folded this pair by accident while corrupting Maven's "1.0-SNAPSHOT"
-// into "1.0-snapshot" -- a different version, since Maven versions are case
-// sensitive. Dropping the blanket rule fixed Maven and cost this fold.
-//
-// PyPI itself does treat the two as one release: PEP 440 normalizes version
-// case, so "1.0.0RC1" and "1.0.0rc1" name the same distribution and cannot
-// both exist. Folding them therefore wants a PEP 440 normalizer applied to
-// pypi coordinates before the identity is minted -- in the SDK, where every
-// producer reaches it, and with a real dependency rather than a hand-written
-// version grammar. That is bomly-dev/bomly-sdk#39. Until it lands, the two
-// spellings are two identities, and this test fails when that changes, which
-// is the point.
-func TestPythonVersionCaseIsNotFoldedYet(t *testing.T) {
-	upper := testnodes.Dep(sdk.Coordinates{Ecosystem: "python", Name: "requests-toolbelt", Version: "1.0.0RC1"})
-	lower := testnodes.Dep(sdk.Coordinates{Ecosystem: "python", Name: "requests-toolbelt", Version: "1.0.0rc1"})
-	if upper.NodeID() == lower.NodeID() {
-		t.Fatalf("identities folded to %q; if a PEP 440 normalizer landed, fold this case back into "+
-			"TestEquivalentPythonSpellingsFoldOnInsertion and delete this test", upper.NodeID())
-	}
-	// The version each carries is the one its coordinates stated: the
-	// identity is authoritative for the field, and it preserved the spelling.
-	if upper.Version != "1.0.0RC1" || lower.Version != "1.0.0rc1" {
-		t.Fatalf("versions = %q and %q; want each preserved as written", upper.Version, lower.Version)
 	}
 }
 

--- a/internal/graphview/graphview.go
+++ b/internal/graphview/graphview.go
@@ -18,35 +18,25 @@
 // This is a leaf: it imports the SDK and nothing else from this repository, so
 // the codec, the renderers, and the TUI can all reach it without any of them
 // depending on each other.
+//
+// PurlFor is now a one-line delegation to sdk.NodePURL: the SDK took the
+// projection in v0.9.2 (bomly-dev/bomly-sdk#43), which is where it belongs.
+// ChildrenAmong and TopLevelParentIDs stay here -- what a document may name
+// and what counts as a top-level parent are the CLI's decisions, not the
+// model's.
 package graphview
 
 import sdk "github.com/bomly-dev/bomly-sdk"
 
 // PurlFor returns the package URL a node publishes, or "" when it has none.
 //
-// The kinds answer differently and the difference matters: a dependency
-// node's ID *is* its canonical package URL, a module's ID is the structural
-// "module:<path>#<purl>" grammar with its package URL in a separate field,
-// and a manifest has no package URL at all -- it is a file. Publishing NodeID
-// in a field consumers parse as a purl hands them a value that is not one.
-//
-// The deepest home for this is the SDK's GraphNode, which owns what a node
-// means (ADR-0040); it is here until bomly-dev/bomly-sdk#43 ships.
+// It delegates to sdk.NodePURL, which is where this belongs (ADR-0040): the
+// SDK owns what a node means, and the three kinds answer this differently.
+// The CLI carried the projection while bomly-dev/bomly-sdk#43 was open, and
+// v0.9.2 closed it -- the wrapper stays only so callers here read one name
+// alongside ChildrenAmong and TopLevelParentIDs, which remain CLI policy.
 func PurlFor(node sdk.GraphNode) string {
-	switch typed := node.(type) {
-	case *sdk.DependencyNode:
-		if typed == nil {
-			return ""
-		}
-		return typed.NodeID()
-	case *sdk.ModuleNode:
-		if typed == nil {
-			return ""
-		}
-		return typed.PURL()
-	default:
-		return ""
-	}
+	return sdk.NodePURL(node)
 }
 
 // ChildrenAmong names a node's children among the IDs a document actually

--- a/internal/sbom/codec_fuzz_test.go
+++ b/internal/sbom/codec_fuzz_test.go
@@ -175,8 +175,24 @@ func FuzzSPDXLicenseValue(f *testing.F) {
 		// may panic on any value a source can produce.
 		licenses := []License{{Value: value}, {SPDXExpression: value}}
 		_ = cycloneDXLicenses(licenses)
-		if got := spdxLicenseValue(licenses); got == "" {
+		got, extracted := spdxLicenseValue(licenses)
+		if got == "" {
 			t.Fatalf("spdx license value must never be empty, got %q for %q", got, value)
+		}
+		// Whatever the value was, the field SPDX will hold has to be
+		// something SPDX can hold: an expression, NOASSERTION, or references
+		// the document also carries the text for. A free-text value that
+		// reached the field verbatim is the defect #410 fixed.
+		if got != "NOASSERTION" && !spdxkit.Valid(got) {
+			t.Fatalf("license field %q does not parse as an SPDX expression, from %q", got, value)
+		}
+		for _, entry := range extracted {
+			if !entry.Valid() {
+				t.Fatalf("minted reference %q does not match its text %q", entry.RefID, entry.Text)
+			}
+			if !strings.Contains(got, entry.RefID) {
+				t.Fatalf("extracted %q is not named by the field %q", entry.RefID, got)
+			}
 		}
 	})
 }

--- a/internal/sbom/license_emission_test.go
+++ b/internal/sbom/license_emission_test.go
@@ -8,6 +8,7 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/bomly-dev/bomly-cli/internal/testnodes"
 	"github.com/bomly-dev/bomly-sdk"
+	"github.com/bomly-dev/bomly-sdk/spdxkit"
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
@@ -249,14 +250,25 @@ func TestSPDXLicenseComposition(t *testing.T) {
 			want: "MIT AND (MIT OR GPL-2.0-only)",
 		},
 		{
-			// Joining free text would produce an expression that does not
-			// parse, so a mixed set keeps the previous first-value behavior.
-			name: "unparseable member falls back to the first value",
+			// A mixed set composes fully now (#410). The unrecognized member
+			// becomes a reference, which is a valid expression element, so
+			// nothing is dropped -- this used to keep "MIT" alone and lose
+			// the fact that a second license was declared at all.
+			name: "an unrecognized member composes as a reference",
 			licenses: []sdk.PackageLicense{
 				{Value: "MIT"},
 				{Value: "non-standard"},
 			},
-			want: "MIT",
+			want: "MIT AND " + spdxkit.MintLicenseRef("non-standard").RefID,
+		},
+		{
+			// A lone unrecognized value is a reference rather than free text
+			// in a field SPDX says must hold an expression.
+			name: "a single unrecognized value becomes a reference",
+			licenses: []sdk.PackageLicense{
+				{Value: "see LICENSE file"},
+			},
+			want: spdxkit.MintLicenseRef("see LICENSE file").RefID,
 		},
 	}
 

--- a/internal/sbom/licenseref_test.go
+++ b/internal/sbom/licenseref_test.go
@@ -1,0 +1,176 @@
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bomly-dev/bomly-cli/internal/testnodes"
+	"github.com/bomly-dev/bomly-sdk"
+	"github.com/bomly-dev/bomly-sdk/spdxkit"
+)
+
+// licenseGraph builds a one-package graph whose licenses a case chooses.
+func licenseGraph(t *testing.T, licenses ...sdk.PackageLicense) *sdk.Graph {
+	t.Helper()
+	g := sdk.New()
+	pkg := testnodes.Dep(sdk.Coordinates{Ecosystem: "npm", Name: "widget", Version: "1.0.0"})
+	sdk.SetDetectionLicenses(pkg, licenses)
+	if _, err := g.InsertNode(pkg); err != nil {
+		t.Fatalf("InsertNode: %v", err)
+	}
+	return g
+}
+
+// spdxDocOf marshals a graph to SPDX and decodes the raw document, so a test
+// can assert on the fields SPDX defines rather than on our model.
+func spdxDocOf(t *testing.T, g *sdk.Graph) map[string]any {
+	t.Helper()
+	out, err := MarshalDepGraphJSON(g, TargetSPDX23JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal spdx: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal spdx: %v", err)
+	}
+	return doc
+}
+
+// SPDX 2.3 has no free-text license field: licenseDeclared must hold a valid
+// expression, NOASSERTION, NONE, or a LicenseRef. Writing "see LICENSE file"
+// verbatim produced a document a strict consumer can reject (#410).
+func TestUnrecognizedLicenseBecomesAReferenceWithItsText(t *testing.T) {
+	const raw = "see LICENSE file"
+	doc := spdxDocOf(t, licenseGraph(t, sdk.PackageLicense{Value: raw}))
+
+	packages, _ := doc["packages"].([]any)
+	if len(packages) == 0 {
+		t.Fatalf("no packages in document")
+	}
+	pkg, _ := packages[0].(map[string]any)
+	declared, _ := pkg["licenseDeclared"].(string)
+
+	want := spdxkit.MintLicenseRef(raw).RefID
+	if declared != want {
+		t.Fatalf("licenseDeclared = %q, want the minted reference %q", declared, want)
+	}
+	if declared == raw {
+		t.Fatalf("the raw value reached licenseDeclared verbatim")
+	}
+	if !spdxkit.Valid(declared) {
+		t.Fatalf("licenseDeclared %q does not parse as an SPDX expression", declared)
+	}
+
+	// And the text travels with it, which is what a reference is for.
+	others, _ := doc["hasExtractedLicensingInfos"].([]any)
+	if len(others) != 1 {
+		t.Fatalf("hasExtractedLicensingInfos = %v, want one entry", others)
+	}
+	entry, _ := others[0].(map[string]any)
+	if got, _ := entry["licenseId"].(string); got != want {
+		t.Fatalf("extracted licenseId = %q, want %q", got, want)
+	}
+	if got, _ := entry["extractedText"].(string); got != raw {
+		t.Fatalf("extractedText = %q, want the original %q", got, raw)
+	}
+}
+
+// A recognized license is untouched: the reference machinery applies only
+// where SPDX cannot hold the value.
+func TestRecognizedLicenseMintsNoReference(t *testing.T) {
+	doc := spdxDocOf(t, licenseGraph(t, sdk.PackageLicense{SPDXExpression: "Apache-2.0"}))
+	packages, _ := doc["packages"].([]any)
+	pkg, _ := packages[0].(map[string]any)
+	if declared, _ := pkg["licenseDeclared"].(string); declared != "Apache-2.0" {
+		t.Fatalf("licenseDeclared = %q, want %q", declared, "Apache-2.0")
+	}
+	if _, present := doc["hasExtractedLicensingInfos"]; present {
+		t.Fatalf("a recognized license produced an extracted-text section")
+	}
+}
+
+// Two components carrying the same unrecognized text mint the same reference
+// and collapse to one entry. That is what makes the identifier safe to share
+// across a document assembled from independent sources.
+func TestIdenticalTextsShareOneReference(t *testing.T) {
+	const raw = "internal use only"
+	g := sdk.New()
+	for _, name := range []string{"alpha", "beta"} {
+		pkg := testnodes.Dep(sdk.Coordinates{Ecosystem: "npm", Name: name, Version: "1.0.0"})
+		sdk.SetDetectionLicenses(pkg, []sdk.PackageLicense{{Value: raw}})
+		if _, err := g.InsertNode(pkg); err != nil {
+			t.Fatalf("InsertNode(%s): %v", name, err)
+		}
+	}
+	doc := spdxDocOf(t, g)
+
+	others, _ := doc["hasExtractedLicensingInfos"].([]any)
+	if len(others) != 1 {
+		t.Fatalf("hasExtractedLicensingInfos has %d entries, want one shared by both packages", len(others))
+	}
+	want := spdxkit.MintLicenseRef(raw).RefID
+	packages, _ := doc["packages"].([]any)
+	if len(packages) != 2 {
+		t.Fatalf("packages = %d, want two", len(packages))
+	}
+	for _, p := range packages {
+		pkg, _ := p.(map[string]any)
+		if declared, _ := pkg["licenseDeclared"].(string); declared != want {
+			t.Fatalf("package %v licenseDeclared = %q, want the shared reference %q", pkg["name"], declared, want)
+		}
+	}
+}
+
+// Different texts must not collide, and the identifier must stay inside the
+// characters SPDX allows for an idstring.
+func TestReferencesAreDistinctAndWellFormed(t *testing.T) {
+	first := spdxkit.MintLicenseRef("see LICENSE file")
+	second := spdxkit.MintLicenseRef("see COPYING file")
+	if first.RefID == second.RefID {
+		t.Fatalf("distinct texts minted the same reference %q", first.RefID)
+	}
+	for _, ref := range []spdxkit.ExtractedText{first, second} {
+		if !spdxkit.ValidLicenseRef(ref.RefID) {
+			t.Fatalf("reference %q is not a well-formed LicenseRef", ref.RefID)
+		}
+		if !strings.HasPrefix(ref.RefID, "LicenseRef-") {
+			t.Fatalf("reference %q lacks the LicenseRef- prefix", ref.RefID)
+		}
+	}
+	// Deterministic: the same text mints the same reference every time.
+	if again := spdxkit.MintLicenseRef("see LICENSE file"); again.RefID != first.RefID {
+		t.Fatalf("minting is not deterministic: %q then %q", first.RefID, again.RefID)
+	}
+}
+
+// Round trip: ingesting the exported document recovers the original text.
+// Without this the reference preserves nothing a reader can use — it would
+// return "LicenseRef-<hash>" where the source said "see LICENSE file".
+func TestReferenceRoundTripRecoversTheOriginalText(t *testing.T) {
+	const raw = "see LICENSE file"
+	out, err := MarshalDepGraphJSON(licenseGraph(t, sdk.PackageLicense{Value: raw}),
+		TargetSPDX23JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("marshal spdx: %v", err)
+	}
+
+	ingested, err := UnmarshalJSON(out, TargetSPDX23JSON)
+	if err != nil {
+		t.Fatalf("unmarshal document: %v", err)
+	}
+	var found bool
+	for _, component := range ingested.Components {
+		for _, license := range component.Licenses {
+			if license.Value == raw {
+				found = true
+			}
+			if license.Value == spdxkit.MintLicenseRef(raw).RefID {
+				t.Fatalf("the reference survived as the license value; the text was not read back")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("round trip lost the original license text %q: %+v", raw, ingested.Components)
+	}
+}

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -31,6 +31,11 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		rootComponents[root] = struct{}{}
 	}
 
+	// Collected while packages render, emitted once as the document's
+	// hasExtractedLicensingInfos: a reference is written per package but the
+	// text it names lives at document scope.
+	var extractedLicenses []spdxkit.ExtractedText
+
 	for _, c := range doc.Components {
 		base := sanitizeSPDXID(c.ID)
 		seq := usedIDs[base]
@@ -41,6 +46,9 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		spdxID := common.ElementID(base)
 		idByComponent[c.ID] = spdxID
 
+		licenseDeclared, componentExtracted := spdxLicenseValue(c.Licenses)
+		extractedLicenses = append(extractedLicenses, componentExtracted...)
+
 		pkg := &v23.Package{
 			PackageName:             c.NameOrID(),
 			PackageSPDXIdentifier:   spdxID,
@@ -48,7 +56,7 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 			PackageDownloadLocation: spdxDownloadLocation(c),
 			FilesAnalyzed:           false,
 			PackageComment:          spdxPackageComment(c),
-			PackageLicenseDeclared:  spdxLicenseValue(c.Licenses),
+			PackageLicenseDeclared:  licenseDeclared,
 
 			// Concluded is the document creator's own determination. Every
 			// license Bomly carries is declared by a lockfile or a registry --
@@ -136,6 +144,7 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		CreationInfo:      creation,
 		Packages:          packages,
 		Relationships:     relationships,
+		OtherLicenses:     spdxOtherLicenses(extractedLicenses),
 	}
 
 	return marshalJSON(spdxDoc, opts.Pretty)
@@ -146,6 +155,8 @@ func (spdx23Codec) decodeJSON(data []byte) (*Document, error) {
 	if err := json.Unmarshal(data, &spdxDoc); err != nil {
 		return nil, err
 	}
+
+	extractedByRef := spdxExtractedTexts(spdxDoc.OtherLicenses)
 
 	components := make([]Component, 0, len(spdxDoc.Packages))
 	for _, p := range spdxDoc.Packages {
@@ -163,7 +174,7 @@ func (spdx23Codec) decodeJSON(data []byte) (*Document, error) {
 			Ecosystem:      parseSPDXYcosystem(p.PackageExternalReferences),
 			PackageManager: parseSPDXPackageManager(p.PackageExternalReferences),
 			Copyright:      parseSPDXCopyright(p.PackageCopyrightText),
-			Licenses:       parseSPDXLicenses(p.PackageLicenseConcluded, p.PackageLicenseDeclared),
+			Licenses:       parseSPDXLicenses(extractedByRef, p.PackageLicenseConcluded, p.PackageLicenseDeclared),
 		})
 	}
 
@@ -417,31 +428,94 @@ func parseSPDXCommentField(comment, field string) string {
 	return ""
 }
 
-// spdxLicenseValue renders a component's licenses into one SPDX license field.
+// spdxLicenseValue renders a component's licenses into one SPDX license field,
+// with the extracted-text entries the field's references depend on.
+//
+// SPDX 2.3 has no free-text license field. licenseDeclared must hold a valid
+// expression, NOASSERTION, NONE, or a LicenseRef-* identifier, so a registry
+// value like "see LICENSE file" cannot be written verbatim -- which is what
+// this did, producing a document a strict consumer can reject (#410). Each
+// unrecognized value mints a reference instead, and the original text travels
+// beside it in hasExtractedLicensingInfos. That is what SPDX defines for this
+// case, and unlike NOASSERTION it keeps the information: an ingest can read
+// the text back.
+//
+// Minting is the kit's, not this package's. A reference has to be
+// deterministic, collision-free across components without coordination, and
+// restricted to the characters the idstring grammar allows; spdxkit.MintLicenseRef
+// answers all three by hashing, and hand-rolling a sanitizer here would be a
+// second, worse answer to a question the SDK already settled.
+//
+// Composition now applies to every set. A LicenseRef is a valid expression
+// element, so a mixed set of recognized and unrecognized values composes
+// fully rather than falling back to the first value and dropping the rest --
+// the silent loss the old comment described as deliberate.
 //
 // SPDX 2.3 holds a single expression per package and has no way to list
-// licenses without relating them, so a component carrying several has to
-// compose them rather than keep only the first, which silently dropped the
-// rest. AND is the conservative reading -- it overstates obligations rather
+// licenses without relating them, so a component carrying several composes
+// them. AND is the conservative reading -- it overstates obligations rather
 // than understating them -- but it is still more than a source that merely
 // listed licenses actually said. CycloneDX lists them instead; this is the
 // one place the two formats differ, and it is recorded in docs/SBOM.md.
 //
 // A source that knows the relationship states it in one value ("Apache-2.0 OR
 // MIT"), which arrives here as a single value and passes through untouched.
-//
-// Composition applies only when every part is a valid expression; joining free
-// text would manufacture an expression that does not parse, so a mixed set
-// falls back to the first value as before.
-func spdxLicenseValue(licenses []License) string {
+func spdxLicenseValue(licenses []License) (string, []spdxkit.ExtractedText) {
 	values := componentLicenseValues(licenses)
 	if len(values) == 0 {
-		return "NOASSERTION"
+		return "NOASSERTION", nil
 	}
-	if len(values) == 1 || !allValidSPDXExpressions(values) {
-		return values[0]
+
+	elements := make([]string, 0, len(values))
+	var extracted []spdxkit.ExtractedText
+	for _, value := range values {
+		if spdxkit.Classify(value) == spdxkit.ClassFreeText {
+			ref := spdxkit.MintLicenseRef(value)
+			elements = append(elements, ref.RefID)
+			extracted = append(extracted, ref)
+			continue
+		}
+		elements = append(elements, value)
 	}
-	return spdxkit.Compose(values)
+	if len(elements) == 1 {
+		return elements[0], extracted
+	}
+	return spdxkit.Compose(elements), extracted
+}
+
+// spdxOtherLicenses renders the document's extracted-text section: one entry
+// per distinct reference, sorted by identifier so the document is stable.
+//
+// The entries are document-scoped while the references that need them are
+// written per package, so they are collected during package assembly and
+// emitted once here. Two components carrying the same unrecognized text mint
+// the same reference and collapse to one entry, which is the property that
+// makes the reference safe to share.
+func spdxOtherLicenses(extracted []spdxkit.ExtractedText) []*v23.OtherLicense {
+	if len(extracted) == 0 {
+		return nil
+	}
+	byRef := make(map[string]spdxkit.ExtractedText, len(extracted))
+	for _, entry := range extracted {
+		if entry.RefID == "" {
+			continue
+		}
+		byRef[entry.RefID] = entry
+	}
+	refs := make([]string, 0, len(byRef))
+	for ref := range byRef {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+
+	out := make([]*v23.OtherLicense, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, &v23.OtherLicense{
+			LicenseIdentifier: ref,
+			ExtractedText:     byRef[ref].Text,
+		})
+	}
+	return out
 }
 
 func spdxCopyrightValue(value string) string {
@@ -595,17 +669,81 @@ func spdxVulnerabilityLocator(vuln Vulnerability) string {
 	return strings.TrimSpace(vuln.ID)
 }
 
-func parseSPDXLicenses(values ...string) []License {
+// spdxExtractedTexts indexes a document's extracted-license section by
+// reference, so ingest can read back the text an exported reference names.
+//
+// An entry whose text does not mint its own identifier is kept under the
+// identifier the document wrote, not repaired. This is a foreign document:
+// the pairing it states is what it means, and re-minting would answer with a
+// reference the document never used. The kit's Valid is the gate for values
+// this process minted; here the document is the authority.
+func spdxExtractedTexts(others []*v23.OtherLicense) map[string]string {
+	if len(others) == 0 {
+		return nil
+	}
+	byRef := make(map[string]string, len(others))
+	for _, other := range others {
+		if other == nil {
+			continue
+		}
+		ref := strings.TrimSpace(other.LicenseIdentifier)
+		if ref == "" {
+			continue
+		}
+		byRef[ref] = other.ExtractedText
+	}
+	return byRef
+}
+
+// parseSPDXLicenses reads a package's license fields back into the model,
+// resolving any reference to the text the document extracted for it.
+//
+// Export mints a reference for a value SPDX cannot hold verbatim (#410), so
+// ingest has to undo it or a round trip would return "LicenseRef-<hash>"
+// where the source said "see LICENSE file" -- information the reference
+// exists to preserve, lost at the boundary that was supposed to carry it.
+//
+// The expression keeps the reference and the value carries the text: the
+// first is what the document said, the second is what a human means, and
+// collapsing them would make the resolved text look like a license
+// identifier to everything downstream.
+func parseSPDXLicenses(extractedByRef map[string]string, values ...string) []License {
 	for _, value := range values {
 		value = strings.TrimSpace(value)
 		switch value {
 		case "", "NOASSERTION", "NONE":
 			continue
 		default:
-			return []License{{SPDXExpression: value, Value: value}}
+			license := License{SPDXExpression: value, Value: value}
+			if text, ok := resolveSingleLicenseRef(extractedByRef, value); ok {
+				license.Value = text
+			}
+			return []License{license}
 		}
 	}
 	return nil
+}
+
+// resolveSingleLicenseRef returns the extracted text when the expression is
+// exactly one reference and the document supplied its text.
+//
+// Only the atomic case resolves. A compound expression naming a reference
+// among other terms ("MIT AND LicenseRef-abc") has no single text to become:
+// substituting free text into it would produce something that no longer
+// parses, and the reference is already the correct representation there.
+func resolveSingleLicenseRef(extractedByRef map[string]string, expression string) (string, bool) {
+	if len(extractedByRef) == 0 {
+		return "", false
+	}
+	refs := spdxkit.LicenseRefsIn(expression)
+	if len(refs) != 1 || refs[0] != expression {
+		return "", false
+	}
+	text, ok := extractedByRef[expression]
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", false
+	}
+	return text, true
 }
 
 func parseSPDXPURL(refs []*v23.PackageExternalReference) string {

--- a/internal/sbom/transform.go
+++ b/internal/sbom/transform.go
@@ -635,19 +635,13 @@ func normalizeSPDXLicenseExpression(expression string) string {
 // members of one workspace cannot collide. The package URL its coordinates
 // mint is what belongs in the document, and a module whose coordinates mint
 // none publishes no purl rather than an unparseable one.
-// The codec's own copy of the node-to-purl projection. It does not import
-// internal/output, where the CLI's copy lives: an SBOM codec depending on the
-// output layer would be backwards. Both converge on the SDK accessor tracked
-// as bomly-dev/bomly-sdk#43, which is where this belongs (ADR-0040).
+// This was the codec's own copy of the projection, kept separate because an
+// SBOM codec importing the CLI's output layer would invert the layering. Both
+// copies converge here: bomly-sdk v0.9.2 took the accessor
+// (bomly-dev/bomly-sdk#43), which is where it belongs (ADR-0040), and the
+// question every surface asks of a node now has exactly one answer.
 func componentPURL(node sdk.GraphNode) string {
-	switch typed := node.(type) {
-	case *sdk.DependencyNode:
-		return typed.NodeID()
-	case *sdk.ModuleNode:
-		return typed.PURL()
-	default:
-		return ""
-	}
+	return sdk.NodePURL(node)
 }
 
 // componentOrg returns the namespace to publish as the component's group.


### PR DESCRIPTION
Closes #410. Phase **2.4**, plus the `bomly-sdk` v0.9.2 adoption folded in.

## The defect

SPDX 2.3 has no free-text license field — `licenseDeclared` must hold a valid expression, `NOASSERTION`, `NONE`, or a `LicenseRef`. Bomly wrote an unrecognized value verbatim, so a package declaring `see LICENSE file` produced a document a strict consumer can reject.

The quieter half was the **mixed-validity fallback**: a set of one recognized and one unrecognized license kept only the first and dropped the rest. A comment called that deliberate, because composing free text would produce something that does not parse. It was still a silent loss of a license a source had actually declared.

| | before | after |
|---|---|---|
| `see LICENSE file` | written verbatim into `licenseDeclared` | `LicenseRef-bomly-<hash>`, with the text in `hasExtractedLicensingInfos` |
| `MIT` + `non-standard` | `MIT` (second dropped) | `MIT AND LicenseRef-bomly-<hash>` |
| `MIT` | unchanged | unchanged |
| nothing | `NOASSERTION` | `NOASSERTION` |

Ingest resolves an **atomic** reference back to its text, so a round trip returns `see LICENSE file` rather than the hash. A compound expression naming a reference among other terms is left alone: it has no single text to become, and substituting free text into it would produce something that no longer parses. A foreign document's own reference-to-text pairing is taken as stated rather than re-minted — there the document is the authority, not our hash.

## SDK v0.9.2 adoption

v0.9.2 closes both SDK issues this branch's predecessors filed, so the workarounds they left behind go with it:

- **sdk#43 → `NodePURL`.** The node-to-purl projection existed twice here, deliberately: `internal/graphview` for the renderers and `internal/sbom` for the codec, because a codec importing the CLI's output layer inverts the layering. Both were commented as converging on the accessor once it shipped. It shipped; both delegate. `graphview` keeps `ChildrenAmong` and `TopLevelParentIDs`, which are CLI policy rather than model semantics.
- **sdk#39 → PEP 440 canonicalization before minting.** Two spellings of one PyPI release fold again. `TestPythonVersionCaseIsNotFoldedYet` existed to make that gap visible rather than silent, and its own failure message said to fold the case back and delete it once a normalizer arrived — done exactly that.

## Delegation check

- **`LicenseRef-*` minting, idstring safety, collision-freedom**: `spdxkit.MintLicenseRef` — delegated. It hashes the whitespace-normalized text, so the identifier is deterministic and collision-resistant across components assembled without coordination, and confined to the characters SPDX allows.
- **Recognized vs free text**: `spdxkit.Classify`. **Expression composition**: `spdxkit.Compose`. **Reference enumeration on ingest**: `spdxkit.LicenseRefsIn` — so a reference is what the grammar says one is, not a prefix match.
- **Node package URL**: `sdk.NodePURL`.
- **CLI-owned policy**: which values classify how, where extracted texts attach, how ingest maps them back, what a document may name, what counts as a top-level parent.

## Verification

`make verify SMOKE=1` green, **zero golden drift** on both halves. No fixture carries an unrecognized license, and the fixtures' PyPI versions are already canonical (pip, poetry and uv all write normalized versions) — so the PEP 440 change reaches only the hand-written requirements case it was filed for. That is exactly why the new tests drive the behaviour directly rather than relying on goldens.

Every acceptance criterion from the issue has a test, each mutation-checked:

- reference minted with its text emitted, and the raw value never reaching the field
- a recognized license mints nothing
- two components sharing a text share one reference and one entry
- distinct texts do not collide; identifiers are well-formed and minting is deterministic
- round trip recovers the original text

`FuzzSPDXLicenseValue` now asserts the stronger invariant the issue implies: whatever the input, the field is `NOASSERTION` or parses as an SPDX expression, and every minted reference is both valid for its text and named by the field.

`docs/SBOM.md` and ADR-0035 drop the limitation they recorded. The ADR gets a dated note rather than a rewritten body — it recorded a decision that was true when made — and the note also redirects its `internal/licenseexpr` references, since #428 deleted that package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SPDX output now converts unrecognized license text into valid `LicenseRef-*` identifiers while preserving the original text.
  - Mixed recognized and unrecognized license sets now retain and compose all license members instead of keeping only the first value.
  - License references are consistently restored when reading SPDX documents.
  - Python package versions with differing letter case are now treated equivalently.
  - SBOM component PURLs now use consistent canonical resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->