### PR TITLE
refactor(detectors): the SDK decides every detector's purl type

### DIFF
--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -469,7 +469,7 @@ func packageNode(pkg metadataPackage, id string, workspace map[string]struct{}, 
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.ParsePackageType("crate"),
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version),
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version),
 	}
 	if _, workspaceMember := workspace[id]; workspaceMember {
 		// A workspace member is the project's own code, so it is a module
@@ -587,7 +587,7 @@ func depGraphFromLockWithScope(lockRaw, manifestRaw []byte, scopeFilter sdk.Scop
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.PackageTypeApplication,
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL("cargo", "", manifest.Name, manifest.Version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", manifest.Name, manifest.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build root node: %w", err)
 	}

--- a/internal/detectors/cargo/workspace.go
+++ b/internal/detectors/cargo/workspace.go
@@ -240,7 +240,7 @@ func depGraphFromLockWorkspace(lockRaw []byte, rootManifest cargoManifest, membe
 			PackageManager: sdk.PackageManagerCargo,
 			Type:           sdk.PackageTypeApplication,
 			Language:       "rust",
-			PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version),
+			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("build cargo module node %q: %w", pkg.Name, err)
@@ -254,7 +254,7 @@ func depGraphFromLockWorkspace(lockRaw []byte, rootManifest cargoManifest, membe
 			PackageManager: sdk.PackageManagerCargo,
 			Type:           sdk.ParsePackageType("crate"),
 			Language:       "rust",
-			PURL:           sdk.BuildPackageURL("cargo", "", pkg.Name, pkg.Version)})
+			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version)})
 		if err != nil {
 			return nil, fmt.Errorf("build cargo node %q: %w", pkg.Name, err)
 		}

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -352,7 +352,7 @@ func packageNode(name, version, checksum string) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerCocoaPods,
 		Type:           "pod",
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL("cocoapods", "", name, version),
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods), "", name, version),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build pod node %q: %w", name, err)

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -305,7 +305,7 @@ func packageNode(name, version string) (*sdk.DependencyNode, error) {
 		Org:            org,
 		Name:           packageName,
 		Version:        version,
-		PURL:           sdk.BuildPackageURL("composer", org, packageName, version),
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPHP, sdk.PackageManagerComposer), org, packageName, version),
 		PackageManager: sdk.PackageManagerComposer,
 		Type:           sdk.PackageTypePackage,
 		Language:       "php",

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -325,7 +325,7 @@ func packageNode(ref conanRef) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerConan,
 		Type:           sdk.PackageTypePackage,
 		Language:       "cpp",
-		PURL:           sdk.BuildPackageURL("conan", "", ref.Name, ref.Version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemCPP, sdk.PackageManagerConan), "", ref.Name, ref.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -616,7 +616,6 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 	t.Helper()
 	const (
 		mint      = "BuildPackageURL"
-		build     = "Build"
 		authority = "PackageURLTypeForValues"
 	)
 	fset := token.NewFileSet()
