### PR TITLE
test(smoke): goldens stop carrying the host architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,7 @@ Smoke tests (`test/smoke/`, `make smoke`) drive the built binary end-to-end agai
 
 - Scan cases come from `test/smoke/testdata/scan_targets.json`; keep it in sync with `internal/benchmark/testdata/scan_targets.json` (the benchmark target list) when cases change.
 - Pin every scan case's detectors with `--detectors`; normalize volatile fields in `helpers_test.go::normalizeJSON` before goldens.
+- A golden must never carry a host architecture. `make smoke ARGS="-update"` on an arm64 laptop writes a golden CI cannot match, so `normalizeJSON` erases the architecture and `TestGoldensCarryNoHostArchitecture` (untagged, runs in `make test`) fails if one reaches a committed golden. A new architecture-bearing shape means teaching the normalizer, not excepting the guard.
 - Register new tests in both slice matrices (`smoke.yml` and exactly one slice in `update-smoke-goldens.yml`); `go test -run` elements are unanchored regexes — use `$` anchors to keep slice ownership exact.
 - `TestExamplePluginFixtureCompiles` runs in `make test` and must keep compiling against the pinned `bomly-dev/bomly-sdk` release; update the fixture source when the SDK contract changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,7 @@ Smoke tests (`test/smoke/`, `make smoke`) drive the built binary end-to-end agai
 
 - Scan cases come from `test/smoke/testdata/scan_targets.json`; keep it in sync with `internal/benchmark/testdata/scan_targets.json` (the benchmark target list) when cases change.
 - Pin every scan case's detectors with `--detectors`; normalize volatile fields in `helpers_test.go::normalizeJSON` before goldens.
+- A golden must never carry a host architecture. `make smoke ARGS="-update"` on an arm64 laptop writes a golden CI cannot match, so `normalizeJSON` erases the architecture and `TestGoldensCarryNoHostArchitecture` (untagged, runs in `make test`) fails if one reaches a committed golden. A new architecture-bearing shape means teaching the normalizer, not excepting the guard.
 - Register new tests in both slice matrices (`smoke.yml` and exactly one slice in `update-smoke-goldens.yml`); `go test -run` elements are unanchored regexes — use `$` anchors to keep slice ownership exact.
 - `TestExamplePluginFixtureCompiles` runs in `make test` and must keep compiling against the pinned `bomly-dev/bomly-sdk` release; update the fixture source when the SDK contract changes.
 

