### PR TITLE
feat(detectors): the purl type stops being something a detector can pass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bomly-dev/bomly-plugin-pyreach-analyzer v0.2.0
 	github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0
 	github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0
-	github.com/bomly-dev/bomly-sdk v0.9.7
+	github.com/bomly-dev/bomly-sdk v0.10.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0 h1:VOK4+GfVGukbccabjD
 github.com/bomly-dev/bomly-plugin-scorecard-matcher v0.2.0/go.mod h1:3ux1Su5UCCKeF+wtttQrlw7r+B7sc6UXrK98Ybuq5gw=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0 h1:UlKwTqp+ZWu25leky9J6NITCKDdePpdgJQl/8dInApg=
 github.com/bomly-dev/bomly-plugin-syft-detector v0.2.0/go.mod h1:NVVrSMHkjC3VEDPtCI7+1c4tWBzwI1eve8tynO1pRoM=
-github.com/bomly-dev/bomly-sdk v0.9.7 h1:kYRSCR5jjzuAM81xyXExKC8yDstaUwxWKR/ml5gAQmQ=
-github.com/bomly-dev/bomly-sdk v0.9.7/go.mod h1:gAGOEa88BE8gELt2rM/ZrqGIJnOzXiR6ocuuKW6AaJ0=
+github.com/bomly-dev/bomly-sdk v0.10.0 h1:Tmiy1AZxT7a73EVTBpY/g82qvipJwmntSKry5+5BXJc=
+github.com/bomly-dev/bomly-sdk v0.10.0/go.mod h1:gAGOEa88BE8gELt2rM/ZrqGIJnOzXiR6ocuuKW6AaJ0=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/internal/detectors/cargo/detector.go
+++ b/internal/detectors/cargo/detector.go
@@ -469,7 +469,7 @@ func packageNode(pkg metadataPackage, id string, workspace map[string]struct{}, 
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.ParsePackageType("crate"),
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version),
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemRust, sdk.PackageManagerCargo, "", pkg.Name, pkg.Version),
 	}
 	if _, workspaceMember := workspace[id]; workspaceMember {
 		// A workspace member is the project's own code, so it is a module
@@ -587,7 +587,7 @@ func depGraphFromLockWithScope(lockRaw, manifestRaw []byte, scopeFilter sdk.Scop
 		PackageManager: sdk.PackageManagerCargo,
 		Type:           sdk.PackageTypeApplication,
 		Language:       "rust",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", manifest.Name, manifest.Version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemRust, sdk.PackageManagerCargo, "", manifest.Name, manifest.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build root node: %w", err)
 	}

--- a/internal/detectors/cargo/workspace.go
+++ b/internal/detectors/cargo/workspace.go
@@ -240,7 +240,7 @@ func depGraphFromLockWorkspace(lockRaw []byte, rootManifest cargoManifest, membe
 			PackageManager: sdk.PackageManagerCargo,
 			Type:           sdk.PackageTypeApplication,
 			Language:       "rust",
-			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version),
+			PURL:           sdk.BuildPackageURLFor(sdk.EcosystemRust, sdk.PackageManagerCargo, "", pkg.Name, pkg.Version),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("build cargo module node %q: %w", pkg.Name, err)
@@ -254,7 +254,7 @@ func depGraphFromLockWorkspace(lockRaw []byte, rootManifest cargoManifest, membe
 			PackageManager: sdk.PackageManagerCargo,
 			Type:           sdk.ParsePackageType("crate"),
 			Language:       "rust",
-			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemRust, sdk.PackageManagerCargo), "", pkg.Name, pkg.Version)})
+			PURL:           sdk.BuildPackageURLFor(sdk.EcosystemRust, sdk.PackageManagerCargo, "", pkg.Name, pkg.Version)})
 		if err != nil {
 			return nil, fmt.Errorf("build cargo node %q: %w", pkg.Name, err)
 		}