@@ -630,6 +629,37 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 
 	var offenders []string
 	ast.Inspect(file, func(n ast.Node) bool {
+		// A purlkit.PURL literal decides the type wherever it is written --
+		// inline at the call, assigned to a variable first, or returned by
+		// a helper. Keying on the literal rather than on Build covers all
+		// three; keying on the call covered only the first.
+		if lit, ok := n.(*ast.CompositeLit); ok && compositeTypeName(lit) == "PURL" {
+			if value, ok := fieldValue(lit, "Type"); ok {
+				if inner, ok := value.(*ast.CallExpr); !ok || calleeName(inner) != "PackageURLTypeForValues" {
+					offenders = append(offenders,
+						where(value.Pos())+" builds a purlkit.PURL whose Type sdk.PackageURLTypeForValues did not decide")
+				}
+			}
+			return true
+		}
+		// Setting the field after the fact is the same choice, later.
+		if assign, ok := n.(*ast.AssignStmt); ok {
+			for i, lhs := range assign.Lhs {
+				sel, ok := lhs.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Type" || i >= len(assign.Rhs) {
+					continue
+				}
+				if inner, ok := assign.Rhs[i].(*ast.CallExpr); ok && calleeName(inner) == "PackageURLTypeForValues" {
+					continue
+				}
+				if _, ok := assign.Rhs[i].(*ast.BasicLit); !ok {
+					continue // only a literal is a hand-picked type here
+				}
+				offenders = append(offenders,
+					where(assign.Rhs[i].Pos())+" sets a Type sdk.PackageURLTypeForValues did not decide")
+			}
+			return true
+		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -644,29 +674,6 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 			}
 			offenders = append(offenders,
 				where(call.Args[0].Pos())+" mints a package URL with a type sdk."+authority+" did not decide")
-		case build:
-			// purlkit.Build is the other way to mint one, and the
-			// concatenation guard below recommends it by name -- so it is
-			// a signposted route around this rule, not an obscure one. A
-			// detector reaching it with a literal Type has picked the type
-			// by hand exactly as the old string literals did.
-			for _, arg := range call.Args {
-				lit, ok := arg.(*ast.CompositeLit)
-				if !ok || compositeTypeName(lit) != "PURL" {
-					continue
-				}
-				value, ok := fieldValue(lit, "Type")
-				if !ok {
-					// No Type at all: purlkit rejects that itself, and a
-					// missing field is not a hand-written mapping.
-					continue
-				}
-				if inner, ok := value.(*ast.CallExpr); ok && calleeName(inner) == authority {
-					continue
-				}
-				offenders = append(offenders,
-					where(value.Pos())+" builds a purlkit.PURL whose Type sdk."+authority+" did not decide")
-			}
 		case authority:
 			// Handing the authority the answer is the same hand-written
 			// mapping wearing its name: a literal here has already picked
@@ -809,5 +816,39 @@ func TestPURLTypeGuardSeesTheShapesItForbids(t *testing.T) {
 		`var _ = thing.Build(thing.Options{Type: "generic", Name: n})`,
 	); len(got) != 0 {
 		t.Errorf("an unrelated Build is reported: %v", got)
+	}
+
+	// The literal decides the type wherever it is written, so putting it in
+	// a variable first must not hide it. The rule keys on the literal rather
+	// than on the call for exactly this reason -- watching Build's arguments
+	// instead would report a delegating hop and miss a literal built in a
+	// helper, which is the wrong answer in both directions.
+	if got := offendersFor("viavar.go",
+		"func f() string {\n\tspec := purlkit.PURL{Type: \"generic\", Name: n}\n\tout, _ := purlkit.Build(spec)\n\treturn out\n}",
+	); len(got) != 1 {
+		t.Errorf("a purlkit.PURL routed through a variable is not reported: %v", got)
+	}
+
+	// Same hop, delegating: allowed.
+	if got := offendersFor("viavar-ok.go",
+		"func f() string {\n\tspec := purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart, "+
+			"sdk.PackageManagerPub), Name: n}\n\tout, _ := purlkit.Build(spec)\n\treturn out\n}",
+	); len(got) != 0 {
+		t.Errorf("a delegating purlkit.PURL through a variable is reported: %v", got)
+	}
+
+	// Setting the field afterwards is the same choice, later.
+	if got := offendersFor("fieldset.go",
+		"func f() {\n\tvar spec purlkit.PURL\n\tspec.Type = \"generic\"\n\t_ = spec\n}",
+	); len(got) != 1 {
+		t.Errorf("a Type assigned after construction is not reported: %v", got)
+	}
+
+	// A delegating literal stays allowed however many hops it takes.
+	if got := offendersFor("viahelper.go",
+		"func f() string {\n\tspec := purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart)}\n\t"+
+			"out, _ := purlkit.Build(spec)\n\treturn out\n}",
+	); len(got) != 0 {
+		t.Errorf("a fully delegating variable hop is reported: %v", got)
 	}
 }

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -616,6 +616,7 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 	t.Helper()
 	const (
 		mint      = "BuildPackageURL"
+		build     = "Build"
 		authority = "PackageURLTypeForValues"
 	)
 	fset := token.NewFileSet()
@@ -643,6 +644,29 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 			}
 			offenders = append(offenders,
 				where(call.Args[0].Pos())+" mints a package URL with a type sdk."+authority+" did not decide")
+		case build:
+			// purlkit.Build is the other way to mint one, and the
+			// concatenation guard below recommends it by name -- so it is
+			// a signposted route around this rule, not an obscure one. A
+			// detector reaching it with a literal Type has picked the type
+			// by hand exactly as the old string literals did.
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.CompositeLit)
+				if !ok || compositeTypeName(lit) != "PURL" {
+					continue
+				}
+				value, ok := fieldValue(lit, "Type")
+				if !ok {
+					// No Type at all: purlkit rejects that itself, and a
+					// missing field is not a hand-written mapping.
+					continue
+				}
+				if inner, ok := value.(*ast.CallExpr); ok && calleeName(inner) == authority {
+					continue
+				}
+				offenders = append(offenders,
+					where(value.Pos())+" builds a purlkit.PURL whose Type sdk."+authority+" did not decide")
+			}
 		case authority:
 			// Handing the authority the answer is the same hand-written
 			// mapping wearing its name: a literal here has already picked
@@ -661,6 +685,36 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 		return true
 	})
 	return offenders