--- a/test/smoke/golden_arch_test.go
+++ b/test/smoke/golden_arch_test.go
@@ -1,0 +1,227 @@
+// This file intentionally has no build tag. The architecture a golden was
+// generated on is a property of the committed file, not of a scan, so the
+// guard below runs in `go test ./...` (make test) rather than only in the
+// slow, network-driven `smoke` suite. Catching a host architecture at
+// `make test` time is the whole point: the failure this guards against was
+// written locally, reviewed green, and only discovered on CI.
+//
+// The architecture vocabulary lives here too, so the normalizer that erases
+// these tokens (helpers_test.go, `smoke`-tagged) and the guard that forbids
+// them cannot drift apart -- adding a spelling to hostArchTokens extends
+// both at once.
+
+package smoke
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// hostArchTokens are the machine-architecture spellings that a scan can pick
+// up from whatever machine it ran on, rather than from anything Bomly
+// decided. The same machine has several names depending on who is asking:
+// dpkg says amd64/arm64/ppc64el, Alpine and RPM say x86_64/aarch64, OCI and
+// Go say amd64/arm64/ppc64le.
+//
+// Delegation check (CLAUDE.md): github.com/containerd/platforms is pinned
+// (indirect) and does own the OCI platform vocabulary, including the
+// x86_64 -> amd64 and aarch64 -> arm64 aliases. It is deliberately NOT used
+// here, for three reasons:
+//
+//  1. Its vocabulary is OCI's, not dpkg's. Debian spells 64-bit
+//     little-endian PowerPC "ppc64el"; OCI spells it "ppc64le". Delegating
+//     would silently stop recognising the Debian spelling -- which is the
+//     exact spelling this guard exists to catch, since the goldens that
+//     carry an architecture are Debian container scans.
+//  2. Membership in a library's list is an open set. This list is
+//     deliberately closed: an architecture Bomly got *wrong* -- one that is
+//     not any real machine -- must stay visible in a golden diff rather than
+//     being normalized away.
+//  3. Promoting an indirect dependency to a direct one is a dependency
+//     addition, which this repo requires discussion for.
+//
+// So the set is hand-listed, and the guard test below is what keeps the
+// hand-listing honest: a spelling missing from here fails review the moment
+// it reaches a golden, instead of years later and silently.
+var hostArchTokens = []string{
+	"mips64le",
+	"mips64el",
+	"ppc64le",
+	"ppc64el",
+	"aarch64",
+	"riscv64",
+	"x86_64",
+	"armv7l",
+	"armv7",
+	"armhf",
+	"amd64",
+	"arm64",
+	"s390x",
+	"i686",
+	"i386",
+}
+
+// hostArchQualifierOnlyTokens are architecture spellings that are only safe
+// to match when something else already proves the value is an architecture.
+//
+// "386" is Go's and OCI's name for 32-bit x86. Scanned loosely across a
+// golden it also matches version fragments and digest-adjacent digits, so it
+// belongs only in the `arch=` qualifier pattern, where the qualifier name
+// settles what the value is.
+var hostArchQualifierOnlyTokens = []string{"386"}
+
+// archAlternation builds a regexp alternation from the given tokens, longest
+// first. Sorting here rather than relying on the declaration order means a
+// token added anywhere in the lists above still wins over any shorter token
+// it has as a prefix (Go's regexp alternation is leftmost, not longest).
+func archAlternation(tokenLists ...[]string) string {
+	var tokens []string
+	for _, list := range tokenLists {
+		tokens = append(tokens, list...)
+	}
+	sort.SliceStable(tokens, func(i, j int) bool {
+		return len(tokens[i]) > len(tokens[j])
+	})
+	return strings.Join(tokens, "|")
+}
+
+// reHostArchQualifier matches the architecture qualifier a container scan
+// reports in a package URL.
+//
+// A multi-arch image resolves to the runner's own architecture, so this is
+// the runner speaking, not Bomly: goldens regenerated on an arm64 laptop and
+// compared on an amd64 CI runner differ on every package in the image. The
+// suite is here to catch regressions in what Bomly does with an image, and an
+// arch that tracks the host is noise in that signal.
+var reHostArchQualifier = regexp.MustCompile(
+	`([?&]arch=)(?:` + archAlternation(hostArchTokens, hostArchQualifierOnlyTokens) + `)(?:&|$)`)
+
+// reHostArchDpkgPath matches Debian's multiarch suffix in the dpkg
+// administrative paths a container scan records as package evidence, e.g.
+// "/var/lib/dpkg/info/libc6:amd64.md5sums".
+//
+// dpkg names a co-installable package's control files "<package>:<arch>.<ext>",
+// so the architecture rides into the evidence path even though the PURL
+// qualifier it also appears in is already normalized. That gap is what
+// issue #445 tripped over: identity was portable, evidence was not, and a
+// golden written on arm64 failed only on CI.
+//
+// The match is anchored to the dpkg directory rather than to ":<arch>."
+// anywhere. An architecture that turns up in some other path shape is a case
+// nobody has thought about yet, and the guard below should stop it and make
+// someone decide, rather than a broad pattern quietly erasing it.
+var reHostArchDpkgPath = regexp.MustCompile(
+	`(/var/lib/dpkg/info/[^/":]+):(?:` + archAlternation(hostArchTokens) + `)(\.)`)
+
+// reHostArchToken matches any distinctive architecture spelling standing as a
+// whole token. It is the guard's catch-all: the two patterns above describe
+// the shapes the normalizer knows how to erase, and this one finds the shapes
+// it does not.
+var reHostArchToken = regexp.MustCompile(
+	`(?:^|[^0-9A-Za-z_])(?:` + archAlternation(hostArchTokens) + `)(?:[^0-9A-Za-z_]|$)`)
+
+// goldenDir is the single directory holding smoke golden files.
+const goldenDir = "testdata/golden"
+
+// TestGoldensCarryNoHostArchitecture fails when a committed golden contains a
+// machine architecture.
+//
+// Not "a foreign architecture" -- any architecture. A golden holding "amd64"
+// is not correct just because CI happens to run on amd64; it is the same
+// defect that happens to be invisible today, and it becomes visible the next
+// time a contributor runs `make smoke ARGS="-update"` on a laptop. The
+// portable value is the placeholder the normalizer writes.
+func TestGoldensCarryNoHostArchitecture(t *testing.T) {
+	entries, err := os.ReadDir(goldenDir)
+	if err != nil {
+		t.Fatalf("read golden dir %s: %v", goldenDir, err)
+	}
+
+	checks := []struct {
+		re     *regexp.Regexp
+		advice string
+	}{
+		{
+			re: reHostArchDpkgPath,
+			advice: "dpkg multiarch evidence path. normalizeMachineDependentString " +
+				"(helpers_test.go) rewrites this to :<arch>; the golden predates that " +
+				"rule, so rewrite the committed value to match.",
+		},
+		{
+			re: reHostArchQualifier,
+			advice: "package URL arch qualifier. normalizeMachineDependentString " +
+				"(helpers_test.go) rewrites this to arch=<arch>; the golden predates " +
+				"that rule, so rewrite the committed value to match.",
+		},
+		{
+			re: reHostArchToken,
+			advice: "architecture in a shape no normalizer covers yet. Decide whether " +
+				"it is host-tracking noise (then teach normalizeMachineDependentString " +
+				"in helpers_test.go to erase it, and add any missing spelling to " +
+				"hostArchTokens) or genuinely part of what the golden asserts (then " +
+				"this guard needs an explicit, argued exception).",
+		},
+	}
+
+	scanned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".golden.json") {
+			continue
+		}
+		scanned++
+
+		path := filepath.Join(goldenDir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read golden %s: %v", path, err)
+		}
+
+		for _, check := range checks {
+			loc := check.re.FindIndex(raw)
+			if loc == nil {
+				continue
+			}
+			t.Errorf("%s:%d: golden carries the host architecture %q\n\n%s\n\n"+
+				"A golden is compared on ubuntu-latest (amd64) but is usually written "+
+				"on a contributor's machine, so an architecture baked into one fails "+
+				"CI for everybody after it merges. See issue #445.",
+				path, lineOf(raw, loc[0]), quoteMatch(raw, loc), check.advice)
+			break
+		}
+	}
+
+	// A guard that scans nothing passes forever. Fail if the goldens moved.
+	if scanned == 0 {
+		t.Fatalf("no *.golden.json files found under %s; the guard scanned nothing", goldenDir)
+	}
+	t.Logf("scanned %d golden files for host architectures", scanned)
+}
+
+// lineOf returns the 1-based line number of the byte offset in raw.
+func lineOf(raw []byte, offset int) int {
+	if offset > len(raw) {
+		offset = len(raw)
+	}
+	return 1 + strings.Count(string(raw[:offset]), "\n")
+}
+
+// quoteMatch renders the matched region with a little surrounding context so
+// the failure names the actual string rather than only a pattern.
+func quoteMatch(raw []byte, loc []int) string {
+	start := loc[0] - 40
+	if start < 0 {
+		start = 0
+	}
+	end := loc[1] + 40
+	if end > len(raw) {
+		end = len(raw)
+	}
+	return fmt.Sprintf("%s  (context: ...%s...)",
+		strings.TrimSpace(string(raw[loc[0]:loc[1]])),
+		strings.TrimSpace(strings.ReplaceAll(string(raw[start:end]), "\n", " ")))
+}