--- a/internal/detectors/cocoapods/detector.go
+++ b/internal/detectors/cocoapods/detector.go
@@ -352,7 +352,7 @@ func packageNode(name, version, checksum string) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerCocoaPods,
 		Type:           "pod",
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods), "", name, version),
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods, "", name, version),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build pod node %q: %w", name, err)

--- a/internal/detectors/composer/detector.go
+++ b/internal/detectors/composer/detector.go
@@ -305,7 +305,7 @@ func packageNode(name, version string) (*sdk.DependencyNode, error) {
 		Org:            org,
 		Name:           packageName,
 		Version:        version,
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPHP, sdk.PackageManagerComposer), org, packageName, version),
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemPHP, sdk.PackageManagerComposer, org, packageName, version),
 		PackageManager: sdk.PackageManagerComposer,
 		Type:           sdk.PackageTypePackage,
 		Language:       "php",

--- a/internal/detectors/conan/detector.go
+++ b/internal/detectors/conan/detector.go
@@ -326,7 +326,7 @@ func packageNode(ref conanRef) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerConan,
 		Type:           sdk.PackageTypePackage,
 		Language:       "cpp",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemCPP, sdk.PackageManagerConan), "", ref.Name, ref.Version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemCPP, sdk.PackageManagerConan, "", ref.Name, ref.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/guards_test.go
+++ b/internal/detectors/guards_test.go
@@ -599,26 +599,38 @@ func TestDetectorPURLTypesComeFromTheSDK(t *testing.T) {
 	}
 }
 
-// purlTypeOffenders reports every place in one Go source file where a package
-// URL is minted with a type the SDK did not decide. src is the source text
-// when the caller has it, and nil to read the file at path.
+// purlTypeOffenders reports every place in one Go source file where a detector
+// reaches a package-URL entry point that takes the type as a string. src is
+// the source text when the caller has it, and nil to read the file at path.
 //
 // Split out from the guard so it can be pinned on fixtures below. A rule only
 // ever exercised against a tree that already passes is a rule nobody has seen
 // fail, and this file's history is mostly that.
+//
+// It is a ban on two names now, where it used to inspect arguments. Once
+// sdk.BuildPackageURLFor takes the ecosystem and the package manager and
+// decides the type itself, a detector has no reason to touch either of the
+// forms that accept a type -- and nothing left to get right at the call site,
+// so there is no shape to describe. Four review rounds went into describing
+// shapes; removing the parameter removed the shapes.
+//
+// Dropping the package qualifier cuts the useful way here. It used to mean a
+// locally defined PackageURLTypeForValues was accepted as the authority
+// (bomly-cli#449 gap 3); under a ban the same local function is reported,
+// because the rule no longer cares who defines the name -- only that a
+// detector is calling it.
 func purlTypeOffenders(t *testing.T, path string, src any) []string {
 	t.Helper()
-	const (
-		mint      = "BuildPackageURL"
-		authority = "PackageURLTypeForValues"
-	)
+	banned := map[string]string{
+		"BuildPackageURL": "takes the package-url type as a string; use sdk.BuildPackageURLFor, " +
+			"which takes the ecosystem and package manager and decides the type itself",
+		"PackageURLTypeForValues": "is the mapping itself; a detector that calls it is choosing when " +
+			"to consult the authority, which sdk.BuildPackageURLFor already does",
+	}
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
 	if err != nil {
 		t.Fatalf("parse %s: %v", path, err)
-	}
-	where := func(pos token.Pos) string {
-		return fmt.Sprintf("%s:%d", filepath.ToSlash(path), fset.Position(pos).Line)
 	}
 
 	var offenders []string
@@ -627,30 +639,9 @@ func purlTypeOffenders(t *testing.T, path string, src any) []string {
 		if !ok {
 			return true
 		}
-		switch calleeName(call) {
-		case mint:
-			if len(call.Args) == 0 {
-				return true
-			}
-			if inner, ok := call.Args[0].(*ast.CallExpr); ok && calleeName(inner) == authority {
-				return true
-			}
-			offenders = append(offenders,
-				where(call.Args[0].Pos())+" mints a package URL with a type sdk."+authority+" did not decide")
-		case authority:
-			// Handing the authority the answer is the same hand-written
-			// mapping wearing its name: a literal here has already picked
-			// the type before any token reaches purlkit. Detectors hold
-			// sdk.Ecosystem and sdk.PackageManager values, so they never
-			// need to spell one.
-			for _, arg := range call.Args {
-				lit, ok := arg.(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					continue
-				}
-				offenders = append(offenders, where(arg.Pos())+" passes the literal "+lit.Value+" to sdk."+
-					authority+" instead of the detector's own ecosystem and package-manager values")
-			}
+		if why, forbidden := banned[calleeName(call)]; forbidden {
+			offenders = append(offenders, fmt.Sprintf("%s:%d %s %s",
+				filepath.ToSlash(path), fset.Position(call.Pos()).Line, calleeName(call), why))
 		}
 		return true
 	})
@@ -720,8 +711,8 @@ func TestDetectorsDoNotReachPURLKitDirectly(t *testing.T) {
 	}
 }
 
