### PR TITLE
docs: record the declined modernizer analyzer in both guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,27 @@ Development may happen inside Git worktrees. Always run commands in the active w
 Do not assume the primary checkout path; use paths relative to the current worktree.
 Avoid destructive Git operations that can affect sibling worktrees or shared refs.
 
+### The modernizer, and the one analyzer we decline
+
+`go fix ./...` is the Go 1.27 modernizer and is worth running. One of its
+analyzers is declined here and in bomly-sdk, and the two must keep agreeing:
+
+```sh
+go fix -embedlit=false ./...
+```
+
+`embedlit` flattens `Coordinates: sdk.Coordinates{...}` into the bare promoted
+fields at construction sites — 119 of them here. It is behaviour-identical and
+nothing mechanical will object, which is exactly why the decision is written
+down. `Coordinates` is a named identity concept (ADR-0041, `dev-docs/MODELS.md`),
+and the wrapper at a construction site is what keeps the identity visible where
+a package is built.
+
+The two repositories disagreed on this once already: this repo's modernizer pass
+rejected the analyzer and the SDK's applied it, so the same question went on
+record with two different answers and cost 43 hunks to undo. Running
+`go fix ./...` without the flag will silently propose all of them again.
+
 ## Architecture
 
 See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the public overview is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)). Component map:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,27 +47,36 @@ Development may happen inside Git worktrees. Always run commands in the active w
 Do not assume the primary checkout path; use paths relative to the current worktree.
 Avoid destructive Git operations that can affect sibling worktrees or shared refs.
 
-### The modernizer, and the one analyzer we decline
+### The modernizer, and the analyzers we decline
 
-`go fix ./...` is the Go 1.27 modernizer and is worth running. One of its
-analyzers is declined here and in bomly-sdk, and the two must keep agreeing:
+`go fix ./...` is the Go 1.27 modernizer. It **applies** its rewrites in place;
+`go fix -diff ./...` prints them instead, which is how to look first.
+
+Three of its analyzers are declined here. Run it as:
 
 ```sh
-go fix -embedlit=false ./...
+go fix -embedlit=false -omitzero=false -stringsbuilder=false ./...
 ```
 
-`embedlit` flattens `Coordinates: sdk.Coordinates{...}` into the bare promoted
-fields at construction sites — 119 of them here. It is behaviour-identical and
-nothing mechanical will object, which is exactly why the decision is written
-down. `Coordinates` is a named identity concept (ADR-0041, `dev-docs/MODELS.md`),
-and the wrapper at a construction site is what keeps the identity visible where
-a package is built.
+- **`embedlit`** flattens `Coordinates: sdk.Coordinates{...}` into the bare
+  promoted fields at construction sites — 119 of them here. `Coordinates` is a
+  named identity concept (ADR-0041, `dev-docs/MODELS.md`), and the wrapper is
+  what keeps the identity visible where a package is built. bomly-sdk declines
+  this one too, and the two repositories must keep agreeing: they disagreed
+  once, and undoing it cost 43 hunks there.
+- **`omitzero`** drops `omitempty` from struct-valued JSON fields in
+  golden- and schema-backed output types. The bytes do not move, so nothing
+  mechanical objects — but the tag *is* the published schema, and a consumer
+  generating one by reflection starts reading the field as required. The SDK
+  took this rewrite in its own pass and spent four review rounds undoing the
+  consequences.
+- **`stringsbuilder`** rewrites small bounded concatenations in the TUI; it
+  still concatenates inside `WriteString`, so it costs readability and saves
+  no allocation.
 
-The two repositories disagreed on this once already: this repo's modernizer pass
-rejected the analyzer and the SDK's applied it, so the same question went on
-record with two different answers and cost 43 hunks to undo. Running
-`go fix ./...` without the flag will silently propose all of them again.
-
+None of these is caught by a test, a linter or the API gate, which is exactly
+why the list lives here. Running `go fix ./...` unqualified silently proposes
+all of them again.
 ## Architecture
 
 See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the public overview is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)). Component map:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,27 @@ Development may happen inside Git worktrees. Always run commands in the active w
 Do not assume the primary checkout path; use paths relative to the current worktree.
 Avoid destructive Git operations that can affect sibling worktrees or shared refs.
 
