### PR TITLE
refactor: run the Go 1.27 modernizer (go fix) across the repo

### DIFF
--- a/cmd/bomly/release_licensing_test.go
+++ b/cmd/bomly/release_licensing_test.go
@@ -226,7 +226,7 @@ func TestLinuxPackagesCarryLicenseSet(t *testing.T) {
 // (rather than substring search) ensures the assertion fails if a statement
 // is commented out, mangled, or merely mentioned in surrounding text.
 func hasStatementLine(block string, pattern *regexp.Regexp) bool {
-	for _, line := range strings.Split(block, "\n") {
+	for line := range strings.SplitSeq(block, "\n") {
 		if pattern.MatchString(strings.TrimSpace(line)) {
 			return true
 		}
@@ -260,7 +260,7 @@ func TestHomebrewFormulaLicensing(t *testing.T) {
 		// Collect the arguments of every doc.install statement line; the
 		// union must cover the full license set.
 		docInstalled := map[string]bool{}
-		for _, line := range strings.Split(brew.ExtraInstall, "\n") {
+		for line := range strings.SplitSeq(brew.ExtraInstall, "\n") {
 			line = strings.TrimSpace(line)
 			if !docInstall.MatchString(line) {
 				continue

--- a/internal/auditors/package/auditor.go
+++ b/internal/auditors/package/auditor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -184,10 +185,8 @@ func appendUniqueString(values []string, value string) []string {
 	if strings.TrimSpace(value) == "" {
 		return values
 	}
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -325,7 +325,7 @@ func validateAutomaticPath(target sdk.ExecutionTarget, path string) error {
 	}
 
 	current := absoluteRoot
-	for _, component := range strings.Split(relative, string(os.PathSeparator)) {
+	for component := range strings.SplitSeq(relative, string(os.PathSeparator)) {
 		if component == "" || component == "." {
 			continue
 		}

--- a/internal/benchmark/run.go
+++ b/internal/benchmark/run.go
@@ -631,7 +631,7 @@ func ParseNames(values ...string) []string {
 	seen := make(map[string]struct{})
 	out := make([]string, 0)
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			name := strings.TrimSpace(part)
 			if name == "" {
 				continue

--- a/internal/benchmark/summary.go
+++ b/internal/benchmark/summary.go
@@ -191,12 +191,9 @@ func comparePackages(bomlyDoc, sourceDoc *sbom.Document, policy ComparisonPolicy
 		sourcePURLs := sourceByBase[base]
 		sort.Strings(bomlyPURLs)
 		sort.Strings(sourcePURLs)
-		matched := len(bomlyPURLs)
-		if len(sourcePURLs) < matched {
-			matched = len(sourcePURLs)
-		}
+		matched := min(len(sourcePURLs), len(bomlyPURLs))
 		metrics.VersionMismatch += matched
-		for idx := 0; idx < matched; idx++ {
+		for idx := range matched {
 			differences = append(differences, ComparisonDifference{Kind: "package", Classification: "version_mismatch", BomlyPURL: bomlyPURLs[idx], SourcePURL: sourcePURLs[idx]})
 		}
 		metrics.BomlyOnly += len(bomlyPURLs) - matched
@@ -403,7 +400,7 @@ func detectorCreators(doc *sbom.Document) []string {
 	}
 	out := make([]string, 0)
 	for _, tool := range doc.Tools {
-		if name := strings.TrimPrefix(tool, "bomly-detector:"); name != tool {
+		if name, ok := strings.CutPrefix(tool, "bomly-detector:"); ok {
 			out = append(out, name)
 		}
 	}

--- a/internal/cli/benchmark_run_test.go
+++ b/internal/cli/benchmark_run_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -69,10 +70,5 @@ func TestBenchmarkNativeScannerUsesBomlyNativeDetector(t *testing.T) {
 }
 
 func benchmarkContainsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }

--- a/internal/cli/opts/filters.go
+++ b/internal/cli/opts/filters.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -112,9 +113,7 @@ func buildEcosystemSelectorCatalog() catalog {
 	}
 	sort.Strings(available)
 	aliasToName := make(map[string]string, len(aliasMap))
-	for k, v := range aliasMap {
-		aliasToName[k] = v
-	}
+	maps.Copy(aliasToName, aliasMap)
 	simplified := append([]string(nil), available...)
 	return catalog{
 		Kind:        "ecosystem",

--- a/internal/cli/opts/filters_test.go
+++ b/internal/cli/opts/filters_test.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -195,12 +196,7 @@ func TestResolveEcosystemFilter_UnknownReturnsError(t *testing.T) {
 }
 
 func containsEcosystem(values []sdk.Ecosystem, target sdk.Ecosystem) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 type fakeMatcher struct {

--- a/internal/cli/opts/flag_options.go
+++ b/internal/cli/opts/flag_options.go
@@ -438,7 +438,7 @@ func csvCompletionFunc(options []string) func(*cobra.Command, []string, string) 
 		}
 
 		used := map[string]struct{}{}
-		for _, part := range strings.Split(toComplete, ",") {
+		for part := range strings.SplitSeq(toComplete, ",") {
 			value := strings.TrimSpace(part)
 			if value == "" {
 				continue

--- a/internal/cli/opts/options_test.go
+++ b/internal/cli/opts/options_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -962,21 +963,11 @@ func newTestRootCommand(t *testing.T) *cobra.Command {
 }
 
 func containsOption(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 func containsManager(values []sdk.PackageManager, target sdk.PackageManager) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 func TestResolveConfigRejectsMaxDepthWithoutRecursive(t *testing.T) {

--- a/internal/cli/opts/planning.go
+++ b/internal/cli/opts/planning.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -420,19 +421,12 @@ func detectorNamesForPackageManager(
 }
 
 func containsPackageManager(managers []sdk.PackageManager, target sdk.PackageManager) bool {
-	for _, manager := range managers {
-		if manager == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(managers, target)
 }
 
 func appendUniqueDetectorName(names []string, name string) []string {
-	for _, existing := range names {
-		if existing == name {
-			return names
-		}
+	if slices.Contains(names, name) {
+		return names
 	}
 	return append(names, name)
 }
@@ -450,13 +444,7 @@ func appendUniquePatterns(existing []string, patterns ...string) []string {
 		if pattern == "" {
 			continue
 		}
-		seen := false
-		for _, current := range existing {
-			if current == pattern {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(existing, pattern)
 		if !seen {
 			existing = append(existing, pattern)
 		}
@@ -520,10 +508,8 @@ func supportsTargetKind(targetKinds []sdk.ExecutionTargetKind, candidates ...sdk
 		return false
 	}
 	for _, targetKind := range targetKinds {
-		for _, candidate := range candidates {
-			if targetKind == candidate {
-				return true
-			}
+		if slices.Contains(candidates, targetKind) {
+			return true
 		}
 	}
 	return false
@@ -547,10 +533,8 @@ func singlePackageManager(managers []sdk.PackageManager) sdk.PackageManager {
 }
 
 func appendUniquePackageManager(values []sdk.PackageManager, value sdk.PackageManager) []sdk.PackageManager {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/cli/opts/selector.go
+++ b/internal/cli/opts/selector.go
@@ -6,6 +6,7 @@ package opts
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -163,22 +164,15 @@ func appendUnique(values []string, value string) []string {
 	if value == "" {
 		return values
 	}
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }
 
 // contains reports whether value is in values.
 func contains(values []string, value string) bool {
-	for _, existing := range values {
-		if existing == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, value)
 }
 
 func differenceSorted(all []string, keep []string) []string {

--- a/internal/cli/plugin_cmd.go
+++ b/internal/cli/plugin_cmd.go
@@ -1535,12 +1535,7 @@ func pluginDetectorEcosystems(info managedplugin.Info) string {
 }
 
 func containsPluginValue(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 func nonEmptyString(value, fallback string) string {

--- a/internal/cli/plugin_cmd_test.go
+++ b/internal/cli/plugin_cmd_test.go
@@ -321,7 +321,7 @@ func TestPluginList_TableWrapsLongDetectorColumns(t *testing.T) {
 	}
 
 	text := render.StripANSI(output.String())
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		if width := len([]rune(line)); width > 140 {
 			t.Fatalf("expected wrapped detector table line <= 140 columns, got %d:\n%s", width, line)
 		}
@@ -330,7 +330,7 @@ func TestPluginList_TableWrapsLongDetectorColumns(t *testing.T) {
 
 func tableHeaderLine(t *testing.T, text string, contains string) string {
 	t.Helper()
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		if strings.Contains(line, contains) {
 			return line
 		}

--- a/internal/cli/render/diff.go
+++ b/internal/cli/render/diff.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
@@ -128,12 +129,7 @@ func dependencyTransitionDescription(transition output.DiffDependencyTransition)
 }
 
 func dependencyDetailFieldChanged(transition output.DiffDependencyTransition, wanted sdk.DependencyDetailField) bool {
-	for _, field := range transition.ChangedFields {
-		if field == wanted {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(transition.ChangedFields, wanted)
 }
 
 func dependencyTransitionDisplayName(state output.DiffDependencyTransitionState) string {

--- a/internal/cli/render/logo.go
+++ b/internal/cli/render/logo.go
@@ -226,7 +226,7 @@ func logoRevealFrames() []string {
 	grid, width := logoRuneGrid(bomlyLogoArt())
 
 	frames := make([]string, 0, logoFrameCount)
-	for frame := 0; frame < logoRevealFrameCount; frame++ {
+	for frame := range logoRevealFrameCount {
 		boundary := (frame + 1) * (width + logoScrambleBand) / logoRevealFrameCount
 		frames = append(frames, renderBomlyLogoFrame(revealFrameCells(grid, frame, boundary), ""))
 	}
@@ -249,7 +249,7 @@ func logoRainFrames() []string {
 	grid, _ := logoRuneGrid(bomlyLogoArt())
 
 	frames := make([]string, 0, logoFrameCount)
-	for frame := 0; frame < logoRevealFrameCount; frame++ {
+	for frame := range logoRevealFrameCount {
 		rows := make([][]logoCell, len(grid))
 		for row, line := range grid {
 			cells := make([]logoCell, len(line))
@@ -289,7 +289,7 @@ func logoGlitchFrames() []string {
 	grid, _ := logoRuneGrid(bomlyLogoArt())
 
 	frames := make([]string, 0, logoFrameCount)
-	for frame := 0; frame < logoRevealFrameCount; frame++ {
+	for frame := range logoRevealFrameCount {
 		density := maxDensity * (logoRevealFrameCount - 1 - frame) / (logoRevealFrameCount - 1)
 		rows := make([][]logoCell, len(grid))
 		for row, line := range grid {
@@ -326,34 +326,28 @@ func logoSlideFrames() []string {
 	slideDuration := logoRevealFrameCount - slideStagger*(len(grid)-1)
 
 	frames := make([]string, 0, logoFrameCount)
-	for frame := 0; frame < logoRevealFrameCount; frame++ {
+	for frame := range logoRevealFrameCount {
 		rows := make([][]logoCell, len(grid))
 		for row, line := range grid {
 			cells := make([]logoCell, len(line))
 			for col := range line {
 				cells[col] = logoCell{glyph: ' ', style: logoCellPlain}
 			}
-			visible := (frame - slideStagger*row + 1) * width / slideDuration
-			if visible < 0 {
-				visible = 0
-			}
-			if visible > width {
-				visible = width
-			}
+			visible := min(max((frame-slideStagger*row+1)*width/slideDuration, 0), width)
 			style := logoCellScramble
 			if visible == width {
 				style = logoCellRevealed
 			}
 			if row%2 == 0 {
 				// Enter from the left: the row's tail is visible at the left edge.
-				for idx := 0; idx < visible; idx++ {
+				for idx := range visible {
 					if glyph := line[width-visible+idx]; glyph != ' ' {
 						cells[idx] = logoCell{glyph: glyph, style: style}
 					}
 				}
 			} else {
 				// Enter from the right: the row's head is visible at the right edge.
-				for idx := 0; idx < visible; idx++ {
+				for idx := range visible {
 					if glyph := line[idx]; glyph != ' ' {
 						cells[width-visible+idx] = logoCell{glyph: glyph, style: style}
 					}

--- a/internal/cli/render/scan_warnings_test.go
+++ b/internal/cli/render/scan_warnings_test.go
@@ -62,7 +62,7 @@ func TestWarningNotices_GroupsRepeatedWarnings(t *testing.T) {
 
 func TestWarningNotices_CapsFanOut(t *testing.T) {
 	warnings := make([]model.DetectorWarning, 0, 9)
-	for idx := 0; idx < 9; idx++ {
+	for idx := range 9 {
 		warnings = append(warnings, model.DetectorWarning{
 			Type:     model.DetectorWarningFallback,
 			Source:   "maven-detector",

--- a/internal/cli/render/scorecard_render_test.go
+++ b/internal/cli/render/scorecard_render_test.go
@@ -208,7 +208,6 @@ func TestFormatPostureDelta(t *testing.T) {
 		{"unchanged", 7.5, 7.5, "0"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := formatPostureDelta(tc.before, tc.after)

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -2368,9 +2369,9 @@ func TestRoot_ScanCommand_TextReportOutput(t *testing.T) {
 		}
 	}
 	// Direct deps appear before transitive in the Top-level section.
-	reactIdx := strings.Index(plain, "react")
+	found := strings.Contains(plain, "react")
 	envifyIdx := strings.Index(plain, "loose-envify")
-	if reactIdx == -1 {
+	if !found {
 		t.Fatalf("expected react in output, got: %s", out)
 	}
 	// loose-envify is transitive and should NOT appear in Top-level dependencies.
@@ -3012,12 +3013,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 }
 
 func containsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 func scanPayloadPackages(payload map[string]any) ([]any, bool) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"path"
@@ -163,7 +164,7 @@ func rejectLegacyFlatKeys(data []byte) error {
 // LegacyMigrationPaths returns former flat YAML keys and their replacements.
 func LegacyMigrationPaths() map[string]string {
 	paths := make(map[string]string)
-	collectLegacyConfigPaths(reflect.TypeOf(File{}), "", paths)
+	collectLegacyConfigPaths(reflect.TypeFor[File](), "", paths)
 	paths["config"] = "--config"
 	paths["verbose"] = "logging.verbosity"
 	return paths
@@ -172,13 +173,12 @@ func LegacyMigrationPaths() map[string]string {
 // YAMLPathsByResolvedField returns nested YAML paths keyed by flat runtime field.
 func YAMLPathsByResolvedField() map[string]string {
 	paths := make(map[string]string)
-	collectResolvedConfigPaths(reflect.TypeOf(File{}), "", paths)
+	collectResolvedConfigPaths(reflect.TypeFor[File](), "", paths)
 	return paths
 }
 
 func collectLegacyConfigPaths(t reflect.Type, prefix string, paths map[string]string) {
-	for idx := 0; idx < t.NumField(); idx++ {
-		field := t.Field(idx)
+	for field := range t.Fields() {
 		key := yamlTagName(field.Tag.Get("yaml"))
 		if key == "" || key == "-" {
 			continue
@@ -197,8 +197,7 @@ func collectLegacyConfigPaths(t reflect.Type, prefix string, paths map[string]st
 }
 
 func collectResolvedConfigPaths(t reflect.Type, prefix string, paths map[string]string) {
-	for idx := 0; idx < t.NumField(); idx++ {
-		field := t.Field(idx)
+	for field := range t.Fields() {
 		key := yamlTagName(field.Tag.Get("yaml"))
 		if key == "" || key == "-" {
 			continue
@@ -218,9 +217,9 @@ func collectResolvedConfigPaths(t reflect.Type, prefix string, paths map[string]
 
 func canonicalRootKeys() map[string]struct{} {
 	keys := make(map[string]struct{})
-	fileType := reflect.TypeOf(File{})
-	for idx := 0; idx < fileType.NumField(); idx++ {
-		key := yamlTagName(fileType.Field(idx).Tag.Get("yaml"))
+	fileType := reflect.TypeFor[File]()
+	for field := range fileType.Fields() {
+		key := yamlTagName(field.Tag.Get("yaml"))
 		if key != "" && key != "-" {
 			keys[key] = struct{}{}
 		}
@@ -442,17 +441,13 @@ func clonePluginConfig(value map[string]any) map[string]any {
 	data, err := json.Marshal(value)
 	if err != nil {
 		out := make(map[string]any, len(value))
-		for key, item := range value {
-			out[key] = item
-		}
+		maps.Copy(out, value)
 		return out
 	}
 	var out map[string]any
 	if err := json.Unmarshal(data, &out); err != nil {
 		copyValue := make(map[string]any, len(value))
-		for key, item := range value {
-			copyValue[key] = item
-		}
+		maps.Copy(copyValue, value)
 		return copyValue
 	}
 	return out

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -796,7 +796,7 @@ func parseCargoLockPackages(text string) []lockPackage {
 func parseCargoManifest(text string) cargoManifest {
 	var manifest cargoManifest
 	section := ""
-	for _, rawLine := range strings.Split(text, "\n") {
+	for rawLine := range strings.SplitSeq(text, "\n") {
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/internal/detectors/cargo/workspace.go
+++ b/internal/detectors/cargo/workspace.go
@@ -42,17 +42,17 @@ func parseCargoWorkspaceMembers(text string) []string {
 				return
 			}
 			rest := fragment[start+1:]
-			end := strings.IndexByte(rest, '"')
-			if end < 0 {
+			before, after, ok := strings.Cut(rest, "\"")
+			if !ok {
 				return
 			}
-			if value := strings.TrimSpace(rest[:end]); value != "" {
+			if value := strings.TrimSpace(before); value != "" {
 				members = append(members, value)
 			}
-			fragment = rest[end+1:]
+			fragment = after
 		}
 	}
-	for _, rawLine := range strings.Split(text, "\n") {
+	for rawLine := range strings.SplitSeq(text, "\n") {
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -92,7 +92,7 @@ func parseCargoWorkspaceMembers(text string) []string {
 // root manifest declares none.
 func parseCargoWorkspaceInheritedVersion(text string) string {
 	section := ""
-	for _, rawLine := range strings.Split(text, "\n") {
+	for rawLine := range strings.SplitSeq(text, "\n") {
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -128,7 +128,7 @@ func inlineTableValue(table, key string) string {
 	if end := strings.LastIndexByte(table, '}'); end >= 0 {
 		table = table[:end]
 	}
-	for _, fragment := range strings.Split(table, ",") {
+	for fragment := range strings.SplitSeq(table, ",") {
 		k, v, ok := strings.Cut(fragment, "=")
 		if ok && strings.TrimSpace(k) == key {
 			return trimTomlString(strings.TrimSpace(v))

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -246,7 +246,7 @@ func parsePodfileTestTargets(path string) map[string]bool {
 		return strings.Contains(lower, "test") || strings.Contains(lower, "spec")
 	}
 
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if m := podfileTargetHeadPattern.FindStringSubmatch(line); m != nil {
 			parentIsTest := len(stack) > 0 && stack[len(stack)-1].isTest

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -346,12 +347,7 @@ func sortedNodeIDs(nodes map[string]*sdk.DependencyNode) []string {
 }
 
 func containsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }
 
 func addNodeIfMissing(g *sdk.Graph, node *sdk.DependencyNode) error {

--- a/internal/detectors/gomod/detector.go
+++ b/internal/detectors/gomod/detector.go
@@ -564,8 +564,8 @@ func parseRequireDirective(value string) (moduleRef, bool, error) {
 }
 
 func stripLineComment(line string) string {
-	if idx := strings.Index(line, "//"); idx >= 0 {
-		return line[:idx]
+	if before, _, ok := strings.Cut(line, "//"); ok {
+		return before
 	}
 	return line
 }

--- a/internal/detectors/gradle/detector.go
+++ b/internal/detectors/gradle/detector.go
@@ -421,7 +421,7 @@ func depGraphFromGradleOutput(raw []byte, rootName string, modules []gradleModul
 	currentGraph := rootGraph
 	stack := []string{rootNode.NodeID()}
 	currentScope := sdk.ScopeUnknown
-	for _, line := range strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
@@ -699,8 +699,8 @@ func gradleDependencyToken(value string) string {
 }
 
 func gradleNodeFromToken(token string, scope sdk.Scope) (sdk.GraphNode, bool) {
-	if strings.HasPrefix(token, "project ") {
-		name := strings.TrimSpace(strings.TrimPrefix(token, "project "))
+	if after, ok := strings.CutPrefix(token, "project "); ok {
+		name := strings.TrimSpace(after)
 		if name == "" {
 			return nil, false
 		}

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -79,10 +80,8 @@ func modulesForRule(t *testing.T, rule string) []string {
 // isForbidden reports whether any rule forbids the module.
 func isForbidden(module string) bool {
 	for _, modules := range forbiddenModules {
-		for _, forbidden := range modules {
-			if forbidden == module {
-				return true
-			}
+		if slices.Contains(modules, module) {
+			return true
 		}
 	}
 	return false
@@ -251,12 +250,7 @@ var guardFiles = map[string][]string{
 // second: a guard that must spell one module was excused from the rules about
 // the others.
 func guardMayName(path, module string) bool {
-	for _, allowed := range guardFiles[filepath.Clean(path)] {
-		if allowed == module {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(guardFiles[filepath.Clean(path)], module)
 }
 
 // importsModule reports whether the Go file at path imports module, or a

--- a/internal/detectors/maven/detector.go
+++ b/internal/detectors/maven/detector.go
@@ -489,8 +489,8 @@ func normalizeMavenTGFLine(line string) (string, bool) {
 		return "", false
 	}
 
-	if strings.HasPrefix(trimmed, "[INFO]") {
-		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "[INFO]"))
+	if after, ok := strings.CutPrefix(trimmed, "[INFO]"); ok {
+		trimmed = strings.TrimSpace(after)
 		if trimmed == "" {
 			return "", false
 		}

--- a/internal/detectors/node/bun/bun_lockfile_parser.go
+++ b/internal/detectors/node/bun/bun_lockfile_parser.go
@@ -347,6 +347,9 @@ func addSyntheticBunDependency(graph *sdk.Graph, name, requested string) (string
 
 func mergeBunDependencyMaps(maps ...map[string]string) map[string]string {
 	out := make(map[string]string)
+	// The parameter is named maps, so maps.Copy here would need an import
+	// alias. The explicit loop is kept on purpose; go fix will offer the
+	// rewrite again and it should be declined again.
 	for _, values := range maps {
 		for name, version := range values {
 			out[name] = version

--- a/internal/detectors/node/bun/bun_native_parser.go
+++ b/internal/detectors/node/bun/bun_native_parser.go
@@ -29,7 +29,7 @@ func depGraphFromBunPMList(raw []byte, manifest node.PackageJSONManifest, projec
 
 	byName := make(map[string]map[string]sdk.GraphNode)
 	parents := make([]string, 0)
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		name, version, depth, ok := parseBunPMListLine(line)
 		if !ok {
 			continue

--- a/internal/detectors/node/lockfile_common.go
+++ b/internal/detectors/node/lockfile_common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strings"
 
@@ -86,11 +87,7 @@ func NormalizeVersionToken(value string) string {
 // MergeStringMaps returns a shallow merge of two string maps.
 func MergeStringMaps(left map[string]string, right map[string]string) map[string]string {
 	out := make(map[string]string, len(left)+len(right))
-	for key, value := range left {
-		out[key] = value
-	}
-	for key, value := range right {
-		out[key] = value
-	}
+	maps.Copy(out, left)
+	maps.Copy(out, right)
 	return out
 }

--- a/internal/detectors/node/package_manager_warnings.go
+++ b/internal/detectors/node/package_manager_warnings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -154,17 +155,10 @@ func lockfileWarnings(projectDir string, pinnedManager sdk.PackageManager, pinne
 // lockfile. Unknown combinations return false, so an undocumented migration path
 // is never reported as a mismatch.
 func lockfileUnread(manager sdk.PackageManager, file string) bool {
-	for _, name := range consumedLockfiles[manager] {
-		if name == file {
-			return false
-		}
+	if slices.Contains(consumedLockfiles[manager], file) {
+		return false
 	}
-	for _, name := range unreadLockfiles[manager] {
-		if name == file {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(unreadLockfiles[manager], file)
 }
 
 // lockfileFormatWarning compares the committed lockfile's format version with
@@ -417,7 +411,7 @@ func readNpmrc(dir string) map[string]string {
 		return nil
 	}
 	settings := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
 			continue

--- a/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
+++ b/internal/detectors/node/pnpm/pnpm_lockfile_parser.go
@@ -463,11 +463,11 @@ func mergeAnyMaps(left map[string]any, right map[string]any) map[string]string {
 // pnpmStripPeerSuffix strips the peer dependency suffix from a pnpm v9 snapshot key.
 // For example: "express@4.18.2(peer-dep@1.0.0)" -> "express@4.18.2".
 func pnpmStripPeerSuffix(key string) string {
-	idx := strings.Index(key, "(")
-	if idx < 0 {
+	before, _, ok := strings.Cut(key, "(")
+	if !ok {
 		return key
 	}
-	return key[:idx]
+	return before
 }
 
 func parsePNPMLockfile(raw []byte) (pnpmLockfile, error) {

--- a/internal/detectors/node/yarn/yarn_lockfile_parser.go
+++ b/internal/detectors/node/yarn/yarn_lockfile_parser.go
@@ -232,8 +232,8 @@ func parseYarnLockEntries(content string) ([]yarnLockEntry, error) {
 		// version field: classic `version "X.Y.Z"`, Berry `version: X.Y.Z`.
 		if strings.HasPrefix(trimmed, "version ") || strings.HasPrefix(trimmed, "version: ") {
 			raw := trimmed
-			if strings.HasPrefix(raw, "version:") {
-				raw = strings.TrimPrefix(raw, "version:")
+			if after, ok := strings.CutPrefix(raw, "version:"); ok {
+				raw = after
 			} else {
 				raw = strings.TrimPrefix(raw, "version")
 			}
@@ -244,8 +244,8 @@ func parseYarnLockEntries(content string) ([]yarnLockEntry, error) {
 		// resolved field: classic `resolved "url"`, Berry `resolved: "url"`.
 		if strings.HasPrefix(trimmed, "resolved ") || strings.HasPrefix(trimmed, "resolved: ") {
 			raw := trimmed
-			if strings.HasPrefix(raw, "resolved:") {
-				raw = strings.TrimPrefix(raw, "resolved:")
+			if after, ok := strings.CutPrefix(raw, "resolved:"); ok {
+				raw = after
 			} else {
 				raw = strings.TrimPrefix(raw, "resolved")
 			}
@@ -264,8 +264,8 @@ func parseYarnLockEntries(content string) ([]yarnLockEntry, error) {
 		// integrity field: classic `integrity sha512-...`, Berry `integrity: sha512-...`.
 		if strings.HasPrefix(trimmed, "integrity ") || strings.HasPrefix(trimmed, "integrity: ") {
 			raw := trimmed
-			if strings.HasPrefix(raw, "integrity:") {
-				raw = strings.TrimPrefix(raw, "integrity:")
+			if after, ok := strings.CutPrefix(raw, "integrity:"); ok {
+				raw = after
 			} else {
 				raw = strings.TrimPrefix(raw, "integrity")
 			}

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -349,9 +350,7 @@ func depGraphFromDepsFiles(paths []string) (*sdk.Graph, error) {
 				}
 				library := deps.Libraries[key]
 				if !strings.EqualFold(strings.TrimSpace(library.Type), "package") {
-					for depName, depVersion := range target.Dependencies {
-						rootDeps[depName] = depVersion
-					}
+					maps.Copy(rootDeps, target.Dependencies)
 					continue
 				}
 				pkg := lockPackage{

--- a/internal/detectors/python/common.go
+++ b/internal/detectors/python/common.go
@@ -752,7 +752,7 @@ func collectRequirementFileDependencies(path string, declared map[string]struct{
 	if err != nil {
 		return fmt.Errorf("read Python requirements %q: %w", path, err)
 	}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		line = strings.TrimSpace(strings.SplitN(line, "#", 2)[0])
 		if line == "" || strings.HasPrefix(line, "-") {
 			continue
@@ -855,13 +855,13 @@ func collectLoosePythonManifestDependencies(path string, declared map[string]str
 	if err != nil {
 		return fmt.Errorf("read Python manifest %q: %w", path, err)
 	}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		if strings.HasPrefix(line, "name = ") {
-			value := strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "name = ")), `"'`)
+		if after, ok := strings.CutPrefix(line, "name = "); ok {
+			value := strings.Trim(strings.TrimSpace(after), `"'`)
 			addDeclaredPythonName(value, declared)
 			continue
 		}
@@ -891,8 +891,8 @@ func requirementName(value string) string {
 // behind an extras marker (e.g. `pytest; extra == "test"`). Such requirements
 // are optional and should not create transitive graph edges.
 func isExtrasRequirement(requirement string) bool {
-	if idx := strings.Index(requirement, ";"); idx >= 0 {
-		marker := strings.ToLower(requirement[idx+1:])
+	if _, after, ok := strings.Cut(requirement, ";"); ok {
+		marker := strings.ToLower(after)
 		return strings.Contains(marker, "extra")
 	}
 	return false
@@ -1038,7 +1038,7 @@ func collectPythonDevDependencies(projectPath string) map[string]struct{} {
 	if raw, err := system.ReadRepositoryFile(filepath.Join(projectPath, "pyproject.toml")); err == nil {
 		section := ""
 		inDevArray := false
-		for _, line := range strings.Split(string(raw), "\n") {
+		for line := range strings.SplitSeq(string(raw), "\n") {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "[") {
 				section = strings.ToLower(strings.Trim(trimmed, "[]"))
@@ -1088,7 +1088,7 @@ func collectPythonDevDependencies(projectPath string) map[string]struct{} {
 	// Pipfile [dev-packages]
 	if raw, err := system.ReadRepositoryFile(filepath.Join(projectPath, "Pipfile")); err == nil {
 		inDev := false
-		for _, line := range strings.Split(string(raw), "\n") {
+		for line := range strings.SplitSeq(string(raw), "\n") {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "[") {
 				inDev = strings.ToLower(strings.Trim(trimmed, "[]")) == "dev-packages"
@@ -1105,7 +1105,7 @@ func collectPythonDevDependencies(projectPath string) map[string]struct{} {
 
 	// pip: requirements-dev.txt (plain list of dev packages)
 	if raw, err := system.ReadRepositoryFile(filepath.Join(projectPath, "requirements-dev.txt")); err == nil {
-		for _, line := range strings.Split(string(raw), "\n") {
+		for line := range strings.SplitSeq(string(raw), "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "-") {
 				continue

--- a/internal/detectors/python/piplock_test.go
+++ b/internal/detectors/python/piplock_test.go
@@ -3,6 +3,7 @@ package python
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"testing"
 
@@ -175,10 +176,5 @@ func findRootID(t *testing.T, g *sdk.Graph) string {
 }
 
 func contains(s []string, v string) bool {
-	for _, x := range s {
-		if x == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, v)
 }

--- a/internal/detectors/ruby/detector.go
+++ b/internal/detectors/ruby/detector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -479,8 +480,8 @@ func parseGemfileScopes(path string) (map[string]sdk.Scope, error) {
 }
 
 func stripGemfileComment(line string) string {
-	if idx := strings.Index(line, "#"); idx >= 0 {
-		return line[:idx]
+	if before, _, ok := strings.Cut(line, "#"); ok {
+		return before
 	}
 	return line
 }
@@ -542,10 +543,8 @@ func addGemNodeIfMissing(depsGraph *sdk.Graph, node *sdk.DependencyNode) error {
 }
 
 func appendUnique(values []string, value string) []string {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/detectors/sbt/sbt_native.go
+++ b/internal/detectors/sbt/sbt_native.go
@@ -146,7 +146,7 @@ func sbtVersion(workingDir string) string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		key, value, ok := strings.Cut(line, "=")
 		if !ok {
 			continue
@@ -241,10 +241,7 @@ func depGraphFromSBTDependencyTree(raw []byte) (*sdk.Graph, error) {
 		// Each "  " (2 chars) or "| " represents one level of nesting.
 		indent := m[1]
 		// Count groups of 2 chars; each group is one level.
-		depth := len([]rune(indent)) / 2
-		if depth < 0 {
-			depth = 0
-		}
+		depth := max(len([]rune(indent))/2, 0)
 
 		coord := strings.TrimSpace(m[2])
 		cm := sbtPackageCoordPattern.FindStringSubmatch(coord)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/bomly-dev/bomly-sdk"
 	"go.uber.org/zap"
@@ -143,9 +144,7 @@ func (e *Engine) Analyze(ctx context.Context, req sdk.AnalyzeRequest) (sdk.Analy
 			aggregated.Registry = updated
 			req.Registry = updated
 		}
-		for analyzerName, stats := range result.AnalyzerStats {
-			aggregated.AnalyzerStats[analyzerName] = stats
-		}
+		maps.Copy(aggregated.AnalyzerStats, result.AnalyzerStats)
 	}
 	if len(errs) > 0 {
 		return aggregated, errors.Join(errs...)

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -97,10 +97,7 @@ func (p *Pipeline) applyFindingPolicy(ctx context.Context, findings []sdk.Findin
 	started := time.Now()
 	resolved := applyFindingPolicy(ctx, findings, registry, req)
 	if req.BaselineEvaluation != nil {
-		accepted := acceptedFindingCount(resolved) - beforeAccepted
-		if accepted < 0 {
-			accepted = 0
-		}
+		accepted := max(acceptedFindingCount(resolved)-beforeAccepted, 0)
 		p.Logger.Info("baseline: policy evaluation completed",
 			zap.String("path", req.BaselineEvaluation.Path),
 			zap.Int("entries", req.BaselineEvaluation.Entries),

--- a/internal/engine/pipeline_explain.go
+++ b/internal/engine/pipeline_explain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/bomly-dev/bomly-cli/internal/engine/consolidation"
 	"github.com/bomly-dev/bomly-cli/internal/engine/explain"
@@ -120,13 +121,7 @@ func appendUnique(values []string, candidates ...string) []string {
 		if candidate == "" {
 			continue
 		}
-		found := false
-		for _, value := range values {
-			if value == candidate {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(values, candidate)
 		if !found {
 			values = append(values, candidate)
 		}

--- a/internal/engine/pipeline_helpers.go
+++ b/internal/engine/pipeline_helpers.go
@@ -34,9 +34,9 @@ func parseWarningSource(text, prefix string) (source, message string) {
 		return "", text
 	}
 	rest := text[len(p):]
-	idx := strings.Index(rest, ": ")
-	if idx < 0 {
+	before, after, ok := strings.Cut(rest, ": ")
+	if !ok {
 		return "", text
 	}
-	return rest[:idx], rest[idx+2:]
+	return before, after
 }

--- a/internal/engine/pipeline_resolve.go
+++ b/internal/engine/pipeline_resolve.go
@@ -47,10 +47,8 @@ func (p *Pipeline) resolveAll(ctx context.Context, req PipelineRequest) ([]sdk.D
 	var wg sync.WaitGroup
 	var progressMu sync.Mutex
 	completed := 0
-	for i := 0; i < workerCount; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workerCount {
+		wg.Go(func() {
 			for idx := range jobs {
 				sub := req.Subprojects[idx]
 				reportProgressDetail(req.Progress, "Detecting dependencies", subprojectProgressDetail(sub))
@@ -63,7 +61,7 @@ func (p *Pipeline) resolveAll(ctx context.Context, req PipelineRequest) ([]sdk.D
 					progressMu.Unlock()
 				}
 			}
-		}()
+		})
 	}
 	for idx := range req.Subprojects {
 		select {
@@ -116,13 +114,7 @@ func resolveWorkerCount(subprojectCount int) int {
 	if subprojectCount <= 1 {
 		return 1
 	}
-	workers := runtime.NumCPU()
-	if workers < 1 {
-		workers = 1
-	}
-	if workers > 4 {
-		workers = 4
-	}
+	workers := min(max(runtime.NumCPU(), 1), 4)
 	if workers > subprojectCount {
 		return subprojectCount
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -433,7 +433,7 @@ func relativePath(root, path string) string {
 func parseChangedLineRanges(diff string) map[string][]LineRange {
 	ranges := make(map[string][]LineRange)
 	currentFile := ""
-	for _, line := range strings.Split(diff, "\n") {
+	for line := range strings.SplitSeq(diff, "\n") {
 		switch {
 		case strings.HasPrefix(line, "+++ "):
 			path := strings.TrimSpace(strings.TrimPrefix(line, "+++ "))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -21,8 +21,7 @@ func TestCloneIntoRedactsUserinfoAndPreservesExitError(t *testing.T) {
 	if err == nil {
 		t.Fatal("cloneInto() error = nil, want unsupported transport error")
 	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 		t.Fatalf("cloneInto() did not preserve exec.ExitError: %v", err)
 	}
 	if strings.Contains(err.Error(), "user") || strings.Contains(err.Error(), "clone-secret") {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -214,7 +214,7 @@ func (e *prettyConsoleEncoder) AddUintptr(key string, value uintptr) {
 	e.context.AddUintptr(key, value)
 }
 
-func (e *prettyConsoleEncoder) AddReflected(key string, value interface{}) error {
+func (e *prettyConsoleEncoder) AddReflected(key string, value any) error {
 	return e.context.AddReflected(key, value)
 }
 

--- a/internal/mcp/compact_diff_test.go
+++ b/internal/mcp/compact_diff_test.go
@@ -124,7 +124,7 @@ func TestBuildCompactDiffBucketsAndRemediation(t *testing.T) {
 
 func TestBuildCompactDiffCapsDependencyTransitions(t *testing.T) {
 	transitions := make([]output.DiffDependencyTransition, 0, maxDependencyTransitions+2)
-	for index := 0; index < maxDependencyTransitions+2; index++ {
+	for index := range maxDependencyTransitions + 2 {
 		name := fmt.Sprintf("package-%03d", index)
 		transitions = append(transitions, output.DiffDependencyTransition{
 			Before: output.DiffDependencyTransitionState{

--- a/internal/mcp/compact_limits_test.go
+++ b/internal/mcp/compact_limits_test.go
@@ -60,7 +60,7 @@ func TestCompactRemediationCapsAliasesAndFindingsWithCounters(t *testing.T) {
 		t.Fatal("fixture package missing")
 	}
 	pkg.Vulnerabilities[0].Aliases = []string{"CVE-1", "CVE-2", "CVE-3", "CVE-4", "CVE-5"}
-	for i := 0; i < maxFindingsPerGroup+6; i++ {
+	for i := range maxFindingsPerGroup + 6 {
 		id := fmt.Sprintf("GHSA-extra-%02d", i)
 		pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
 			ID:             id,

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -639,9 +640,7 @@ func TestTools_PropagateRecursiveDiscoveryArgs(t *testing.T) {
 	adapter = &mockAdapter{explainResult: mcp.ExplainRunResult{Response: output.ExplainResponse{Command: "explain"}}}
 	c = newTestClient(t, adapter)
 	explainArgs := map[string]any{"package": "lodash"}
-	for k, v := range args {
-		explainArgs[k] = v
-	}
+	maps.Copy(explainArgs, args)
 	if result := callTool(t, c, "bomly_explain", explainArgs); result.IsError {
 		t.Fatalf("unexpected explain tool error: %v", result.Content)
 	}
@@ -652,9 +651,7 @@ func TestTools_PropagateRecursiveDiscoveryArgs(t *testing.T) {
 	adapter = &mockAdapter{diffResult: mcp.DiffRunResult{Response: output.DiffResponse{Command: "diff"}}}
 	c = newTestClient(t, adapter)
 	diffArgs := map[string]any{"base": "main", "head": "HEAD"}
-	for k, v := range args {
-		diffArgs[k] = v
-	}
+	maps.Copy(diffArgs, args)
 	if result := callTool(t, c, "bomly_diff", diffArgs); result.IsError {
 		t.Fatalf("unexpected diff tool error: %v", result.Content)
 	}

--- a/internal/mcp/remediation_test.go
+++ b/internal/mcp/remediation_test.go
@@ -265,7 +265,7 @@ func TestBuildRemediationsSameFixClosesMultipleFindings(t *testing.T) {
 func TestBuildRemediationsTruncatesWithCounters(t *testing.T) {
 	in := remediationFixture(t)
 	// Add one no-fix finding per synthetic package to exceed the group cap.
-	for i := 0; i < maxRemediationGroups+10; i++ {
+	for i := range maxRemediationGroups + 10 {
 		purl := fmt.Sprintf("pkg:npm/synth-%03d@1.0.0", i)
 		in.Registry.Add(&sdk.Package{
 			Coordinates: sdk.Coordinates{PURL: purl, Name: fmt.Sprintf("synth-%03d", i), Version: "1.0.0", Ecosystem: sdk.EcosystemNPM},
@@ -314,7 +314,7 @@ func TestBuildRemediationsCountsDistinctOmissionsAcrossSuggestions(t *testing.T)
 		},
 	}
 	var findings []sdk.Finding
-	for idx := 0; idx < maxFindingsPerGroup+5; idx++ {
+	for idx := range maxFindingsPerGroup + 5 {
 		id := fmt.Sprintf("GHSA-shared-%02d", idx)
 		pkg.Vulnerabilities = append(pkg.Vulnerabilities, sdk.Vulnerability{
 			ID: id, ParsedSeverity: sdk.SeverityHigh, FixedIn: "1.1.0",
@@ -395,7 +395,7 @@ func TestBuildRemediationsCapsLeftoverPackagesDeterministically(t *testing.T) {
 			PackageRef: fmt.Sprintf("pkg:npm/leftover-%03d@1.0.0", idx),
 		}
 	}
-	for run := 0; run < 10; run++ {
+	for run := range 10 {
 		out := buildRemediations(remediationInput{
 			Findings: findings,
 			Registry: sdk.NewPackageRegistry(),
@@ -416,7 +416,7 @@ func TestBuildRemediationsCapsLeftoverPackagesDeterministically(t *testing.T) {
 func TestShortestPathBoundsLongChains(t *testing.T) {
 	g := sdk.New()
 	var previous string
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		node := testnodes.DepFrom(sdk.DependencyNode{Coordinates: sdk.Coordinates{
 			Name: fmt.Sprintf("chain-%d", i), Version: "1.0.0", Ecosystem: sdk.EcosystemNPM,
 			PURL: fmt.Sprintf("pkg:npm/chain-%d@1.0.0", i),
@@ -451,7 +451,7 @@ func TestCompactScanSizeStaysUnderBudget(t *testing.T) {
 	in := remediationFixture(t)
 	// Grow the fixture to ~15 vulnerable packages — the scale from issue
 	// #245 — and assert the serialized compact response stays a few KB.
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		purl := fmt.Sprintf("pkg:npm/extra-%02d@1.0.0", i)
 		in.Registry.Add(&sdk.Package{
 			Coordinates: sdk.Coordinates{PURL: purl, Name: fmt.Sprintf("extra-%02d", i), Version: "1.0.0", Ecosystem: sdk.EcosystemNPM},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -235,8 +235,7 @@ func jsonResult(v any) (*mcplib.CallToolResult, error) {
 
 func toolErrorResult(mcpCtx Context, tool string, err error) *mcplib.CallToolResult {
 	kind := ToolErrorKind("")
-	var categorized *toolError
-	if errors.As(err, &categorized) {
+	if categorized, ok := errors.AsType[*toolError](err); ok {
 		kind = categorized.kind
 	}
 	cause := errors.Unwrap(err)

--- a/internal/output/hierarchy.go
+++ b/internal/output/hierarchy.go
@@ -101,7 +101,7 @@ func ClassifyManifest(subprojectRel, manifestPath string) (subprojectDir, module
 // hasHiddenPathSegment reports whether any segment of a slash path starts
 // with a dot.
 func hasHiddenPathSegment(dir string) bool {
-	for _, segment := range strings.Split(dir, "/") {
+	for segment := range strings.SplitSeq(dir, "/") {
 		if strings.HasPrefix(segment, ".") && segment != "." && segment != ".." {
 			return true
 		}

--- a/internal/output/registry_lookup.go
+++ b/internal/output/registry_lookup.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/bomly-dev/bomly-sdk"
@@ -110,10 +111,8 @@ func PackageAdvisory(pkg *sdk.Package, vulnerabilityID string) *sdk.Vulnerabilit
 		if vuln.ID == vulnerabilityID {
 			return vuln
 		}
-		for _, alias := range vuln.Aliases {
-			if alias == vulnerabilityID {
-				return vuln
-			}
+		if slices.Contains(vuln.Aliases, vulnerabilityID) {
+			return vuln
 		}
 	}
 	return nil

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -615,10 +616,8 @@ func appendUniqueString(values []string, value string) []string {
 	if value == "" {
 		return values
 	}
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -326,9 +328,7 @@ func cloneRefMetadata(src map[string]any) map[string]any {
 		return nil
 	}
 	clone := make(map[string]any, len(src))
-	for key, value := range src {
-		clone[key] = value
-	}
+	maps.Copy(clone, src)
 	return clone
 }
 
@@ -521,10 +521,8 @@ func MatchVulnerabilityRef(refs []VulnerabilityRef, id string) *VulnerabilityRef
 		if refs[idx].ID == id {
 			return &refs[idx]
 		}
-		for _, alias := range refs[idx].Aliases {
-			if alias == id {
-				return &refs[idx]
-			}
+		if slices.Contains(refs[idx].Aliases, id) {
+			return &refs[idx]
 		}
 	}
 	return nil

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"maps"
 	"math"
 	"path/filepath"
 	"sort"
@@ -470,9 +471,7 @@ func metadataWithReportOptions(metadata Metadata, options ReportOptions) Metadat
 	}
 	if len(options.AnalyzerStats) > 0 {
 		metadata.AnalyzerStats = make(map[string]sdk.ReachabilityStats, len(options.AnalyzerStats))
-		for k, v := range options.AnalyzerStats {
-			metadata.AnalyzerStats[k] = v
-		}
+		maps.Copy(metadata.AnalyzerStats, options.AnalyzerStats)
 	}
 	return metadata
 }

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -530,8 +531,7 @@ func (p *Progress) findStepLocked(doneLabel string) *Step {
 			}
 		}
 	}
-	for i := len(p.active) - 1; i >= 0; i-- {
-		s := p.active[i]
+	for _, s := range slices.Backward(p.active) {
 		if s.state == stepActive || s.state == stepFinishing {
 			return s
 		}
@@ -549,9 +549,9 @@ func (p *Progress) findStepByActiveLabelLocked(label string) *Step {
 			}
 		}
 	}
-	for i := len(p.active) - 1; i >= 0; i-- {
-		if p.active[i].active == label {
-			return p.active[i]
+	for _, v := range slices.Backward(p.active) {
+		if v.active == label {
+			return v
 		}
 	}
 	return nil
@@ -565,9 +565,9 @@ func (p *Progress) Stage(text string) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for i := len(p.active) - 1; i >= 0; i-- {
-		if p.active[i].state == stepActive || p.active[i].state == stepFinishing {
-			p.active[i].detail = strings.TrimSpace(text)
+	for _, v := range slices.Backward(p.active) {
+		if v.state == stepActive || v.state == stepFinishing {
+			v.detail = strings.TrimSpace(text)
 			return
 		}
 	}
@@ -883,7 +883,7 @@ func (p *Progress) drawLocked() {
 		_, _ = fmt.Fprintf(&buf, "\x1b[%dA", prev)
 	}
 	buf.WriteString("\r")
-	for i := 0; i < prev; i++ {
+	for i := range prev {
 		buf.WriteString(eraseLineSeq)
 		if i < prev-1 {
 			buf.WriteString("\n")
@@ -1016,7 +1016,7 @@ func renderFrozenBlock(s *Step) string {
 
 	var buf bytes.Buffer
 	buf.WriteString(head)
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		buf.WriteString("   ")
 		buf.WriteString(line)
 		buf.WriteString("\n")

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -192,7 +192,7 @@ func TestConcurrentSteps_NoRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		s := p.Start("g1", "Goroutine 1")
-		for i := 0; i < 50; i++ {
+		for i := range 50 {
 			s.SetProgress(i, 50)
 		}
 		s.Complete("Goroutine 1 done", nil)
@@ -200,7 +200,7 @@ func TestConcurrentSteps_NoRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		s := p.Start("g2", "Goroutine 2")
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			s.Advance()
 		}
 		s.Complete("Goroutine 2 done", nil)

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -735,12 +737,8 @@ func (r *Registry) DiscoveryPlans() map[string]DetectorDiscoveryPlan {
 func (r *Registry) Filter(filter Filter) *Registry {
 	filtered := NewRegistry(r.configs, *r.logger)
 	filtered.httpProvider = r.httpProvider
-	for key, enabled := range r.defaultEnabled {
-		filtered.defaultEnabled[key] = enabled
-	}
-	for key, origin := range r.componentOrigins {
-		filtered.componentOrigins[key] = origin
-	}
+	maps.Copy(filtered.defaultEnabled, r.defaultEnabled)
+	maps.Copy(filtered.componentOrigins, r.componentOrigins)
 
 	allowedDetectors := make(map[string]struct{}, len(r.detectors))
 	for _, detector := range r.detectors {
@@ -809,36 +807,21 @@ func supportsEcosystem(supported []sdk.Ecosystem, ecosystem sdk.Ecosystem) bool 
 	if len(supported) == 0 {
 		return true
 	}
-	for _, candidate := range supported {
-		if candidate == ecosystem {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supported, ecosystem)
 }
 
 func supportsLanguage(supported []sdk.Language, language sdk.Language) bool {
 	if len(supported) == 0 {
 		return true
 	}
-	for _, candidate := range supported {
-		if candidate == language {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supported, language)
 }
 
 func supportsPackageManager(supported []sdk.PackageManager, manager sdk.PackageManager) bool {
 	if len(supported) == 0 {
 		return true
 	}
-	for _, candidate := range supported {
-		if candidate == manager {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supported, manager)
 }
 
 func (r *Registry) detectorSelected(filter sdk.DetectorFilter, descriptor sdk.DetectorDescriptor) bool {

--- a/internal/registry/discovery.go
+++ b/internal/registry/discovery.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bomly-dev/bomly-sdk"
@@ -203,7 +204,7 @@ func pyprojectHasTable(path string, table string) (bool, bool) {
 	if err != nil {
 		return false, false
 	}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmed, "[") || !strings.Contains(trimmed, "]") {
 			continue
@@ -260,10 +261,5 @@ func sameStringSet(left []string, right []string) bool {
 }
 
 func containsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }

--- a/internal/registry/discovery_test.go
+++ b/internal/registry/discovery_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/bomly-dev/bomly-sdk"
@@ -34,10 +35,5 @@ func TestDetectPackageManagersDoesNotGuessPDMFromUnreadablePyproject(t *testing.
 }
 
 func containsPackageManager(managers []sdk.PackageManager, target sdk.PackageManager) bool {
-	for _, manager := range managers {
-		if manager == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(managers, target)
 }

--- a/internal/registry/support.go
+++ b/internal/registry/support.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"slices"
 	"strings"
 
 	rootdetectors "github.com/bomly-dev/bomly-cli/internal/detectors"
@@ -168,11 +169,8 @@ func DetectorNamesForPackageManager(manager sdk.PackageManager) []string {
 func PackageManagersByDetector(detectorName string) ([]sdk.PackageManager, bool) {
 	values := make([]sdk.PackageManager, 0)
 	for _, manager := range SupportedPackageManagers() {
-		for _, detector := range DetectorNamesForPackageManager(manager) {
-			if detector == detectorName {
-				values = append(values, manager)
-				break
-			}
+		if slices.Contains(DetectorNamesForPackageManager(manager), detectorName) {
+			values = append(values, manager)
 		}
 	}
 	if len(values) == 0 {
@@ -346,13 +344,7 @@ func appendUniqueStrings(values []string, additions ...string) []string {
 		if value == "" {
 			continue
 		}
-		seen := false
-		for _, existing := range values {
-			if existing == value {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(values, value)
 		if !seen {
 			values = append(values, value)
 		}

--- a/internal/remediation/derive.go
+++ b/internal/remediation/derive.go
@@ -3,6 +3,7 @@ package remediation
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -602,12 +603,7 @@ func advertisedActions(
 }
 
 func containsManager(managers []sdk.PackageManager, target sdk.PackageManager) bool {
-	for _, manager := range managers {
-		if manager == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(managers, target)
 }
 
 func deriveSuggestions(

--- a/internal/remediation/derive_test.go
+++ b/internal/remediation/derive_test.go
@@ -569,7 +569,7 @@ func TestInferredPlacementCollapsesEqualLengthDiamondPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 	previous := []string{root.NodeID()}
-	for layer := 0; layer < 20; layer++ {
+	for layer := range 20 {
 		current := []string{
 			fmt.Sprintf("a-%02d", layer),
 			fmt.Sprintf("b-%02d", layer),

--- a/internal/sbom/cyclonedx_assertions.go
+++ b/internal/sbom/cyclonedx_assertions.go
@@ -329,6 +329,9 @@ func cycloneDXDocumentAssertions(bom *cdx.BOM) sdk.DocumentAssertions {
 	}
 	var assertions sdk.DocumentAssertions
 	version := bom.Version
+	// Kept as an if instead of max(bom.Version, 1) so the reason below stays
+	// attached to the default it explains; go fix will offer the rewrite
+	// again and it should be declined again.
 	if version < 1 {
 		// ADR-0037's default: a document that did not number itself is
 		// version 1, which is also the only value NewBOMLink accepts below.

--- a/internal/sbom/document_sources_test.go
+++ b/internal/sbom/document_sources_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -274,12 +275,7 @@ func TestConversionDoesNotLinkTheDocumentItRestates(t *testing.T) {
 }
 
 func containsStringValue(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, want)
 }
 
 // sha256Hex is the digest form the ingest checksum is written in.

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -443,7 +443,7 @@ func parseSPDXCommentField(comment, field string) string {
 	if !strings.HasPrefix(comment, "bomly:") {
 		return ""
 	}
-	for _, part := range strings.Split(strings.TrimPrefix(comment, "bomly:"), ";") {
+	for part := range strings.SplitSeq(strings.TrimPrefix(comment, "bomly:"), ";") {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
 			continue

--- a/internal/support/component_docs.go
+++ b/internal/support/component_docs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -819,12 +820,7 @@ func remediationActionsForDetectorChain(detectorNames []string, manager sdk.Pack
 }
 
 func containsPackageManager(managers []sdk.PackageManager, target sdk.PackageManager) bool {
-	for _, manager := range managers {
-		if manager == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(managers, target)
 }
 
 func writeMatcherDocs(outputDir string) error {
@@ -1070,12 +1066,7 @@ func matcherBehavior(name string) matcherDocBehavior {
 }
 
 func chainSupportsInstallFirst(detectors []string) bool {
-	for _, detectorName := range detectors {
-		if detectorSupportsInstallFirst(detectorName) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(detectors, detectorSupportsInstallFirst)
 }
 
 func detectorSupportsInstallFirst(detectorName string) bool {

--- a/internal/support/config_reference.go
+++ b/internal/support/config_reference.go
@@ -217,12 +217,11 @@ func writeNestedConfigExample(builder *strings.Builder, fields []configField) {
 	for _, field := range fields {
 		fieldsByPath[field.YAMLKey] = field
 	}
-	writeNestedConfigType(builder, reflect.TypeOf(config.File{}), "", 0, fieldsByPath)
+	writeNestedConfigType(builder, reflect.TypeFor[config.File](), "", 0, fieldsByPath)
 }
 
 func writeNestedConfigType(builder *strings.Builder, t reflect.Type, prefix string, depth int, fields map[string]configField) {
-	for idx := 0; idx < t.NumField(); idx++ {
-		structField := t.Field(idx)
+	for structField := range t.Fields() {
 		key := yamlTagName(structField.Tag.Get("yaml"))
 		if key == "" || key == "-" {
 			continue

--- a/internal/support/generate_test.go
+++ b/internal/support/generate_test.go
@@ -44,7 +44,7 @@ func TestGenerateJSONSchemaUsesSharedCommandModels(t *testing.T) {
 	if _, ok := properties["metadata"]; !ok {
 		t.Fatalf("expected scan schema to expose metadata property: %#v", properties)
 	}
-	if commandOutputSpecs()[0].typ != reflect.TypeOf(output.ScanResponse{}) {
+	if commandOutputSpecs()[0].typ != reflect.TypeFor[output.ScanResponse]() {
 		t.Fatal("expected command schema list to use canonical output types")
 	}
 }

--- a/internal/support/schema.go
+++ b/internal/support/schema.go
@@ -3,6 +3,7 @@ package support
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -77,8 +78,7 @@ func structSchema(t reflect.Type, visited map[reflect.Type]bool) map[string]any 
 	properties := map[string]any{}
 	var required []string
 
-	for idx := 0; idx < t.NumField(); idx++ {
-		field := t.Field(idx)
+	for field := range t.Fields() {
 		if !field.IsExported() {
 			continue
 		}
@@ -93,9 +93,7 @@ func structSchema(t reflect.Type, visited map[reflect.Type]bool) map[string]any 
 			if field.Anonymous {
 				child := typeSchema(field.Type, visited)
 				if childProperties, ok := child["properties"].(map[string]any); ok {
-					for key, value := range childProperties {
-						properties[key] = value
-					}
+					maps.Copy(properties, childProperties)
 				}
 				if childRequired, ok := child["required"].([]string); ok {
 					required = append(required, childRequired...)

--- a/internal/support/schema_docs.go
+++ b/internal/support/schema_docs.go
@@ -87,8 +87,7 @@ func writeTypeTable(builder *strings.Builder, t reflect.Type) {
 func flatFields(t reflect.Type) []reflect.StructField {
 	t = derefType(t)
 	fields := make([]reflect.StructField, 0, t.NumField())
-	for idx := 0; idx < t.NumField(); idx++ {
-		field := t.Field(idx)
+	for field := range t.Fields() {
 		if !field.IsExported() {
 			continue
 		}
@@ -140,8 +139,7 @@ func collectStructTypes(t reflect.Type, visited map[reflect.Type]bool) {
 		return
 	}
 	visited[t] = true
-	for idx := 0; idx < t.NumField(); idx++ {
-		field := t.Field(idx)
+	for field := range t.Fields() {
 		if !field.IsExported() {
 			continue
 		}

--- a/internal/support/schema_outputs.go
+++ b/internal/support/schema_outputs.go
@@ -13,8 +13,8 @@ type commandOutputSpec struct {
 
 func commandOutputSpecs() []commandOutputSpec {
 	return []commandOutputSpec{
-		{name: "scan", typ: reflect.TypeOf(output.ScanResponse{})},
-		{name: "diff", typ: reflect.TypeOf(output.DiffResponse{})},
-		{name: "explain", typ: reflect.TypeOf(output.ExplainResponse{})},
+		{name: "scan", typ: reflect.TypeFor[output.ScanResponse]()},
+		{name: "diff", typ: reflect.TypeFor[output.DiffResponse]()},
+		{name: "explain", typ: reflect.TypeFor[output.ExplainResponse]()},
 	}
 }

--- a/internal/support/support_matrix.go
+++ b/internal/support/support_matrix.go
@@ -3,6 +3,7 @@ package support
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -139,10 +140,8 @@ func appendUnique(values []string, value string) []string {
 	if value == "" {
 		return values
 	}
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/tools/benchmarkrun/main.go
+++ b/internal/tools/benchmarkrun/main.go
@@ -224,8 +224,7 @@ func executeSample(outputDir, mode string, index int, cacheDir, executable strin
 	exitCode := 0
 	if err != nil {
 		exitCode = -1
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 		}
 	}

--- a/internal/tools/publicevidence/main.go
+++ b/internal/tools/publicevidence/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -204,10 +205,8 @@ func validateCase(root string, current evidenceCase) error {
 		if len(command) == 0 {
 			return fmt.Errorf("reproduction command %d is empty", index+1)
 		}
-		for _, argument := range command {
-			if argument == "" {
-				return fmt.Errorf("reproduction command %d contains an empty argument", index+1)
-			}
+		if slices.Contains(command, "") {
+			return fmt.Errorf("reproduction command %d contains an empty argument", index+1)
 		}
 	}
 	if len(current.Evidence) == 0 {

--- a/internal/tools/sbomassurance/main.go
+++ b/internal/tools/sbomassurance/main.go
@@ -268,8 +268,7 @@ func execute(ctx context.Context, executable string, args ...string) (commandRes
 	exitCode := 0
 	if err != nil {
 		exitCode = -1
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 		}
 	}

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -1054,7 +1055,7 @@ func (m *DiffModel) overviewDashboardView(width, height int) string {
 			render.Style(fmt.Sprintf("%d package", stats.findingsByKind["package"]), render.Cyan),
 		), cardWidth, cardHeight, render.Magenta),
 	}
-	for idx := 0; idx < cardHeight; idx++ {
+	for idx := range cardHeight {
 		row := cards[0][idx]
 		for c := 1; c < len(cards); c++ {
 			row += " " + cards[c][idx]
@@ -1071,10 +1072,7 @@ func (m *DiffModel) overviewDashboardView(width, height int) string {
 		leftA = 6
 	}
 	leftB := (remaining - leftA - 2) / 2
-	leftC := remaining - leftA - leftB - 2
-	if leftC < 4 {
-		leftC = 4
-	}
+	leftC := max(remaining-leftA-leftB-2, 4)
 	leftContent := stackBoxes(
 		boxView("Changes per Ecosystem", coloredDistributionLines(stats.ecosystems, stats.changedTotal, 8, leftWidth-2), leftWidth, leftA, render.Cyan),
 		boxView("Changes per Relationship", coloredDistributionLines(stats.relationships, sumCounts(stats.relationships), 6, leftWidth-2), leftWidth, leftB, render.Cyan),
@@ -1085,10 +1083,7 @@ func (m *DiffModel) overviewDashboardView(width, height int) string {
 		rightA = 6
 	}
 	rightB := (remaining - rightA - 2) / 2
-	rightC := remaining - rightA - rightB - 2
-	if rightC < 4 {
-		rightC = 4
-	}
+	rightC := max(remaining-rightA-rightB-2, 4)
 	rightContent := stackBoxes(
 		boxView("Vulnerability Findings", findingsTableLines("Severity", severityRowKeys(), stats.vulnByStatus, severityRowColor, rightWidth-2), rightWidth, rightA, render.Red),
 		boxView("License Findings", findingsTableLines("Rule", licenseRuleRowKeys(), stats.licenseByStatus, ruleRowColor, rightWidth-2), rightWidth, rightB, render.Yellow),
@@ -1332,11 +1327,8 @@ func (m *DiffModel) overviewTopChangedManifests() []string {
 	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i].count > rows[j].count })
 	lines := []string{render.Style("Top Changed Manifests", render.Bold, render.Cyan), ""}
-	limit := 10
-	if len(rows) < limit {
-		limit = len(rows)
-	}
-	for i := 0; i < limit; i++ {
+	limit := min(len(rows), 10)
+	for i := range limit {
 		if rows[i].count == 0 {
 			continue
 		}
@@ -1907,12 +1899,7 @@ func renderDependencyDetailTransition(transition output.DiffDependencyTransition
 }
 
 func dependencyDetailFieldChangedForTUI(transition output.DiffDependencyTransition, wanted sdk.DependencyDetailField) bool {
-	for _, field := range transition.ChangedFields {
-		if field == wanted {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(transition.ChangedFields, wanted)
 }
 
 func tuiRegistryEligibilityLabel(eligible bool) string {
@@ -2789,8 +2776,8 @@ func auditGroupDetails(key, group string, deltas []auditDelta, noun string) []st
 // pluralize is a *very* dumb pluralizer that's fine for our nouns
 // ("vulnerability" → "vulnerabilities", "finding" → "findings").
 func pluralize(noun string) string {
-	if strings.HasSuffix(noun, "y") {
-		return strings.TrimSuffix(noun, "y") + "ies"
+	if before, ok := strings.CutSuffix(noun, "y"); ok {
+		return before + "ies"
 	}
 	if strings.HasSuffix(noun, "s") {
 		return noun
@@ -3153,7 +3140,7 @@ func (m *DiffModel) renderSourceBody(width, height int, focused diffSourceSide, 
 	rightBox := boxView(rightTitle, rightLines, rightWidth, height, rightColor)
 
 	out := make([]string, 0, height)
-	for i := 0; i < height; i++ {
+	for i := range height {
 		l := ""
 		r := ""
 		if i < len(leftBox) {

--- a/internal/tui/diff_aggregations_test.go
+++ b/internal/tui/diff_aggregations_test.go
@@ -1258,7 +1258,7 @@ func TestFindingsOutcomePanels_BucketsCoverAllKinds(t *testing.T) {
 // shows vulnerability + license + package counts.
 func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
 	var intro []output.AuditFinding
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		intro = append(intro, output.AuditFinding{
 			ID:       "CVE-X-" + string(rune('A'+i)),
 			Kind:     sdk.FindingKindVulnerability,
@@ -1268,7 +1268,7 @@ func TestFindingsOutcomePanels_SpansAllKinds(t *testing.T) {
 		})
 	}
 	var persisted []output.AuditFinding
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		persisted = append(persisted, output.AuditFinding{
 			ID:       "license:unknown-license:pkg-" + string(rune('A'+i)),
 			Kind:     sdk.FindingKindLicense,

--- a/internal/tui/posture.go
+++ b/internal/tui/posture.go
@@ -281,13 +281,7 @@ func postureTopFailingLines(rows []postureRow, width int) []string {
 	if width < 32 {
 		width = 32
 	}
-	baseLabelWidth := width / 2
-	if baseLabelWidth < 18 {
-		baseLabelWidth = 18
-	}
-	if baseLabelWidth > 32 {
-		baseLabelWidth = 32
-	}
+	baseLabelWidth := min(max(width/2, 18), 32)
 	out := make([]string, 0, len(checks))
 	maxFail := 0
 	for _, c := range checks {
@@ -304,10 +298,7 @@ func postureTopFailingLines(rows []postureRow, width int) []string {
 			labelWidth = width - barWidth - 1 - len(suffix) - 2
 			if labelWidth < 8 {
 				labelWidth = 8
-				barWidth = width - labelWidth - 1 - len(suffix) - 2
-				if barWidth < 1 {
-					barWidth = 1
-				}
+				barWidth = max(width-labelWidth-1-len(suffix)-2, 1)
 			}
 		}
 		label := padRight(truncateToWidth(c.Name, labelWidth), labelWidth)

--- a/internal/tui/posture_diff.go
+++ b/internal/tui/posture_diff.go
@@ -254,17 +254,8 @@ func postureDiffMoversLines(rows []postureDiffRow, width int) []string {
 	if len(movers) > 6 {
 		movers = movers[:6]
 	}
-	labelWidth := width / 2
-	if labelWidth < 18 {
-		labelWidth = 18
-	}
-	if labelWidth > 38 {
-		labelWidth = 38
-	}
-	barWidth := width - labelWidth - 12
-	if barWidth < 8 {
-		barWidth = 8
-	}
+	labelWidth := min(max(width/2, 18), 38)
+	barWidth := max(width-labelWidth-12, 8)
 	maxMag := 0.0
 	for _, m := range movers {
 		mag := m.delta

--- a/internal/tui/posture_test.go
+++ b/internal/tui/posture_test.go
@@ -158,7 +158,7 @@ func TestTopAffectedLines_FitBoxBudget(t *testing.T) {
 		Version: "6.0.0"}, Scopes: sdk.ScopesOf(sdk.ScopeRuntime),
 	})
 	rows := make([]packageVulnerabilityRow, 0, 12)
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		rows = append(rows, packageVulnerabilityRow{
 			pkg:           pkg,
 			vulnerability: sdk.Vulnerability{ID: "CVE-2026-" + string(rune('A'+i))},
@@ -229,7 +229,7 @@ func TestPostureRowsFromGraph_DedupesAndSortsWorstFirst(t *testing.T) {
 
 func TestPostureTopFailingLines_FitBoxBudget(t *testing.T) {
 	rows := make([]postureRow, 0, 196)
-	for i := 0; i < 196; i++ {
+	for range 196 {
 		rows = append(rows, postureRow{
 			repository: "github.com/example/repo",
 			card: newTestScorecardTUI("github.com/example/repo", 4.8,

--- a/internal/tui/scan.go
+++ b/internal/tui/scan.go
@@ -1355,7 +1355,7 @@ func (m *ScanModel) overviewDashboardView(width, height int) string {
 			render.Style("Manifests: ", render.Dim) + fmt.Sprintf("%d", len(m.manifests)),
 		}, targetWidth, cardHeight, render.Green),
 	}
-	for idx := 0; idx < cardHeight; idx++ {
+	for idx := range cardHeight {
 		lines = append(lines, cards[0][idx]+" "+cards[1][idx]+" "+cards[2][idx]+" "+cards[3][idx])
 	}
 	lines = append(lines, "")
@@ -1369,10 +1369,7 @@ func (m *ScanModel) overviewDashboardView(width, height int) string {
 		leftA = 7
 	}
 	leftB := (remaining - leftA - 2) / 2
-	leftC := remaining - leftA - leftB - 2
-	if leftC < 4 {
-		leftC = 4
-	}
+	leftC := max(remaining-leftA-leftB-2, 4)
 	leftContent := stackBoxes(
 		boxView("Ecosystem Distribution", coloredDistributionLines(stats.ecosystems, stats.components, 8, leftWidth-2), leftWidth, leftA, render.Cyan),
 		boxView("Relationship Distribution", componentsByRelationshipLines(m.manifests, m.graphValue, leftWidth-2), leftWidth, leftB, render.Cyan),
@@ -1383,10 +1380,7 @@ func (m *ScanModel) overviewDashboardView(width, height int) string {
 		rightA = 6
 	}
 	rightB := (remaining - rightA - 2) / 2
-	rightC := remaining - rightA - rightB - 2
-	if rightC < 4 {
-		rightC = 4
-	}
+	rightC := max(remaining-rightA-rightB-2, 4)
 	rightContent := stackBoxes(
 		boxView("License Distribution", coloredDistributionLines(groupedLicenseCounts(m.graphValue, m.registry, 10), stats.components, 10, rightWidth-2), rightWidth, rightA, render.Yellow),
 		boxView("Vulnerability Severity", severityDistributionLines(vulnerabilities, rightWidth-2, m.reachabilityEnabled), rightWidth, rightB, render.Red),
@@ -1613,13 +1607,7 @@ func topAffectedLines(vulnerabilities []packageVulnerabilityRow, limit, width in
 		if width < 32 {
 			width = 32
 		}
-		labelWidth := width / 3
-		if labelWidth < 18 {
-			labelWidth = 18
-		}
-		if labelWidth > 34 {
-			labelWidth = 34
-		}
+		labelWidth := min(max(width/3, 18), 34)
 		suffix := fmt.Sprintf(" %d", counts[key])
 		barWidth := width - labelWidth - 1 - len(suffix) - 2
 		if barWidth < 10 {
@@ -1627,10 +1615,7 @@ func topAffectedLines(vulnerabilities []packageVulnerabilityRow, limit, width in
 			labelWidth = width - barWidth - 1 - len(suffix) - 2
 			if labelWidth < 8 {
 				labelWidth = 8
-				barWidth = width - labelWidth - 1 - len(suffix) - 2
-				if barWidth < 1 {
-					barWidth = 1
-				}
+				barWidth = max(width-labelWidth-1-len(suffix)-2, 1)
 			}
 		}
 		lines = append(lines, padRight(truncateToWidth(key, labelWidth), labelWidth)+render.Style(" ", render.Dim)+coloredBarLine(counts[key], maxVal, barWidth, paletteColor(idx))+suffix)
@@ -1894,10 +1879,7 @@ func licenseTableRow(row licenseRow, totalComponents int, width int) string {
 	if totalComponents > 0 {
 		percent = len(row.packages) * 100 / totalComponents
 	}
-	nameWidth := width - 28
-	if nameWidth < 18 {
-		nameWidth = 18
-	}
+	nameWidth := max(width-28, 18)
 	return padRight(truncateToWidth(row.license, nameWidth), nameWidth) +
 		padRight(fmt.Sprintf("%d", len(row.packages)), 7) +
 		coloredBarLine(len(row.packages), totalComponents, 12, render.Yellow) +
@@ -1938,13 +1920,7 @@ func (m *ScanModel) buildPostureListModel() *listModel {
 				maxRepo = len(row.repository)
 			}
 		}
-		repoWidth = maxRepo
-		if repoWidth > 32 {
-			repoWidth = 32
-		}
-		if repoWidth < 24 {
-			repoWidth = 24
-		}
+		repoWidth = max(min(maxRepo, 32), 24)
 	}
 
 	group := valueOrDefault(m.postureGroup, "check")
@@ -1952,10 +1928,7 @@ func (m *ScanModel) buildPostureListModel() *listModel {
 	var listTitle, listHeader string
 	switch group {
 	case "check":
-		checkRepoWidth := repoWidth
-		if checkRepoWidth > 24 {
-			checkRepoWidth = 24
-		}
+		checkRepoWidth := min(repoWidth, 24)
 		items, listTitle, listHeader = m.postureItemsByCheck(rows, checkRepoWidth)
 	default:
 		items = m.postureItemsByRepository(rows, repoWidth)
@@ -3243,13 +3216,7 @@ func distributionLine(label string, value, total, maxVal int, color string, widt
 	//   padRight(text, textWidth+2) + bar(barWidth)   ==>   total = width - 2
 	//
 	// Anything longer gets clipped by boxView and we lose the bar tail.
-	textWidth := width / 2
-	if textWidth < 22 {
-		textWidth = 22
-	}
-	if textWidth > 40 {
-		textWidth = 40
-	}
+	textWidth := min(max(width/2, 22), 40)
 	// Bar takes whatever's left after the label column. We prefer at
 	// least 8 cols of bar, but never at the cost of overflowing the
 	// `width-2` box budget — when the pane is genuinely narrow, the
@@ -3260,10 +3227,7 @@ func distributionLine(label string, value, total, maxVal int, color string, widt
 		textWidth = width - barWidth - 4
 		if textWidth < 8 {
 			textWidth = 8
-			barWidth = width - textWidth - 4
-			if barWidth < 1 {
-				barWidth = 1
-			}
+			barWidth = max(width-textWidth-4, 1)
 		}
 	}
 	return padRight(truncateToWidth(text, textWidth), textWidth+2) + coloredBarLine(value, maxVal, barWidth, color)
@@ -3361,10 +3325,7 @@ func groupedLicenseCounts(graphValue *sdk.Graph, registry *sdk.PackageRegistry, 
 		return counts
 	}
 	grouped := make(map[string]int, limit)
-	keep := limit - 1
-	if keep < 1 {
-		keep = 1
-	}
+	keep := max(limit-1, 1)
 	for idx, key := range keys {
 		if idx < keep {
 			grouped[key] = counts[key]
@@ -3472,10 +3433,7 @@ func componentsByRelationshipLines(manifests []listPackageRow, graphValue *sdk.G
 	if len(manifests) == 0 {
 		return []string{render.Style("(none)", render.Dim)}
 	}
-	nameWidth := width - 36
-	if nameWidth < 16 {
-		nameWidth = 16
-	}
+	nameWidth := max(width-36, 16)
 	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Direct", 8)+padRight("Transitive", 12)+"Root", render.Dim)}
 	displayed, remaining := displayManifestsWithRemainder(manifests, 10)
 	for _, manifest := range displayed {
@@ -3502,10 +3460,7 @@ func componentsByScopeLines(manifests []listPackageRow, graphValue *sdk.Graph, w
 	if len(manifests) == 0 {
 		return []string{render.Style("(none)", render.Dim)}
 	}
-	nameWidth := width - 42
-	if nameWidth < 16 {
-		nameWidth = 16
-	}
+	nameWidth := max(width-42, 16)
 	lines := []string{render.Style(padRight("Manifest", nameWidth)+padRight("Runtime", 9)+padRight("Development", 13)+"Unset", render.Dim)}
 	displayed, remaining := displayManifestsWithRemainder(manifests, 10)
 	for _, manifest := range displayed {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -731,10 +731,7 @@ func (m *listModel) View(width, height int) string {
 	}
 
 	selectedIndex := visible[m.selectedVisibleIndex(visible)]
-	contentHeight := bodyHeight - 2
-	if contentHeight < 1 {
-		contentHeight = 1
-	}
+	contentHeight := max(bodyHeight-2, 1)
 	listContentHeight := contentHeight
 	if strings.TrimSpace(m.listHeader) != "" {
 		listContentHeight--
@@ -824,7 +821,7 @@ func renderListPanels(panels []listPanel, width int) []string {
 		rendered = append(rendered, boxView(panel.title, lines, panelWidth, panelHeight, color))
 	}
 	out := make([]string, 0, panelHeight)
-	for row := 0; row < panelHeight; row++ {
+	for row := range panelHeight {
 		parts := make([]string, 0, len(rendered))
 		for idx := range rendered {
 			parts = append(parts, rendered[idx][row])
@@ -911,10 +908,7 @@ func (m *listModel) visibleListLines(width, height int, visible []int) []string 
 	}
 
 	out := make([]string, 0, height)
-	end := m.scrollOffset + height
-	if end > len(visible) {
-		end = len(visible)
-	}
+	end := min(m.scrollOffset+height, len(visible))
 	for visibleIdx := m.scrollOffset; visibleIdx < end; visibleIdx++ {
 		idx := visible[visibleIdx]
 		item := m.items[idx]
@@ -957,10 +951,7 @@ func (m *listModel) visibleDetailLines(lines []string, width, height int) []stri
 		return nil
 	}
 	wrapped := wrapLines(lines, width)
-	maxOffset := len(wrapped) - height
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
+	maxOffset := max(len(wrapped)-height, 0)
 	if m.detailOffset > maxOffset {
 		m.detailOffset = maxOffset
 	}
@@ -968,10 +959,7 @@ func (m *listModel) visibleDetailLines(lines []string, width, height int) []stri
 		m.detailOffset = 0
 	}
 	start := m.detailOffset
-	end := start + height
-	if end > len(wrapped) {
-		end = len(wrapped)
-	}
+	end := min(start+height, len(wrapped))
 	out := make([]string, 0, height)
 	if start < end {
 		out = append(out, wrapped[start:end]...)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1201,7 +1201,7 @@ func assertInteractiveListTitles(t *testing.T, model *ScanModel, contains, exclu
 }
 
 func expandTreeLayers(model treeControlModel, layers int) {
-	for i := 0; i < layers; i++ {
+	for range layers {
 		model.ExpandAll()
 	}
 }

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -61,10 +61,7 @@ func boxView(title string, content []string, width, height int, color string) []
 			topLabel = truncateToWidth(topLabel, inner)
 		}
 	}
-	topFill := inner - len(render.StripANSI(topLabel))
-	if topFill < 0 {
-		topFill = 0
-	}
+	topFill := max(inner-len(render.StripANSI(topLabel)), 0)
 	border := func(value string) string {
 		if color == "" {
 			return render.Style(value, render.Dim, render.Gray)
@@ -81,7 +78,7 @@ func boxView(title string, content []string, width, height int, color string) []
 	}
 	leftPad := strings.Repeat(" ", horizontalPadding)
 	rightPad := strings.Repeat(" ", horizontalPadding)
-	for idx := 0; idx < contentHeight; idx++ {
+	for idx := range contentHeight {
 		line := ""
 		if idx < len(content) {
 			line = content[idx]
@@ -117,12 +114,9 @@ func centerLine(value string, width int) string {
 }
 
 func joinColumns(left, right []string, leftWidth, rightWidth int) []string {
-	height := len(left)
-	if len(right) > height {
-		height = len(right)
-	}
+	height := max(len(right), len(left))
 	out := make([]string, 0, height)
-	for idx := 0; idx < height; idx++ {
+	for idx := range height {
 		l := ""
 		if idx < len(left) {
 			l = left[idx]

--- a/test/assurance/execution_boundaries_test.go
+++ b/test/assurance/execution_boundaries_test.go
@@ -69,7 +69,6 @@ func TestRemediationPackageDependencyBoundaries(t *testing.T) {
 	}
 	t.Run("detector hint packages", func(t *testing.T) {
 		for _, target := range detectorHintPackages {
-			target := target
 			t.Run(target.name, func(t *testing.T) {
 				packages := goListDependencies(t, root, target.path)
 				importPath := module + strings.TrimPrefix(target.path, "./")


### PR DESCRIPTION
Phase 3 of the SDK maturity plan (`dev-docs/SDK_MATURITY_PLAN.md`) asks for a modernizer pass per repo, reviewed as its own PR. This is that pass for `bomly-cli`.

## Tool

`go fix` from the **Go 1.27.0** toolchain — i.e. `cmd/fix`, which since Go 1.26 carries the modernizer analyzers that previously lived in `golang.org/x/tools/gopls/internal/analysis/modernize`. There is no separate `modernize` binary to fetch on this toolchain; `go tool fix help` lists the 27 registered analyzers, and `go fix -diff` prints the patch without applying it.

Every category was reviewed in `-diff` mode first, per analyzer, before anything was applied. The final command was:

```
go fix -embedlit=false -omitzero=false -stringsbuilder=false ./...
```

## What changed

88 files, no behavior changes. Sites rewritten per analyzer:

| analyzer | sites | what it does |
|---|---|---|
| `slicescontains` | 63 | membership loop → `slices.Contains` / `slices.ContainsFunc` |
| `minmax` | 29 | if/else clamp → `min()` / `max()` |
| `rangeint` | 28 | 3-clause counting loop → `for range n` |
| `stringsseq` | 28 | `range strings.Split(...)` → `strings.SplitSeq` |
| `mapsloop` | 22 | copy loop → `maps.Copy` |
| `stringscutprefix` | 8 | `HasPrefix`+`TrimPrefix` → `CutPrefix` / `CutSuffix` |
| `stditerators` | 7 | `reflect` `NumField`/`Field(i)` → `Type.Fields()` |
| `stringscut` | 7 | `Index` + slicing → `strings.Cut` |
| `reflecttypefor` | 6 | `reflect.TypeOf(T{})` → `reflect.TypeFor[T]()` |
| `errorsastype` | 4 | `errors.As` → `errors.AsType[T]` |
| `slicesbackward` | 4 | reverse index loop → `slices.Backward` |
| `waitgroupgo` | 3 | `Add(1)`/`go`/`Done()` → `wg.Go` |
| `forvar` | 2 | drop redundant loop-variable re-declaration |
| `any` | 1 | `interface{}` → `any` |

`stringsseq` is the one with a real runtime effect: it drops the intermediate slice allocation in the lockfile and build-tool output parsers, which run per line over untrusted input.

## What was rejected

The three disabled analyzers, plus two individual hunks. Each declined hunk that `go fix` will offer again now carries a short comment at the call site saying so, so the next pass does not re-litigate it from scrollback.

- **`embedlit` (119 sites)** — flattens `Coordinates: sdk.Coordinates{...}` into the surrounding literal at all 119 sites. `Coordinates` is a named identity concept (`dev-docs/MODELS.md`, ADR-0041); writing it explicitly is documentation, not redundancy. The rewrite also reflows multi-line literals badly (dangling `})` and lost key alignment), and it would churn 49 files — 4 of them under `internal/detectors/node/` — for no behavior or performance gain.
- **`omitzero` (2 sites)** — drops `omitempty` from struct-valued JSON fields in `internal/output/view.go` and `internal/benchmark/summary.go`. The tool's own preferred fix (`omitempty` → `omitzero`) is a behavior change it declines to make; the fallback it does offer has no upside and moves a published output contract that `docs/schemas/*` and the goldens key on.
- **`stringsbuilder` (2 sites)** — rewrites small bounded TUI concatenations into `strings.Builder` while still concatenating inside `WriteString(" " + x)`. Readability loss, no allocation win.
- **`maps.Copy` in `mergeBunDependencyMaps`** (`internal/detectors/node/bun/bun_lockfile_parser.go`) — the variadic parameter is named `maps`, so the fix imports the stdlib package as `maps0`. The explicit loop reads better than the alias.
- **`max()` in `cycloneDXDocumentAssertions`** (`internal/sbom/cyclonedx_assertions.go`) — the rewrite hoists the ADR-0037 comment that explains the default into the middle of the `max(...)` call arguments.

## Golden-backed areas

`internal/sbom` and `internal/output` were reviewed hunk by hunk. What landed there is `slices.Contains`, `maps.Copy`, and `strings.SplitSeq` in lookup/clone helpers — nothing that touches field ordering, tags, or emitted values. Confirmed by the suite and by `make generate` producing no drift.

## Verification

`make verify` passes end to end: `fmt-check`, `golangci-lint` (0 issues), `go vet` on the default and lite build tags, `go vet -tags smoke`, both builds, `go test ./...`, and `make generate` with a clean `git diff -- docs/`.

## Note for reviewers: overlap with the in-flight `internal/detectors` work

19 files under `internal/detectors/` are touched here, in case a concurrent branch is routing purl-type literals through the SDK:

```
cargo/detector.go                 cargo/workspace.go
cocoapods/detector.go             conan/detector.go
gomod/detector.go                 gradle/detector.go
guards_test.go                    maven/detector.go
node/bun/bun_lockfile_parser.go   node/bun/bun_native_parser.go
node/lockfile_common.go           node/package_manager_warnings.go
node/pnpm/pnpm_lockfile_parser.go node/yarn/yarn_lockfile_parser.go
nuget/detector.go                 python/common.go
python/piplock_test.go            ruby/detector.go
sbt/sbt_native.go
```

All of it is line-local (`slices.Contains`, `strings.Cut`/`CutPrefix`, `SplitSeq`, `maps.Copy`, `max()`) inside parser and helper functions. Rejecting `embedlit` kept the `sdk.Coordinates` literals — the construct that branch is most likely editing — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modernized internal processing, iteration, string handling, collection checks, map copying, reflection, and layout calculations using current Go standard-library features.
  - Parsing, validation, dependency analysis, reporting, and terminal interface behavior remain unchanged.
  - Some line-processing paths avoid unnecessary intermediate allocations.

- **Tests**
  - Updated test utilities and loops to use modern Go syntax and standard-library helpers.
  - Existing assertions and coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->