-// The predicate behind that guard, pinned on fixtures in both directions so
-// it keeps its meaning when the detectors change. Four times in this file's
+// The predicate behind that guard, pinned on fixtures in both directions so it
+// keeps its meaning when the detectors change. Four times in this file's
 // history a guard reported nothing because its pattern had stopped matching
 // the shape it was written for, and a rule exercised only against a passing
 // tree cannot tell that apart from success.
@@ -734,33 +725,54 @@ func TestPURLTypeGuardSeesTheShapesItForbids(t *testing.T) {
 
 	// What every detector does now, and the only shape that passes.
 	if got := offendersFor("ok.go",
-		`var _ = sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods), "", n, v)`,
+		`var _ = sdk.BuildPackageURLFor(sdk.EcosystemSwift, sdk.PackageManagerCocoaPods, "", n, v)`,
 	); len(got) != 0 {
 		t.Errorf("the delegating shape is reported as an offender: %v", got)
 	}
 
-	// The defect the guard exists for.
-	if got := offendersFor("literal.go", `var _ = sdk.BuildPackageURL("cocoapods", "", n, v)`); len(got) != 1 {
-		t.Errorf("a literal purl type at the mint site is not reported: %v", got)
+	// A hand-picked type at the mint site: the defect this rule exists for.
+	if got := offendersFor("literal.go", `var _ = sdk.BuildPackageURL("cocoapods", "", n, v)`); len(got) == 0 {
+		t.Error("a literal purl type at the mint site is not reported")
 	}
 
-	// The escape a "no string literal there" rule would have left open.
+	// The shape that *used* to be the required one. It is forbidden now, not
+	// because it was wrong, but because the type is no longer a parameter a
+	// detector has any business supplying -- and a form that takes one is a
+	// form somebody can supply the wrong thing to.
+	if got := offendersFor("oldgood.go",
+		`var _ = sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemDart, sdk.PackageManagerPub), "", n, v)`,
+	); len(got) == 0 {
+		t.Error("the superseded type-taking form is not reported")
+	}
+
+	// A const hoists the literal out of the call and changes nothing: the
+	// rule bans the entry point, so there is no argument left to inspect.
 	if got := offendersFor("const.go",
 		"const podType = \"cocoapods\"\n\nvar _ = sdk.BuildPackageURL(podType, \"\", n, v)",
-	); len(got) != 1 {
-		t.Errorf("a purl type hoisted into a const is not reported: %v", got)
-	}
-
-	// Restating the answer as the question.
-	if got := offendersFor("restated.go",
-		`var _ = sdk.BuildPackageURL(sdk.PackageURLTypeForValues("cocoapods"), "", n, v)`,
-	); len(got) != 1 {
-		t.Errorf("a literal handed to the authority itself is not reported: %v", got)
+	); len(got) == 0 {
+		t.Error("a purl type hoisted into a const is not reported")
 	}
 
 	// The qualifier is not part of the rule, so an alias must not evade it.
-	if got := offendersFor("aliased.go", `var _ = bomly.BuildPackageURL("cocoapods", "", n, v)`); len(got) != 1 {
-		t.Errorf("an aliased import of the SDK evades the rule: %v", got)
+	if got := offendersFor("aliased.go", `var _ = bomly.BuildPackageURL("cocoapods", "", n, v)`); len(got) == 0 {
+		t.Error("an aliased import of the SDK evades the rule")
 	}
 
+	// bomly-cli#449 gap 3, closed by inversion. A local function wearing the
+	// authority's name used to be *accepted* as the authority, because
+	// calleeName drops the qualifier. Under a ban that same property reports
+	// it: the rule no longer asks who defines the name, only whether a
+	// detector calls it.
+	if got := offendersFor("shadow.go",
+		"func PackageURLTypeForValues(values ...any) string { return \"generic\" }\n\n"+
+			"var _ = sdk.BuildPackageURL(PackageURLTypeForValues(sdk.EcosystemDart), \"\", n, v)",
+	); len(got) == 0 {
+		t.Error("a local function wearing the authority's name is not reported")
+	}
+
+	// An unrelated call must not be swept in: the rule names two functions,
+	// it does not guess at intent.
+	if got := offendersFor("unrelated.go", `var _ = thing.BuildSomethingElse("cocoapods", n, v)`); len(got) != 0 {
+		t.Errorf("an unrelated call is reported: %v", got)
+	}
 }

--- a/internal/detectors/mix/detector.go
+++ b/internal/detectors/mix/detector.go
@@ -408,7 +408,7 @@ func packageNode(pkg mixPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerMix,
 		Type:           sdk.PackageTypePackage,
 		Language:       "elixir",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemElixir, sdk.PackageManagerMix), "", pkg.Name, version),
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemElixir, sdk.PackageManagerMix, "", pkg.Name, version),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build mix node %q: %w", pkg.Name, err)