--- a/test/smoke/golden_arch_test.go
+++ b/test/smoke/golden_arch_test.go
@@ -13,6 +13,8 @@
 package smoke
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -125,6 +127,40 @@ var reHostArchDpkgPath = regexp.MustCompile(
 var reHostArchToken = regexp.MustCompile(
 	`(?:^|[^0-9A-Za-z_])(?:` + archAlternation(hostArchTokens) + `)(?:[^0-9A-Za-z_]|$)`)
 
+// forEachJSONString visits every string in a decoded JSON document, including
+// object keys, since a key is wire surface too.
+func forEachJSONString(value any, visit func(string)) {
+	switch typed := value.(type) {
+	case string:
+		visit(typed)
+	case []any:
+		for _, element := range typed {
+			forEachJSONString(element, visit)
+		}
+	case map[string]any:
+		for key, element := range typed {
+			visit(key)
+			forEachJSONString(element, visit)
+		}
+	}
+}
+
+// lineOfValue reports the line a decoded string sits on, by asking
+// encoding/json to write the value back the way the file would have written
+// it. Searching for the raw text would miss exactly the escaped values this
+// scan exists to catch.
+func lineOfValue(raw []byte, value string) int {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return 0
+	}
+	index := bytes.Index(raw, encoded)
+	if index < 0 {
+		return 0
+	}
+	return lineOf(raw, index)
+}
+
 // goldenDir is the single directory holding smoke golden files.
 const goldenDir = "testdata/golden"
 
@@ -181,18 +217,37 @@ func TestGoldensCarryNoHostArchitecture(t *testing.T) {
 			t.Fatalf("read golden %s: %v", path, err)
 		}
 
-		for _, check := range checks {
-			loc := check.re.FindIndex(raw)
-			if loc == nil {
-				continue
-			}
-			t.Errorf("%s:%d: golden carries the host architecture %q\n\n%s\n\n"+
-				"A golden is compared on ubuntu-latest (amd64) but is usually written "+
-				"on a contributor's machine, so an architecture baked into one fails "+
-				"CI for everybody after it merges. See issue #445.",
-				path, lineOf(raw, loc[0]), quoteMatch(raw, loc), check.advice)
-			break
+		// Scan the decoded strings, not the file bytes. Go writes "&" as
+		// \u0026 inside JSON, and five goldens here carry it that way, so a
+		// pattern expecting a literal separator walks straight past
+		// "?arch=386\u0026distro=..." -- the very qualifier it exists to
+		// find. encoding/json owns that escaping, so it decides what the
+		// value is rather than this file learning the escapes.
+		var document any
+		if err := json.Unmarshal(raw, &document); err != nil {
+			t.Errorf("%s: golden is not valid JSON: %v", path, err)
+			continue
 		}
+
+		found := false
+		forEachJSONString(document, func(value string) {
+			if found {
+				return
+			}
+			for _, check := range checks {
+				loc := check.re.FindStringIndex(value)
+				if loc == nil {
+					continue
+				}
+				found = true
+				t.Errorf("%s:%d: golden carries the host architecture %q\n\n%s\n\n"+
+					"A golden is compared on ubuntu-latest (amd64) but is usually written "+
+					"on a contributor's machine, so an architecture baked into one fails "+
+					"CI for everybody after it merges. See issue #445.",
+					path, lineOfValue(raw, value), value[loc[0]:loc[1]], check.advice)
+				return
+			}
+		})
 	}
 
 	// A guard that scans nothing passes forever. Fail if the goldens moved.