+}
+
+// compositeTypeName returns the type name a composite literal names, with its
+// package qualifier dropped, so purlkit.PURL{...} answers "PURL".
+//
+// The literal's type is checked rather than only the callee, because "Build"
+// is a common enough name that matching it alone would report unrelated
+// builders that happen to take a struct.
+func compositeTypeName(lit *ast.CompositeLit) string {
+	switch typ := lit.Type.(type) {
+	case *ast.Ident:
+		return typ.Name
+	case *ast.SelectorExpr:
+		return typ.Sel.Name
+	}
+	return ""
+}
+
+// fieldValue returns the value a keyed composite literal gives one field.
+func fieldValue(lit *ast.CompositeLit, field string) (ast.Expr, bool) {
+	for _, element := range lit.Elts {
+		kv, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == field {
+			return kv.Value, true
+		}
+	}
+	return nil, false
 }
 
 // calleeName returns the function name a call names, with its package
@@ -722,5 +776,38 @@ func TestPURLTypeGuardSeesTheShapesItForbids(t *testing.T) {
 	// The qualifier is not part of the rule, so an alias must not evade it.
 	if got := offendersFor("aliased.go", `var _ = bomly.BuildPackageURL("cocoapods", "", n, v)`); len(got) != 1 {
 		t.Errorf("an aliased import of the SDK evades the rule: %v", got)
+	}
+
+	// purlkit.Build is the other mint, and the concatenation guard below
+	// recommends it by name -- so this route around the rule is signposted
+	// rather than obscure.
+	if got := offendersFor("kitbuild.go",
+		`var _, _ = purlkit.Build(purlkit.PURL{Type: "generic", Name: n, Version: v})`,
+	); len(got) != 1 {
+		t.Errorf("a hand-picked Type on purlkit.Build is not reported: %v", got)
+	}
+
+	// Same call, delegating: allowed, or the guard would forbid the very
+	// construction the rest of the codebase is being moved onto.
+	if got := offendersFor("kitbuild-ok.go",
+		"var _, _ = purlkit.Build(purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart, "+
+			"sdk.PackageManagerPub), Name: n, Version: v})",
+	); len(got) != 0 {
+		t.Errorf("a delegating purlkit.Build is reported as an offender: %v", got)
+	}
+
+	// A Type set from a const is the same hoisting escape, one call over.
+	if got := offendersFor("kitbuild-const.go",
+		"const t = \"generic\"\n\nvar _, _ = purlkit.Build(purlkit.PURL{Type: t, Name: n, Version: v})",
+	); len(got) != 1 {
+		t.Errorf("a purlkit.PURL Type hoisted into a const is not reported: %v", got)
+	}
+
+	// An unrelated Build taking a struct must not be swept in: the rule is
+	// about purlkit.PURL, not about every function called Build.
+	if got := offendersFor("otherbuild.go",
+		`var _ = thing.Build(thing.Options{Type: "generic", Name: n})`,
+	); len(got) != 0 {
+		t.Errorf("an unrelated Build is reported: %v", got)
 	}
 }

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -629,37 +629,6 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 
 	var offenders []string
 	ast.Inspect(file, func(n ast.Node) bool {
-		// A purlkit.PURL literal decides the type wherever it is written --
-		// inline at the call, assigned to a variable first, or returned by
-		// a helper. Keying on the literal rather than on Build covers all
-		// three; keying on the call covered only the first.
-		if lit, ok := n.(*ast.CompositeLit); ok && compositeTypeName(lit) == "PURL" {
-			if value, ok := fieldValue(lit, "Type"); ok {
-				if inner, ok := value.(*ast.CallExpr); !ok || calleeName(inner) != "PackageURLTypeForValues" {
-					offenders = append(offenders,
-						where(value.Pos())+" builds a purlkit.PURL whose Type sdk.PackageURLTypeForValues did not decide")
-				}
-			}
-			return true
-		}
-		// Setting the field after the fact is the same choice, later.
-		if assign, ok := n.(*ast.AssignStmt); ok {
-			for i, lhs := range assign.Lhs {
-				sel, ok := lhs.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "Type" || i >= len(assign.Rhs) {
-					continue
-				}
-				if inner, ok := assign.Rhs[i].(*ast.CallExpr); ok && calleeName(inner) == "PackageURLTypeForValues" {
-					continue
-				}
-				if _, ok := assign.Rhs[i].(*ast.BasicLit); !ok {
-					continue // only a literal is a hand-picked type here
-				}
-				offenders = append(offenders,
-					where(assign.Rhs[i].Pos())+" sets a Type sdk.PackageURLTypeForValues did not decide")
-			}
-			return true
-		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -694,36 +663,6 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 	return offenders
 }
 
-// compositeTypeName returns the type name a composite literal names, with its
-// package qualifier dropped, so purlkit.PURL{...} answers "PURL".
-//
-// The literal's type is checked rather than only the callee, because "Build"
-// is a common enough name that matching it alone would report unrelated
-// builders that happen to take a struct.
-func compositeTypeName(lit *ast.CompositeLit) string {
-	switch typ := lit.Type.(type) {
-	case *ast.Ident:
-		return typ.Name
-	case *ast.SelectorExpr:
-		return typ.Sel.Name
-	}
-	return ""
-}
-
-// fieldValue returns the value a keyed composite literal gives one field.
-func fieldValue(lit *ast.CompositeLit, field string) (ast.Expr, bool) {
-	for _, element := range lit.Elts {
-		kv, ok := element.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == field {
-			return kv.Value, true
-		}
-	}
-	return nil, false
-}
-
 // calleeName returns the function name a call names, with its package
 // qualifier or receiver dropped: sdk.BuildPackageURL(...) and a dot-imported
 // BuildPackageURL(...) both answer "BuildPackageURL".
@@ -740,6 +679,51 @@ func calleeName(call *ast.CallExpr) string {
 		return fn.Sel.Name
 	}
 	return ""
+}
+
+// Detectors reach package URLs through the SDK, never through purlkit.
+//
+// This is the durable half of the rule above, and it is why that rule got to
+// shrink. purlkit is where a package URL is built, so a detector holding it
+// can pick a type by hand in more shapes than a pattern can enumerate: a
+// literal at the call, a literal assigned first, a literal in a helper, a
+// field set afterwards. Three review rounds found three of those. Removing the
+// import removes all of them and the ones nobody has thought of.
+//
+// Scoped to detectors on purpose. internal/sbom, internal/output and
+// internal/auditors use purlkit legitimately -- they read and render package
+// URLs that were minted elsewhere, and a minting rule has nothing to say about
+// reading.
+func TestDetectorsDoNotReachPURLKitDirectly(t *testing.T) {
+	const purlkitModule = "github.com/bomly-dev/bomly-sdk/purlkit"
+
+	root := filepath.Join(internalRoot, "detectors")
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// This file is the exception: it has to spell the module it forbids.
+		// No exemption for this file: it names purlkit in a string, and
+		// naming is not importing -- the distinction the entitlement rules
+		// above exist to make.
+		if !importsModule(t, path, purlkitModule) {
+			return nil
+		}
+		offenders = append(offenders, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("these detectors import purlkit directly; a detector asks the SDK for a package URL "+
+			"(sdk.BuildPackageURL with sdk.PackageURLTypeForValues) and never builds one itself, so "+
+			"holding purlkit is holding the ability to choose a type by hand: %v", offenders)
+	}
 }
 
 // The predicate behind that guard, pinned on fixtures in both directions so
@@ -785,70 +769,4 @@ func TestPURLTypeGuardSeesTheShapesItForbids(t *testing.T) {
 		t.Errorf("an aliased import of the SDK evades the rule: %v", got)
 	}
 
-	// purlkit.Build is the other mint, and the concatenation guard below
-	// recommends it by name -- so this route around the rule is signposted
-	// rather than obscure.
-	if got := offendersFor("kitbuild.go",
-		`var _, _ = purlkit.Build(purlkit.PURL{Type: "generic", Name: n, Version: v})`,
-	); len(got) != 1 {
-		t.Errorf("a hand-picked Type on purlkit.Build is not reported: %v", got)
-	}
-
-	// Same call, delegating: allowed, or the guard would forbid the very
-	// construction the rest of the codebase is being moved onto.
-	if got := offendersFor("kitbuild-ok.go",
-		"var _, _ = purlkit.Build(purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart, "+
-			"sdk.PackageManagerPub), Name: n, Version: v})",
-	); len(got) != 0 {
-		t.Errorf("a delegating purlkit.Build is reported as an offender: %v", got)
-	}
-
-	// A Type set from a const is the same hoisting escape, one call over.
-	if got := offendersFor("kitbuild-const.go",
-		"const t = \"generic\"\n\nvar _, _ = purlkit.Build(purlkit.PURL{Type: t, Name: n, Version: v})",
-	); len(got) != 1 {
-		t.Errorf("a purlkit.PURL Type hoisted into a const is not reported: %v", got)
-	}
-
-	// An unrelated Build taking a struct must not be swept in: the rule is
-	// about purlkit.PURL, not about every function called Build.
-	if got := offendersFor("otherbuild.go",
-		`var _ = thing.Build(thing.Options{Type: "generic", Name: n})`,
-	); len(got) != 0 {
-		t.Errorf("an unrelated Build is reported: %v", got)
-	}
-
-	// The literal decides the type wherever it is written, so putting it in
-	// a variable first must not hide it. The rule keys on the literal rather
-	// than on the call for exactly this reason -- watching Build's arguments
-	// instead would report a delegating hop and miss a literal built in a
-	// helper, which is the wrong answer in both directions.
-	if got := offendersFor("viavar.go",
-		"func f() string {\n\tspec := purlkit.PURL{Type: \"generic\", Name: n}\n\tout, _ := purlkit.Build(spec)\n\treturn out\n}",
-	); len(got) != 1 {
-		t.Errorf("a purlkit.PURL routed through a variable is not reported: %v", got)
-	}
-
-	// Same hop, delegating: allowed.
-	if got := offendersFor("viavar-ok.go",
-		"func f() string {\n\tspec := purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart, "+
-			"sdk.PackageManagerPub), Name: n}\n\tout, _ := purlkit.Build(spec)\n\treturn out\n}",
-	); len(got) != 0 {
-		t.Errorf("a delegating purlkit.PURL through a variable is reported: %v", got)
-	}
-
-	// Setting the field afterwards is the same choice, later.
-	if got := offendersFor("fieldset.go",
-		"func f() {\n\tvar spec purlkit.PURL\n\tspec.Type = \"generic\"\n\t_ = spec\n}",
-	); len(got) != 1 {
-		t.Errorf("a Type assigned after construction is not reported: %v", got)
-	}
-
-	// A delegating literal stays allowed however many hops it takes.
-	if got := offendersFor("viahelper.go",
-		"func f() string {\n\tspec := purlkit.PURL{Type: sdk.PackageURLTypeForValues(sdk.EcosystemDart)}\n\t"+
-			"out, _ := purlkit.Build(spec)\n\treturn out\n}",
-	); len(got) != 0 {
-		t.Errorf("a fully delegating variable hop is reported: %v", got)
-	}
 }

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -1,6 +1,8 @@
 package detectors_test
 
 import (
+	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -548,5 +550,177 @@ func TestNamingAModuleIsNotImportingIt(t *testing.T) {
 	if importsModule(t, other, packageURLModule) {
 		t.Errorf("%s-extras reads as %s; the prefix match is missing its separator",
 			packageURLModule, packageURLModule)
+	}
+}
+
+// A purl type is a name in the package-url specification, and choosing which
+// one an ecosystem gets is the SDK's job: sdk.PackageURLTypeForValues
+// delegates to purlkit, whose doc comment calls itself the one authority for
+// this mapping (ADR-0038). Fourteen detectors used to spell the answer out
+// themselves, as a string literal in the first argument to BuildPackageURL --
+// a second mapping table, maintained by whoever happened to be writing a
+// detector, next to the one that is maintained on purpose.
+//
+// It is the kind of table that is wrong without looking wrong. Nothing reads
+// oddly about pkg:generic until an advisory fails to match, which is how
+// go4.org shipped under that type (bomly-sdk#67). The swift pair is the
+// standing trap here: CocoaPods and SwiftPM share the ecosystem token
+// "swift", but their purl types are "cocoapods" and "swift", so the two
+// detectors sitting side by side need different literals -- and purlkit has
+// deliberately no "swift" case, so that the package manager is what decides.
+//
+// Written as a positive requirement -- the first argument must BE the call to
+// the SDK -- rather than as "no string literal in that position". A negative
+// rule is escaped by lifting the literal into a const one line up, which
+// renames the defect instead of removing it, and this file has four recorded
+// cases of a guard passing while the thing it forbade was present. A const
+// identifier is not a call to the authority either, so the positive form has
+// no such escape: anything but the delegation is reported, a type threaded in
+// through a parameter included, which fails in the direction that gets looked
+// at.
+//
+// Scoped to internal/detectors because that is where the duplicated table
+// lived and where new ones get written. Ingest is a different question -- a
+// document under internal/sbom arrives carrying a type somebody else chose --
+// and a rule about minting has nothing to say about reading.
+func TestDetectorPURLTypesComeFromTheSDK(t *testing.T) {
+	root := filepath.Join(internalRoot, "detectors")
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		offenders = append(offenders, purlTypeOffenders(t, path, nil)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("these detectors decide an ecosystem's package-url type themselves; the mapping belongs to "+
+			"sdk.PackageURLTypeForValues, which delegates to purlkit (ADR-0038): %v", offenders)
+	}
+}
+
+// purlTypeOffenders reports every place in one Go source file where a package
+// URL is minted with a type the SDK did not decide. src is the source text
+// when the caller has it, and nil to read the file at path.
+//
+// Split out from the guard so it can be pinned on fixtures below. A rule only
+// ever exercised against a tree that already passes is a rule nobody has seen
+// fail, and this file's history is mostly that.
+func purlTypeOffenders(t *testing.T, path string, src any) []string {
+	t.Helper()
+	const (
+		mint      = "BuildPackageURL"
+		authority = "PackageURLTypeForValues"
+	)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	where := func(pos token.Pos) string {
+		return fmt.Sprintf("%s:%d", filepath.ToSlash(path), fset.Position(pos).Line)
+	}
+
+	var offenders []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch calleeName(call) {
+		case mint:
+			if len(call.Args) == 0 {
+				return true
+			}
+			if inner, ok := call.Args[0].(*ast.CallExpr); ok && calleeName(inner) == authority {
+				return true
+			}
+			offenders = append(offenders,
+				where(call.Args[0].Pos())+" mints a package URL with a type sdk."+authority+" did not decide")
+		case authority:
+			// Handing the authority the answer is the same hand-written
+			// mapping wearing its name: a literal here has already picked
+			// the type before any token reaches purlkit. Detectors hold
+			// sdk.Ecosystem and sdk.PackageManager values, so they never
+			// need to spell one.
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				offenders = append(offenders, where(arg.Pos())+" passes the literal "+lit.Value+" to sdk."+
+					authority+" instead of the detector's own ecosystem and package-manager values")
+			}
+		}
+		return true
+	})
+	return offenders
+}
+
+// calleeName returns the function name a call names, with its package
+// qualifier or receiver dropped: sdk.BuildPackageURL(...) and a dot-imported
+// BuildPackageURL(...) both answer "BuildPackageURL".
+//
+// Dropping the qualifier is deliberate. Matching "sdk.BuildPackageURL" as one
+// string is what a textual rule does, and an import alias -- or a local
+// helper somebody wraps the call in -- walks straight past that. The name of
+// the act is the stable half.
+func calleeName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+// The predicate behind that guard, pinned on fixtures in both directions so
+// it keeps its meaning when the detectors change. Four times in this file's
+// history a guard reported nothing because its pattern had stopped matching
+// the shape it was written for, and a rule exercised only against a passing
+// tree cannot tell that apart from success.
+func TestPURLTypeGuardSeesTheShapesItForbids(t *testing.T) {
+	dir := t.TempDir()
+	offendersFor := func(name, body string) []string {
+		t.Helper()
+		return purlTypeOffenders(t, filepath.Join(dir, name), "package p\n\n"+body)
+	}
+
+	// What every detector does now, and the only shape that passes.
+	if got := offendersFor("ok.go",
+		`var _ = sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods), "", n, v)`,
+	); len(got) != 0 {
+		t.Errorf("the delegating shape is reported as an offender: %v", got)
+	}
+
+	// The defect the guard exists for.
+	if got := offendersFor("literal.go", `var _ = sdk.BuildPackageURL("cocoapods", "", n, v)`); len(got) != 1 {
+		t.Errorf("a literal purl type at the mint site is not reported: %v", got)
+	}
+
+	// The escape a "no string literal there" rule would have left open.
+	if got := offendersFor("const.go",
+		"const podType = \"cocoapods\"\n\nvar _ = sdk.BuildPackageURL(podType, \"\", n, v)",
+	); len(got) != 1 {
+		t.Errorf("a purl type hoisted into a const is not reported: %v", got)
+	}
+
+	// Restating the answer as the question.
+	if got := offendersFor("restated.go",
+		`var _ = sdk.BuildPackageURL(sdk.PackageURLTypeForValues("cocoapods"), "", n, v)`,
+	); len(got) != 1 {
+		t.Errorf("a literal handed to the authority itself is not reported: %v", got)
+	}
+
+	// The qualifier is not part of the rule, so an alias must not evade it.
+	if got := offendersFor("aliased.go", `var _ = bomly.BuildPackageURL("cocoapods", "", n, v)`); len(got) != 1 {
+		t.Errorf("an aliased import of the SDK evades the rule: %v", got)
 	}
 }

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -408,7 +408,7 @@ func packageNode(pkg mixPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerMix,
 		Type:           sdk.PackageTypePackage,
 		Language:       "elixir",
-		PURL:           sdk.BuildPackageURL("hex", "", pkg.Name, version),
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemElixir, sdk.PackageManagerMix), "", pkg.Name, version),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build mix node %q: %w", pkg.Name, err)

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -551,7 +551,7 @@ func packageNode(name, version string, pkg lockPackage) (*sdk.DependencyNode, er
 		PackageManager: sdk.PackageManagerNuGet,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dotnet",
-		PURL:           sdk.BuildPackageURL("nuget", "", name, version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemDotNet, sdk.PackageManagerNuGet), "", name, version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -196,7 +196,7 @@ func packageNode(name string, pkg pubLockPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerPub,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dart",
-		PURL:           sdk.BuildPackageURL("pub", "", name, pkg.Version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemDart, sdk.PackageManagerPub), "", name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/python/piplock.go
+++ b/internal/detectors/python/piplock.go
@@ -75,7 +75,7 @@ func depGraphFromRequirementsLock(lockPath, projectPath, rootName string) (*sdk.
 			PackageManager: sdk.PackageManagerPip,
 			Language:       "python",
 			Type:           sdk.PackageTypePackage,
-			PURL:           sdk.BuildPackageURL("pypi", "", e.name, e.version)})
+			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPython, sdk.PackageManagerPip), "", e.name, e.version)})
 		if err != nil {
 			return nil, fmt.Errorf("build dependency node: %w", err)
 		}