+### The modernizer, and the one analyzer we decline
+
+`go fix ./...` is the Go 1.27 modernizer and is worth running. One of its
+analyzers is declined here and in bomly-sdk, and the two must keep agreeing:
+
+```sh
+go fix -embedlit=false ./...
+```
+
+`embedlit` flattens `Coordinates: sdk.Coordinates{...}` into the bare promoted
+fields at construction sites — 119 of them here. It is behaviour-identical and
+nothing mechanical will object, which is exactly why the decision is written
+down. `Coordinates` is a named identity concept (ADR-0041, `dev-docs/MODELS.md`),
+and the wrapper at a construction site is what keeps the identity visible where
+a package is built.
+
+The two repositories disagreed on this once already: this repo's modernizer pass
+rejected the analyzer and the SDK's applied it, so the same question went on
+record with two different answers and cost 43 hunks to undo. Running
+`go fix ./...` without the flag will silently propose all of them again.
+
 ## Architecture
 
 See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the public overview is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)). Component map:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,27 +47,36 @@ Development may happen inside Git worktrees. Always run commands in the active w
 Do not assume the primary checkout path; use paths relative to the current worktree.
 Avoid destructive Git operations that can affect sibling worktrees or shared refs.
 
-### The modernizer, and the one analyzer we decline
+### The modernizer, and the analyzers we decline
 
-`go fix ./...` is the Go 1.27 modernizer and is worth running. One of its
-analyzers is declined here and in bomly-sdk, and the two must keep agreeing:
+`go fix ./...` is the Go 1.27 modernizer. It **applies** its rewrites in place;
+`go fix -diff ./...` prints them instead, which is how to look first.
+
+Three of its analyzers are declined here. Run it as:
 
 ```sh
-go fix -embedlit=false ./...
+go fix -embedlit=false -omitzero=false -stringsbuilder=false ./...
 ```
 
-`embedlit` flattens `Coordinates: sdk.Coordinates{...}` into the bare promoted
-fields at construction sites — 119 of them here. It is behaviour-identical and
-nothing mechanical will object, which is exactly why the decision is written
-down. `Coordinates` is a named identity concept (ADR-0041, `dev-docs/MODELS.md`),
-and the wrapper at a construction site is what keeps the identity visible where
-a package is built.
+- **`embedlit`** flattens `Coordinates: sdk.Coordinates{...}` into the bare
+  promoted fields at construction sites — 119 of them here. `Coordinates` is a
+  named identity concept (ADR-0041, `dev-docs/MODELS.md`), and the wrapper is
+  what keeps the identity visible where a package is built. bomly-sdk declines
+  this one too, and the two repositories must keep agreeing: they disagreed
+  once, and undoing it cost 43 hunks there.
+- **`omitzero`** drops `omitempty` from struct-valued JSON fields in
+  golden- and schema-backed output types. The bytes do not move, so nothing
+  mechanical objects — but the tag *is* the published schema, and a consumer
+  generating one by reflection starts reading the field as required. The SDK
+  took this rewrite in its own pass and spent four review rounds undoing the
+  consequences.
+- **`stringsbuilder`** rewrites small bounded concatenations in the TUI; it
+  still concatenates inside `WriteString`, so it costs readability and saves
+  no allocation.
 
-The two repositories disagreed on this once already: this repo's modernizer pass
-rejected the analyzer and the SDK's applied it, so the same question went on
-record with two different answers and cost 43 hunks to undo. Running
-`go fix ./...` without the flag will silently propose all of them again.
-
+None of these is caught by a test, a linter or the API gate, which is exactly
+why the list lives here. Running `go fix ./...` unqualified silently proposes
+all of them again.
 ## Architecture
 
 See [`dev-docs/ARCHITECTURE.md`](dev-docs/ARCHITECTURE.md) for full detail (the public overview is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)). Component map:


### PR DESCRIPTION
The CLI half of "the two repos should agree on `embedlit`". The SDK half is [bomly-dev/bomly-sdk#82](https://github.com/bomly-dev/bomly-sdk/pull/82), which reverts 43 hunks.

## Why a doc change is the deliverable

The revert makes the two repositories agree **today**. Nothing keeps them agreeing tomorrow:

- `embedlit` is behaviour-identical, so tests do not object.
- `gorelease` is indifferent, so the API gate does not object.
- The reasoning lived in a commit message, which is scrollback.

The next `go fix ./...` in either repo proposes every hunk again — 119 here, 43 there — and whoever runs it has no way to know the question was already settled.

## What it says

The flag (`go fix -embedlit=false ./...`) and the reason: `Coordinates` is a named identity concept under ADR-0041 and `dev-docs/MODELS.md`, and the wrapper at a construction site is what keeps the identity visible where a package is built.

It also records that the disagreement already happened once and what it cost, so the note reads as a decision with a price rather than a preference.

Both `CLAUDE.md` and `AGENTS.md` get it, since this repo maintains them as copies.

`make verify` green. `[skip release]` — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)