--- a/test/smoke/helpers_test.go
+++ b/test/smoke/helpers_test.go
@@ -530,19 +530,6 @@ var reBomlyGitID = regexp.MustCompile(`(pkg:[^/]+/bomly-git)-\d+`)
 // in the "name" field of a package when no PURL prefix is present).
 var reBomlyGitName = regexp.MustCompile(`(bomly-git)-\d+`)
 
-// reHostArch matches the architecture qualifier a container scan reports.
-//
-// A multi-arch image resolves to the runner's own architecture, so this is the
-// runner speaking, not Bomly: goldens regenerated on an arm64 laptop and
-// compared on an amd64 CI runner differ on every package in the image. The
-// suite is here to catch regressions in what Bomly does with an image, and an
-// arch that tracks the host is noise in that signal.
-// The alternation covers both spellings a package manager uses for the same
-// machine: Debian says amd64/arm64, Alpine and RPM say x86_64/aarch64. Listing
-// them rather than matching any value keeps a genuinely wrong arch -- one
-// Bomly mislabelled -- visible in the diff.
-var reHostArch = regexp.MustCompile(`([?&]arch=)(?:amd64|arm64|386|armv7|armhf|ppc64le|s390x|x86_64|aarch64|i386|i686)(?:&|$)`)
-
 // reTempRoot matches the temporary directory a run cloned or built into.
 //
 // The suffix was already normalized; the prefix was not, and it differs by
@@ -589,12 +576,22 @@ func normalizeMachineDependentString(s string) string {
 	} else if reBomlyGitName.MatchString(s) {
 		s = reBomlyGitName.ReplaceAllString(s, "${1}-<normalized>")
 	}
