### PR TITLE
fix(sbom): a transformed export mints its own identity and links its source

### DIFF
--- a/dev-docs/adr/0037-sbom-assertions-are-typed-sdk-model-fields.md
+++ b/dev-docs/adr/0037-sbom-assertions-are-typed-sdk-model-fields.md
@@ -174,7 +174,9 @@ formats are validated through the codecs and the official format validators
 as part of the adoption phase. The fixed-point
 round-trip promise is correspondingly scoped to single-source flows: one
 ingested document re-exported reproduces its own assertions; a merged
-export preserves component assertions and references its sources.
+export preserves component assertions and references its sources. (ADR-0042
+as amended by #433 narrows the first case further: a single source whose
+graph was transformed after ingest is exported as a merge of one.)
 
 **Validation lives with the type.** Every field that carries untrusted input
 validates at the model boundary the way `DependencyOrigin` already does:

--- a/dev-docs/adr/0042-a-conversion-restates-its-source-a-merge-links-its-sources.md
+++ b/dev-docs/adr/0042-a-conversion-restates-its-source-a-merge-links-its-sources.md
@@ -46,6 +46,19 @@ linked instead. A caller-pinned identity always wins over both. The document
 *name* is not adopted at the CLI, which names a document after the scanned
 project.
 
+> **Amended 2026-09-12 (issue #433):** only a conversion that *restates* its
+> source adopts its identity. An export whose graph was scope-filtered,
+> enriched, or degraded between ingest and export is a different document with
+> the same one input, and behaves as a merge of one: its own identity and
+> timestamp, the source linked. The caller declares this through
+> `BuildOptions.RestatesSource`, which defaults to false; the CLI derives it
+> from the same predicate that decides `compositions.aggregate`, so a document
+> that cannot claim to be complete cannot claim to be its source either. The
+> fixed point in Consequences holds for restating exports only. An SPDX link
+> still requires the checksum captured at ingest, so a source written onto an
+> entry by a plugin without one is neither adopted nor linked -- the merge
+> behaviour that already existed, now stated.
+
 **A merge links its sources.** With two or more, the document mints its own
 identity and names each source through a reference of type `bom` carrying a
 BOM-Link or the source's namespace URI. Creators and tools union in both

--- a/internal/cli/scan_cmd.go
+++ b/internal/cli/scan_cmd.go
@@ -234,6 +234,9 @@ func scanSBOMBuildOptions(logger *zap.Logger, project output.ProjectDescriptor, 
 		Registry:    registry,
 		Lifecycle:   sbomLifecyclePhase(project.TargetType),
 		Aggregate:   sbomCompositionAggregate(selectedScope, degraded),
+		// The same predicate decides both: a graph that cannot claim to be
+		// complete cannot claim to be its source document either.
+		RestatesSource: sbomRestatesSource(current, selectedScope, degraded),
 		Provenance: sbom.Provenance{
 			Manufacturer:               strings.TrimSpace(current.SBOMManufacturer),
 			SecurityContact:            strings.TrimSpace(current.SBOMSecurityContact),
@@ -279,6 +282,18 @@ func sbomCompositionAggregate(selectedScope sdk.Scope, degraded bool) string {
 		return "incomplete"
 	}
 	return "complete"
+}
+
+// sbomRestatesSource reports whether an export of a single ingested SBOM may
+// adopt that document's identity (ADR-0042, issue #433): only when the graph
+// handed to the exporter is the ingested one, untransformed. A scope filter
+// dropped part of the graph, enrichment added registry data to it, and
+// degraded resolution means it is not known to be whole -- each makes the
+// export a different document from its source, which then mints its own
+// identity and links the source. --analyze needs --enrich and writes nothing
+// into the SBOM, so enrichment covers it.
+func sbomRestatesSource(current config.Resolved, selectedScope sdk.Scope, degraded bool) bool {
+	return sbomCompositionAggregate(selectedScope, degraded) == "complete" && !current.Enrich
 }
 
 // gitDescribeVersion derives a project version from Git history when the scan

--- a/internal/cli/scan_cmd_test.go
+++ b/internal/cli/scan_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bomly-dev/bomly-cli/internal/cli/render"
+	"github.com/bomly-dev/bomly-cli/internal/config"
 	"github.com/bomly-dev/bomly-cli/internal/output"
 	"github.com/bomly-dev/bomly-cli/internal/testnodes"
 	"github.com/bomly-dev/bomly-sdk"
@@ -266,6 +267,33 @@ func TestSBOMCompositionAggregate(t *testing.T) {
 	}
 	if got := sbomCompositionAggregate(sdk.ScopeUnknown, true); got != "unknown" {
 		t.Fatalf("degraded resolution must declare unknown completeness, got %q", got)
+	}
+}
+
+// TestSBOMRestatesSourceOnlyForAnUntransformedScan pins the predicate that
+// lets a single-source export adopt its source's identity (ADR-0042 as
+// amended by #433): anything that changed the graph after ingest -- a scope
+// filter, enrichment, degraded resolution -- makes the export a different
+// document, which mints its own identity and links the source instead.
+func TestSBOMRestatesSourceOnlyForAnUntransformedScan(t *testing.T) {
+	cases := []struct {
+		name     string
+		current  config.Resolved
+		scope    sdk.Scope
+		degraded bool
+		want     bool
+	}{
+		{name: "plain scan restates", scope: sdk.ScopeUnknown, want: true},
+		{name: "enrichment transforms", current: config.Resolved{Enrich: true}, scope: sdk.ScopeUnknown, want: false},
+		{name: "scope filter transforms", scope: sdk.ScopeRuntime, want: false},
+		{name: "degraded resolution transforms", scope: sdk.ScopeUnknown, degraded: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sbomRestatesSource(tc.current, tc.scope, tc.degraded); got != tc.want {
+				t.Fatalf("sbomRestatesSource(enrich=%v, scope=%q, degraded=%v) = %v, want %v", tc.current.Enrich, tc.scope, tc.degraded, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/sbom/document_assertions.go
+++ b/internal/sbom/document_assertions.go
@@ -10,14 +10,21 @@ import (
 // This file decides what an export says about itself when the graph it
 // describes was read from other documents (ADR-0037, issue #396).
 //
-// The rule turns on how many documents were ingested, because both formats
-// give a document exactly one identity:
+// The rule turns on how many documents were ingested and, for exactly one,
+// on whether the export still restates it, because both formats give a
+// document exactly one identity:
 //
 //   - none: a native scan. Bomly asserts everything itself; nothing here
 //     applies.
-//   - one: a conversion. The document restates that source's assertions,
-//     identity included, so `export -> ingest -> export` reproduces its own
-//     bytes -- the fixed point #396 asks for.
+//   - one, restated: a conversion. The document restates that source's
+//     assertions, identity included, so `export -> ingest -> export`
+//     reproduces its own bytes -- the fixed point #396 asks for.
+//   - one, transformed: a scope filter, enrichment, or degraded resolution
+//     changed the graph between ingest and export, so the document is a new
+//     one with a single input. It behaves as a merge of one: its own
+//     identity, timestamp, name and comment, with the source *linked*
+//     (issue #433). Only the caller can tell this case from the previous
+//     one, and says so through BuildOptions.RestatesSource.
 //   - many: a merge. The document is a new one and says so: it keeps its own
 //     identity and *links* each source instead of adopting one of them.
 //
@@ -47,7 +54,11 @@ func DocumentAssertionsFor(doc *Document) *sdk.DocumentAssertions {
 
 // applySourceAssertions folds the source documents' own claims into the
 // document being built, and records the sources for link emission.
-func applySourceAssertions(doc *Document, sources []sdk.DocumentAssertions) {
+//
+// restates is the caller's declaration that the graph being exported is the
+// single source's graph, untransformed; it decides whether one source's
+// identity is adopted or linked, and means nothing for zero or several.
+func applySourceAssertions(doc *Document, sources []sdk.DocumentAssertions, restates bool) {
 	if doc == nil {
 		return
 	}
@@ -80,9 +91,18 @@ func applySourceAssertions(doc *Document, sources []sdk.DocumentAssertions) {
 	doc.Assertions.Creators = aggregate.Creators
 	doc.Assertions.Tools = aggregate.Tools
 
-	if len(cleaned) > 1 {
+	if len(cleaned) > 1 || !restates {
 		// A merged document asserts its own identity. Its sources are named
 		// by documentSourceLinks, not adopted here.
+		//
+		// So does a transformed conversion. A graph that was scope-filtered,
+		// enriched, or degraded after ingest no longer describes the source
+		// document, and a document claiming that source's identity over
+		// different content is two documents sharing one name (issue #433).
+		// It is a new document with one input and behaves as a merge of one:
+		// its own identity, timestamp, name and comment, the source named by
+		// documentSourceLinks. Creators and tools were still unioned above --
+		// the source did produce this document's inventory.
 		return
 	}
 

--- a/internal/sbom/document_assertions_fuzz_test.go
+++ b/internal/sbom/document_assertions_fuzz_test.go
@@ -58,7 +58,7 @@ func FuzzDocumentAssertions(f *testing.F) {
 
 		g := mustFuzzGraph(t)
 		entry := sdk.GraphEntry{Graph: g, Document: &hostile}
-		doc, err := FromGraphEntries(g, []sdk.GraphEntry{entry}, BuildOptions{})
+		doc, err := FromGraphEntries(g, []sdk.GraphEntry{entry}, BuildOptions{RestatesSource: true})
 		if err != nil {
 			t.Fatalf("export: %v", err)
 		}
@@ -96,6 +96,29 @@ func FuzzDocumentAssertions(f *testing.F) {
 			}
 		}
 
+		// Without the caller's word that the graph still restates the
+		// source, the same entry is exported as a merge of one: the source's
+		// identity is never adopted, and it is linked whenever it clears the
+		// gate (issue #433).
+		transformed, err := FromGraphEntries(g, []sdk.GraphEntry{entry}, BuildOptions{})
+		if err != nil {
+			t.Fatalf("transformed export: %v", err)
+		}
+		if publishable, ok := hostile.Normalized(); ok && publishable.Identity != "" {
+			if transformed.Namespace == publishable.Identity {
+				t.Fatalf("a transformed export adopted the source identity %q", publishable.Identity)
+			}
+			linked := false
+			for _, link := range documentSourceLinks(transformed, documentIdentity{Namespace: transformed.Namespace}) {
+				if link.Identity == publishable.Identity {
+					linked = true
+				}
+			}
+			if !linked {
+				t.Fatalf("a transformed export neither adopted nor linked the source identity %q", publishable.Identity)
+			}
+		}
+
 		// Feeding the projection back its own output changes nothing.
 		second := sdk.GraphEntry{Graph: g, Document: &sdk.DocumentAssertions{
 			Identity:    doc.Namespace,
@@ -106,7 +129,7 @@ func FuzzDocumentAssertions(f *testing.F) {
 			Tools:       doc.Assertions.Tools,
 			Comment:     doc.Assertions.Comment,
 		}}
-		again, err := FromGraphEntries(g, []sdk.GraphEntry{second}, BuildOptions{})
+		again, err := FromGraphEntries(g, []sdk.GraphEntry{second}, BuildOptions{RestatesSource: true})
 		if err != nil {
 			t.Fatalf("second export: %v", err)
 		}

--- a/internal/sbom/document_assertions_test.go
+++ b/internal/sbom/document_assertions_test.go
@@ -138,7 +138,7 @@ func TestDocumentClaimsSurviveTheGraphHop(t *testing.T) {
 func TestSingleSourceExportIsAFixedPoint(t *testing.T) {
 	for _, target := range []Target{TargetSPDX23JSON, TargetCycloneDX16JSON} {
 		t.Run(string(target), func(t *testing.T) {
-			opts := BuildOptions{ToolVersion: "0.0.0-test"}
+			opts := BuildOptions{ToolVersion: "0.0.0-test", RestatesSource: true}
 
 			_, entry := ingestDocument(t, supplierRichCycloneDX)
 			first, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, target, opts, EncodeOptions{Pretty: true})
@@ -163,7 +163,7 @@ func TestSingleSourceExportIsAFixedPoint(t *testing.T) {
 // produces still says which document it restates.
 func TestSingleSourceExportAdoptsTheSourceIdentity(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
-	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{})
+	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{RestatesSource: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -188,8 +188,9 @@ func TestSingleSourceExportAdoptsTheSourceIdentity(t *testing.T) {
 func TestPinnedIdentityWinsOverTheSource(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
 	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{
-		DocumentNS:   "https://pinned.example/ns",
-		DocumentName: "pinned-name",
+		RestatesSource: true,
+		DocumentNS:     "https://pinned.example/ns",
+		DocumentName:   "pinned-name",
 	})
 	if err != nil {
 		t.Fatalf("export: %v", err)
@@ -316,7 +317,7 @@ func TestSourceClaimsAreRegatedOnExport(t *testing.T) {
 		Comment:  strings.Repeat("x", 1<<20),
 		Creators: []sdk.Contact{{Kind: sdk.ContactKindPerson, Name: "ctrl\x00char"}},
 	}
-	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{})
+	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{RestatesSource: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -340,7 +341,7 @@ func TestSourceClaimsAreRegatedOnExport(t *testing.T) {
 // same tool at the same version, which is what would otherwise make each hop
 // of a round trip grow the creator list.
 func TestBomlyCreditIsNotDuplicatedAcrossHops(t *testing.T) {
-	opts := BuildOptions{ToolVersion: "0.0.0-test", Created: fixedExportTime()}
+	opts := BuildOptions{ToolVersion: "0.0.0-test", Created: fixedExportTime(), RestatesSource: true}
 	_, entry := ingestDocument(t, supplierRichCycloneDX)
 	first, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetSPDX23JSON, opts, EncodeOptions{Pretty: true})
 	if err != nil {
@@ -369,7 +370,7 @@ func TestBomlyCreditIsNotDuplicatedAcrossHops(t *testing.T) {
 // says nothing at all about where it came from.
 func TestCycloneDXConversionLinksAnSPDXSourceItCannotAdopt(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
-	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{Pretty: true})
+	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -393,7 +394,7 @@ func TestCycloneDXConversionLinksAnSPDXSourceItCannotAdopt(t *testing.T) {
 // point at this document itself.
 func TestCycloneDXConversionDoesNotLinkTheIdentityItAdopted(t *testing.T) {
 	_, entry := ingestDocument(t, serialCycloneDX)
-	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{Pretty: true})
+	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -459,7 +460,7 @@ func TestAnAnonymousSourceStillCountsAsASource(t *testing.T) {
 // creation time is two statements that disagree.
 func TestConversionKeepsTheSourceCreationTime(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
-	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{})
+	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{RestatesSource: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -473,7 +474,7 @@ func TestConversionKeepsTheSourceCreationTime(t *testing.T) {
 // configured provenance.
 func TestCycloneDXCreditsAnIngestedOrganization(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
-	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{Pretty: true})
+	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -491,7 +492,8 @@ func TestCycloneDXCreditsAnIngestedOrganization(t *testing.T) {
 func TestConfiguredProvenanceOutranksAnIngestedOrganization(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
 	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{
-		Provenance: Provenance{Manufacturer: "Operator Ltd"},
+		RestatesSource: true,
+		Provenance:     Provenance{Manufacturer: "Operator Ltd"},
 	})
 	if err != nil {
 		t.Fatalf("export: %v", err)
@@ -589,7 +591,7 @@ func TestConversionKeepsTheSourceBOMRevision(t *testing.T) {
 	if entry.Document.Identity != "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/4" {
 		t.Fatalf("identity = %q, want the revision kept", entry.Document.Identity)
 	}
-	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{Pretty: true})
+	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, BuildOptions{RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -635,9 +637,10 @@ func TestADifferentRevisionOfTheSameSerialIsStillASource(t *testing.T) {
 // extra author per hop, in a flow advertised as a fixed point.
 func TestConfiguredProvenanceDoesNotDuplicateAuthorsAcrossHops(t *testing.T) {
 	opts := BuildOptions{
-		Provenance:   Provenance{Manufacturer: "Operator Ltd"},
-		Created:      fixedExportTime(),
-		SerialNumber: "urn:uuid:11111111-2222-4333-8444-555555555555",
+		RestatesSource: true,
+		Provenance:     Provenance{Manufacturer: "Operator Ltd"},
+		Created:        fixedExportTime(),
+		SerialNumber:   "urn:uuid:11111111-2222-4333-8444-555555555555",
 	}
 	_, entry := ingestDocument(t, supplierRichCycloneDX)
 	first, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON, opts, EncodeOptions{Pretty: true})

--- a/internal/sbom/document_restatement_test.go
+++ b/internal/sbom/document_restatement_test.go
@@ -1,0 +1,129 @@
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+// A single source whose graph was transformed after ingest -- scope-filtered,
+// enriched, degraded -- is a different document with one input, and it says
+// so: its own identity, timestamp, name and comment, with the source linked
+// rather than adopted (ADR-0042 as amended by issue #433). Before the
+// amendment a `--scope runtime` export of one SBOM republished that SBOM's
+// namespace over a subset of its inventory, two documents sharing one name.
+//
+// The caller's declaration is the only signal; this package cannot tell a
+// filtered graph from a whole one. So the default -- no declaration -- is the
+// safe side, and these tests pass no RestatesSource at all.
+func TestATransformedConversionMintsItsOwnIdentity(t *testing.T) {
+	_, entry := ingestDocument(t, documentRichSPDX)
+	doc, err := FromGraphEntries(entry.Graph, []sdk.GraphEntry{entry}, BuildOptions{Created: fixedExportTime()})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	const sourceNamespace = "https://acme.example/spdx/acme-platform-7f3c"
+	if doc.Namespace == sourceNamespace {
+		t.Fatalf("a transformed export republished its source's namespace %q", doc.Namespace)
+	}
+	if !strings.HasPrefix(doc.Namespace, "https://bomly.dev/spdx/") {
+		t.Fatalf("namespace = %q, want one minted by this export", doc.Namespace)
+	}
+	if doc.Name != defaultDocumentName {
+		t.Fatalf("name = %q, want the default rather than the source's", doc.Name)
+	}
+	if doc.Assertions.Comment != "" {
+		t.Fatalf("comment = %q, want none: it described the source's full contents", doc.Assertions.Comment)
+	}
+	if !doc.Created.Equal(fixedExportTime()) {
+		t.Fatalf("created = %v, want this export's own time %v, not the source's", doc.Created, fixedExportTime())
+	}
+	if len(doc.Sources) != 1 {
+		t.Fatalf("sources = %d, want the one document read", len(doc.Sources))
+	}
+	// Creators still union: the source did produce this document's inventory.
+	var credited bool
+	for _, creator := range doc.Assertions.Creators {
+		if creator.Name == "Acme Corp" {
+			credited = true
+		}
+	}
+	if !credited {
+		t.Fatalf("creators = %+v, want the source's organization credited", doc.Assertions.Creators)
+	}
+}
+
+// The identity a transformed export does not adopt is not lost: it is written
+// as a link, in whichever form the target format has for one.
+func TestATransformedConversionLinksItsSource(t *testing.T) {
+	t.Run("spdx", func(t *testing.T) {
+		_, entry := ingestDocument(t, documentRichSPDX)
+		raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetSPDX23JSON,
+			BuildOptions{Created: fixedExportTime()}, EncodeOptions{Pretty: true})
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		refs := spdxExternalDocumentRefs(t, raw)
+		if len(refs) != 1 {
+			t.Fatalf("externalDocumentRefs = %+v, want exactly the source", refs)
+		}
+		if refs[0].URI != "https://acme.example/spdx/acme-platform-7f3c" {
+			t.Fatalf("linked %q, want the source namespace", refs[0].URI)
+		}
+		if refs[0].Checksum.Value != sha256Hex(documentRichSPDX) {
+			t.Fatalf("checksum = %q, want a digest of the source bytes", refs[0].Checksum.Value)
+		}
+	})
+	t.Run("cyclonedx", func(t *testing.T) {
+		_, entry := ingestDocument(t, serialCycloneDX)
+		raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetCycloneDX16JSON,
+			BuildOptions{Created: fixedExportTime()}, EncodeOptions{Pretty: true})
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		var bom cdx.BOM
+		if err := json.Unmarshal(raw, &bom); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if bom.SerialNumber == "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" {
+			t.Fatalf("a transformed export republished its source's serial %q", bom.SerialNumber)
+		}
+		refs := cycloneDXSourceRefs(t, raw)
+		if len(refs) != 1 {
+			t.Fatalf("bom references = %+v, want exactly the source", refs)
+		}
+		if refs[0].URL != "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1" {
+			t.Fatalf("linked %q, want the source's BOM-Link", refs[0].URL)
+		}
+		if refs[0].Hashes == nil || len(*refs[0].Hashes) == 0 {
+			t.Fatalf("the source link carries no hash")
+		}
+	})
+}
+
+// The declaration means nothing for a merge: two sources are two documents
+// whatever the caller says, and both are linked.
+func TestRestatementFlagIsIgnoredByAMerge(t *testing.T) {
+	_, first := ingestDocument(t, documentRichSPDX)
+	_, second := ingestDocument(t, serialCycloneDX)
+	merged := sdk.New()
+	if err := sdk.MergeGraph(merged, first.Graph); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if err := sdk.MergeGraph(merged, second.Graph); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	doc, err := FromGraphEntries(merged, []sdk.GraphEntry{first, second}, BuildOptions{RestatesSource: true})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if doc.Namespace == "https://acme.example/spdx/acme-platform-7f3c" {
+		t.Fatalf("a merge adopted one source's namespace despite the flag")
+	}
+	if got := documentSourceLinks(doc, documentIdentity{Namespace: doc.Namespace}); len(got) != 2 {
+		t.Fatalf("source links = %+v, want both documents", got)
+	}
+}

--- a/internal/sbom/document_sources_test.go
+++ b/internal/sbom/document_sources_test.go
@@ -180,7 +180,7 @@ func TestMergedSourceLinksSurviveASecondConversion(t *testing.T) {
 			// documents that document named are still named.
 			_, entry := ingestDocument(t, string(first))
 			second, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, target,
-				BuildOptions{Created: fixedExportTime()}, EncodeOptions{Pretty: true})
+				BuildOptions{Created: fixedExportTime(), RestatesSource: true}, EncodeOptions{Pretty: true})
 			if err != nil {
 				t.Fatalf("second export: %v", err)
 			}
@@ -228,7 +228,7 @@ func TestCycloneDXSourceLinksCarryTheirChecksum(t *testing.T) {
 	// the whole reason the hash is written.
 	_, entry := ingestDocument(t, string(raw))
 	converted, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetSPDX23JSON,
-		BuildOptions{Created: fixedExportTime()}, EncodeOptions{Pretty: true})
+		BuildOptions{Created: fixedExportTime(), RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("convert to spdx: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestNativeExportNamesNoSources(t *testing.T) {
 func TestConversionDoesNotLinkTheDocumentItRestates(t *testing.T) {
 	_, entry := ingestDocument(t, documentRichSPDX)
 	raw, err := MarshalGraphEntriesJSON(entry.Graph, []sdk.GraphEntry{entry}, TargetSPDX23JSON,
-		BuildOptions{Created: fixedExportTime()}, EncodeOptions{Pretty: true})
+		BuildOptions{Created: fixedExportTime(), RestatesSource: true}, EncodeOptions{Pretty: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}

--- a/internal/sbom/model.go
+++ b/internal/sbom/model.go
@@ -77,6 +77,14 @@ type BuildOptions struct {
 	// must only claim "complete" when nothing filtered or degraded the graph.
 	Aggregate string
 
+	// RestatesSource is true only when the export is a faithful restatement
+	// of its single source document: nothing filtered, enriched, or degraded
+	// the graph between ingest and export. Only then does a conversion adopt
+	// the source's identity, creation time, name and comment (ADR-0042). The
+	// default, false, is the safe side: the document mints its own identity
+	// and links the source. Ignored with zero or several sources.
+	RestatesSource bool
+
 	// Registry, when non-nil, supplies matching-stage enrichment (licenses,
 	// vulnerabilities, CPEs, digests, EOL) resolved by PURL and folded onto
 	// each component during projection.

--- a/internal/sbom/spdx23.go
+++ b/internal/sbom/spdx23.go
@@ -134,8 +134,9 @@ func (spdx23Codec) encodeJSON(doc *Document, opts EncodeOptions) ([]byte, error)
 		DocumentName:      doc.NameOrDefault(),
 		DocumentNamespace: doc.NamespaceOrDefault(),
 		// The documents this one was built from, named rather than inherited.
-		// Empty for a native scan and for a conversion that adopted its single
-		// source's identity; populated for a merge.
+		// Empty for a native scan and for a restating conversion that adopted
+		// its single source's identity; populated for a merge and for a
+		// transformed conversion.
 		ExternalDocumentReferences: spdxSourceLinks(doc),
 		CreationInfo:               creation,
 		DocumentComment:            doc.Assertions.Comment,

--- a/internal/sbom/transform.go
+++ b/internal/sbom/transform.go
@@ -213,7 +213,10 @@ func FromGraphEntries(g *sdk.Graph, entries []sdk.GraphEntry, opts BuildOptions)
 	// Before the identity is minted, not after: a conversion adopts its
 	// single source's identity, and it can only do that while the slot is
 	// still empty. An identity the caller pinned always wins over both.
-	applySourceAssertions(doc, sources)
+	// Adoption also needs the caller's word that the graph still restates
+	// the source; a transformed export leaves the slot empty here, mints its
+	// own identity below, and links the source instead.
+	applySourceAssertions(doc, sources, opts.RestatesSource)
 	mintDocumentIdentity(doc)
 	if doc.Created.IsZero() {
 		// Only once nothing else supplied one: a caller's pinned timestamp


### PR DESCRIPTION
Closes #433.

`applySourceAssertions` adopted a single ingested document's identity (and creation time, name, comment) whenever exactly one document was read, even when `--scope` or `--enrich` had transformed the graph. A filtered subset was published under the full document's namespace or serial: two documents, one identity.

**The seam**: `internal/sbom` cannot see the transformation, only the caller can. `BuildOptions.RestatesSource` is the caller's declaration that nothing filtered, enriched, or degraded the graph between ingest and export; only then does a conversion adopt its source's identity. Default false is the safe side: a transformed conversion behaves as a merge of one (own identity and timestamp, default name, no comment, source linked). Creators and tools still union.

**The CLI predicate** (`sbomRestatesSource` in `scan_cmd.go`) is `sbomCompositionAggregate(...) == "complete" && !Enrich`, so the completeness and restatement claims stay mechanically consistent. `--analyze` requires `--enrich` and nothing under `internal/sbom` reads reachability, so enrichment covers it. The registry is never nil at the CLI, so it cannot be the signal.

**Visible behaviour change**: `bomly scan --sbom <one document> --scope runtime -f cyclonedx` (or `--enrich`) now emits a fresh serial and this run's timestamp, plus an external reference of type `bom` with a hash naming the source; SPDX gets an `externalDocumentRef` with the ingest checksum. Without `--scope`/`--enrich` the source serial is kept as before. Verified end to end with the built binary on a self-scan export:

```
--scope runtime: serial urn:uuid:6acbde59-…, refs [urn:cdx:2089beb2-…/1 (1 hash)]
plain:           serial urn:uuid:2089beb2-… (the source's), refs []
spdx --scope:    namespace https://bomly.dev/spdx/…, externalDocumentRefs [urn:cdx:2089beb2-…/1, SHA256]
```

**Tests**: every test asserting adoption now declares `RestatesSource: true` (`TestSingleSourceExportIsAFixedPoint` still pins nothing else); the fuzz target gains a pass without the flag asserting the identity is never adopted and is linked whenever it clears the gate; new `TestATransformedConversionMintsItsOwnIdentity`, `TestATransformedConversionLinksItsSource` (both formats), `TestRestatementFlagIsIgnoredByAMerge`, `TestSBOMRestatesSourceOnlyForAnUntransformedScan`.

**Docs**: ADR-0042 amended in place (dated blockquote), ADR-0037 cross-references it. A plugin-written source with no ingest checksum is neither adopted nor linked on a transformed SPDX export, which was already the merge behaviour and is now stated.

**Gates**: `make verify` passes; smoke `TestScan/scan-sbom-spdx`, `TestScan/scan-sbom-cyclonedx`, `TestScanSBOMExportGolden`, `TestScanSBOMExportOrigin` pass with no golden change.

Follow-up: bomly-dev/bomly-sdk#61 (source links are not yet read back on ingest), so a transformed export that links its source still loses that link on the next hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)