--- a/internal/detectors/nuget/detector.go
+++ b/internal/detectors/nuget/detector.go
@@ -550,7 +550,7 @@ func packageNode(name, version string, pkg lockPackage) (*sdk.DependencyNode, er
 		PackageManager: sdk.PackageManagerNuGet,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dotnet",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemDotNet, sdk.PackageManagerNuGet), "", name, version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemDotNet, sdk.PackageManagerNuGet, "", name, version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/pub/detector.go
+++ b/internal/detectors/pub/detector.go
@@ -196,7 +196,7 @@ func packageNode(name string, pkg pubLockPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerPub,
 		Type:           sdk.PackageTypePackage,
 		Language:       "dart",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemDart, sdk.PackageManagerPub), "", name, pkg.Version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemDart, sdk.PackageManagerPub, "", name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/python/piplock.go
+++ b/internal/detectors/python/piplock.go
@@ -75,7 +75,7 @@ func depGraphFromRequirementsLock(lockPath, projectPath, rootName string) (*sdk.
 			PackageManager: sdk.PackageManagerPip,
 			Language:       "python",
 			Type:           sdk.PackageTypePackage,
-			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPython, sdk.PackageManagerPip), "", e.name, e.version)})
+			PURL:           sdk.BuildPackageURLFor(sdk.EcosystemPython, sdk.PackageManagerPip, "", e.name, e.version)})
 		if err != nil {
 			return nil, fmt.Errorf("build dependency node: %w", err)
 		}

--- a/internal/detectors/python/poetrylock.go
+++ b/internal/detectors/python/poetrylock.go
@@ -86,7 +86,7 @@ func depGraphFromPoetryLock(lockPath, projectPath string) (*sdk.Graph, error) {
 			PackageManager: sdk.PackageManagerPoetry,
 			Language:       "python",
 			Type:           sdk.PackageTypePackage,
-			PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemPython, sdk.PackageManagerPoetry), "", pkg.Name, pkg.Version)})
+			PURL:           sdk.BuildPackageURLFor(sdk.EcosystemPython, sdk.PackageManagerPoetry, "", pkg.Name, pkg.Version)})
 		if err != nil {
 			return nil, fmt.Errorf("build dependency node: %w", err)
 		}