-	s = reHostArch.ReplaceAllStringFunc(s, func(match string) string {
+	// The architecture vocabulary and both architecture patterns live in
+	// golden_arch_test.go, which carries no build tag: the guard test there
+	// forbids exactly what this function erases, and one shared list is what
+	// stops the two from drifting apart.
+	s = reHostArchQualifier.ReplaceAllStringFunc(s, func(match string) string {
 		if strings.HasSuffix(match, "&") {
-			return reHostArch.ReplaceAllString(match, "${1}<arch>&")
+			return reHostArchQualifier.ReplaceAllString(match, "${1}<arch>&")
 		}
-		return reHostArch.ReplaceAllString(match, "${1}<arch>")
+		return reHostArchQualifier.ReplaceAllString(match, "${1}<arch>")
 	})
+	// dpkg names a co-installable package's control files
+	// "<package>:<arch>.<ext>", so a container scan's evidence paths carry the
+	// runner's architecture even though the PURL qualifier above is already
+	// normalized. Identity was portable and evidence was not, which is how a
+	// golden written on arm64 passed locally and failed on CI (#445).
+	s = reHostArchDpkgPath.ReplaceAllString(s, "${1}:<arch>${2}")
 	return reTempRoot.ReplaceAllString(s, "<tmp>/")
 }
 

--- a/test/smoke/testdata/golden/container-scan-debian.golden.json
+++ b/test/smoke/testdata/golden/container-scan-debian.golden.json
@@ -257,8 +257,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -403,8 +403,8 @@
               "real_path": "/usr/share/doc/libapt-pkg6.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libapt-pkg6.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libapt-pkg6.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libapt-pkg6.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libapt-pkg6.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -493,8 +493,8 @@
               "real_path": "/usr/share/doc/libaudit1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -528,8 +528,8 @@
               "real_path": "/usr/share/doc/libbz2-1.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -558,12 +558,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -613,8 +613,8 @@
               "real_path": "/usr/share/doc/libcap-ng0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -654,8 +654,8 @@
               "real_path": "/usr/share/doc/libcap2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -684,8 +684,8 @@
               "real_path": "/usr/share/doc/libcrypt1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -760,8 +760,8 @@
               "real_path": "/usr/share/doc/libdb5.3/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libdb5.3:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libdb5.3:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libdb5.3:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libdb5.3:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -818,8 +818,8 @@
               "real_path": "/usr/share/doc/libffi8/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libffi8:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libffi8:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libffi8:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libffi8:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -849,8 +849,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -880,8 +880,8 @@
               "real_path": "/usr/share/doc/libgcrypt20/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -936,8 +936,8 @@
               "real_path": "/usr/share/doc/libgmp10/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgmp10:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgmp10:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgmp10:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgmp10:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -973,8 +973,8 @@
               "real_path": "/usr/share/doc/libgnutls30/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgnutls30:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgnutls30:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgnutls30:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgnutls30:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1028,8 +1028,8 @@
               "real_path": "/usr/share/doc/libgpg-error0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1106,8 +1106,8 @@
               "real_path": "/usr/share/doc/libhogweed6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libhogweed6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libhogweed6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libhogweed6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libhogweed6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1167,8 +1167,8 @@
               "real_path": "/usr/share/doc/libidn2-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libidn2-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libidn2-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libidn2-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libidn2-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1208,8 +1208,8 @@
               "real_path": "/usr/share/doc/liblz4-1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1296,8 +1296,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1372,8 +1372,8 @@
               "real_path": "/usr/share/doc/libnettle8/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libnettle8:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libnettle8:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libnettle8:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libnettle8:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1436,8 +1436,8 @@
               "real_path": "/usr/share/doc/libp11-kit0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libp11-kit0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libp11-kit0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libp11-kit0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libp11-kit0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1607,12 +1607,12 @@
               "real_path": "/usr/share/doc/libpam-modules/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam-modules:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libpam-modules:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam-modules:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpam-modules:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1691,8 +1691,8 @@
               "real_path": "/usr/share/doc/libpam0g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1740,8 +1740,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1771,8 +1771,8 @@
               "real_path": "/usr/share/doc/libseccomp2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libseccomp2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libseccomp2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libseccomp2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libseccomp2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1802,8 +1802,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1873,8 +1873,8 @@
               "real_path": "/usr/share/doc/libsemanage2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsemanage2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsemanage2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsemanage2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsemanage2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1924,8 +1924,8 @@
               "real_path": "/usr/share/doc/libsepol2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsepol2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsepol2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsepol2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsepol2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -1956,8 +1956,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libstdc++6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libstdc++6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libstdc++6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libstdc++6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2020,8 +2020,8 @@
               "real_path": "/usr/share/doc/libsystemd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2050,8 +2050,8 @@
               "real_path": "/usr/share/doc/libtasn1-6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libtasn1-6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libtasn1-6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libtasn1-6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libtasn1-6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2109,8 +2109,8 @@
               "real_path": "/usr/share/doc/libudev1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libudev1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libudev1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libudev1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libudev1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2184,8 +2184,8 @@
               "real_path": "/usr/share/doc/libunistring2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libunistring2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libunistring2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libunistring2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libunistring2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2220,8 +2220,8 @@
               "real_path": "/usr/share/doc/libxxhash0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libxxhash0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libxxhash0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libxxhash0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libxxhash0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2265,8 +2265,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2376,8 +2376,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2469,8 +2469,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2499,12 +2499,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2549,8 +2549,8 @@
               "real_path": "/usr/share/doc/libdebconfclient0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libdebconfclient0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libdebconfclient0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libdebconfclient0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libdebconfclient0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2580,8 +2580,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2629,8 +2629,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2660,8 +2660,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2899,8 +2899,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2929,12 +2929,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -2964,8 +2964,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3004,8 +3004,8 @@
               "real_path": "/usr/share/doc/libtinfo6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3201,8 +3201,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3231,12 +3231,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3276,8 +3276,8 @@
               "real_path": "/usr/share/doc/libcap2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3307,8 +3307,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3338,8 +3338,8 @@
               "real_path": "/usr/share/doc/libgcrypt20/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3393,8 +3393,8 @@
               "real_path": "/usr/share/doc/libgpg-error0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3434,8 +3434,8 @@
               "real_path": "/usr/share/doc/liblz4-1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3522,8 +3522,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3586,8 +3586,8 @@
               "real_path": "/usr/share/doc/libsystemd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3631,8 +3631,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3743,8 +3743,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3789,8 +3789,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3835,12 +3835,12 @@
               "real_path": "/usr/share/doc/libattr1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libattr1:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libattr1:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libattr1:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libattr1:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libattr1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libattr1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libattr1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libattr1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3869,12 +3869,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3904,8 +3904,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -3960,8 +3960,8 @@
               "real_path": "/usr/share/doc/libgmp10/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgmp10:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgmp10:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgmp10:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgmp10:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4009,8 +4009,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4040,8 +4040,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4281,8 +4281,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4327,8 +4327,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4362,8 +4362,8 @@
               "real_path": "/usr/share/doc/libbz2-1.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4392,12 +4392,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4427,8 +4427,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4515,8 +4515,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4582,8 +4582,8 @@
               "real_path": "/usr/share/doc/libmd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4631,8 +4631,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4662,8 +4662,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4707,8 +4707,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4808,8 +4808,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4952,8 +4952,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -4982,12 +4982,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5017,8 +5017,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5158,8 +5158,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5261,8 +5261,8 @@
               "real_path": "/usr/share/doc/libblkid1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5291,12 +5291,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5370,8 +5370,8 @@
               "real_path": "/usr/share/doc/libcom-err2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcom-err2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcom-err2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcom-err2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcom-err2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5445,8 +5445,8 @@
               "real_path": "/usr/share/doc/libext2fs2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libext2fs2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libext2fs2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libext2fs2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libext2fs2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5476,8 +5476,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5552,8 +5552,8 @@
               "real_path": "/usr/share/doc/libss2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libss2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libss2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libss2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libss2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5655,8 +5655,8 @@
               "real_path": "/usr/share/doc/libuuid1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libuuid1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libuuid1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libuuid1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libuuid1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5893,8 +5893,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5923,12 +5923,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -5958,8 +5958,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6007,8 +6007,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6038,8 +6038,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6146,8 +6146,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6234,8 +6234,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6269,8 +6269,8 @@
               "real_path": "/usr/share/doc/libbz2-1.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6299,12 +6299,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6334,8 +6334,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6422,8 +6422,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6489,8 +6489,8 @@
               "real_path": "/usr/share/doc/libmd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6538,8 +6538,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6569,8 +6569,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6614,8 +6614,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6715,8 +6715,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6823,8 +6823,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6922,8 +6922,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6957,8 +6957,8 @@
               "real_path": "/usr/share/doc/libbz2-1.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -6987,12 +6987,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7022,8 +7022,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7110,8 +7110,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7177,8 +7177,8 @@
               "real_path": "/usr/share/doc/libmd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7226,8 +7226,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7257,8 +7257,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7302,8 +7302,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7403,8 +7403,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7439,8 +7439,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7504,12 +7504,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7539,8 +7539,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7678,8 +7678,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7754,12 +7754,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7789,8 +7789,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7874,8 +7874,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7964,8 +7964,8 @@
               "real_path": "/usr/share/doc/libaudit1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -7994,12 +7994,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8049,8 +8049,8 @@
               "real_path": "/usr/share/doc/libcap-ng0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8079,8 +8079,8 @@
               "real_path": "/usr/share/doc/libcrypt1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8155,8 +8155,8 @@
               "real_path": "/usr/share/doc/libdb5.3/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libdb5.3:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libdb5.3:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libdb5.3:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libdb5.3:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8186,8 +8186,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8357,12 +8357,12 @@
               "real_path": "/usr/share/doc/libpam-modules/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam-modules:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libpam-modules:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam-modules:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpam-modules:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpam-modules:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8544,8 +8544,8 @@
               "real_path": "/usr/share/doc/libpam0g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8593,8 +8593,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8624,8 +8624,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8739,8 +8739,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8842,8 +8842,8 @@
               "real_path": "/usr/share/doc/libblkid1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8872,12 +8872,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -8907,8 +8907,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9012,8 +9012,8 @@
               "real_path": "/usr/share/doc/libmount1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmount1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmount1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmount1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmount1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9061,8 +9061,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9092,8 +9092,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9195,8 +9195,8 @@
               "real_path": "/usr/share/doc/libsmartcols1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsmartcols1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsmartcols1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsmartcols1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsmartcols1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9396,8 +9396,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9426,12 +9426,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9461,8 +9461,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9501,8 +9501,8 @@
               "real_path": "/usr/share/doc/libtinfo6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9654,8 +9654,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9700,8 +9700,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9735,8 +9735,8 @@
               "real_path": "/usr/share/doc/libbz2-1.0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libbz2-1.0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9765,12 +9765,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9799,8 +9799,8 @@
               "real_path": "/usr/share/doc/libcrypt1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9830,8 +9830,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9918,8 +9918,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -9985,8 +9985,8 @@
               "real_path": "/usr/share/doc/libmd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10034,8 +10034,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10065,8 +10065,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10110,8 +10110,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10368,8 +10368,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10404,8 +10404,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10450,8 +10450,8 @@
               "real_path": "/usr/share/doc/libacl1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libacl1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libacl1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10480,12 +10480,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10515,8 +10515,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10564,8 +10564,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10595,8 +10595,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10706,8 +10706,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10736,12 +10736,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -10771,8 +10771,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11026,8 +11026,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/gcc-12-base:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/gcc-12-base:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11116,8 +11116,8 @@
               "real_path": "/usr/share/doc/libaudit1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libaudit1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libaudit1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11219,8 +11219,8 @@
               "real_path": "/usr/share/doc/libblkid1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libblkid1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libblkid1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11249,12 +11249,12 @@
               "real_path": "/usr/share/doc/libc6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.conffiles"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.conffiles"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libc6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libc6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11304,8 +11304,8 @@
               "real_path": "/usr/share/doc/libcap-ng0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap-ng0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap-ng0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11345,8 +11345,8 @@
               "real_path": "/usr/share/doc/libcap2/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcap2:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcap2:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11375,8 +11375,8 @@
               "real_path": "/usr/share/doc/libcrypt1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libcrypt1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libcrypt1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11406,8 +11406,8 @@
               "real_path": "/usr/share/doc/gcc-12-base/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcc-s1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcc-s1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11437,8 +11437,8 @@
               "real_path": "/usr/share/doc/libgcrypt20/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgcrypt20:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgcrypt20:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11492,8 +11492,8 @@
               "real_path": "/usr/share/doc/libgpg-error0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libgpg-error0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libgpg-error0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11533,8 +11533,8 @@
               "real_path": "/usr/share/doc/liblz4-1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblz4-1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblz4-1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11621,8 +11621,8 @@
               "real_path": "/usr/share/doc/liblzma5/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/liblzma5:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/liblzma5:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11726,8 +11726,8 @@
               "real_path": "/usr/share/doc/libmount1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libmount1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libmount1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libmount1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libmount1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11806,8 +11806,8 @@
               "real_path": "/usr/share/doc/libpam0g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpam0g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpam0g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11855,8 +11855,8 @@
               "real_path": "/usr/share/doc/libpcre2-8-0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libpcre2-8-0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11886,8 +11886,8 @@
               "real_path": "/usr/share/doc/libselinux1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libselinux1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libselinux1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -11989,8 +11989,8 @@
               "real_path": "/usr/share/doc/libsmartcols1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsmartcols1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsmartcols1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsmartcols1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsmartcols1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12053,8 +12053,8 @@
               "real_path": "/usr/share/doc/libsystemd0/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libsystemd0:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libsystemd0:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12093,8 +12093,8 @@
               "real_path": "/usr/share/doc/libtinfo6/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libtinfo6:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libtinfo6:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12152,8 +12152,8 @@
               "real_path": "/usr/share/doc/libudev1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libudev1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libudev1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libudev1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libudev1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12255,8 +12255,8 @@
               "real_path": "/usr/share/doc/libuuid1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libuuid1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libuuid1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libuuid1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libuuid1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12300,8 +12300,8 @@
               "real_path": "/usr/share/doc/libzstd1/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/libzstd1:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/libzstd1:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",
@@ -12592,8 +12592,8 @@
               "real_path": "/usr/share/doc/zlib1g/copyright"
             },
             {
-              "access_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
-              "real_path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums"
+              "access_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums",
+              "real_path": "/var/lib/dpkg/info/zlib1g:\u003carch\u003e.md5sums"
             },
             {
               "access_path": "/var/lib/dpkg/status",


### PR DESCRIPTION
Closes #445.

## Direction chosen: (a) normalize

The issue offered two mutually exclusive fixes. I took **(a) normalize the architecture**, and the investigation made the choice one-sided.

**The repo had already decided this, and the rule just did not reach far enough.** `helpers_test.go` has carried `reHostArch` for a while, normalizing the `arch=` qualifier in every package URL, with this comment:

> A multi-arch image resolves to the runner's own architecture, so this is the runner speaking, not Bomly [...] The suite is here to catch regressions in what Bomly does with an image, and an arch that tracks the host is noise in that signal.

So in `container-scan-debian.golden.json` the architecture was *already* erased from everything that constitutes package identity:

```
"id":   "pkg:deb/debian/libc6@2.36-9%2Bdeb12u14?arch=<arch>&distro=debian-12.15&upstream=glibc"
"purl": "pkg:deb/debian/libc6@2.36-9%2Bdeb12u14?arch=<arch>&distro=debian-12.15&upstream=glibc"
```

All 209 surviving occurrences were in `locations[].access_path` / `locations[].real_path` — and nowhere else. I checked every field in the file:

| field carrying an arch token | count |
|---|---|
| `access_path` | 209 |
| `real_path` | 209 |
| everything else (`id`, `purl`, `package_ref`, `name`, `version`, `depends_on`) | 0 |

dpkg names a co-installable package's control files `<package>:<arch>.<ext>`, which is why `libc6` gets `/var/lib/dpkg/info/libc6:amd64.md5sums`. That is one evidence path among four for the same package (`/usr/share/doc/libc6/copyright`, `.conffiles`, `.md5sums`, `/var/lib/dpkg/status`) — the assertion is "Bomly recorded the dpkg control files as evidence", not "it recorded them for amd64 specifically".

**Why (b) was wrong here.** (b) — refuse the write — is the correct fix when the architecture is load-bearing, because normalizing it would weaken the assertion. It is not load-bearing: identity is already arch-free by deliberate design, so (b) would have left a value in the golden that the suite does not assert, and paid for it with a permanent tax — every arm64 contributor sent to a workflow dispatch to refresh a golden, for a field nobody reads. It also treats the symptom: the golden would still be a machine-specific artifact, just one only CI is allowed to write. (a) removes the class instead of routing around it. That is the "fix at the right depth" call — the rule had a home already, it was one regex short.

## What changed

- **`reHostArchDpkgPath`** erases the Debian multiarch suffix in dpkg evidence paths. It is anchored to `/var/lib/dpkg/info/` rather than matching `:<arch>.` anywhere: an architecture in a path shape nobody has considered yet should stop the build and make someone decide, not be quietly erased by a broad pattern.
- **The architecture vocabulary and all three patterns moved to `test/smoke/golden_arch_test.go`, which carries no build tag.** The normalizer that erases these tokens and the guard that forbids them now share one list, so adding a spelling extends both at once. Two hand-lists would have drifted, and the drift would have been silent in the guard's favour.
- **`TestGoldensCarryNoHostArchitecture`** runs in `make test`. It follows the existing `fixture_compile_test.go` precedent (untagged file in the `smoke` package) — the architecture in a golden is a property of the committed file, not of a scan, so it needs no network and should fail before review, not after merge.
- **The debian golden was rewritten, not regenerated.** No scan was re-run. I fed the committed file back through the real `normalizeJSON` — the same read-path normalization `assertGolden` already applies to goldens — so the committed bytes are exactly what the normalizer produces. The diff is **418 lines changed, 100% of them dpkg evidence paths**; verified that zero `+` lines fail to match the `:<arch>.` form.

Note that smoke would have gone green without this rewrite, because `assertGolden` re-normalizes the golden on read. The rewrite is for the guard, and because a golden should not store a value the harness is going to throw away.

## The guard forbids *any* architecture, not a foreign one

A golden holding `amd64` is not correct because CI runs amd64 — it is the identical defect, invisible only because CI happens to agree with it today, and it becomes visible the next time someone runs `-update` on a laptop. The portable value is the placeholder.

## Mutation results

Every mutation kept the tree compiling (`go vet ./test/smoke/` OK in each case), and each was verified to have actually landed in the file before the guard ran.

| # | Mutation | Expected | Result |
|---|---|---|---|
| baseline | unmutated tree | pass | **pass** |
| **M1** | `libc6:<arch>.md5sums` → `gcc-12-base:arm64.md5sums` (the exact reported defect) | fail | **fail** — `container-scan-debian.golden.json:260` |
| **M2** | same, but `amd64` (CI-native, still host-tracking) | fail | **fail** — `container-scan-debian.golden.json:260` |
| **M3** | `?arch=<arch>` → `?arch=aarch64` in a PURL | fail | **fail** — `container-scan-debian.golden.json:64` |
| **M4** | `/usr/lib/aarch64-linux-gnu/...` injected into `container-scan-alpine.golden.json` — a shape *no normalizer covers*, in a *different* golden | fail | **fail** — `container-scan-alpine.golden.json:19` |
| **M5** | `s390x` token in `scan-go.golden.json` — a golden with no container content at all | fail | **fail** — `scan-go.golden.json:15` |

**A false pass I caught, worth recording.** M4 and M5 *passed* on the first attempt. The guard was not at fault: the `sed -i '' '0,/re/s#...#'` I used is a GNU address form BSD sed rejects, so the mutation never landed. That is exactly the "mutation that proves nothing" failure — the run looked like evidence and was not. I re-ran both with a Python edit and an explicit `grep` confirming the mutated bytes were on disk before invoking the guard; both then failed as they should. No conclusion in the table above rests on an unverified mutation.

Negative controls, to show the guard is discriminating rather than merely loud — all three still **pass**:

| # | Injected | Why it must not fire |
|---|---|---|
| **N1** | `arch=all` | architecture-*independent*; a real, legitimate dpkg value |
| **N2** | `v2.386.1` | `386` inside a version fragment |
| **N3** | `libamd64codec` | arch token glued inside a longer identifier |

N2 is why `386` is in a separate `hostArchQualifierOnlyTokens` list used only by the `arch=`-anchored pattern, where the qualifier name settles what the value is. The broad scan requires a non-alphanumeric boundary on both sides, which is what N3 exercises.

The guard also fails if it scans zero files, so it cannot pass forever by being pointed at a directory that moved.

## Delegation check

`github.com/containerd/platforms` is pinned (indirect) and genuinely owns the OCI platform vocabulary, including the `x86_64`→`amd64` and `aarch64`→`arm64` aliases. I declined it, and recorded why in the code rather than only here:

1. **Its vocabulary is OCI's, not dpkg's.** Debian spells 64-bit little-endian PowerPC `ppc64el`; OCI spells it `ppc64le`. Delegating would have silently stopped recognising the Debian spelling — the exact family of spellings this guard exists to catch, since the arch-bearing goldens are Debian container scans.
2. **Library membership is an open set; this one is deliberately closed.** An architecture Bomly got *wrong* — one that is not any real machine — must stay visible in a golden diff rather than be normalized away. That property is inherited from the existing `reHostArch` comment and is the reason the list is enumerated at all.
3. Promoting an indirect dependency to a direct one is a dependency addition, which this repo requires discussion for.

The guard is what keeps the hand-listing honest: a missing spelling fails at `make test` the moment it reaches a golden, instead of years later and silently.

## Verification

- `make verify` passes (fmt-check, lint, `go vet ./...`, `go vet -tags lite`, `go vet -tags smoke ./test/smoke/...`, both builds, `go test ./...`, generated-docs drift check).
- `make smoke` was **not** run (slow, network) and no golden was regenerated.
- `CLAUDE.md` / `AGENTS.md` smoke sections gained one line stating the rule and naming the guard, so the next `-update` author meets it before CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to detect host-specific architecture details in committed test artifacts.
  * Improved normalization of architecture-dependent package and container-scan data for consistent results across environments.

* **Documentation**
  * Clarified testing guidance for maintaining portable, architecture-neutral golden files and updating normalization when new architecture-specific data appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->