### PR TITLE
docs(maturity): done-criterion 2 states the measurement that was actually taken

### DIFF
--- a/dev-docs/SDK_MATURITY_PLAN.md
+++ b/dev-docs/SDK_MATURITY_PLAN.md
@@ -206,9 +206,32 @@ the golden refresh happens **once**:
 
 1. Issues #410 and #396 closed by phase-2 PRs; survey defects 1–4 closed;
    ADR-0033 prose corrected.
-2. `bomly scan` → export → ingest → export is a fixed point for every
-   preserved field, and a self-scan round trip preserves `org` for 24/24
-   packages (today: 0/24).
+2. `bomly scan` → export → ingest → export is a fixed point, and a
+   self-scan round trip preserves `org` for every package that has one.
+   Measured, not assumed — the criterion originally read "24/24 packages
+   (today: 0/24)", but no fixture, script, or test behind that figure exists
+   in the repository, so it could not be reproduced and is amended here
+   (#455). The measurement that stands, taken 2026-09-12 on this repository
+   with the `gomod` detector:
+
+   ```sh
+   bomly scan --path . --detectors gomod -q -f json -o cyclonedx=hop1.cdx.json > hop0.json
+   bomly scan --sbom --path hop1.cdx.json -q -f json -o cyclonedx=hop2.cdx.json > hop1.json
+   bomly scan --sbom --path hop2.cdx.json -q -f json -o cyclonedx=hop3.cdx.json > hop2.json
+   diff <(jq -S 'del(.serialNumber,.metadata.timestamp)' hop2.cdx.json) \
+        <(jq -S 'del(.serialNumber,.metadata.timestamp)' hop3.cdx.json)
+   jq -r '.components[] | select(.group == null) | .purl' hop1.cdx.json
+   ```
+
+   Result: 317 components on every hop; hop 2 and hop 3 identical once the
+   serial and timestamp are stripped; 316 of 317 components carry `group`.
+   The one that does not is `pkg:golang/go4.org@v0.0.0-20230225012048-214862532bf5`,
+   whose module path has no organization segment, so there was nothing to
+   preserve — the original denominator counted it as a loss.
+   `TestOrgSurvivesACycloneDXRoundTripOnlyWhereItExists` (`internal/sbom`)
+   pins both halves so the check is no longer a one-off, and
+   `TestSingleSourceExportIsAFixedPoint` pins the fixed point over a source
+   document.
 3. Grep-level: zero purl-type string literals in detectors, zero
    `packageurl-go`/`go-spdx` imports outside the kits, zero PURL string
    concatenation outside `purlkit` — each enforced by a guard test, not a

--- a/internal/sbom/org_round_trip_test.go
+++ b/internal/sbom/org_round_trip_test.go
@@ -1,0 +1,103 @@
+package sbom
+
+import (
+	"encoding/json"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/bomly-dev/bomly-cli/internal/testnodes"
+	"github.com/bomly-dev/bomly-sdk"
+)
+
+// TestOrgSurvivesACycloneDXRoundTripOnlyWhereItExists pins done-criterion 2
+// of the SDK maturity program (dev-docs/SDK_MATURITY_PLAN.md §6, issue #455)
+// as a test rather than a one-off measurement: a package whose module path
+// carries an organization segment keeps its org through export → ingest →
+// export, and a package whose path has none gains none. The second half is
+// what the original "24/24" framing got wrong -- a self-scan of this
+// repository holds `go4.org`, a module with no organization to preserve, and
+// counting it as a loss made a correct round trip look like a defect.
+func TestOrgSurvivesACycloneDXRoundTripOnlyWhereItExists(t *testing.T) {
+	g := sdk.New()
+	withOrg := testnodes.Dep(sdk.Coordinates{
+		Ecosystem: sdk.EcosystemGo,
+		Org:       "github.com/spf13",
+		Name:      "cobra",
+		Version:   "v1.8.0",
+	})
+	withoutOrg := testnodes.Dep(sdk.Coordinates{
+		Ecosystem: sdk.EcosystemGo,
+		Name:      "go4.org",
+		Version:   "v0.0.0-20230225012048-214862532bf5",
+	})
+	for _, node := range []*sdk.DependencyNode{withOrg, withoutOrg} {
+		if err := g.AddNode(node); err != nil {
+			t.Fatalf("add node: %v", err)
+		}
+	}
+
+	first, err := MarshalDepGraphJSON(g, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	doc, _, err := UnmarshalAutoJSON(first)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	ingested, err := ToGraph(doc)
+	if err != nil {
+		t.Fatalf("graph: %v", err)
+	}
+
+	cases := []struct {
+		node     *sdk.DependencyNode
+		wantOrg  string
+		wantName string
+	}{
+		{node: withOrg, wantOrg: "github.com/spf13", wantName: "github.com/spf13/cobra"},
+		{node: withoutOrg, wantOrg: "", wantName: "go4.org"},
+	}
+	for _, tc := range cases {
+		got, ok := ingested.DependencyNode(tc.node.NodeID())
+		if !ok {
+			t.Fatalf("%s did not survive ingest; graph holds %d nodes", tc.node.NodeID(), ingested.Size())
+		}
+		if got.Org != tc.wantOrg {
+			t.Errorf("%s: org = %q after the round trip, want %q", tc.node.NodeID(), got.Org, tc.wantOrg)
+		}
+		if name := got.EcosystemName(); name != tc.wantName {
+			t.Errorf("%s: name = %q after the round trip, want %q (no doubled or lost namespace)", tc.node.NodeID(), name, tc.wantName)
+		}
+	}
+
+	// And the second hop writes the same groups the first did.
+	second, err := MarshalDepGraphJSON(ingested, TargetCycloneDX16JSON, BuildOptions{}, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("re-export: %v", err)
+	}
+	groups := func(raw []byte) map[string]string {
+		var bom cdx.BOM
+		if err := json.Unmarshal(raw, &bom); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out := map[string]string{}
+		if bom.Components != nil {
+			for _, component := range *bom.Components {
+				out[component.PackageURL] = component.Group
+			}
+		}
+		return out
+	}
+	before, after := groups(first), groups(second)
+	if len(before) != 2 || len(after) != 2 {
+		t.Fatalf("component sets differ across hops: %v then %v", before, after)
+	}
+	for purl, group := range before {
+		if after[purl] != group {
+			t.Errorf("%s: group %q became %q on the second hop", purl, group, after[purl])
+		}
+	}
+	if before[withOrg.NodeID()] != "github.com/spf13" || before[withoutOrg.NodeID()] != "" {
+		t.Errorf("first hop groups = %v, want the org written exactly where one exists", before)
+	}
+}


### PR DESCRIPTION
Closes #455.

Done-criterion 2 in `dev-docs/SDK_MATURITY_PLAN.md` §6 read "a self-scan round trip preserves `org` for 24/24 packages (today: 0/24)". Searched the whole repository: no fixture, script, or test defines those 24 packages, so the criterion could not be reproduced and should not have been signed off as written.

**What the criterion now says**: the measurement that was taken on 2026-09-12, with the four commands to repeat it (self-scan with `gomod` → CycloneDX → ingest → export → export). Result: 317 components on every hop; hop 2 and hop 3 identical once serial and timestamp are stripped; 316 of 317 components carry `group`. The one that does not is `pkg:golang/go4.org@v0.0.0-20230225012048-214862532bf5`, whose module path has no organization segment, so there was nothing to preserve. The original denominator counted it as a loss.

**Made into a test**: `TestOrgSurvivesACycloneDXRoundTripOnlyWhereItExists` (`internal/sbom/org_round_trip_test.go`) exports a Go module with an org and one without, ingests, and asserts the first keeps `github.com/spf13` with the name `github.com/spf13/cobra` (no doubled or lost namespace) and the second stays org-less as `go4.org`, and that the second hop writes the same groups as the first. `TestSingleSourceExportIsAFixedPoint` already pins the fixed-point half over a source document.

`make verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)