--- a/internal/detectors/sbt/detector.go
+++ b/internal/detectors/sbt/detector.go
@@ -180,7 +180,7 @@ func packageNode(pkg sbtPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerSBT,
 		Type:           sdk.PackageTypePackage,
 		Language:       "scala",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemScala, sdk.PackageManagerSBT), pkg.Org, pkg.Name, pkg.Version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemScala, sdk.PackageManagerSBT, pkg.Org, pkg.Name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}

--- a/internal/detectors/swiftpm/detector.go
+++ b/internal/detectors/swiftpm/detector.go
@@ -290,7 +290,7 @@ func packageNode(pkg swiftPackage) (*sdk.DependencyNode, error) {
 		PackageManager: sdk.PackageManagerSwiftPM,
 		Type:           sdk.PackageTypePackage,
 		Language:       "swift",
-		PURL:           sdk.BuildPackageURL(sdk.PackageURLTypeForValues(sdk.EcosystemSwift, sdk.PackageManagerSwiftPM), namespace, name, pkg.Version)})
+		PURL:           sdk.BuildPackageURLFor(sdk.EcosystemSwift, sdk.PackageManagerSwiftPM, namespace, name, pkg.Version)})
 	if err != nil {
 		return nil, fmt.Errorf("build dependency node: %w", err)
 	}


### PR DESCRIPTION
Adopts **bomly-sdk v0.10.0** and moves all fourteen detector mint sites to `sdk.BuildPackageURLFor(ecosystem, manager, namespace, name, version)`.

## No identity moves — checked before a line changed

A moved purl type moves node IDs, OSV matching and SBOM references at once, so this was verified first, not discovered later:

```
python/poetry    pkg:pypi/pkg@1            same
rust/cargo       pkg:cargo/pkg@1           same
php/composer     pkg:composer/org/pkg@1    same
elixir/mix       pkg:hex/pkg@1             same
scala/sbt        pkg:maven/org/pkg@1       same
swift/cocoapods  pkg:cocoapods/pkg@1       same
swift/swiftpm    pkg:swift/ns/pkg@1        same
…11 pairs, all unchanged, none refused
```

v0.10.0's constructor **refuses** an ecosystem that spans two registries when the manager does not disambiguate it. Both swift sites pass a manager belonging to `EcosystemSwift`, so none hits that path — confirmed rather than assumed.

## The guard collapses to a ban

It used to inspect arguments, in four clauses accumulated over four review rounds:

| Clause | Round that produced it |
|---|---|
| first argument must be the authority's call | original |
| no literal handed to the authority | original |
| `purlkit.PURL` literal's `Type` must delegate | Codex round 1 |
| `.Type =` assignment must not set a literal | Codex round 2 |

Each closed the shape the previous round had left open. **With no type parameter, there is nothing at the call site to get right — so there is no shape to describe.** The rule is now: a detector does not call `BuildPackageURL` or `PackageURLTypeForValues`.

## This closes [#449](https://github.com/bomly-dev/bomly-cli/issues/449) gap 3, by inversion

`calleeName` drops the package qualifier. That property is what made a locally defined `PackageURLTypeForValues` get *accepted* as the authority — the gap the issue recorded as needing `go/types`.

Under a ban, the same property **reports** it. The rule no longer asks who defines the name, only whether a detector calls it. No type resolution required.

## Mutations

| Mutation | Result |
|---|---|
| literal at the mint site | reported, file and line |
| the superseded `BuildPackageURL(PackageURLTypeForValues(…))` form | reported |
| local function wearing the authority's name (gap 3) | reported |
| an unrelated `BuildSomethingElse` call | not reported |

`make verify` green, `make generate` produced no docs drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)