--- a/internal/detectors/python/poetrylock.go
+++ b/internal/detectors/python/poetrylock.go
@@ -86,7 +86,7 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 			PackageManager: sdk.PackageManagerPoetry,
 			Language:       "python",
 			Type:           sdk.PackageTypePackage,
-			PURL:           sdk.BuildPackageURL("pypi", "", pkg.Name, pkg.Version)})
+			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPython, sdk.PackageManagerPoetry), "", pkg.Name, pkg.Version)})
 		if err != nil {
 			return nil, fmt.Errorf("build dependency node: %w", err)
 		}

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -180,7 +180,7 @@ func packageNode(pkg sbtPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerSBT,
 		Type:           sdk.PackageTypePackage,
 		Language:       "scala",
-		PURL:           sdk.BuildPackageURL("maven", pkg.Org, pkg.Name, pkg.Version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemScala, sdk.PackageManagerSBT), pkg.Org, pkg.Name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -290,7 +290,7 @@ func packageNode(pkg swiftPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerSwiftPM,
 		Type:           sdk.PackageTypePackage,
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL("swift", namespace, name, pkg.Version)})
+		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerSwiftPM), namespace, name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}


### PR DESCRIPTION
## The defect

Fourteen call sites across twelve detector files spelled their ecosystem's package-url type as a string literal in the first argument to `sdk.BuildPackageURL`:

```go
PURL: sdk.BuildPackageURL("cocoapods", "", name, version),
```

That literal is a mapping decision — ecosystem to purl type — and it is exactly the *second mapping table* the SDK maturity program set out to delete. The first one is `bomly-sdk/purlkit.TypeForValues`, whose own doc comment calls it "the one authority for this mapping (ADR-0038)". The second one had no home, no tests, and no reviewer: it was whatever the person writing a detector typed that day.

It is the kind of table that is wrong without looking wrong. Nothing reads oddly about `pkg:generic` until an advisory fails to match — which is how `go4.org` went out under that type (bomly-sdk#67).

The swift pair is the standing trap and shows why the rule cannot be a review habit. `cocoapods/detector.go` and `swiftpm/detector.go` sit next to each other, both carry `sdk.EcosystemSwift`, and they need *different* purl types — `cocoapods` and `swift`. purlkit has deliberately no `"swift"` case precisely so the package manager is what decides. A detector hand-mapping from its ecosystem alone gets one of the two wrong, silently.

## The change

Every site now hands the SDK the ecosystem and package-manager values it already held:

```go
PURL: sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods), "", name, version),
```

Nothing is re-derived — each detector already had both tokens in the same `sdk.Coordinates` literal.

## Before / after types — all fourteen sites

Probed against the pinned `bomly-dev/bomly-sdk v0.9.7` with each site's actual tokens, in **both** argument orders, so the result does not depend on the order I happened to pass them in.

| # | Site | Literal (before) | Ecosystem | PackageManager.Name() | SDK type (after) | Changed? |
|---|------|------------------|-----------|------------------------|------------------|----------|
| 1 | `python/piplock.go:78` | `pypi` | `python` | `pip` | `pypi` | no |
| 2 | `python/poetrylock.go:89` | `pypi` | `python` | `poetry` | `pypi` | no |
| 3 | `cargo/detector.go:472` | `cargo` | `rust` | `cargo` | `cargo` | no |
| 4 | `cargo/detector.go:590` | `cargo` | `rust` | `cargo` | `cargo` | no |
| 5 | `cargo/workspace.go:243` | `cargo` | `rust` | `cargo` | `cargo` | no |
| 6 | `cargo/workspace.go:257` | `cargo` | `rust` | `cargo` | `cargo` | no |
| 7 | `composer/detector.go:308` | `composer` | `php` | `composer` | `composer` | no |
| 8 | `mix/detector.go:411` | `hex` | `elixir` | `mix` | `hex` | no |
| 9 | `nuget/detector.go:554` | `nuget` | `dotnet` | `nuget` | `nuget` | no |
| 10 | `conan/detector.go:328` | `conan` | `cpp` | `conan` | `conan` | no |
| 11 | `sbt/detector.go:183` | `maven` | `scala` | `sbt` | `maven` | no |
| 12 | `pub/detector.go:199` | `pub` | `dart` | `pub` | `pub` | no |
| 13 | `cocoapods/detector.go:355` | `cocoapods` | `swift` | `cocoapods` | `cocoapods` | no |
| 14 | `swiftpm/detector.go:293` | `swift` | `swift` | `swiftpm` | `swift` | no |

**No emitted purl type changes.** No node ID, OSV match, or SBOM reference moves, and no golden shifts — `make verify` confirms.

Two results worth stating rather than assuming, because they were the flagged traps:

- **cocoapods vs swift.** Both detectors carry ecosystem `swift`. purlkit has no `"swift"` case, so the ecosystem token falls through and the package manager answers: `cocoapods` → `cocoapods`, `swiftpm` → `swift`. Had either site passed only its ecosystem, CocoaPods would have silently started minting `pkg:swift`. It passes both.
- **mix/hex.** purlkit's refusal to guess between Elixir and Erlang is on the *reverse* join (`EcosystemForType("hex")` returns unknown by decision). The forward direction is unambiguous: `elixir` and `mix` both map to `hex`, matching the literal. Nothing changes here.

## The guard

`TestDetectorPURLTypesComeFromTheSDK` in `internal/detectors/guards_test.go`, alongside the existing guards.

It is written as a **positive requirement** — the first argument to `BuildPackageURL` must *be* the call to `sdk.PackageURLTypeForValues` — rather than as "no string literal in that position". A negative rule is escaped by lifting the literal into a `const` one line up, which renames the defect instead of removing it. A const identifier is not a call to the authority either, so the positive form has no such escape.

It is AST-based, not textual, and matches the callee by name with the package qualifier dropped, so an import alias or a local wrapper does not walk past it. A second check reports a string literal passed *to* `PackageURLTypeForValues`, since restating the answer as the question is the same hand-mapping wearing the authority's name.

Scoped to `internal/detectors/`: that is where the duplicated table lived and where new ones get written. Ingest is a different question — a document under `internal/sbom` arrives carrying a type somebody else chose — and a rule about minting has nothing to say about reading.

`TestPURLTypeGuardSeesTheShapesItForbids` pins the predicate on fixtures in both directions, because a rule only ever exercised against a tree that already passes is a rule nobody has seen fail — which is this file's documented failure mode.

## Mutation results

This file has four recorded cases of a guard passing while the thing it forbade was present, so the guard was mutation-tested against real production code. Each mutation was applied on its own, **verified to still compile** (`go build ./...`), and reverted:

| # | Mutation | Compiles? | Guard |
|---|----------|-----------|-------|
| M1 | Bare literal restored: `BuildPackageURL("cocoapods", …)` in `cocoapods/detector.go` | yes | **FAIL** — `cocoapods/detector.go:355 mints a package URL with a type sdk.PackageURLTypeForValues did not decide` |
| M2 | Literal hoisted into a package const `swiftPURLType = "swift"` in `swiftpm/detector.go` | yes | **FAIL** — `swiftpm/detector.go:293 mints a package URL with a type sdk.PackageURLTypeForValues did not decide` |
| M3 | Literal handed to the authority: `PackageURLTypeForValues("hex")` in `mix/detector.go` | yes | **FAIL** — `mix/detector.go:411 passes the literal "hex" to sdk.PackageURLTypeForValues instead of the detector's own ecosystem and package-manager values` |
| M4 | Mint hidden behind a local helper `pubPURL(purlType, …)` in `pub/detector.go` | yes | **FAIL** — `pub/detector.go:284 mints a package URL with a type sdk.PackageURLTypeForValues did not decide` |
| — | Control: clean tree | yes | **PASS** |

M2 is the one that matters most: it is the mutation a regex-based "no literal here" guard would have passed.

## Verification

`make verify` passes end to end — `fmt-check`, `golangci-lint` (0 issues), `go vet` for the full, lite and smoke build tags, both builds, `go test ./...`, and `make generate` with **no docs drift**.

## Scope

Closes the open half of `dev-docs/SDK_MATURITY_PLAN.md` §6 criterion 3: "zero purl-type string literals in detectors … enforced by a guard test, not a review habit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
